### PR TITLE
Polish conversation navigation layout

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -25077,8 +25077,8 @@ function createNewChatTabButton() {
     const newTab = document.createElement('button');
     newTab.type = 'button';
     newTab.className = 'chat-session-tab chat-session-tab-new';
-    newTab.title = 'New chat. Modifier-click, right-click, or press Shift+F10 for conversation-list options.';
-    newTab.setAttribute('aria-label', 'New chat');
+    newTab.title = 'New conversation. Modifier-click, right-click, or press Shift+F10 for conversation-list options.';
+    newTab.setAttribute('aria-label', 'New conversation');
     newTab.setAttribute('aria-haspopup', 'menu');
     newTab.setAttribute('aria-keyshortcuts', 'Shift+F10');
     newTab.textContent = '+';
@@ -25902,7 +25902,7 @@ function renderChatSessionTabs(sessions, activeSessionId) {
 function buildNewChatContextMenuItems() {
     const items = [
         {
-            label: 'New chat',
+            label: 'New conversation',
             onClick: () => {
                 void createNewChatSession();
             }

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -177,7 +177,9 @@ let chatSessionLinksSaveDebounceId = null;
 let chatSessionLinksDirtySessionId = null;
 let chatSessionLinksDirtyPayload = null;
 let chatSessionMetadataOpenKey = null;
-const LS_CHAT_SESSION_METADATA_COLLAPSED = 'von:chatSessionMetadataCollapsed';
+// Versioned so browsers carrying the former expanded-by-default preference
+// start this release furled once. Choices made with the new UI still persist.
+const LS_CHAT_SESSION_METADATA_COLLAPSED = 'von:chatSessionMetadataCollapsed:v2';
 let chatSessionMetadataCollapsed = null;
 
 const chatSessionConceptMetaCache = new Map();

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -24,6 +24,7 @@ import {
     resetCopyJsonButtonPreCopyState
 } from './utils/copyJsonButtonState.js';
 import { saveJsonTextViaDialog } from './utils/fileSave.js';
+import { scrollConversationToSessionList } from './utils/conversationListNavigation.js';
 import {
     armRetryableLoadState,
     clearRetryableLoadState,
@@ -1009,6 +1010,7 @@ let chatTabsFirstLoadStartEpochMs = null;
 let chatTabsLoadingTickerId = null;
 let chatTabsLoadingTickerLastRenderedSec = -1;
 let chatSessionMenuEl = null;
+let chatSessionMenuReturnFocusEl = null;
 let activeHistoryRequest = null;
 let historyRequestCounter = 0;
 const HISTORY_SEGMENT_SIZE = 200;
@@ -1019,6 +1021,10 @@ const LS_HIDDEN_CHAT_SESSIONS_PREFIX = 'von:hiddenChatSessionIds';
 const LS_PINNED_CHAT_SESSIONS_PREFIX = 'von:pinnedChatSessionIds';
 const LS_CHAT_SESSION_LAST_ACCESSED_PREFIX = 'von:chatSessionLastAccessed';
 const LS_AGENT_CREATED_CHAT_SESSIONS_VISIBLE_PREFIX = 'von:showAgentCreatedChatSessions';
+const LS_CHAT_SESSION_TABS_LAYOUT_PREFIX = 'von:chatSessionTabsLayout';
+const CHAT_SESSION_TABS_LAYOUT_HORIZONTAL = 'horizontal';
+const CHAT_SESSION_TABS_LAYOUT_VERTICAL = 'vertical';
+const CHAT_SESSION_TABS_NARROW_MEDIA_QUERY = '(max-width: 800px)';
 const MAX_DELETABLE_TURNS = 4;
 const CHAT_SESSION_TABS_FETCH_LIMIT = 200;
 const AGENT_CREATED_CHAT_SESSION_ORIGIN_KINDS = new Set([
@@ -1038,6 +1044,9 @@ let _agentCreatedSessionsVisibleUserKey = null;
 let chatSessionLastAccessedMap = new Map();
 let _chatSessionLastAccessedUserKey = null;
 let showAllConversationHistoryMatches = false;
+let chatSessionTabsLayout = CHAT_SESSION_TABS_LAYOUT_HORIZONTAL;
+let chatSessionTabsLayoutMediaQuery = null;
+let chatSessionTabsLayoutMediaListenerBound = false;
 let agentCreatedSessionVisibilityState = {
     totalCount: 0,
     hiddenCount: 0,
@@ -1072,6 +1081,144 @@ function getPinnedSessionsStorageKey() {
 
 function getAgentCreatedSessionsVisibleStorageKey() {
     return buildUserScopedStorageKey(LS_AGENT_CREATED_CHAT_SESSIONS_VISIBLE_PREFIX);
+}
+
+function getChatSessionTabsLayoutStorageKey() {
+    // This controls the browser's navigation chrome rather than user-owned
+    // conversation data, so it deliberately survives authentication changes.
+    return LS_CHAT_SESSION_TABS_LAYOUT_PREFIX;
+}
+
+function normaliseChatSessionTabsLayout(value) {
+    return value === CHAT_SESSION_TABS_LAYOUT_VERTICAL
+        ? CHAT_SESSION_TABS_LAYOUT_VERTICAL
+        : CHAT_SESSION_TABS_LAYOUT_HORIZONTAL;
+}
+
+function isChatSessionTabsNarrowViewport() {
+    try {
+        return typeof window.matchMedia === 'function'
+            && window.matchMedia(CHAT_SESSION_TABS_NARROW_MEDIA_QUERY).matches;
+    } catch (_) {
+        return false;
+    }
+}
+
+function getEffectiveChatSessionTabsLayout(preferredLayout = chatSessionTabsLayout) {
+    const preferred = normaliseChatSessionTabsLayout(preferredLayout);
+    if (preferred !== CHAT_SESSION_TABS_LAYOUT_VERTICAL) {
+        return CHAT_SESSION_TABS_LAYOUT_HORIZONTAL;
+    }
+    if (isChatSessionTabsNarrowViewport()) {
+        return CHAT_SESSION_TABS_LAYOUT_HORIZONTAL;
+    }
+    return CHAT_SESSION_TABS_LAYOUT_VERTICAL;
+}
+
+function getChatSessionTabsLayoutMenuLabel() {
+    if (chatSessionTabsLayout === CHAT_SESSION_TABS_LAYOUT_VERTICAL) {
+        return isChatSessionTabsNarrowViewport()
+            ? 'Use conversation tabs across top on wider screens'
+            : 'Move conversation tabs to top';
+    }
+    return isChatSessionTabsNarrowViewport()
+        ? 'Use conversation tabs on left on wider screens'
+        : 'Move conversation tabs to left';
+}
+
+function applyChatSessionTabsLayout(layout = chatSessionTabsLayout) {
+    const preferred = normaliseChatSessionTabsLayout(layout);
+    const effective = getEffectiveChatSessionTabsLayout(preferred);
+    chatSessionTabsLayout = preferred;
+
+    const workspace = document.getElementById('conversationWorkspace');
+    const chatTab = document.getElementById('chatTab');
+    const tabs = getChatSessionTabsContainer();
+
+    if (workspace) {
+        workspace.dataset.tabsLayout = preferred;
+        workspace.dataset.effectiveTabsLayout = effective;
+    }
+    if (chatTab) {
+        chatTab.dataset.conversationTabsLayout = preferred;
+    }
+    if (tabs) {
+        tabs.setAttribute('aria-orientation', effective === CHAT_SESSION_TABS_LAYOUT_VERTICAL ? 'vertical' : 'horizontal');
+    }
+
+    try {
+        document.dispatchEvent(new CustomEvent('von:conversation-tabs-layout-changed', {
+            detail: { preferred, effective }
+        }));
+    } catch (_) {
+        // Layout still applies in constrained test environments without CustomEvent.
+    }
+
+    return { preferred, effective };
+}
+
+function loadChatSessionTabsLayoutPreference() {
+    const storageKey = getChatSessionTabsLayoutStorageKey();
+    let stored = null;
+    try {
+        stored = localStorage.getItem(storageKey);
+    } catch (e) {
+        console.warn('[chatTab] Failed to load conversation tab layout from localStorage:', e);
+    }
+    return applyChatSessionTabsLayout(normaliseChatSessionTabsLayout(stored));
+}
+
+function saveChatSessionTabsLayoutPreference() {
+    const storageKey = getChatSessionTabsLayoutStorageKey();
+    try {
+        localStorage.setItem(storageKey, normaliseChatSessionTabsLayout(chatSessionTabsLayout));
+    } catch (e) {
+        console.warn('[chatTab] Failed to save conversation tab layout to localStorage:', e);
+    }
+}
+
+function setChatSessionTabsLayout(layout, options = {}) {
+    const result = applyChatSessionTabsLayout(layout);
+    if (options.persist !== false) {
+        saveChatSessionTabsLayoutPreference();
+    }
+    if (options.announce === true) {
+        let message;
+        if (result.preferred === CHAT_SESSION_TABS_LAYOUT_VERTICAL
+            && result.effective === CHAT_SESSION_TABS_LAYOUT_HORIZONTAL) {
+            message = 'Left conversation tabs saved for wider screens.';
+        } else if (result.preferred === CHAT_SESSION_TABS_LAYOUT_VERTICAL) {
+            message = 'Conversation tabs moved to the left.';
+        } else {
+            message = 'Conversation tabs set across the top.';
+        }
+        showToast(message, 'success');
+    }
+    return result;
+}
+
+function toggleChatSessionTabsLayout(options = {}) {
+    const next = chatSessionTabsLayout === CHAT_SESSION_TABS_LAYOUT_VERTICAL
+        ? CHAT_SESSION_TABS_LAYOUT_HORIZONTAL
+        : CHAT_SESSION_TABS_LAYOUT_VERTICAL;
+    return setChatSessionTabsLayout(next, options);
+}
+
+function setupChatSessionTabsResponsiveLayout() {
+    if (chatSessionTabsLayoutMediaListenerBound || typeof window.matchMedia !== 'function') {
+        return;
+    }
+    chatSessionTabsLayoutMediaQuery = window.matchMedia(CHAT_SESSION_TABS_NARROW_MEDIA_QUERY);
+    const handleChange = () => {
+        applyChatSessionTabsLayout(chatSessionTabsLayout);
+    };
+    if (typeof chatSessionTabsLayoutMediaQuery.addEventListener === 'function') {
+        chatSessionTabsLayoutMediaQuery.addEventListener('change', handleChange);
+        chatSessionTabsLayoutMediaListenerBound = true;
+    } else if (typeof chatSessionTabsLayoutMediaQuery.addListener === 'function') {
+        chatSessionTabsLayoutMediaQuery.addListener(handleChange);
+        chatSessionTabsLayoutMediaListenerBound = true;
+    }
 }
 
 function loadHiddenChatSessionIds() {
@@ -23517,7 +23664,7 @@ function _appendChatSessionCurrentTitle(container, sessionId) {
     const title = _resolveCurrentChatSessionTitle(sessionId);
     if (!title) return;
 
-    const titleEl = document.createElement('div');
+    const titleEl = document.createElement('h2');
     titleEl.className = 'chat-session-current-title';
     titleEl.textContent = title;
     titleEl.title = title;
@@ -24101,9 +24248,10 @@ function _isChatSessionMetadataCollapsed() {
         return chatSessionMetadataCollapsed;
     }
     try {
-        chatSessionMetadataCollapsed = window.localStorage.getItem(LS_CHAT_SESSION_METADATA_COLLAPSED) === 'true';
+        const stored = window.localStorage.getItem(LS_CHAT_SESSION_METADATA_COLLAPSED);
+        chatSessionMetadataCollapsed = stored === null ? true : stored === 'true';
     } catch (_) {
-        chatSessionMetadataCollapsed = false;
+        chatSessionMetadataCollapsed = true;
     }
     return chatSessionMetadataCollapsed;
 }
@@ -24902,6 +25050,64 @@ function openSettingsToLogin() {
     }
 }
 
+function getNewChatMenuAnchor(button, event = null) {
+    const clientX = Number(event?.clientX);
+    const clientY = Number(event?.clientY);
+    if (Number.isFinite(clientX) && Number.isFinite(clientY) && (clientX !== 0 || clientY !== 0)) {
+        return { x: clientX, y: clientY };
+    }
+    const rect = button?.getBoundingClientRect?.();
+    return {
+        x: Number(rect?.left || 0) + 8,
+        y: Number(rect?.bottom || 0) + 4
+    };
+}
+
+function openNewChatOptions(button, event = null) {
+    const { x, y } = getNewChatMenuAnchor(button, event);
+    openChatSessionMenu(x, y, buildNewChatContextMenuItems(), {
+        focusFirst: true,
+        returnFocus: button
+    });
+}
+
+function createNewChatTabButton() {
+    const newTab = document.createElement('button');
+    newTab.type = 'button';
+    newTab.className = 'chat-session-tab chat-session-tab-new';
+    newTab.title = 'New chat. Modifier-click, right-click, or press Shift+F10 for conversation-list options.';
+    newTab.setAttribute('aria-label', 'New chat');
+    newTab.setAttribute('aria-haspopup', 'menu');
+    newTab.setAttribute('aria-keyshortcuts', 'Shift+F10');
+    newTab.textContent = '+';
+
+    newTab.addEventListener('click', (event) => {
+        if (event?.ctrlKey || event?.metaKey) {
+            event.preventDefault();
+            event.stopPropagation();
+            openNewChatOptions(newTab, event);
+            return;
+        }
+        void createNewChatSession();
+    });
+    newTab.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openNewChatOptions(newTab, event);
+    });
+    newTab.addEventListener('keydown', (event) => {
+        const opensContextMenu = event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10');
+        if (!opensContextMenu) {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        openNewChatOptions(newTab, event);
+    });
+
+    return newTab;
+}
+
 function renderChatSessionTabsPlaceholder(mode = 'loading') {
     const container = getChatSessionTabsContainer();
     if (!container) {
@@ -24917,16 +25123,7 @@ function renderChatSessionTabsPlaceholder(mode = 'loading') {
 
     const allowNewChat = mode !== 'unauthenticated';
     if (allowNewChat) {
-        const newTab = document.createElement('button');
-        newTab.type = 'button';
-        newTab.className = 'chat-session-tab chat-session-tab-new';
-        newTab.title = 'New chat';
-        newTab.setAttribute('aria-label', 'New chat');
-        newTab.textContent = '+';
-        newTab.addEventListener('click', () => {
-            void createNewChatSession();
-        });
-        fragment.appendChild(newTab);
+        fragment.appendChild(createNewChatTabButton());
     }
 
     const placeholder = document.createElement('div');
@@ -25368,23 +25565,7 @@ function renderChatSessionTabs(sessions, activeSessionId) {
     const fragment = document.createDocumentFragment();
 
     // Always show the "+" button to create new chats
-    const newTab = document.createElement('button');
-    newTab.type = 'button';
-    newTab.className = 'chat-session-tab chat-session-tab-new';
-    newTab.title = agentCreatedSessionVisibilityState.hiddenCount > 0
-        ? 'New chat. Right-click to show test conversations.'
-        : 'New chat';
-    newTab.setAttribute('aria-label', 'New chat');
-    newTab.textContent = '+';
-    newTab.addEventListener('click', () => {
-        void createNewChatSession();
-    });
-    newTab.addEventListener('contextmenu', (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        openChatSessionMenu(event.clientX, event.clientY, buildNewChatContextMenuItems());
-    });
-    fragment.appendChild(newTab);
+    fragment.appendChild(createNewChatTabButton());
 
     if (orderedVisibleSessions.length === 0) {
         const placeholder = document.createElement('div');
@@ -25723,6 +25904,12 @@ function buildNewChatContextMenuItems() {
             onClick: () => {
                 void createNewChatSession();
             }
+        },
+        {
+            label: getChatSessionTabsLayoutMenuLabel(),
+            onClick: () => {
+                toggleChatSessionTabsLayout({ announce: true });
+            }
         }
     ];
 
@@ -25813,12 +26000,15 @@ function populateChatSessionMenu(items) {
     return menu;
 }
 
-function openChatSessionMenu(x, y, items) {
+function openChatSessionMenu(x, y, items, options = {}) {
     if (!Array.isArray(items) || items.length === 0) {
         return;
     }
 
     const menu = populateChatSessionMenu(items);
+    chatSessionMenuReturnFocusEl = options.returnFocus instanceof HTMLElement
+        ? options.returnFocus
+        : null;
     const padding = 8;
     menu.classList.add('open');
     menu.setAttribute('aria-hidden', 'false');
@@ -25828,14 +26018,25 @@ function openChatSessionMenu(x, y, items) {
     const top = Math.max(padding, Math.min(y, maxY));
     menu.style.left = `${left}px`;
     menu.style.top = `${top}px`;
+    if (options.focusFirst === true) {
+        const firstItem = menu.querySelector('button');
+        try { firstItem?.focus?.(); } catch (_) { /* ignore */ }
+    }
 }
 
 function closeChatSessionMenu() {
     if (!chatSessionMenuEl) {
         return;
     }
+    const shouldRestoreFocus = chatSessionMenuEl.contains(document.activeElement)
+        && chatSessionMenuReturnFocusEl?.isConnected;
+    const returnFocusEl = chatSessionMenuReturnFocusEl;
     chatSessionMenuEl.classList.remove('open');
     chatSessionMenuEl.setAttribute('aria-hidden', 'true');
+    chatSessionMenuReturnFocusEl = null;
+    if (shouldRestoreFocus) {
+        try { returnFocusEl.focus(); } catch (_) { /* ignore */ }
+    }
 }
 
 function setupChatTabContextMenu() {
@@ -28275,31 +28476,6 @@ function ensureScrollToEndButton(scrollableField = null) {
     }
 
     return button;
-}
-
-function scrollConversationToSessionList(options = {}) {
-    const tabs = document.getElementById('chatSessionTabs');
-    const target = tabs?.closest?.('.chat-session-tabs-row') || tabs || document.getElementById('chatTab');
-    if (!(target instanceof HTMLElement)) {
-        return false;
-    }
-
-    const smooth = options?.smooth !== false;
-    if (typeof target.scrollIntoView === 'function') {
-        target.scrollIntoView({
-            behavior: smooth ? 'smooth' : 'auto',
-            block: 'start',
-            inline: 'nearest'
-        });
-        return true;
-    }
-
-    if (typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
-        window.scrollTo({ top: 0, behavior: smooth ? 'smooth' : 'auto' });
-        return true;
-    }
-
-    return false;
 }
 
 function isScrollableFieldNearBottom(scrollableField, thresholdPx = CHAT_SCROLL_BOTTOM_THRESHOLD_PX) {
@@ -30794,6 +30970,8 @@ function handleAuthStatusChangeForChatTab(detail) {
     loadPinnedChatSessionIds();
     loadAgentCreatedSessionsVisibilityPreference();
     loadChatSessionLastAccessedMap();
+    loadChatSessionTabsLayoutPreference();
+    setupChatSessionTabsResponsiveLayout();
     showAllConversationHistoryMatches = false;
 
     const container = getChatSessionTabsContainer();
@@ -30855,6 +31033,8 @@ export function initializeChatTab() {
     loadPinnedChatSessionIds();
     loadAgentCreatedSessionsVisibilityPreference();
     loadChatSessionLastAccessedMap();
+    loadChatSessionTabsLayoutPreference();
+    setupChatSessionTabsResponsiveLayout();
 
     // Reload hidden sessions when user changes (settings change event)
     try {
@@ -36545,6 +36725,19 @@ export function __testOnly_resetConversationSituationState() {
 }
 export async function __testOnly_refreshChatSessionTabs() {
     return refreshChatSessionTabs();
+}
+export function __testOnly_loadChatSessionTabsLayoutPreference() {
+    return loadChatSessionTabsLayoutPreference();
+}
+export function __testOnly_setChatSessionTabsLayout(layout, options = {}) {
+    return setChatSessionTabsLayout(layout, options);
+}
+export function __testOnly_getChatSessionTabsLayout() {
+    return {
+        preferred: chatSessionTabsLayout,
+        effective: getEffectiveChatSessionTabsLayout(chatSessionTabsLayout),
+        storageKey: getChatSessionTabsLayoutStorageKey()
+    };
 }
 export function __testOnly_setActiveChatSession(sessionId, sessionName = null) {
     setActiveChatSession(sessionId, sessionName);

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -157,7 +157,9 @@ export function updateHeaderOrgName() {
     }
   } catch { /* ignore */ }
 
-  headerOrgNameEl.textContent = orgName || 'Personal';
+  const displayName = orgName || 'Personal';
+  headerOrgNameEl.textContent = displayName;
+  headerOrgNameEl.title = displayName;
 }
 
 /**

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -571,11 +571,15 @@ function setupDynamicLayout() {
     const headerHeight = header.getBoundingClientRect().height;
     tabContainer.style.top = `${headerHeight}px`;
     const measuredTabHeight = Math.max(
-      48,
-      Math.ceil(tabContainer.getBoundingClientRect().height || tabContainer.scrollHeight || 48)
+      44,
+      Math.ceil(tabContainer.getBoundingClientRect().height || tabContainer.scrollHeight || 44)
     );
     const tabHeight = measuredTabHeight;
     const contentTop = headerHeight + tabHeight + 8; // 8px margin
+    const footerSpace = 64; // Fixed footer overlap space
+
+    document.documentElement.style.setProperty('--von-fixed-shell-height', `${contentTop}px`);
+    document.documentElement.style.setProperty('--von-fixed-footer-clearance', `${footerSpace}px`);
 
     console.log(`Dynamic layout: Header ${headerHeight}px, positioning tabs at ${headerHeight}px, content at ${contentTop}px`);
 
@@ -583,7 +587,6 @@ function setupDynamicLayout() {
     if (tabContentArea) {
       tabContentArea.style.marginTop = `${contentTop}px`;
       // Also update the minimum height calculation to account for dynamic header
-      const footerSpace = 64; // Footer overlap space
       const totalTopSpace = contentTop + 20; // content margin + padding
       tabContentArea.style.minHeight = `calc(100vh - ${totalTopSpace + footerSpace}px)`;
       tabContentArea.style.setProperty('--von-tab-content-available-height', `calc(100vh - ${contentTop + footerSpace}px)`);

--- a/src/frontend/web/von_interface/static/js/tabNavigation.js
+++ b/src/frontend/web/von_interface/static/js/tabNavigation.js
@@ -3,6 +3,7 @@ import { elements } from './domUtils.js';
 import { initializeDynamicTabs, loadDynamicConceptTabContent } from './dynamicTabs.js';
 import { isExpertTabsEnabled } from './featureFlags.js';
 import { initializeImportExportTab } from './importExportTab.js';
+import { scrollConversationToSessionList } from './utils/conversationListNavigation.js';
 import { initializeVontologyTab } from './vontology.js';
 
 const GUARDED_TAB_IDS = new Set(['vontologyTab', 'importExportTab', 'annotationTab']);
@@ -33,8 +34,12 @@ export function setupTabNavigation() {
         event.preventDefault();
       }
       const tabId = button.dataset.tab;
+      const conversationTabWasActive = tabId === 'chatTab' && button.classList.contains('active');
       console.log(`Tab clicked: ${tabId}`);
       activateTab(tabId);
+      if (conversationTabWasActive) {
+        scrollConversationToSessionList({ smooth: true });
+      }
       if (tabId === 'globalTasksTab') {
         await loadTabData(tabId);
       }

--- a/src/frontend/web/von_interface/static/js/utils/conversationListNavigation.js
+++ b/src/frontend/web/von_interface/static/js/utils/conversationListNavigation.js
@@ -1,0 +1,28 @@
+/**
+ * Bring the saved-conversation list back into view without changing the
+ * selected conversation or reloading its transcript.
+ */
+export function scrollConversationToSessionList(options = {}) {
+    const tabs = document.getElementById('chatSessionTabs');
+    const target = tabs?.closest?.('.chat-session-tabs-row') || tabs || document.getElementById('chatTab');
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    const smooth = options?.smooth !== false;
+    if (typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({
+            behavior: smooth ? 'smooth' : 'auto',
+            block: 'start',
+            inline: 'nearest'
+        });
+        return true;
+    }
+
+    if (typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
+        window.scrollTo({ top: 0, behavior: smooth ? 'smooth' : 'auto' });
+        return true;
+    }
+
+    return false;
+}

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -2367,14 +2367,102 @@ body {
     border-bottom: 1px solid #e5e7eb;
 }
 
-/* Stack: header (variable height) then tab bar */
+.global-header-shell {
+    width: min(100%, 1600px);
+    min-width: 0;
+    margin: 0 auto;
+    padding: 8px 20px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(18px, 3vw, 42px);
+}
+
 .global-header .main-container {
-    padding: 12px 16px 4px 16px;
+    position: relative;
+    flex: 0 1 46%;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.global-header .global-organisation-title {
+    min-width: 0;
+    max-width: 100%;
+    margin: 0;
+    color: #334155;
+    font-size: clamp(0.88rem, 1.2vw, 1.02rem);
+    font-weight: 550;
+    line-height: 1.25;
+    letter-spacing: 0;
+    text-align: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.global-product-name {
+    color: #0f172a;
+    font-weight: 700;
+}
+
+.global-organisation-separator {
+    margin: 0 0.25em;
+    color: #94a3b8;
+}
+
+.global-header .info-icon {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    margin: 0;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #475569;
+    font: 700 0.78rem/1 system-ui, sans-serif;
+}
+
+.global-header .info-icon:hover {
+    border-color: #94a3b8;
+    background: #f1f5f9;
+    color: #0f172a;
+}
+
+.global-header .info-icon:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.global-header .popup-container {
+    top: calc(100% + 8px);
+    right: 0;
+    left: auto;
+    z-index: 1300;
+    width: min(320px, calc(100vw - 24px));
+    height: auto;
+    min-height: 0;
+    max-height: min(420px, calc(100vh - var(--von-fixed-shell-height, 104px) - 16px));
+    margin: 0;
+    padding: 14px;
+    box-sizing: border-box;
+    overflow: auto;
+    resize: none;
 }
 
 /* Restore search input styling within global header */
 .global-header #vontologySearchInput {
-    width: 550px;
+    width: 100%;
+    min-width: 0;
     max-width: 100%;
     padding: 8px 12px;
     border: 1px solid #d1d5db;
@@ -2448,7 +2536,8 @@ body {
 .global-header .vontology-search {
     position: relative;
     flex: 1;
-    max-width: 600px;
+    max-width: none;
+    margin: 0;
 }
 
 /* Search result items within global header */
@@ -2615,7 +2704,7 @@ body {
     /* below global header height (increased for safety) */
     left: 0;
     right: 0;
-    min-height: 48px;
+    min-height: 44px;
     height: auto;
     z-index: 1100 !important;
     /* force above everything */
@@ -2625,11 +2714,11 @@ body {
     /* Light background for the tab bar */
     border-bottom: 1px solid #dee2e6;
     /* Subtle border */
-    padding: 6px 20px 0;
+    padding: 4px 16px 0;
     box-sizing: border-box;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
     /* Soft shadow for depth */
-    gap: 8px;
+    gap: 6px;
     align-items: flex-start;
 
     /* Allow many dynamic tabs without pushing Settings off-screen */
@@ -6811,24 +6900,26 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 
 /* Global concept search wrapper (JVNAUTOSCI-550) */
 .global-concept-search {
+    flex: 1 1 680px;
+    min-width: 280px;
     background: #ffffff;
-    border-bottom: 1px solid #e5e7eb;
-    padding: 8px 16px 4px 16px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    border: 0;
+    padding: 0;
+    box-shadow: none;
 }
 
 .global-concept-search-inner {
     display: flex;
-    align-items: flex-start;
-    gap: 20px;
+    align-items: center;
+    gap: 8px;
     flex-wrap: nowrap;
-    max-width: 1400px;
-    margin: 0 auto;
+    max-width: none;
+    margin: 0;
 }
 
 .global-concept-search-inner .vontology-title {
-    margin: 4px 0 0 0;
-    font-size: 1.25rem;
+    margin: 0;
+    font-size: 1rem;
     line-height: 1.3;
     flex: 0 0 auto;
 }
@@ -6847,8 +6938,9 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     padding: 4px;
     border-radius: 6px;
     background: #ffffff;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-    color: #555;
+    border: 1px solid #e2e8f0;
+    box-shadow: none;
+    color: #64748b;
     align-items: center;
     justify-content: center;
 }
@@ -6867,36 +6959,43 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     background: #e8e8e8;
 }
 
-@media (max-width: 900px) {
-    .global-concept-search-inner {
+@media (max-width: 760px) {
+    .global-header-shell {
+        padding: 7px 12px;
         flex-wrap: wrap;
+        gap: 5px 10px;
+    }
+
+    .global-concept-search {
+        flex-basis: 100%;
+        min-width: 0;
+    }
+
+    .global-concept-search-inner {
+        flex-wrap: nowrap;
     }
 
     .global-concept-search-inner .vontology-title {
-        width: 100%;
+        width: auto;
     }
 
     #globalVontologySearchWrapper {
         width: 100%;
+        min-width: 0;
     }
 
-    /* Make search input responsive on smaller screens */
     .global-header #vontologySearchInput {
         width: 100%;
-        min-width: 280px;
-    }
-}
-
-@media (max-width: 600px) {
-
-    /* On very small screens, ensure search is still usable */
-    .global-header #vontologySearchInput {
-        width: 100%;
-        min-width: 200px;
+        min-width: 0;
     }
 
-    .global-concept-search {
-        padding: 6px 12px 4px 12px;
+    .global-header .main-container {
+        flex: 1 1 100%;
+        justify-content: flex-end;
+    }
+
+    .global-header .global-organisation-title {
+        font-size: 0.82rem;
     }
 }
 
@@ -6947,26 +7046,31 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     color: #333;
 }
 
-.chat-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 20px;
-    position: relative;
+.conversation-workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    min-width: 0;
 }
 
-.chat-header .main-title {
-    margin-bottom: 0;
-    flex: 1;
-    text-align: center;
+.chat-conversation-main {
+    min-width: 0;
+}
+
+.chat-conversation-masthead {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 12px 20px;
+    margin-bottom: 12px;
+    padding: 4px 0 10px;
+    border-bottom: 1px solid #e2e8f0;
 }
 
 .chat-header-controls {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    gap: 10px;
+    gap: 7px;
     flex-wrap: wrap;
     min-width: 0;
 }
@@ -6994,7 +7098,7 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     align-items: flex-end;
     gap: 6px;
     margin-bottom: 0;
-    padding: 18px 0 10px;
+    padding: 18px 0 8px;
     border-bottom: 1px solid #e5e7eb;
     overflow-x: auto;
 }
@@ -7003,7 +7107,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-bottom: 12px;
+    margin-bottom: 10px;
+    scroll-margin-top: calc(var(--von-fixed-shell-height, 104px) + 10px);
 }
 
 .chat-session-tab-group-start {
@@ -7397,13 +7502,15 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 .chat-session-metadata {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 10px 0 12px;
-    margin-bottom: 10px;
-    border-bottom: 1px solid #e5e7eb;
+    gap: 6px;
+    min-width: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
 }
 
 .chat-session-current-title {
+    margin: 0;
     font-size: 21px;
     font-weight: 700;
     line-height: 1.25;
@@ -7465,6 +7572,120 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 
 .chat-session-metadata.is-hidden {
     display: none;
+}
+
+.chat-conversation-masthead .chat-export-btn {
+    min-height: 32px;
+    padding: 5px 9px;
+    border-color: #cbd5e1;
+    border-radius: 7px;
+    background: #ffffff;
+    color: #334155;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.chat-conversation-masthead .chat-export-btn:hover,
+.chat-conversation-masthead .chat-export-btn:focus-visible {
+    border-color: #93c5fd;
+    background: #eff6ff;
+    color: #1d4ed8;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] {
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+    align-items: start;
+    gap: clamp(16px, 2vw, 28px);
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tabs-row {
+    position: sticky;
+    top: calc(var(--von-fixed-shell-height, 104px) + 8px);
+    z-index: 20;
+    align-self: start;
+    min-width: 0;
+    max-height: calc(100vh - var(--von-fixed-shell-height, 104px) - var(--von-fixed-footer-clearance, 64px) - 24px);
+    margin: 0;
+    padding: 10px;
+    box-sizing: border-box;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 7px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.96);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(8px);
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tabs {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    padding: 20px 3px 3px;
+    flex-direction: column;
+    align-items: stretch;
+    overflow-x: hidden;
+    overflow-y: auto;
+    border: 0;
+    scrollbar-width: thin;
+    scrollbar-color: #cbd5e1 transparent;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-count {
+    order: -1;
+    align-self: flex-end;
+    padding-right: 3px;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab {
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
+    border-radius: 8px;
+    padding: 8px 9px;
+    text-align: left;
+    white-space: normal;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab.is-active,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab.is-open.is-active,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab.is-shared.is-active,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab.is-pinned.is-active,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab.is-agent-created.is-active {
+    box-shadow: inset 3px 0 0 #2563eb;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-new {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    min-height: 36px;
+    align-items: center;
+    text-align: center;
+    background: #ffffff;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-group-start {
+    margin-top: 18px;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-group-badge {
+    top: -17px;
+    left: 5px;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tabs-placeholder,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tabs-placeholder-filtered {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-label,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-meta,
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-tab-preview {
+    white-space: nowrap;
 }
 
 .chat-situation-toggle {
@@ -7675,14 +7896,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 }
 
 @media (max-width: 640px) {
-    .chat-header {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-
-    .chat-header .main-title {
-        width: 100%;
-        text-align: left;
+    .chat-conversation-masthead {
+        grid-template-columns: minmax(0, 1fr);
     }
 
     .chat-header-controls {

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -1,55 +1,56 @@
 <!-- Chat Tab Content -->
 <div id="chatTab" class="tab-content active">
   <div class="content-wrapper">
-    <!-- Header with Von intro -->
-    <div class="chat-header">
-      <h2 class="main-title">Talk to Von Neumarkt</h2>
-      <div class="chat-header-controls" role="group" aria-label="Conversation tools">
-        <button id="conversationSituationToggleBtn" class="chat-export-btn chat-situation-toggle" type="button"
-          title="Inspect this conversation's shared situation" aria-label="Inspect conversation situation"
-          aria-expanded="false" aria-controls="conversationSituationPanel" data-keep-title="true">
-          <span class="chat-situation-toggle-label">Situation</span>
-          <span id="conversationSituationBadge" class="chat-situation-badge hidden" aria-hidden="true"></span>
-        </button>
-        <button id="taskPanelToggleBtn" class="chat-export-btn" type="button"
-          title="Open tasks panel" aria-label="Tasks" data-keep-title="true">
-          <span class="btn-icon">📋</span>
-          <span id="taskCountBadge" class="task-count-badge hidden" aria-hidden="true"></span>
-        </button>
-        <button id="inviteConversationBtn" class="chat-export-btn" type="button"
-          title="Invite people to this conversation" aria-label="Invite to conversation" data-keep-title="true">
-          <span class="btn-icon">👥</span>
-        </button>
-        <button id="incomingInvitesBtn" class="chat-export-btn" type="button"
-          title="View incoming conversation invites" aria-label="View conversation invites" data-keep-title="true">
-          <span class="btn-icon">📨</span>
-          <span id="incomingInvitesBadge" class="invite-badge hidden" aria-hidden="true"></span>
-        </button>
-        <button id="exportConversationMarkdownBtn" class="chat-export-btn" type="button"
-          title="Copy conversation transcript as Markdown" aria-label="Export conversation as Markdown"
-          data-keep-title="true">
-          <span class="btn-icon">MD</span>
-        </button>
-        <button id="copyConversationInfoJsonBtn" class="chat-export-btn" type="button"
-          title="Copy conversation info as JSON" aria-label="Copy conversation info as JSON"
-          data-keep-title="true" data-copy-json-role="copy-json" disabled>
-          <span class="btn-icon">ℹ</span>
-        </button>
-        <button id="exportConversationJsonBtn" class="chat-export-btn" type="button"
-          title="Save conversation info as JSON file" aria-label="Save conversation info as JSON"
-          data-keep-title="true">
-          <span class="btn-icon">{}</span>
-        </button>
+    <div id="conversationWorkspace" class="conversation-workspace" data-tabs-layout="horizontal"
+      data-effective-tabs-layout="horizontal">
+      <div class="chat-session-tabs-row" aria-label="Conversation sessions">
+        <div id="chatSessionTabs" class="chat-session-tabs" role="tablist" aria-label="Conversation sessions"
+          aria-orientation="horizontal"></div>
+        <div id="chatSessionCount" class="chat-session-count" aria-label="Conversation count" title="Conversations">—
+        </div>
       </div>
-    </div>
 
-    <div class="chat-session-tabs-row" aria-label="Conversation sessions">
-      <div id="chatSessionTabs" class="chat-session-tabs" role="tablist" aria-label="Conversation sessions"></div>
-      <div id="chatSessionCount" class="chat-session-count" aria-label="Conversation count" title="Conversations">—
-      </div>
-    </div>
-
-    <div id="chatSessionMetadata" class="chat-session-metadata" aria-label="Conversation metadata"></div>
+      <div class="chat-conversation-main">
+        <div class="chat-conversation-masthead">
+          <div id="chatSessionMetadata" class="chat-session-metadata" aria-label="Conversation metadata"></div>
+          <div class="chat-header-controls" role="group" aria-label="Conversation tools">
+            <button id="conversationSituationToggleBtn" class="chat-export-btn chat-situation-toggle" type="button"
+              title="Inspect this conversation's shared situation" aria-label="Inspect conversation situation"
+              aria-expanded="false" aria-controls="conversationSituationPanel" data-keep-title="true">
+              <span class="chat-situation-toggle-label">Situation</span>
+              <span id="conversationSituationBadge" class="chat-situation-badge hidden" aria-hidden="true"></span>
+            </button>
+            <button id="taskPanelToggleBtn" class="chat-export-btn" type="button"
+              title="Open tasks panel" aria-label="Tasks" data-keep-title="true">
+              <span class="btn-icon">📋</span>
+              <span id="taskCountBadge" class="task-count-badge hidden" aria-hidden="true"></span>
+            </button>
+            <button id="inviteConversationBtn" class="chat-export-btn" type="button"
+              title="Invite people to this conversation" aria-label="Invite to conversation" data-keep-title="true">
+              <span class="btn-icon">👥</span>
+            </button>
+            <button id="incomingInvitesBtn" class="chat-export-btn" type="button"
+              title="View incoming conversation invites" aria-label="View conversation invites" data-keep-title="true">
+              <span class="btn-icon">📨</span>
+              <span id="incomingInvitesBadge" class="invite-badge hidden" aria-hidden="true"></span>
+            </button>
+            <button id="exportConversationMarkdownBtn" class="chat-export-btn" type="button"
+              title="Copy conversation transcript as Markdown" aria-label="Export conversation as Markdown"
+              data-keep-title="true">
+              <span class="btn-icon">MD</span>
+            </button>
+            <button id="copyConversationInfoJsonBtn" class="chat-export-btn" type="button"
+              title="Copy conversation info as JSON" aria-label="Copy conversation info as JSON"
+              data-keep-title="true" data-copy-json-role="copy-json" disabled>
+              <span class="btn-icon">ℹ</span>
+            </button>
+            <button id="exportConversationJsonBtn" class="chat-export-btn" type="button"
+              title="Save conversation info as JSON file" aria-label="Save conversation info as JSON"
+              data-keep-title="true">
+              <span class="btn-icon">{}</span>
+            </button>
+          </div>
+        </div>
 
     <section id="conversationSituationPanel" class="chat-situation-panel hidden" role="dialog"
       aria-modal="false" aria-labelledby="conversationSituationTitle" tabindex="-1">
@@ -221,6 +222,8 @@
             </label>
           </div>
         </details>
+      </div>
+    </div>
       </div>
     </div>
   </div>

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -22,40 +22,47 @@
 <body>
   <!-- Fixed Global Header (title + search above tabs) JVNAUTOSCI-550 -->
   <div class="global-header" id="globalHeader">
-    <div class="main-container">
-      <!-- Popup for info (dynamically loaded from Vontology) -->
-      <div class="popup popup-container" id="infoPopup">
-        <div id="infoPopupContent">
-          <p class="info-loading">Loading...</p>
-        </div>
-      </div>
-      <!-- Header with info icon and dynamic organisation name -->
-      <h1>
-        <span class="info-icon" id="infoIcon" title="Click for more info">ℹ️</span>
-        Von: <span id="headerOrgName">...</span>
-      </h1>
-    </div>
-    <!-- Global Concept Search -->
-    <div class="global-concept-search" id="globalConceptSearchRegion">
-      <div class="global-concept-search-inner">
-        <h2 class="vontology-title" id="vontologyGlobalTitle">
-          <span class="vontology-search-icon" aria-hidden="true">
-            <!-- Simple magnifying glass icon (SVG) -->
-            <svg class="icon" viewBox="0 0 24 24" focusable="false" role="img" aria-hidden="true">
-              <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" fill="none" />
-              <line x1="16.5" y1="16.5" x2="22" y2="22" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-            </svg>
-          </span>
-          <span class="visually-hidden">Concept Search</span>
-        </h2>
-        <div class="vontology-search" id="globalVontologySearchWrapper">
-          <input type="text" id="vontologySearchInput" placeholder="Search concepts by name…"
-            aria-label="Search concepts" role="combobox" aria-autocomplete="list" aria-expanded="false"
-            aria-haspopup="listbox" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-            name="_vontology_search" />
-          <div id="vontologySearchResults" class="vontology-search-results" role="listbox" aria-label="Search results">
+    <div class="global-header-shell">
+      <!-- Global Concept Search -->
+      <div class="global-concept-search" id="globalConceptSearchRegion">
+        <div class="global-concept-search-inner">
+          <h2 class="vontology-title" id="vontologyGlobalTitle">
+            <span class="vontology-search-icon" aria-hidden="true">
+              <!-- Simple magnifying glass icon (SVG) -->
+              <svg class="icon" viewBox="0 0 24 24" focusable="false" role="img" aria-hidden="true">
+                <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" fill="none" />
+                <line x1="16.5" y1="16.5" x2="22" y2="22" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" />
+              </svg>
+            </span>
+            <span class="visually-hidden">Concept Search</span>
+          </h2>
+          <div class="vontology-search" id="globalVontologySearchWrapper">
+            <input type="text" id="vontologySearchInput" placeholder="Search concepts by name…"
+              aria-label="Search concepts" role="combobox" aria-autocomplete="list" aria-expanded="false"
+              aria-haspopup="listbox" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+              name="_vontology_search" />
+            <div id="vontologySearchResults" class="vontology-search-results" role="listbox"
+              aria-label="Search results">
+            </div>
           </div>
         </div>
+      </div>
+
+      <div class="main-container global-organisation-identity">
+        <!-- Popup for info (dynamically loaded from Vontology) -->
+        <div class="popup popup-container" id="infoPopup">
+          <div id="infoPopupContent">
+            <p class="info-loading">Loading...</p>
+          </div>
+        </div>
+        <h1 class="global-organisation-title" title="Current organisation">
+          <span class="global-product-name">Von</span>
+          <span class="global-organisation-separator" aria-hidden="true">·</span>
+          <span id="headerOrgName">...</span>
+        </h1>
+        <button class="info-icon" id="infoIcon" type="button" title="About this organisation"
+          aria-label="About this organisation">i</button>
       </div>
     </div>
   </div>

--- a/tests/frontend/chatConversationLayout.test.js
+++ b/tests/frontend/chatConversationLayout.test.js
@@ -5,10 +5,20 @@ const template = fs.readFileSync(
     path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/chat_tab.html'),
     'utf8'
 );
+const interfaceTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/von_interface.html'),
+    'utf8'
+);
 const styles = fs.readFileSync(
     path.resolve(__dirname, '../../src/frontend/web/von_interface/static/styles.css'),
     'utf8'
 );
+
+function parseTemplate(markup) {
+    const parsed = document.createElement('template');
+    parsed.innerHTML = markup;
+    return parsed.content;
+}
 
 describe('conversation single-scroll layout', () => {
     test('keeps the transcript in document flow', () => {
@@ -35,5 +45,55 @@ describe('conversation single-scroll layout', () => {
         const jumpRule = styles.match(/\.chat-scroll-to-end-btn\s*\{([^}]*)\}/)?.[1] || '';
 
         expect(jumpRule).toContain('position: fixed');
+    });
+
+    test('uses a horizontal conversation workspace as the accessible default', () => {
+        const fragment = parseTemplate(template);
+        const workspace = fragment.querySelector('#conversationWorkspace');
+        const sessionTabs = fragment.querySelector('#chatSessionTabs');
+
+        expect(workspace).toBeTruthy();
+        expect(workspace.getAttribute('data-tabs-layout')).toBe('horizontal');
+        expect(sessionTabs).toBeTruthy();
+        expect(sessionTabs.getAttribute('role')).toBe('tablist');
+        expect(sessionTabs.getAttribute('aria-orientation')).toBe('horizontal');
+    });
+
+    test('places the conversation masthead below the session list with its tools beside metadata', () => {
+        const fragment = parseTemplate(template);
+        const sessionRow = fragment.querySelector('.chat-session-tabs-row');
+        const masthead = fragment.querySelector('.chat-conversation-masthead');
+        const metadata = masthead?.querySelector('#chatSessionMetadata');
+        const controls = masthead?.querySelector('.chat-header-controls');
+
+        expect(sessionRow).toBeTruthy();
+        expect(masthead).toBeTruthy();
+        expect(
+            sessionRow.compareDocumentPosition(masthead) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+        expect(metadata).toBeTruthy();
+        expect(controls).toBeTruthy();
+        expect(controls.getAttribute('aria-label')).toBe('Conversation tools');
+        expect(template).not.toContain('Talk to Von Neumarkt');
+    });
+
+    test('keeps search and the lighter organisation identity in one shell with search first', () => {
+        const fragment = parseTemplate(interfaceTemplate);
+        const headerShell = fragment.querySelector('.global-header-shell');
+        const search = headerShell?.querySelector('#globalConceptSearchRegion');
+        const organisation = headerShell?.querySelector('.main-container');
+
+        expect(headerShell).toBeTruthy();
+        expect(search).toBeTruthy();
+        expect(organisation).toBeTruthy();
+        expect(
+            search.compareDocumentPosition(organisation) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+        expect(organisation.querySelector('#headerOrgName')).toBeTruthy();
+    });
+
+    test('keeps the scrollable vertical conversation rail clear of the fixed footer', () => {
+        expect(styles).toContain('var(--von-fixed-footer-clearance, 64px)');
+        expect(styles).toContain('max-height: calc(100vh - var(--von-fixed-shell-height, 104px)');
     });
 });

--- a/tests/frontend/chatSessionAgentCreatedFilter.test.js
+++ b/tests/frontend/chatSessionAgentCreatedFilter.test.js
@@ -17,16 +17,26 @@ jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
 }));
 
 describe('chat session agent-created filtering', () => {
+    let originalMatchMedia;
+
     beforeEach(() => {
+        originalMatchMedia = window.matchMedia;
         const now = Date.now();
         const humanTimestamp = new Date(now - 60 * 60 * 1000).toISOString();
         const newestAgentTimestamp = new Date(now - 2 * 60 * 60 * 1000).toISOString();
         const olderAgentTimestamp = new Date(now - 3 * 60 * 60 * 1000).toISOString();
 
         document.body.innerHTML = `
-            <div id="chatSessionTabs"></div>
-            <div id="chatSessionMetadata"></div>
-            <div id="scrollableField"></div>
+            <div id="chatTab">
+                <div id="conversationWorkspace" data-tabs-layout="horizontal" data-effective-tabs-layout="horizontal">
+                    <div class="chat-session-tabs-row">
+                        <div id="chatSessionTabs" aria-orientation="horizontal"></div>
+                        <div id="chatSessionCount"></div>
+                    </div>
+                    <div id="chatSessionMetadata"></div>
+                    <div id="scrollableField"></div>
+                </div>
+            </div>
         `;
 
         localStorage.clear();
@@ -106,6 +116,7 @@ describe('chat session agent-created filtering', () => {
         jest.resetModules();
         jest.restoreAllMocks();
         localStorage.clear();
+        window.matchMedia = originalMatchMedia;
     });
 
     test('hides older agent-created conversations by default and toggles them from the new-chat menu', async () => {
@@ -207,5 +218,143 @@ describe('chat session agent-created filtering', () => {
                 namespace: '#V#agent_filter_user@test_org',
             }),
         }));
+    });
+
+    test('modifier-click opens layout options without creating a chat and persists the left list', async () => {
+        const chatTab = require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        const newChatButton = document.querySelector('#chatSessionTabs .chat-session-tab-new');
+        const createCallsBefore = global.fetch.mock.calls.filter(([url]) => (
+            String(url).startsWith('/von/api/session/create_chat_session')
+        )).length;
+
+        newChatButton.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            ctrlKey: true,
+            clientX: 18,
+            clientY: 18
+        }));
+
+        const moveLeftButton = Array.from(document.querySelectorAll('.chat-session-menu button'))
+            .find((button) => button.textContent === 'Move conversation tabs to left');
+        expect(moveLeftButton).toBeTruthy();
+        expect(global.fetch.mock.calls.filter(([url]) => (
+            String(url).startsWith('/von/api/session/create_chat_session')
+        ))).toHaveLength(createCallsBefore);
+
+        moveLeftButton.click();
+
+        const workspace = document.getElementById('conversationWorkspace');
+        const tabs = document.getElementById('chatSessionTabs');
+        const storageKey = 'von:chatSessionTabsLayout';
+        expect(workspace.dataset.tabsLayout).toBe('vertical');
+        expect(workspace.dataset.effectiveTabsLayout).toBe('vertical');
+        expect(tabs.getAttribute('aria-orientation')).toBe('vertical');
+        expect(localStorage.getItem(storageKey)).toBe('vertical');
+
+        chatTab.__testOnly_setChatSessionTabsLayout('horizontal', { persist: false });
+        expect(workspace.dataset.tabsLayout).toBe('horizontal');
+        expect(localStorage.getItem(storageKey)).toBe('vertical');
+
+        chatTab.__testOnly_loadChatSessionTabsLayoutPreference();
+        expect(workspace.dataset.tabsLayout).toBe('vertical');
+        expect(tabs.getAttribute('aria-orientation')).toBe('vertical');
+
+        newChatButton.dispatchEvent(new MouseEvent('contextmenu', {
+            bubbles: true,
+            clientX: 22,
+            clientY: 22
+        }));
+        expect(Array.from(document.querySelectorAll('.chat-session-menu button'))
+            .some((button) => button.textContent === 'Move conversation tabs to top')).toBe(true);
+    });
+
+    test('keeps the browser layout preference stable when a user signs in after chat initialisation', async () => {
+        const { getCurrentUserConceptId } = require(
+            '../../src/frontend/web/von_interface/static/js/domUtils.js'
+        );
+        getCurrentUserConceptId.mockReturnValue(null);
+        require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        getCurrentUserConceptId.mockReturnValue('#V#late_login_user');
+
+        const newChatButton = document.querySelector('#chatSessionTabs .chat-session-tab-new');
+        newChatButton.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            metaKey: true,
+            clientX: 18,
+            clientY: 18
+        }));
+
+        const moveLeftButton = Array.from(document.querySelectorAll('.chat-session-menu button'))
+            .find((button) => button.textContent === 'Move conversation tabs to left');
+        expect(moveLeftButton).toBeTruthy();
+        moveLeftButton.click();
+
+        expect(localStorage.getItem('von:chatSessionTabsLayout')).toBe('vertical');
+    });
+
+    test('opens the new-chat options from the keyboard and restores focus on Escape', async () => {
+        require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        const newChatButton = document.querySelector('#chatSessionTabs .chat-session-tab-new');
+        newChatButton.focus();
+        newChatButton.dispatchEvent(new KeyboardEvent('keydown', {
+            bubbles: true,
+            key: 'F10',
+            shiftKey: true
+        }));
+
+        const menu = document.querySelector('.chat-session-menu');
+        expect(menu?.classList.contains('open')).toBe(true);
+        expect(document.activeElement).toBe(menu.querySelector('button'));
+
+        document.dispatchEvent(new KeyboardEvent('keydown', {
+            bubbles: true,
+            key: 'Escape'
+        }));
+
+        expect(menu.classList.contains('open')).toBe(false);
+        expect(document.activeElement).toBe(newChatButton);
+    });
+
+    test('describes a left-rail preference truthfully when the narrow layout stays horizontal', async () => {
+        window.matchMedia = jest.fn(() => ({
+            matches: true,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }));
+        require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        const newChatButton = document.querySelector('#chatSessionTabs .chat-session-tab-new');
+        newChatButton.dispatchEvent(new MouseEvent('contextmenu', {
+            bubbles: true,
+            clientX: 18,
+            clientY: 18
+        }));
+
+        const chooseLeftButton = Array.from(document.querySelectorAll('.chat-session-menu button'))
+            .find((button) => button.textContent === 'Use conversation tabs on left on wider screens');
+        expect(chooseLeftButton).toBeTruthy();
+        chooseLeftButton.click();
+
+        const workspace = document.getElementById('conversationWorkspace');
+        expect(workspace.dataset.tabsLayout).toBe('vertical');
+        expect(workspace.dataset.effectiveTabsLayout).toBe('horizontal');
+        expect(document.querySelector('.toast')?.textContent)
+            .toBe('Left conversation tabs saved for wider screens.');
+
+        newChatButton.dispatchEvent(new MouseEvent('contextmenu', {
+            bubbles: true,
+            clientX: 22,
+            clientY: 22
+        }));
+        expect(Array.from(document.querySelectorAll('.chat-session-menu button'))
+            .some((button) => button.textContent === 'Use conversation tabs across top on wider screens'))
+            .toBe(true);
     });
 });

--- a/tests/frontend/chatSessionAgentCreatedFilter.test.js
+++ b/tests/frontend/chatSessionAgentCreatedFilter.test.js
@@ -154,6 +154,7 @@ describe('chat session agent-created filtering', () => {
         }));
 
         const menuButtons = Array.from(document.querySelectorAll('.chat-session-menu button'));
+        expect(menuButtons[0]?.textContent).toBe('New conversation');
         const showTestsButton = menuButtons.find((button) => (
             button.textContent || ''
         ).startsWith('Show test conversations'));

--- a/tests/frontend/chatSessionMetadataLabelLinks.test.js
+++ b/tests/frontend/chatSessionMetadataLabelLinks.test.js
@@ -18,11 +18,14 @@ jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
 describe('chat session metadata label links', () => {
     beforeEach(() => {
         jest.resetModules();
+        localStorage.clear();
         document.body.innerHTML = '<div id="chatSessionMetadata"></div>';
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
+        localStorage.clear();
+        delete global.fetch;
     });
 
     test('Clicking group labels opens the corresponding type concept tab', () => {
@@ -120,5 +123,51 @@ describe('chat session metadata label links', () => {
         const header = metadataEl.querySelector('.chat-session-metadata-header');
         expect(header).toBeTruthy();
         expect(header.previousElementSibling).toBe(titleEl);
+    });
+
+    test('Defaults conversation context to furled when no preference is stored', () => {
+        const { __test_only__renderChatSessionMetadataPanel } = require(chatTabModulePath);
+
+        expect(localStorage.getItem('von:chatSessionMetadataCollapsed')).toBeNull();
+        __test_only__renderChatSessionMetadataPanel({
+            sessionId: 's-default-furled',
+            links: {},
+            statusText: null,
+            statusTone: null,
+            disabled: false
+        });
+
+        const metadataEl = document.getElementById('chatSessionMetadata');
+        const toggle = metadataEl.querySelector('.chat-session-metadata-toggle');
+        const body = metadataEl.querySelector('.chat-session-metadata-body');
+
+        expect(toggle).toBeTruthy();
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(toggle.title).toBe('Show conversation context');
+        expect(body).toBeTruthy();
+        expect(body.classList).toContain('is-collapsed');
+    });
+
+    test('Honours a stored expanded conversation-context preference', () => {
+        localStorage.setItem('von:chatSessionMetadataCollapsed', 'false');
+        const { __test_only__renderChatSessionMetadataPanel } = require(chatTabModulePath);
+
+        __test_only__renderChatSessionMetadataPanel({
+            sessionId: 's-stored-expanded',
+            links: {},
+            statusText: null,
+            statusTone: null,
+            disabled: false
+        });
+
+        const metadataEl = document.getElementById('chatSessionMetadata');
+        const toggle = metadataEl.querySelector('.chat-session-metadata-toggle');
+        const body = metadataEl.querySelector('.chat-session-metadata-body');
+
+        expect(toggle).toBeTruthy();
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        expect(toggle.title).toBe('Hide conversation context');
+        expect(body).toBeTruthy();
+        expect(body.classList).not.toContain('is-collapsed');
     });
 });

--- a/tests/frontend/chatSessionMetadataLabelLinks.test.js
+++ b/tests/frontend/chatSessionMetadataLabelLinks.test.js
@@ -125,10 +125,11 @@ describe('chat session metadata label links', () => {
         expect(header.previousElementSibling).toBe(titleEl);
     });
 
-    test('Defaults conversation context to furled when no preference is stored', () => {
+    test('Defaults conversation context to furled and ignores the legacy expanded preference', () => {
+        localStorage.setItem('von:chatSessionMetadataCollapsed', 'false');
         const { __test_only__renderChatSessionMetadataPanel } = require(chatTabModulePath);
 
-        expect(localStorage.getItem('von:chatSessionMetadataCollapsed')).toBeNull();
+        expect(localStorage.getItem('von:chatSessionMetadataCollapsed:v2')).toBeNull();
         __test_only__renderChatSessionMetadataPanel({
             sessionId: 's-default-furled',
             links: {},
@@ -146,10 +147,15 @@ describe('chat session metadata label links', () => {
         expect(toggle.title).toBe('Show conversation context');
         expect(body).toBeTruthy();
         expect(body.classList).toContain('is-collapsed');
+
+        toggle.click();
+        expect(localStorage.getItem('von:chatSessionMetadataCollapsed:v2')).toBe('false');
+        expect(metadataEl.querySelector('.chat-session-metadata-toggle')?.getAttribute('aria-expanded'))
+            .toBe('true');
     });
 
-    test('Honours a stored expanded conversation-context preference', () => {
-        localStorage.setItem('von:chatSessionMetadataCollapsed', 'false');
+    test('Honours an expanded preference chosen with the new furled-default UI', () => {
+        localStorage.setItem('von:chatSessionMetadataCollapsed:v2', 'false');
         const { __test_only__renderChatSessionMetadataPanel } = require(chatTabModulePath);
 
         __test_only__renderChatSessionMetadataPanel({

--- a/tests/frontend/tabNavigationGlobalTasks.test.js
+++ b/tests/frontend/tabNavigationGlobalTasks.test.js
@@ -40,4 +40,52 @@ describe('tab navigation global tasks loading', () => {
         expect(document.querySelector('#globalTasksTab').classList).toContain('active');
         expect(showGlobalTasks).toHaveBeenCalledTimes(1);
     });
+
+    test('re-clicking active Conversations scrolls to the conversation session list', () => {
+        document.body.innerHTML = `
+            <button class="tab-button active" data-tab="chatTab">Conversations</button>
+            <section id="chatTab" class="tab-content active">
+                <div class="chat-session-tabs-row">
+                    <div id="chatSessionTabs"></div>
+                </div>
+            </section>
+        `;
+        const sessionTabsRow = document.querySelector('.chat-session-tabs-row');
+        sessionTabsRow.scrollIntoView = jest.fn();
+        const { setupTabNavigation } = require(tabNavigationModulePath);
+
+        setupTabNavigation();
+        document.querySelector('[data-tab="chatTab"]').click();
+
+        expect(sessionTabsRow.scrollIntoView).toHaveBeenCalledWith({
+            behavior: 'smooth',
+            block: 'start',
+            inline: 'nearest',
+        });
+        expect(document.querySelector('#chatTab').classList).toContain('active');
+    });
+
+    test('clicking inactive Conversations activates it without treating the click as a re-click', () => {
+        document.body.innerHTML = `
+            <button class="tab-button" data-tab="chatTab">Conversations</button>
+            <button class="tab-button active" data-tab="settingsTab">Settings</button>
+            <section id="chatTab" class="tab-content">
+                <div class="chat-session-tabs-row">
+                    <div id="chatSessionTabs"></div>
+                </div>
+            </section>
+            <section id="settingsTab" class="tab-content active"></section>
+        `;
+        const sessionTabsRow = document.querySelector('.chat-session-tabs-row');
+        sessionTabsRow.scrollIntoView = jest.fn();
+        const { setupTabNavigation } = require(tabNavigationModulePath);
+
+        setupTabNavigation();
+        document.querySelector('[data-tab="chatTab"]').click();
+
+        expect(sessionTabsRow.scrollIntoView).not.toHaveBeenCalled();
+        expect(document.querySelector('#chatTab').classList).toContain('active');
+        expect(document.querySelector('[data-tab="chatTab"]').classList).toContain('active');
+        expect(document.querySelector('#settingsTab').classList).not.toContain('active');
+    });
 });


### PR DESCRIPTION
## What changed

- compacted the global header and conversation masthead
- made an active Conversations tab scroll back to the conversation list
- added a cross-platform context-menu preference for top or left conversation tabs
- furled conversation context by default, including legacy stored state
- moved conversation controls beside the title and removed the redundant chat heading
- renamed the menu action to **New conversation**

## Why

The conversation screen used excessive vertical space, hid navigation affordances, and retained an expanded legacy context state. The revised layout keeps conversation switching and controls close to the active conversation while preserving responsive top tabs on narrow screens.

## Validation

- `npx jest tests/frontend/tabNavigationGlobalTasks.test.js tests/frontend/chatConversationLayout.test.js tests/frontend/chatSessionMetadataLabelLinks.test.js tests/frontend/chatSessionAgentCreatedFilter.test.js --runInBand` — 4 suites, 21 tests passed
- `npm run lint:frontend:static -- <five changed JavaScript files>` — passed
- `git diff --check origin/main...HEAD` — passed