### PR TITLE
Propagate conversation and applied prompt context

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -31239,6 +31239,46 @@ def _jira_hygiene_emit_audit(**kwargs):
     )
 
 
+def _chat_get_applied_prompt_context(
+    *,
+    applied_prompt_snapshot_json: str | None = None,
+    include_content: bool = True,
+    max_chars: int | None = 20000,
+    **_kwargs,
+):
+    """Return the represented prompt fragments actually applied to this turn."""
+
+    if not isinstance(applied_prompt_snapshot_json, str) or not (
+        applied_prompt_snapshot_json.strip()
+    ):
+        return make_error_response(
+            "trusted_turn_snapshot_required",
+            "A server-bound applied-prompt snapshot is required.",
+        )
+    if not isinstance(include_content, bool):
+        include_content = True
+    try:
+        max_chars_int = 20000 if max_chars is None else int(max_chars)
+    except (TypeError, ValueError):
+        max_chars_int = 20000
+
+    from src.backend.services.chat_auxiliary_prompt_service import (
+        render_applied_prompt_context,
+    )
+
+    try:
+        return render_applied_prompt_context(
+            applied_prompt_snapshot_json,
+            include_content=include_content,
+            max_chars=max_chars_int,
+        )
+    except ValueError as exc:
+        return make_error_response(
+            "invalid_trusted_turn_snapshot",
+            str(exc),
+        )
+
+
 def _chat_get_prompt_context(
     *,
     namespace: str | None = None,
@@ -36327,6 +36367,38 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "Get the browser-reported client capability snapshot for the current session (speech synthesis, "
                 "speech recognition, and basic audio hints). Use for debugging speech/narration behaviours without "
                 "collecting high-fidelity fingerprinting data."
+            ),
+        ),
+        MethodDefinition(
+            name="chat_get_applied_prompt_context",
+            handler=_chat_get_applied_prompt_context,
+            input_schema=Schema(
+                required={"applied_prompt_snapshot_json": str},
+                optional={
+                    "include_content": bool,
+                    "max_chars": (int, type(None)),
+                    # Compatibility only. The handler deliberately ignores a
+                    # model-supplied namespace and uses the server-bound snapshot.
+                    "namespace": (str, type(None)),
+                },
+                allow_unknown=False,
+                description=(
+                    "Return the actor-owned Vontology prompt concepts actually "
+                    "applied to this turn. The turn snapshot is supplied by the "
+                    "trusted server and cannot be selected by the model."
+                ),
+            ),
+            output_schema=None,
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "applied_prompt_snapshot_json": "applied_prompt_snapshot",
+            },
+            description=(
+                "Inspect the behaviour, narration, and screen prompt concepts "
+                "actually applied to the current turn, including concept IDs, "
+                "application surfaces, content hashes, and bounded exact content. "
+                "Use this when the user asks which prompt is currently operative "
+                "or what represented instructions shaped the answer."
             ),
         ),
         MethodDefinition(

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -10454,6 +10454,11 @@ class InternalMCPChatOrchestrator:
                 if isinstance(data.get("required_prompt_tools"), list)
                 else None
             ),
+            applied_prompt_snapshot=(
+                data.get("applied_prompt_snapshot")
+                if isinstance(data.get("applied_prompt_snapshot"), Mapping)
+                else None
+            ),
         )
 
         completion_gate = turn_execution_record.get("completion_gate")

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -10946,11 +10946,14 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         # JVNAUTOSCI-797: user-specific system prompt from Vontology
         # ---------------------------------------------------------
         dynamic_instructions = None
+        behaviour_prompt_fragments = []
         narration_prompt_text = None
         narration_prompt_fragments = []
         screen_prompt_text = None
         screen_prompt_fragments = []
         screen_prompt_source = None
+        applied_prompt_snapshot_json = None
+        applied_prompt_manifest_message = None
         user_prompt_debug = {
             "effective_user_concept_id": user_concept_id,
             "loaded": False,
@@ -10961,6 +10964,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             "screen_prompt_concept_ids": [],
             "screen_prompt_source": None,
             "screen_prompt_chars": 0,
+            "applied_prompt_snapshot_sha256": None,
         }
         if user_concept_id:
             _emit_context_setup_progress(
@@ -11116,6 +11120,42 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             user_prompt_debug["screen_prompt_source"] = screen_prompt_source
             user_prompt_debug["screen_prompt_chars"] = len(screen_prompt_text)
 
+        if user_concept_id:
+            from ...services.chat_auxiliary_prompt_service import (
+                build_applied_prompt_manifest_message,
+                build_applied_prompt_snapshot,
+                serialise_applied_prompt_snapshot,
+            )
+
+            applied_prompt_snapshot = build_applied_prompt_snapshot(
+                user_concept_id=user_concept_id,
+                namespace=(
+                    user_namespace
+                    if isinstance(user_namespace, str) and user_namespace.strip()
+                    else None
+                ),
+                organisation_concept_id=org_concept_id,
+                turn_id=request_id,
+                behaviour_fragments=behaviour_prompt_fragments,
+                narration_fragments=narration_prompt_fragments,
+                screen_fragments=screen_prompt_fragments,
+                screen_prompt_text=screen_prompt_text,
+                screen_prompt_concept_ids=_normalise_prompt_concept_ids(
+                    user_prompt_debug.get("screen_prompt_concept_ids")
+                ),
+                screen_prompt_source=screen_prompt_source,
+            )
+            if applied_prompt_snapshot.get("prompt_count"):
+                applied_prompt_snapshot_json = serialise_applied_prompt_snapshot(
+                    applied_prompt_snapshot
+                )
+                applied_prompt_manifest_message = build_applied_prompt_manifest_message(
+                    applied_prompt_snapshot
+                )
+                user_prompt_debug["applied_prompt_snapshot_sha256"] = (
+                    applied_prompt_snapshot.get("snapshot_sha256")
+                )
+
         authenticated_user_context_id = (
             user_concept_id.strip()
             if isinstance(user_concept_id, str) and user_concept_id.strip()
@@ -11195,6 +11235,20 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 enhanced_context.insert(0, user_prompt_message)
             else:
                 enhanced_context.insert(1, user_prompt_message)
+
+        if applied_prompt_manifest_message:
+            manifest_insert_index = 0
+            while manifest_insert_index < len(enhanced_context) and str(
+                enhanced_context[manifest_insert_index].get("role") or ""
+            ).strip().lower() in {"system", "developer"}:
+                manifest_insert_index += 1
+            enhanced_context.insert(
+                manifest_insert_index,
+                {
+                    "role": "system",
+                    "content": applied_prompt_manifest_message,
+                },
+            )
 
         if request_workflow_launch_inputs:
             enhanced_context.append(
@@ -11540,6 +11594,16 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         _check_background_cancellation("direct adaptive turn entry")
         adaptive_turn_started = time.perf_counter()
         adaptive_input_context = enhanced_context
+        trusted_turn_argument_values: dict[str, Any] = {}
+        if gmail_profile_trusted_binding is not None:
+            trusted_turn_argument_values["gmail_profile"] = (
+                gmail_profile_trusted_binding
+            )
+        if applied_prompt_snapshot_json is not None:
+            trusted_turn_argument_values["applied_prompt_snapshot"] = (
+                applied_prompt_snapshot_json
+            )
+
         adaptive_turn_result = execute_adaptive_turn(
             gateway=gateway,
             prompt=prompt_text,
@@ -11550,11 +11614,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             user_namespace=user_namespace,
             user_concept_id=user_concept_id,
             org_concept_id=org_concept_id,
-            trusted_argument_values=(
-                {"gmail_profile": gmail_profile_trusted_binding}
-                if gmail_profile_trusted_binding is not None
-                else None
-            ),
+            trusted_argument_values=trusted_turn_argument_values or None,
             workflow_launch_inputs=request_workflow_launch_inputs,
             progress_tracker=progress_tracker,
             turn_id=request_id,

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -7301,6 +7301,7 @@ def _finalise_llm_debug_info(
     actor_concept_id: str | None = None,
     user_id: str | None,
     org_id: str | None,
+    applied_prompt_snapshot: Mapping[str, Any] | str | None = None,
     **_legacy_controller_fields: Any,
 ) -> dict[str, Any]:
     """Finalise an observational ordinary-turn record.
@@ -7387,6 +7388,16 @@ def _finalise_llm_debug_info(
     if isinstance(resolved_actor_concept_id, str) and resolved_actor_concept_id.strip():
         llm_debug_info["actor_concept_id"] = resolved_actor_concept_id
 
+    from ...services.chat_auxiliary_prompt_service import (
+        normalise_applied_prompt_snapshot,
+    )
+
+    applied_prompt_snapshot_payload = normalise_applied_prompt_snapshot(
+        applied_prompt_snapshot,
+        expected_user_concept_id=(user_id or resolved_actor_concept_id),
+        expected_namespace=namespace,
+    )
+
     llm_interaction_payload = (
         llm_debug_info.get("llm_interaction")
         if isinstance(llm_debug_info.get("llm_interaction"), Mapping)
@@ -7463,6 +7474,7 @@ def _finalise_llm_debug_info(
                 else None
             ),
         },
+        "applied_prompt_snapshot": applied_prompt_snapshot_payload,
         "llm_calls": [dict(item) for item in llm_calls_payload if isinstance(item, Mapping)],
         "llm_usage_cost_summary": llm_usage_cost_summary,
         "tool_invocations": [
@@ -10019,6 +10031,7 @@ def _persist_terminal_failure_turn_record_best_effort(
             prompt_text=local_vars.get("prompt_text"),
             llm_debug_info=debug_payload,
             progress_snapshot=progress_snapshot,
+            applied_prompt_snapshot=local_vars.get("applied_prompt_snapshot"),
         )
     except Exception as exc:
         try:
@@ -10952,6 +10965,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         screen_prompt_text = None
         screen_prompt_fragments = []
         screen_prompt_source = None
+        applied_prompt_snapshot = None
         applied_prompt_snapshot_json = None
         applied_prompt_manifest_message = None
         user_prompt_debug = {
@@ -13312,6 +13326,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 actor_concept_id=user_concept_id,
                 user_id=user_concept_id,
                 org_id=org_concept_id,
+                applied_prompt_snapshot=applied_prompt_snapshot,
             )
 
         def _refresh_llm_debug_timing_payload(debug_payload: dict[str, Any]) -> None:

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -4206,6 +4206,17 @@ def _effect_requires_turn_finality(
         return False
     if capability_kind != "represented_workflow":
         return True
+    if (
+        effect_status == "succeeded"
+        and isinstance(raw_payload, Mapping)
+        and raw_payload.get("operational_state_effect") is True
+        and raw_payload.get("semantic_effect") is False
+    ):
+        # A represented workflow can terminate successfully by returning a
+        # typed clarification or another explicitly non-semantic outcome. Its
+        # durable instance is real operational state, but it is not a completed
+        # user-domain effect and must not be counted as one.
+        return False
     return not (effect_status == "not_started" and changed is False and not instance_id)
 
 
@@ -5034,6 +5045,10 @@ def execute_adaptive_turn(
         canonical_readback: Mapping[str, Any] | None = None,
         late_observation: Mapping[str, Any] | None = None,
         evidence_id: str | None = None,
+        execution_method: str | None = None,
+        effective_arguments: Mapping[str, Any] | None = None,
+        original_result: Mapping[str, Any] | None = None,
+        result_target_ids: Sequence[str] | None = None,
     ) -> None:
         nonlocal effect_state_generation
         with effect_state_lock:
@@ -5050,7 +5065,18 @@ def execute_adaptive_turn(
                 "instance_id": instance_id,
                 "workflow_id": workflow_id,
                 "evidence_id": evidence_id,
+                "execution_method": execution_method,
             }
+            if effective_arguments is not None:
+                state["effective_arguments"] = dict(effective_arguments)
+            if original_result is not None:
+                state["original_result"] = dict(original_result)
+            if result_target_ids:
+                state["result_target_ids"] = [
+                    str(item).strip()
+                    for item in result_target_ids
+                    if isinstance(item, str) and str(item).strip()
+                ]
             if canonical_readback is not None:
                 state["canonical_readback"] = dict(canonical_readback)
             if late_observation is not None:
@@ -5076,6 +5102,10 @@ def execute_adaptive_turn(
                     "instance_id",
                     "workflow_id",
                     "canonical_readback",
+                    "execution_method",
+                    "effective_arguments",
+                    "original_result",
+                    "result_target_ids",
                 ):
                     if not state.get(identity_field) and existing.get(identity_field):
                         state[identity_field] = existing[identity_field]
@@ -5088,6 +5118,160 @@ def execute_adaptive_turn(
                         state[recovery_field] = existing[recovery_field]
             effect_states[effect_id] = state
             effect_state_generation += 1
+
+    def reconcile_indeterminate_ontology_effects() -> None:
+        """Resolve exact ontology postconditions once more before terminal output."""
+
+        nonlocal effect_state_generation
+        with effect_state_lock:
+            candidates = [
+                (effect_id, dict(state))
+                for effect_id, state in effect_states.items()
+                if state.get("effect_status") == "indeterminate"
+                and state.get("turn_finality_required") is not False
+                and isinstance(state.get("original_result"), Mapping)
+                and state["original_result"].get("outcome_finality")
+                == "requires_canonical_reconciliation"
+                and isinstance(
+                    state["original_result"].get("postcondition_reconciliation"),
+                    Mapping,
+                )
+                and state["original_result"]["postcondition_reconciliation"].get(
+                    "schema_version"
+                )
+                == "ontology_mutation_postcondition_reconciliation.v1"
+            ]
+        if not candidates:
+            return
+        from src.backend.services.ontology_mutation_command_service import (
+            reconcile_governed_ontology_postcondition,
+        )
+
+        for effect_id, candidate in candidates:
+            method_name = str(candidate.get("execution_method") or "").strip()
+            arguments = candidate.get("effective_arguments")
+            original_result = candidate.get("original_result")
+            if not isinstance(arguments, Mapping) or not isinstance(
+                original_result, Mapping
+            ):
+                continue
+            try:
+                with override_current_actor(
+                    scope.user_concept_id,
+                    scope.organisation_concept_id,
+                ):
+                    reconciliation = reconcile_governed_ontology_postcondition(
+                        method_name=method_name,
+                        arguments=arguments,
+                        original_result=original_result,
+                    )
+            except Exception as exc:  # noqa: BLE001 - unresolved remains indeterminate
+                reconciliation = {
+                    "success": False,
+                    "verified": False,
+                    "error_code": "ontology_reconciliation_unavailable",
+                    "exception_type": type(exc).__name__,
+                }
+            verified = reconciliation.get("verified") is True
+            aux_calls.append(
+                {
+                    "type": "adaptive_turn_ontology_postcondition_reconciliation",
+                    "schema_version": (
+                        "adaptive_turn_ontology_postcondition_reconciliation.v1"
+                    ),
+                    "effect_id": effect_id,
+                    "method_name": method_name,
+                    "verified": verified,
+                    "receipt_id": reconciliation.get("receipt_id"),
+                    "error_code": reconciliation.get("error_code"),
+                }
+            )
+            if not verified:
+                continue
+            envelope = evidence_store.record(
+                f"{method_name}_canonical_reconciliation",
+                f"{effect_id}:canonical_reconciliation",
+                reconciliation,
+                provenance={
+                    "namespace": scope.namespace,
+                    "user_concept_id": scope.user_concept_id,
+                    "organisation_concept_id": scope.organisation_concept_id,
+                    "effect_id": effect_id,
+                    "effect_status": "succeeded",
+                    "reconciliation": True,
+                },
+                status="succeeded",
+            )
+            target_ids = [
+                str(item).strip()
+                for item in reconciliation.get("target_concept_ids") or ()
+                if isinstance(item, str) and str(item).strip()
+            ]
+            canonical_projection = {
+                "schema_version": "ontology_mutation_canonical_reconciliation.v1",
+                "status": "verified",
+                "verified": True,
+                "method_name": method_name,
+                "receipt_id": reconciliation.get("receipt_id"),
+                "intent_fingerprint": reconciliation.get("intent_fingerprint"),
+                "target_concept_ids": target_ids,
+                "evidence_id": envelope.evidence_id,
+            }
+            with effect_state_lock:
+                current = effect_states.get(effect_id)
+                if (
+                    current is None
+                    or current.get("effect_status") != "indeterminate"
+                    or int(current.get("phase") or 0) > 2
+                ):
+                    continue
+                current.update(
+                    {
+                        "phase": 2,
+                        "initial_effect_status": "indeterminate",
+                        "initial_changed": current.get("changed"),
+                        "effect_status": "succeeded",
+                        "changed": True,
+                        "recovery_status": "succeeded",
+                        "reconciliation_status": "canonically_verified",
+                        "reconciliation_evidence_id": envelope.evidence_id,
+                        "canonical_readback": canonical_projection,
+                        "result_target_ids": target_ids
+                        or list(current.get("result_target_ids") or ()),
+                    }
+                )
+                effect_state_generation += 1
+            try:
+                persist_effect_observation_phase(
+                    effect_id=effect_id,
+                    phase="canonical_reconciliation",
+                    observation={
+                        "schema_version": (
+                            "ontology_mutation_canonical_reconciliation.v1"
+                        ),
+                        "effect_status": "succeeded",
+                        "changed": True,
+                        "method_name": method_name,
+                        "receipt_id": reconciliation.get("receipt_id"),
+                        "intent_fingerprint": reconciliation.get(
+                            "intent_fingerprint"
+                        ),
+                        "target_concept_ids": target_ids,
+                        "evidence_id": envelope.evidence_id,
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001 - receipt is already durable
+                aux_calls.append(
+                    {
+                        "type": "effect_observation_persistence_failure",
+                        "schema_version": (
+                            "effect_observation_persistence_failure.v1"
+                        ),
+                        "effect_id": effect_id,
+                        "phase": "canonical_reconciliation",
+                        "reason": type(exc).__name__,
+                    }
+                )
 
     def reconcile_workflow_instance_readback(
         *,
@@ -5318,6 +5502,7 @@ def execute_adaptive_turn(
                     "user-visible answer."
                 )
         model_answer_completed = status == "completed"
+        reconcile_indeterminate_ontology_effects()
         with effect_state_lock:
             effect_snapshot = {
                 effect_id: dict(state) for effect_id, state in effect_states.items()
@@ -5420,6 +5605,29 @@ def execute_adaptive_turn(
                     )
                 if state.get("recovery_status"):
                     invocation["recovery_status"] = state.get("recovery_status")
+                if state.get("reconciliation_status"):
+                    invocation["reconciliation_status"] = state.get(
+                        "reconciliation_status"
+                    )
+                    invocation["status"] = "ok"
+                    invocation["mutation_outcome"] = "succeeded"
+                    invocation["outcome_finality"] = "terminal_for_turn"
+                    if invocation.get("error_code"):
+                        invocation["initial_error_code"] = invocation.get("error_code")
+                        invocation.pop("error_code", None)
+                if state.get("initial_effect_status"):
+                    invocation["initial_effect_status"] = state.get(
+                        "initial_effect_status"
+                    )
+                    invocation["initial_changed"] = state.get("initial_changed")
+                if state.get("reconciliation_evidence_id"):
+                    invocation["reconciliation_evidence_id"] = state.get(
+                        "reconciliation_evidence_id"
+                    )
+                if state.get("result_target_ids"):
+                    invocation["result_target_ids"] = list(
+                        state.get("result_target_ids") or ()
+                    )
                 if isinstance(state.get("late_observation"), Mapping):
                     invocation["late_completion"] = dict(state["late_observation"])
                 if isinstance(state.get("canonical_readback"), Mapping):
@@ -6591,6 +6799,7 @@ def execute_adaptive_turn(
                         arguments,
                         prompt=prompt,
                         context=current_context,
+                        conversation_situation=conversation_situation,
                         request_workflow_launch_inputs=workflow_launch_inputs,
                         user_concept_id=scope.user_concept_id,
                         organisation_concept_id=scope.organisation_concept_id,
@@ -7274,6 +7483,11 @@ def execute_adaptive_turn(
                 canonical_name = contained_result.capability_name
                 is_effect = contained_result.is_effect
                 semantic_effect = contained_result.semantic_effect
+                if (
+                    isinstance(raw_payload, Mapping)
+                    and isinstance(raw_payload.get("semantic_effect"), bool)
+                ):
+                    semantic_effect = raw_payload["semantic_effect"]
                 execution_method_name = contained_result.execution_method_name
                 effect_identifier = (
                     _effect_id(
@@ -7468,6 +7682,12 @@ def execute_adaptive_turn(
                             else None
                         ),
                         canonical_readback=canonical_effect_readback,
+                        execution_method=execution_method_name,
+                        effective_arguments=arguments,
+                        original_result=(
+                            raw_payload if isinstance(raw_payload, Mapping) else None
+                        ),
+                        result_target_ids=result_target_ids,
                     )
                     remember_recovery_affordance(
                         effect_id=effect_identifier,
@@ -7498,6 +7718,7 @@ def execute_adaptive_turn(
                             "durable_submission_status",
                             "final_status",
                             "created_new",
+                            "semantic_outcome",
                         ):
                             receipt_value = raw_payload.get(receipt_key)
                             if isinstance(receipt_value, (str, int, float, bool)):
@@ -7602,6 +7823,7 @@ def execute_adaptive_turn(
                             "durable_submission_status",
                             "final_status",
                             "created_new",
+                            "semantic_outcome",
                         ):
                             receipt_value = raw_payload.get(receipt_key)
                             if isinstance(receipt_value, (str, int, float, bool)):
@@ -7731,6 +7953,12 @@ def execute_adaptive_turn(
                         completed_progress["progress_facts"] = list(progress_facts)
                 _emit(progress_tracker, completed_progress)
 
+        # A batch can contain the original write plus the exact supporting
+        # writes/reads that make its postcondition provable. Reconcile before
+        # the next model call so it receives the latest canonical outcome, not
+        # a stale indeterminate envelope. ``finish`` repeats this bounded read
+        # for terminal paths that do not return to the model loop.
+        reconcile_indeterminate_ontology_effects()
         correlated_results = [
             result for result in batch_results if isinstance(result, ToolResult)
         ]
@@ -7741,6 +7969,60 @@ def execute_adaptive_turn(
                 or "A capability result could not be correlated to its model call.",
                 status=terminal_status,
             )
+        invocation_by_call_id = {
+            str(item.get("call_id") or ""): item
+            for item in tool_invocations
+            if isinstance(item, Mapping) and item.get("call_id")
+        }
+        with effect_state_lock:
+            reconciled_states = {
+                effect_id: dict(state)
+                for effect_id, state in effect_states.items()
+                if state.get("reconciliation_status") == "canonically_verified"
+            }
+        reconciled_results: list[ToolResult] = []
+        for result in correlated_results:
+            invocation = invocation_by_call_id.get(result.call_id)
+            effect_id = (
+                str(invocation.get("effect_id") or "").strip()
+                if isinstance(invocation, Mapping)
+                else ""
+            )
+            state = reconciled_states.get(effect_id)
+            if state is None or not isinstance(result.output, Mapping):
+                reconciled_results.append(result)
+                continue
+            output = dict(result.output)
+            if output.get("error_code"):
+                output["initial_error_code"] = output.get("error_code")
+                output.pop("error_code", None)
+            output.update(
+                {
+                    "effect_status": "succeeded",
+                    "changed": True,
+                    "mutation_outcome": "succeeded",
+                    "outcome_finality": "terminal_for_turn",
+                    "reconciliation_status": "canonically_verified",
+                    "reconciliation_evidence_id": state.get(
+                        "reconciliation_evidence_id"
+                    ),
+                    "canonical_readback": dict(
+                        state.get("canonical_readback") or {}
+                    ),
+                    "result_target_ids": list(
+                        state.get("result_target_ids") or ()
+                    ),
+                }
+            )
+            reconciled_results.append(
+                ToolResult(
+                    call_id=result.call_id,
+                    tool_name=result.tool_name,
+                    output=output,
+                    status="ok",
+                )
+            )
+        correlated_results = reconciled_results
         bounded_results = _bound_tool_results_for_model(correlated_results)
         if bounded_results is None:
             aux_calls.append(

--- a/src/backend/services/chat_auxiliary_prompt_service.py
+++ b/src/backend/services/chat_auxiliary_prompt_service.py
@@ -11,6 +11,8 @@ This module keeps the logic small and testable.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 import logging
 import os
@@ -33,6 +35,235 @@ _SPECIFIC_TO_USER_PREDICATE_CANDIDATES = (
 
 
 logger = logging.getLogger(__name__)
+
+APPLIED_PROMPT_SNAPSHOT_SCHEMA_VERSION = "applied_prompt_snapshot.v1"
+APPLIED_PROMPT_CONTEXT_SCHEMA_VERSION = "applied_prompt_context.v1"
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def build_applied_prompt_snapshot(
+    *,
+    user_concept_id: str,
+    namespace: str | None,
+    organisation_concept_id: str | None,
+    turn_id: str | None,
+    behaviour_fragments: Sequence[Dict[str, Any]] = (),
+    narration_fragments: Sequence[Dict[str, Any]] = (),
+    screen_fragments: Sequence[Dict[str, Any]] = (),
+    screen_prompt_text: str | None = None,
+    screen_prompt_concept_ids: Sequence[str] = (),
+    screen_prompt_source: str | None = None,
+) -> Dict[str, Any]:
+    """Build the exact server-bound represented-prompt snapshot for one turn."""
+
+    prompts: List[Dict[str, Any]] = []
+
+    def add_fragments(
+        application_kind: str,
+        application_surface: str,
+        fragments: Sequence[Dict[str, Any]],
+        *,
+        source: str = "user_specific_vontology_prompt",
+    ) -> None:
+        for fragment in fragments:
+            if not isinstance(fragment, dict):
+                continue
+            concept_id = fragment.get("concept_id")
+            content = fragment.get("content")
+            if not isinstance(concept_id, str) or not concept_id.strip():
+                continue
+            if not isinstance(content, str) or not content.strip():
+                continue
+            normalised_content = content.strip()
+            prompts.append(
+                {
+                    "application_kind": application_kind,
+                    "application_surface": application_surface,
+                    "application_order": len(prompts),
+                    "concept_id": concept_id.strip(),
+                    "content": normalised_content,
+                    "content_char_count": len(normalised_content),
+                    "content_sha256": _sha256_text(normalised_content),
+                    "source": source,
+                }
+            )
+
+    add_fragments("behaviour", "model_behaviour", behaviour_fragments)
+    add_fragments("narration", "spoken_block", narration_fragments)
+    add_fragments("screen", "screen_block", screen_fragments)
+
+    # The screen prompt may come from the represented stage-prompt fallback rather
+    # than the user's directly linked screen fragments. Preserve what was actually
+    # applied, not merely what a fresh configuration lookup would find later.
+    if (
+        not any(item.get("application_kind") == "screen" for item in prompts)
+        and isinstance(screen_prompt_text, str)
+        and screen_prompt_text.strip()
+    ):
+        prompt_ids = [
+            value.strip()
+            for value in screen_prompt_concept_ids
+            if isinstance(value, str) and value.strip()
+        ]
+        concept_id = prompt_ids[0] if prompt_ids else None
+        if concept_id:
+            normalised_content = screen_prompt_text.strip()
+            prompts.append(
+                {
+                    "application_kind": "screen",
+                    "application_surface": "screen_block",
+                    "application_order": len(prompts),
+                    "concept_id": concept_id,
+                    "content": normalised_content,
+                    "content_char_count": len(normalised_content),
+                    "content_sha256": _sha256_text(normalised_content),
+                    "source": screen_prompt_source or "represented_screen_prompt",
+                }
+            )
+
+    snapshot: Dict[str, Any] = {
+        "schema_version": APPLIED_PROMPT_SNAPSHOT_SCHEMA_VERSION,
+        "turn_id": turn_id,
+        "actor": {
+            "user_concept_id": user_concept_id,
+            "organisation_concept_id": organisation_concept_id,
+            "namespace": namespace,
+        },
+        "prompt_count": len(prompts),
+        "prompts": prompts,
+    }
+    snapshot["snapshot_sha256"] = _sha256_text(_canonical_json(snapshot))
+    return snapshot
+
+
+def serialise_applied_prompt_snapshot(snapshot: Dict[str, Any]) -> str:
+    return _canonical_json(snapshot)
+
+
+def build_applied_prompt_manifest_message(snapshot: Dict[str, Any]) -> str | None:
+    prompts = snapshot.get("prompts")
+    if not isinstance(prompts, list) or not prompts:
+        return None
+    manifest = {
+        "schema_version": "applied_prompt_manifest.v1",
+        "turn_id": snapshot.get("turn_id"),
+        "snapshot_sha256": snapshot.get("snapshot_sha256"),
+        "prompts": [
+            {
+                "application_kind": item.get("application_kind"),
+                "application_surface": item.get("application_surface"),
+                "concept_id": item.get("concept_id"),
+                "content_char_count": item.get("content_char_count"),
+                "content_sha256": item.get("content_sha256"),
+            }
+            for item in prompts
+            if isinstance(item, dict)
+        ],
+    }
+    return (
+        "APPLIED VONTOLOGY PROMPT MANIFEST (server-derived):\n"
+        "These represented prompts are owned by or applicable to the authenticated "
+        "actor and are distinct from provider/platform instructions. Their exact "
+        "turn-applied content is inspectable with the delegated "
+        "chat_get_applied_prompt_context capability.\n" + _canonical_json(manifest)
+    )
+
+
+def render_applied_prompt_context(
+    snapshot_json: str,
+    *,
+    include_content: bool = True,
+    max_chars: int = 20000,
+) -> Dict[str, Any]:
+    """Render a bounded actor-safe view of a trusted turn snapshot."""
+
+    if not isinstance(snapshot_json, str) or not snapshot_json.strip():
+        raise ValueError("trusted applied-prompt snapshot is required")
+    try:
+        snapshot = json.loads(snapshot_json)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("trusted applied-prompt snapshot is invalid") from exc
+    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != (
+        APPLIED_PROMPT_SNAPSHOT_SCHEMA_VERSION
+    ):
+        raise ValueError("trusted applied-prompt snapshot has an unsupported schema")
+    supplied_snapshot_sha256 = snapshot.get("snapshot_sha256")
+    unsigned_snapshot = dict(snapshot)
+    unsigned_snapshot.pop("snapshot_sha256", None)
+    expected_snapshot_sha256 = _sha256_text(_canonical_json(unsigned_snapshot))
+    if supplied_snapshot_sha256 != expected_snapshot_sha256:
+        raise ValueError("trusted applied-prompt snapshot integrity check failed")
+    actor = snapshot.get("actor")
+    prompts = snapshot.get("prompts")
+    if not isinstance(actor, dict) or not isinstance(prompts, list):
+        raise ValueError("trusted applied-prompt snapshot is incomplete")
+
+    bounded_max_chars = max(0, min(int(max_chars), 50000))
+    remaining = bounded_max_chars
+    rendered_prompts: List[Dict[str, Any]] = []
+    truncated = False
+    for item in prompts:
+        if not isinstance(item, dict):
+            continue
+        rendered = {
+            key: item.get(key)
+            for key in (
+                "application_kind",
+                "application_surface",
+                "application_order",
+                "concept_id",
+                "content_char_count",
+                "content_sha256",
+                "source",
+            )
+        }
+        content = item.get("content")
+        if include_content and isinstance(content, str):
+            returned_content = content[:remaining]
+            rendered["content"] = returned_content
+            rendered["content_truncated"] = len(returned_content) < len(content)
+            remaining -= len(returned_content)
+            truncated = truncated or rendered["content_truncated"]
+        rendered_prompts.append(rendered)
+
+    return {
+        "success": True,
+        "schema_version": APPLIED_PROMPT_CONTEXT_SCHEMA_VERSION,
+        "source": "server_bound_turn_snapshot",
+        "turn_id": snapshot.get("turn_id"),
+        "snapshot_sha256": snapshot.get("snapshot_sha256"),
+        "actor": dict(actor),
+        "prompt_count": len(rendered_prompts),
+        "prompt_concept_ids": [
+            item["concept_id"]
+            for item in rendered_prompts
+            if isinstance(item.get("concept_id"), str)
+        ],
+        "prompt_classes": list(
+            dict.fromkeys(
+                item["application_kind"]
+                for item in rendered_prompts
+                if isinstance(item.get("application_kind"), str)
+            )
+        ),
+        "include_content": bool(include_content),
+        "max_chars": bounded_max_chars,
+        "content_truncated": truncated,
+        "prompts": rendered_prompts,
+    }
 
 
 def _debug_user_prompt_logging_enabled() -> bool:

--- a/src/backend/services/chat_auxiliary_prompt_service.py
+++ b/src/backend/services/chat_auxiliary_prompt_service.py
@@ -11,9 +11,10 @@ This module keeps the logic small and testable.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 import logging
 import os
 
@@ -153,6 +154,57 @@ def serialise_applied_prompt_snapshot(snapshot: Dict[str, Any]) -> str:
     return _canonical_json(snapshot)
 
 
+def normalise_applied_prompt_snapshot(
+    value: Any,
+    *,
+    expected_user_concept_id: str | None = None,
+    expected_namespace: str | None = None,
+) -> Dict[str, Any] | None:
+    """Validate and copy an exact turn-applied prompt snapshot.
+
+    Persisted telemetry may carry the snapshot beyond the request that built it,
+    so consumers must verify both its integrity hash and, when supplied, its
+    actor scope before treating it as historical prompt evidence.
+    """
+
+    if isinstance(value, str):
+        if not value.strip():
+            return None
+        try:
+            snapshot = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(value, Mapping):
+        snapshot = copy.deepcopy(dict(value))
+    else:
+        return None
+    if snapshot.get("schema_version") != APPLIED_PROMPT_SNAPSHOT_SCHEMA_VERSION:
+        return None
+    supplied_snapshot_sha256 = snapshot.get("snapshot_sha256")
+    unsigned_snapshot = dict(snapshot)
+    unsigned_snapshot.pop("snapshot_sha256", None)
+    expected_snapshot_sha256 = _sha256_text(_canonical_json(unsigned_snapshot))
+    if supplied_snapshot_sha256 != expected_snapshot_sha256:
+        return None
+    actor = snapshot.get("actor")
+    prompts = snapshot.get("prompts")
+    if not isinstance(actor, dict) or not isinstance(prompts, list):
+        return None
+    if (
+        isinstance(expected_user_concept_id, str)
+        and expected_user_concept_id.strip()
+        and actor.get("user_concept_id") != expected_user_concept_id.strip()
+    ):
+        return None
+    if (
+        isinstance(expected_namespace, str)
+        and expected_namespace.strip()
+        and actor.get("namespace") != expected_namespace.strip()
+    ):
+        return None
+    return snapshot
+
+
 def build_applied_prompt_manifest_message(snapshot: Dict[str, Any]) -> str | None:
     prompts = snapshot.get("prompts")
     if not isinstance(prompts, list) or not prompts:
@@ -192,24 +244,13 @@ def render_applied_prompt_context(
 
     if not isinstance(snapshot_json, str) or not snapshot_json.strip():
         raise ValueError("trusted applied-prompt snapshot is required")
-    try:
-        snapshot = json.loads(snapshot_json)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("trusted applied-prompt snapshot is invalid") from exc
-    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != (
-        APPLIED_PROMPT_SNAPSHOT_SCHEMA_VERSION
-    ):
-        raise ValueError("trusted applied-prompt snapshot has an unsupported schema")
-    supplied_snapshot_sha256 = snapshot.get("snapshot_sha256")
-    unsigned_snapshot = dict(snapshot)
-    unsigned_snapshot.pop("snapshot_sha256", None)
-    expected_snapshot_sha256 = _sha256_text(_canonical_json(unsigned_snapshot))
-    if supplied_snapshot_sha256 != expected_snapshot_sha256:
-        raise ValueError("trusted applied-prompt snapshot integrity check failed")
+    snapshot = normalise_applied_prompt_snapshot(snapshot_json)
+    if snapshot is None:
+        raise ValueError("trusted applied-prompt snapshot is invalid or failed integrity checks")
     actor = snapshot.get("actor")
     prompts = snapshot.get("prompts")
-    if not isinstance(actor, dict) or not isinstance(prompts, list):
-        raise ValueError("trusted applied-prompt snapshot is incomplete")
+    assert isinstance(actor, dict)
+    assert isinstance(prompts, list)
 
     bounded_max_chars = max(0, min(int(max_chars), 50000))
     remaining = bounded_max_chars

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -941,6 +941,11 @@ def _ensure_turn_execution_record_for_assistant_message(
                 if isinstance(llm_debug_data.get("aux_llm_calls"), list)
                 else []
             ),
+            applied_prompt_snapshot=(
+                llm_debug_data.get("applied_prompt_snapshot")
+                if isinstance(llm_debug_data.get("applied_prompt_snapshot"), dict)
+                else None
+            ),
         )
         if isinstance(rebuilt, dict):
             rebuilt["reconstruction"] = {

--- a/src/backend/services/conversation_turn_memory_context_service.py
+++ b/src/backend/services/conversation_turn_memory_context_service.py
@@ -620,6 +620,17 @@ def _render_runtime_turn_fact_block(projection: Mapping[str, Any]) -> str | None
             mode = _safe_str(effect.get("mode"))
             if mode:
                 details.append(f"mode={mode}")
+            reconciliation_status = _safe_str(
+                effect.get("reconciliation_status")
+            )
+            if reconciliation_status:
+                details.append(f"reconciliation={reconciliation_status}")
+            semantic_outcome = _safe_str(effect.get("semantic_outcome"))
+            if semantic_outcome:
+                details.append(f"semantic_outcome={semantic_outcome}")
+            target_ids = _normalise_strings(effect.get("target_ids"), limit=12)
+            if target_ids:
+                details.append("targets=" + ",".join(target_ids))
             rendered_effects.append(f"{identity}: " + "; ".join(details))
         if rendered_effects:
             lines.append("effect receipts:")

--- a/src/backend/services/episode_critic_evidence_service.py
+++ b/src/backend/services/episode_critic_evidence_service.py
@@ -23,6 +23,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
+from .chat_auxiliary_prompt_service import normalise_applied_prompt_snapshot
 from .chat_history_service import get_chat_history_collection_service
 from .namespace_service import coerce_namespace
 from .turn_execution_record_service import (
@@ -71,6 +72,11 @@ _SECTION_LIMITS: dict[str, dict[str, int]] = {
     "turn_execution_record": {
         "max_string_chars": 1200,
         "max_list_items": 60,
+        "max_depth": 7,
+    },
+    "applied_prompt_snapshot": {
+        "max_string_chars": 20_000,
+        "max_list_items": 20,
         "max_depth": 7,
     },
     "selected_llm_debug": {
@@ -702,6 +708,11 @@ def _reconstruct_turn_execution_record_from_history(
             llm_debug.get("aux_llm_calls")
             if isinstance(llm_debug.get("aux_llm_calls"), list)
             else []
+        ),
+        applied_prompt_snapshot=(
+            llm_debug.get("applied_prompt_snapshot")
+            if isinstance(llm_debug.get("applied_prompt_snapshot"), Mapping)
+            else None
         ),
     )
     rebuilt["reconstruction"] = {
@@ -1742,6 +1753,37 @@ def build_episode_critic_evidence_bundle(
     selected_llm_debug = _build_selected_llm_debug(
         llm_debug if isinstance(llm_debug, Mapping) else None
     )
+    raw_applied_prompt_snapshot = (
+        turn_record.get("applied_prompt_snapshot")
+        if isinstance(turn_record, Mapping)
+        and isinstance(turn_record.get("applied_prompt_snapshot"), Mapping)
+        else (
+            llm_debug.get("applied_prompt_snapshot")
+            if isinstance(llm_debug, Mapping)
+            and isinstance(llm_debug.get("applied_prompt_snapshot"), Mapping)
+            else None
+        )
+    )
+    raw_applied_prompt_snapshot_source = (
+        "mongo.turn_execution_records"
+        if isinstance(turn_record, Mapping)
+        and isinstance(turn_record.get("applied_prompt_snapshot"), Mapping)
+        else "mongo.chat_history"
+    )
+    applied_prompt_snapshot = normalise_applied_prompt_snapshot(
+        raw_applied_prompt_snapshot,
+        expected_user_concept_id=(
+            _safe_str(turn_record.get("user_id"))
+            if isinstance(turn_record, Mapping)
+            else _safe_str(history_context.get("user_id"))
+            if isinstance(history_context, Mapping)
+            else None
+        ),
+        expected_namespace=resolved_namespace,
+    )
+    applied_prompt_snapshot_source = (
+        raw_applied_prompt_snapshot_source if applied_prompt_snapshot else None
+    )
     aux_llm_calls = (
         llm_debug.get("aux_llm_calls")
         if isinstance(llm_debug, Mapping) and isinstance(llm_debug.get("aux_llm_calls"), list)
@@ -1785,6 +1827,7 @@ def build_episode_critic_evidence_bundle(
 
     observed_evidence_raw: dict[str, Any] = {
         "turn_execution_record": _normalise_mapping(turn_record),
+        "applied_prompt_snapshot": _normalise_mapping(applied_prompt_snapshot),
         "selected_llm_debug": selected_llm_debug,
         "aux_llm_calls": aux_llm_calls or None,
         "tool_ledger": tool_ledger,
@@ -1822,6 +1865,7 @@ def build_episode_critic_evidence_bundle(
     for section_id, value in observed_evidence_raw.items():
         source_system = {
             "turn_execution_record": "mongo.turn_execution_records",
+            "applied_prompt_snapshot": applied_prompt_snapshot_source,
             "selected_llm_debug": "mongo.chat_history",
             "aux_llm_calls": "mongo.chat_history",
             "tool_ledger": "mongo.turn_execution_records",

--- a/src/backend/services/failure_case_intake_service.py
+++ b/src/backend/services/failure_case_intake_service.py
@@ -596,6 +596,45 @@ def _extract_prompt_metadata(*payloads: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _extract_applied_prompt_snapshot(
+    *,
+    turn_record: Mapping[str, Any],
+    target_debug: Mapping[str, Any],
+    namespace: str | None,
+    user_concept_id: str | None,
+    max_text_chars: int,
+) -> dict[str, Any]:
+    """Project integrity-checked historical applied-prompt evidence."""
+
+    from .chat_auxiliary_prompt_service import normalise_applied_prompt_snapshot
+
+    snapshot = normalise_applied_prompt_snapshot(
+        turn_record.get("applied_prompt_snapshot"),
+        expected_user_concept_id=user_concept_id,
+        expected_namespace=namespace,
+    ) or normalise_applied_prompt_snapshot(
+        target_debug.get("applied_prompt_snapshot"),
+        expected_user_concept_id=user_concept_id,
+        expected_namespace=namespace,
+    )
+    if snapshot is None:
+        return {}
+    bounded = dict(snapshot)
+    bounded["source_snapshot_schema_version"] = snapshot.get("schema_version")
+    bounded["schema_version"] = "failure_case_applied_prompt_snapshot_projection.v1"
+    prompts: list[dict[str, Any]] = []
+    for raw_prompt in _mapping_list(snapshot.get("prompts")):
+        prompt = dict(raw_prompt)
+        content = _safe_str(prompt.get("content"))
+        if content is not None:
+            prompt["content"] = content[: max(0, int(max_text_chars))]
+            prompt["content_truncated"] = len(content) > max_text_chars
+        prompts.append(prompt)
+    bounded["prompts"] = prompts
+    bounded["source"] = "target_turn_applied_prompt_snapshot"
+    return bounded
+
+
 def _extract_model_summary(*payloads: Mapping[str, Any]) -> dict[str, Any]:
     candidates: list[str] = []
     for payload in payloads:
@@ -1445,6 +1484,22 @@ def collect_failure_case_intake(
         diagnostics_payload,
         turn_record,
     )
+    applied_prompt_snapshot = _extract_applied_prompt_snapshot(
+        turn_record=turn_record,
+        target_debug=target_debug,
+        namespace=namespace_value,
+        user_concept_id=_safe_str(user_concept_id),
+        max_text_chars=text_limit,
+    )
+    if applied_prompt_snapshot:
+        prompt_metadata["applied_prompt_snapshot_sha256"] = _safe_str(
+            applied_prompt_snapshot.get("snapshot_sha256")
+        )
+        prompt_metadata["applied_prompt_ids"] = [
+            concept_id
+            for item in _mapping_list(applied_prompt_snapshot.get("prompts"))
+            if (concept_id := _safe_str(item.get("concept_id")))
+        ]
     model_summary = _extract_model_summary(
         target_debug, diagnostics_payload, turn_record
     )
@@ -1508,6 +1563,14 @@ def collect_failure_case_intake(
         },
         "turn_execution_get": {
             "success": bool(turn_record_payload.get("success")),
+        },
+        "applied_prompt_snapshot": {
+            "present": bool(applied_prompt_snapshot),
+            "source": (
+                applied_prompt_snapshot.get("source")
+                if applied_prompt_snapshot
+                else None
+            ),
         },
         "turn_execution_list": {
             "attempted": bool(turn_list_payload),
@@ -1573,6 +1636,7 @@ def collect_failure_case_intake(
             "stage_id": _safe_str(stage_id),
         },
         "prompt_metadata": prompt_metadata,
+        "applied_prompt_snapshot": applied_prompt_snapshot or None,
         "tool_ledger": tool_ledger,
         "completion_gate": completion_gate,
         "critic": critic,

--- a/src/backend/services/failure_case_prompt_replay_experiment_service.py
+++ b/src/backend/services/failure_case_prompt_replay_experiment_service.py
@@ -113,6 +113,12 @@ def _base_prompt_from_intake(
         if prompt_id:
             return prompt_id
 
+    applied_prompt_ids = _normalise_strings(
+        _first_path(failure_case_intake, ("prompt_metadata", "applied_prompt_ids"))
+    )
+    if applied_prompt_ids:
+        return applied_prompt_ids[0]
+
     prompt_ids = _normalise_strings(
         _first_path(failure_case_intake, ("prompt_metadata", "prompt_ids"))
     )

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -25,6 +25,7 @@ from ..security.visibility_predicates import (
     SPECIFIC_TO_ORG_PREDICATES_READ,
     SPECIFIC_TO_USER_PREDICATES,
 )
+from .concept_predicate_metadata_service import get_structural_inverse_map
 from .ontology_publication_authority_service import (
     RESERVED_GENERIC_MUTATION_PREDICATES,
     OntologyMutationIntent,
@@ -40,8 +41,8 @@ from .ontology_publication_authority_service import (
     ontology_authority_resource_keys,
     ontology_mutation_resource_lock,
     publication_context_for_creation,
+    reconcile_indeterminate_mutation_receipt,
 )
-from .concept_predicate_metadata_service import get_structural_inverse_map
 from .relationship_write_service import (
     CORE_RELATIONSHIP_TEXT_PREDICATES,
     is_structural_predicate,
@@ -1957,6 +1958,205 @@ def _verify_method_postcondition(
     return False
 
 
+def _postcondition_reconciliation_contract(
+    *,
+    method_name: str,
+    intent: OntologyMutationIntent,
+) -> dict[str, Any]:
+    """Carry the immutable verified intent needed for a later exact read."""
+
+    return {
+        "schema_version": "ontology_mutation_postcondition_reconciliation.v1",
+        "method_name": _clean_text(method_name),
+        "intent_fingerprint": intent.fingerprint,
+        "intent": intent.canonical_payload(),
+    }
+
+
+def _publication_context_from_payload(value: Any) -> PublicationContext | None:
+    if not isinstance(value, Mapping):
+        return None
+    from .ontology_publication_authority_service import PublicationContextKind
+
+    try:
+        kind = PublicationContextKind(_clean_text(value.get("kind")))
+    except ValueError:
+        return None
+    historical_predicates = tuple(
+        _clean_text(item)
+        for item in value.get("historical_predicates") or ()
+        if _clean_text(item)
+    )
+    return PublicationContext(
+        kind=kind,
+        concept_id=_normalise_concept_id(value.get("concept_id")),
+        source=_clean_text(value.get("source")) or "resolved",
+        historical_predicates=historical_predicates,
+    )
+
+
+def _intent_from_postcondition_reconciliation_contract(
+    value: Any,
+) -> OntologyMutationIntent | None:
+    if not isinstance(value, Mapping) or value.get("schema_version") != (
+        "ontology_mutation_postcondition_reconciliation.v1"
+    ):
+        return None
+    payload = value.get("intent")
+    if not isinstance(payload, Mapping):
+        return None
+    publication_context = _publication_context_from_payload(
+        payload.get("publication_context")
+    )
+    if publication_context is None:
+        return None
+    source_contexts: list[PublicationContext] = []
+    for raw_context in payload.get("source_contexts") or ():
+        context = _publication_context_from_payload(raw_context)
+        if context is None:
+            return None
+        source_contexts.append(context)
+    intent = OntologyMutationIntent(
+        operation=_clean_text(payload.get("operation")),
+        publication_context=publication_context,
+        target_concept_ids=tuple(
+            concept_id
+            for concept_id in (
+                _normalise_concept_id(item)
+                for item in payload.get("target_concept_ids") or ()
+            )
+            if concept_id
+        ),
+        tool_name=_clean_text(payload.get("tool_name")) or None,
+        predicate=_normalise_predicate(payload.get("predicate")),
+        source_contexts=tuple(source_contexts),
+        delta=dict(payload.get("delta") or {}),
+    )
+    expected_fingerprint = _clean_text(value.get("intent_fingerprint"))
+    if not expected_fingerprint or intent.fingerprint != expected_fingerprint:
+        return None
+    return intent
+
+
+def reconcile_governed_ontology_postcondition(
+    *,
+    method_name: str,
+    arguments: Mapping[str, Any],
+    original_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Re-read and prove an earlier indeterminate ontology mutation exactly.
+
+    No mutation is retried.  The original command's immutable intent contract
+    and authority receipt are required, then the same method verifier is run
+    over current canonical state.  A successful proof also advances the
+    durable operational receipt from indeterminate to succeeded.
+    """
+
+    method = _clean_text(method_name)
+    contract = original_result.get("postcondition_reconciliation")
+    intent = _intent_from_postcondition_reconciliation_contract(contract)
+    authority_receipt = original_result.get("authority_receipt")
+    authority_receipt = (
+        authority_receipt if isinstance(authority_receipt, Mapping) else {}
+    )
+    if (
+        intent is None
+        or method != intent.tool_name
+        or method != _clean_text((contract or {}).get("method_name"))
+        or authority_receipt.get("intent_fingerprint") != intent.fingerprint
+        or _clean_text(authority_receipt.get("status")) != "indeterminate"
+    ):
+        return {
+            "success": False,
+            "verified": False,
+            "error_code": "ontology_reconciliation_contract_invalid",
+        }
+    try:
+        reconciliation_arguments = resolve_governed_ontology_arguments(
+            method,
+            normalise_governed_ontology_arguments(method, arguments),
+        )
+    except OntologyMutationCommandError:
+        reconciliation_arguments = None
+    if (
+        reconciliation_arguments is None
+        or intent.delta.get("effect_arguments_sha256")
+        != _effect_arguments_sha256(reconciliation_arguments)
+    ):
+        return {
+            "success": False,
+            "verified": False,
+            "error_code": "ontology_reconciliation_contract_invalid",
+        }
+
+    result_hint = dict(original_result)
+    result_hint.update({"success": True, "changed": True})
+    if method == "create_concepts":
+        expected_concept_id = _normalise_concept_id(
+            intent.delta.get("expected_concept_id")
+        )
+        result_hint["created_concept_ids"] = (
+            [expected_concept_id] if expected_concept_id else []
+        )
+    try:
+        canonical_state = canonical_read_back_for_method(
+            method_name=method,
+            arguments=reconciliation_arguments,
+            result=result_hint,
+        )
+        verified = _verify_method_postcondition(
+            method_name=method,
+            intent=intent,
+            result=result_hint,
+            canonical_state=canonical_state,
+        )
+    except Exception:
+        logger.exception("Governed ontology postcondition reconciliation failed")
+        return {
+            "success": False,
+            "verified": False,
+            "error_code": "ontology_reconciliation_read_failed",
+        }
+    if not verified:
+        return {
+            "success": True,
+            "verified": False,
+            "receipt_id": authority_receipt.get("receipt_id"),
+            "intent_fingerprint": intent.fingerprint,
+            "target_concept_ids": list(intent.target_concept_ids),
+            "canonical_read_back": canonical_state,
+        }
+
+    receipt = reconcile_indeterminate_mutation_receipt(
+        receipt_id=_clean_text(authority_receipt.get("receipt_id")),
+        intent_fingerprint=intent.fingerprint,
+        canonical_read_back=canonical_state,
+        response_projection={
+            **result_hint,
+            "effect_status": "succeeded",
+            "mutation_outcome": "succeeded",
+            "outcome_finality": "terminal_for_turn",
+        },
+    )
+    if not isinstance(receipt, Mapping) or receipt.get("status") != "succeeded":
+        return {
+            "success": False,
+            "verified": False,
+            "error_code": "ontology_reconciliation_receipt_not_finalised",
+        }
+    return {
+        "success": True,
+        "verified": True,
+        "status": "verified",
+        "method_name": method,
+        "receipt_id": receipt.get("receipt_id"),
+        "intent_fingerprint": intent.fingerprint,
+        "target_concept_ids": list(intent.target_concept_ids),
+        "canonical_read_back": canonical_state,
+        "authority_receipt": dict(receipt),
+    }
+
+
 def execute_governed_ontology_method(
     *,
     method_name: str,
@@ -2202,7 +2402,7 @@ def execute_governed_ontology_method(
                 "error": "Another ontology mutation is already in progress.",
             }
 
-    return execute_authorised_ontology_mutation(
+    outcome = execute_authorised_ontology_mutation(
         intent=intent,
         mutate=perform,
         read_before=lambda: canonical_read_back_for_method(
@@ -2222,6 +2422,20 @@ def execute_governed_ontology_method(
         ),
         preview=preview,
     )
+    if outcome.get("effect_status") == "indeterminate" or outcome.get(
+        "mutation_outcome"
+    ) in {"unknown", "partial"}:
+        outcome.setdefault(
+            "outcome_finality",
+            "requires_canonical_reconciliation",
+        )
+        outcome["postcondition_reconciliation"] = (
+            _postcondition_reconciliation_contract(
+                method_name=method_name,
+                intent=intent,
+            )
+        )
+    return outcome
 
 
 def issue_same_turn_method_delegation(
@@ -2329,6 +2543,7 @@ __all__ = [
     "is_ontology_mutation_method",
     "issue_same_turn_method_delegation",
     "normalise_governed_ontology_arguments",
+    "reconcile_governed_ontology_postcondition",
     "resolve_governed_ontology_arguments",
     "scope_read_back",
 ]

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -1702,6 +1702,87 @@ def finalise_mutation_receipt(
     return _receipt_public_projection(updated)
 
 
+def reconcile_indeterminate_mutation_receipt(
+    *,
+    receipt_id: str,
+    intent_fingerprint: str,
+    canonical_read_back: Any,
+    response_projection: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Finalise one indeterminate receipt after an exact later postcondition read.
+
+    This is an operational receipt transition, not a second ontology mutation.
+    The caller must have verified the original immutable intent against the
+    later canonical state.  Actor identity and the original intent fingerprint
+    are checked again here so a read-back for another actor or effect cannot be
+    attached to this receipt.
+    """
+
+    actor_id, actor_identity_source = get_effective_user_concept_id_with_source()
+    actor_id = _normalise_concept_id(actor_id)
+    clean_receipt_id = _clean_text(receipt_id)
+    clean_fingerprint = _clean_text(intent_fingerprint)
+    if (
+        not actor_id
+        or not clean_receipt_id
+        or not clean_fingerprint
+        or actor_identity_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE
+    ):
+        return None
+
+    collection = _receipt_collection()
+    existing = collection.find_one(
+        {
+            "receipt_id": clean_receipt_id,
+            "actor_concept_id": actor_id,
+            "intent_fingerprint": clean_fingerprint,
+        }
+    )
+    if not isinstance(existing, Mapping):
+        return None
+    if _clean_text(existing.get("status")) == "succeeded":
+        return _receipt_public_projection(existing)
+    if _clean_text(existing.get("status")) != "indeterminate":
+        return None
+
+    now = _now()
+    bounded_response = _bounded_projection(response_projection)
+    updated = collection.find_one_and_update(
+        {
+            "receipt_id": clean_receipt_id,
+            "actor_concept_id": actor_id,
+            "intent_fingerprint": clean_fingerprint,
+            "status": "indeterminate",
+        },
+        {
+            "$set": {
+                "status": "succeeded",
+                "mutation_outcome": "succeeded",
+                "changed": True,
+                "canonical_read_back": _bounded_projection(canonical_read_back),
+                "canonical_read_back_sha256": _sha256_json(canonical_read_back),
+                "response_projection": bounded_response,
+                "response_projection_truncated": bool(
+                    isinstance(bounded_response, Mapping)
+                    and bounded_response.get("truncated")
+                ),
+                "response_success": True,
+                "response_effect_status": "succeeded",
+                "response_error_code": None,
+                "error_code": None,
+                "reconciled_from_status": "indeterminate",
+                "reconciled_at": now,
+                "updated_at": now,
+                "completed_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    return (
+        _receipt_public_projection(updated) if isinstance(updated, Mapping) else None
+    )
+
+
 def get_mutation_receipt_for_actor(
     *,
     receipt_id: str,
@@ -2159,6 +2240,7 @@ __all__ = [
     "ontology_mutation_resource_lock",
     "parse_authority_role_storage_text",
     "publication_context_for_creation",
+    "reconcile_indeterminate_mutation_receipt",
     "resolve_delegation_principal",
     "resolve_live_semantic_roles",
     "revoke_agent_delegation",

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -1120,6 +1120,11 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "category": "internal",
         "display_template": None,
     },
+    "chat_get_applied_prompt_context": {
+        "salience": "none",
+        "category": "internal",
+        "display_template": None,
+    },
     "chat_introspect": {
         "salience": "none",
         "category": "internal",

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -8169,6 +8169,15 @@ def _turn_projection_effect_mode(
     if status in {"partial", "indeterminate", "not_started", "timeout", "error"}:
         return status
     if (
+        invocation.get("reconciliation_status") == "canonically_verified"
+        and (
+            _safe_str(invocation.get("tool"))
+            or _safe_str(invocation.get("method"))
+        )
+        == "create_concepts"
+    ):
+        return "created"
+    if (
         payload.get("created_new") is True
         or _safe_non_negative_int(payload.get("created")) > 0
         or bool(payload.get("created_concept_ids"))
@@ -8464,6 +8473,11 @@ def build_conversation_situation_turn_projection(
             invocation=invocation,
             payload=payload,
         )
+        canonically_reconciled = (
+            invocation.get("reconciliation_status") == "canonically_verified"
+        )
+        if canonically_reconciled:
+            status = "ok"
         successful = status == "ok"
         # Adaptive effect invocations carry receipt metadata. Use that local
         # evidence instead of consulting represented tool metadata during
@@ -8502,9 +8516,24 @@ def build_conversation_situation_turn_projection(
                     }
                 ),
             )
+            if canonically_reconciled:
+                result_concept_ids = _dedupe_string_sequence(
+                    [
+                        *result_concept_ids,
+                        *(
+                            invocation.get("result_target_ids")
+                            if isinstance(invocation.get("result_target_ids"), Sequence)
+                            and not isinstance(
+                                invocation.get("result_target_ids"),
+                                (str, bytes, bytearray),
+                            )
+                            else []
+                        ),
+                    ]
+                )
             for concept_id in result_concept_ids:
                 if (
-                    not is_write
+                    (not is_write or canonically_reconciled)
                     and concept_id.startswith("#V#")
                     and concept_id.lower() in answer_concept_ids
                 ):
@@ -8702,6 +8731,22 @@ def build_conversation_situation_turn_projection(
                 effect["effect_id"] = effect_id
             if isinstance(changed, bool):
                 effect["changed"] = changed
+            reconciliation_status = _safe_str(
+                invocation.get("reconciliation_status")
+            )
+            if reconciliation_status:
+                effect["reconciliation_status"] = reconciliation_status
+            semantic_outcome = _safe_str(invocation.get("semantic_outcome"))
+            if semantic_outcome:
+                effect["semantic_outcome"] = semantic_outcome
+            if canonically_reconciled:
+                reconciled_targets = _dedupe_string_sequence(
+                    invocation.get("result_target_ids") or ()
+                )
+                if reconciled_targets:
+                    effect["target_ids"] = reconciled_targets[
+                        :_CONVERSATION_SITUATION_PROJECTION_MAX_IDS
+                    ]
             mode = _turn_projection_effect_mode(
                 invocation=invocation,
                 payload=payload,

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -10525,11 +10525,21 @@ def build_turn_execution_record(
     tool_observation_ledger: Mapping[str, Any] | None = None,
     method_catalogue: Mapping[str, Any] | None = None,
     workflow_failure_evidence: Mapping[str, Any] | None = None,
+    applied_prompt_snapshot: Mapping[str, Any] | str | None = None,
 ) -> dict[str, Any]:
     resolved_actor_concept_id, actor_identity_source = _resolve_actor_concept_identity(
         actor_concept_id=actor_concept_id,
         user_id=user_id,
         namespace=namespace,
+    )
+    from .chat_auxiliary_prompt_service import normalise_applied_prompt_snapshot
+
+    applied_prompt_snapshot_payload = normalise_applied_prompt_snapshot(
+        applied_prompt_snapshot,
+        expected_user_concept_id=(
+            _safe_str(user_id) or resolved_actor_concept_id
+        ),
+        expected_namespace=_safe_str(namespace),
     )
     workflow_discovery_normalised = _extract_workflow_discovery(workflow_discovery)
     final_answer_synthesis = _build_final_answer_synthesis_telemetry(
@@ -11535,6 +11545,7 @@ def build_turn_execution_record(
             "sha256": _hash_text(prompt_text),
             "source": "user_message",
         },
+        "applied_prompt_snapshot": applied_prompt_snapshot_payload,
         "workflow_selection": {
             "selected_workflow_id": selected_workflow_id,
             "selector_verdict": selector_verdict,
@@ -11930,6 +11941,7 @@ def persist_failed_turn_execution_record(
     prompt_text: Any = None,
     llm_debug_info: Mapping[str, Any] | None = None,
     progress_snapshot: Mapping[str, Any] | None = None,
+    applied_prompt_snapshot: Mapping[str, Any] | str | None = None,
 ) -> dict[str, Any]:
     """Persist a turn execution record for a turn that did not complete.
 
@@ -12020,6 +12032,11 @@ def persist_failed_turn_execution_record(
             completion_report=_debug_mapping("completion_report"),
             required_prompt_tools=_debug_list("required_prompt_tools"),
             tool_observation_ledger=_debug_mapping("tool_observation_ledger"),
+            applied_prompt_snapshot=(
+                applied_prompt_snapshot
+                or _debug_mapping("applied_prompt_snapshot")
+                or _debug_mapping("applied_prompt_provenance")
+            ),
         )
     except Exception as exc:
         logger.warning(

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import hashlib
 import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from src.backend.security.access_control import override_current_actor
-
 
 WORKFLOW_TURN_CAPABILITY_SCHEMA_VERSION = "workflow_turn_capability.v1"
 WORKFLOW_TURN_DISCOVERY_SCHEMA_VERSION = "workflow_turn_capability_discovery.v1"
@@ -28,6 +28,7 @@ _SERVER_PROVIDED_WORKFLOW_INPUT_KEYS = frozenset(
         "actor_concept_id",
         "actor_user_concept_id",
         "augmented_context",
+        "conversation_situation",
         "namespace",
         "org_concept_id",
         "organisation_concept_id",
@@ -55,6 +56,27 @@ _MODEL_WORKFLOW_CONTROL_ARGUMENTS = frozenset(
 _TERMINAL_SUCCESS_STATUSES = frozenset({"completed", "succeeded", "success"})
 _TERMINAL_FAILURE_STATUSES = frozenset(
     {"cancelled", "canceled", "failed", "rejected", "terminated"}
+)
+
+_WORKFLOW_SEMANTIC_OUTCOMES = frozenset(
+    {
+        "blocked",
+        "clarification_required",
+        "completed",
+        "failed",
+        "follow_up_required",
+        "not_completed",
+        "partial",
+    }
+)
+
+_WORKFLOW_NON_EFFECT_OUTCOMES = frozenset(
+    {
+        "blocked",
+        "clarification_required",
+        "failed",
+        "not_completed",
+    }
 )
 
 
@@ -642,6 +664,7 @@ def build_workflow_execution_arguments(
     *,
     prompt: str,
     context: Sequence[Mapping[str, Any]] | None,
+    conversation_situation: str | None,
     request_workflow_launch_inputs: Mapping[str, Any] | None,
     user_concept_id: str,
     organisation_concept_id: str | None,
@@ -711,6 +734,9 @@ def build_workflow_execution_arguments(
     context_projection = _bounded_context_projection(context)
     if context_projection:
         launch_inputs["augmented_context"] = context_projection
+    clean_situation = str(conversation_situation or "").strip()
+    if clean_situation:
+        launch_inputs["conversation_situation"] = clean_situation[:24_000]
 
     try:
         requested_wait = float(model_arguments.get("timeout_seconds", 60.0))
@@ -846,6 +872,54 @@ def normalise_workflow_effect_receipt(
     else:
         effect_status = "partial" if instance_id is not None else "failed"
 
+    workflow_execution = receipt.get("workflow_execution")
+    workflow_outputs = (
+        workflow_execution.get("outputs")
+        if isinstance(workflow_execution, Mapping)
+        and isinstance(workflow_execution.get("outputs"), Mapping)
+        else None
+    )
+    if workflow_outputs is None and isinstance(workflow_instance, Mapping):
+        candidate_outputs = workflow_instance.get("outputs")
+        workflow_outputs = (
+            candidate_outputs if isinstance(candidate_outputs, Mapping) else None
+        )
+    explicit_semantic_outcome = (
+        _normalise_non_empty_text(workflow_outputs.get("semantic_outcome"))
+        if isinstance(workflow_outputs, Mapping)
+        else None
+    )
+    if explicit_semantic_outcome:
+        explicit_semantic_outcome = explicit_semantic_outcome.lower().replace(" ", "_")
+    clarification_required = bool(
+        effect_status == "succeeded"
+        and isinstance(workflow_outputs, Mapping)
+        and (
+            workflow_outputs.get("requires_user_affirmation") is True
+            or workflow_outputs.get("needs_user_affirmation") is True
+            or explicit_semantic_outcome == "clarification_required"
+        )
+    )
+    if effect_status != "succeeded":
+        semantic_outcome = "not_completed"
+    elif clarification_required:
+        semantic_outcome = "clarification_required"
+    elif explicit_semantic_outcome in _WORKFLOW_SEMANTIC_OUTCOMES:
+        semantic_outcome = explicit_semantic_outcome
+    elif (
+        isinstance(workflow_outputs, Mapping)
+        and workflow_outputs.get("follow_up_required") is True
+    ):
+        semantic_outcome = "follow_up_required"
+    else:
+        semantic_outcome = "completed"
+    semantic_effect = (
+        False
+        if effect_status == "succeeded"
+        and semantic_outcome in _WORKFLOW_NON_EFFECT_OUTCOMES
+        else capability.semantic_effect
+    )
+
     receipt.update(
         {
             "workflow_turn_receipt_schema_version": (
@@ -856,7 +930,8 @@ def normalise_workflow_effect_receipt(
             "workflow_id": capability.workflow_id,
             "effect_status": effect_status,
             "changed": changed,
-            "semantic_effect": capability.semantic_effect,
+            "semantic_effect": semantic_effect,
+            "semantic_outcome": semantic_outcome,
             "operational_state_effect": True,
             "mutation_outcome": (
                 "completed"

--- a/src/backend/workflows/durable/turn_execution_runtime_support.py
+++ b/src/backend/workflows/durable/turn_execution_runtime_support.py
@@ -1240,6 +1240,11 @@ def run_turn_execution_critic(
         ),
         method_catalogue=method_catalogue,
         workflow_failure_evidence=data,
+        applied_prompt_snapshot=(
+            data.get("applied_prompt_snapshot")
+            if isinstance(data.get("applied_prompt_snapshot"), Mapping)
+            else None
+        ),
     )
 
     completion_gate = turn_execution_record.get("completion_gate")

--- a/src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py
+++ b/src/backend/workflows/durable/workflow_introspection_maintenance_workflow.py
@@ -151,6 +151,81 @@ def _coerce_mapping_list(value: Any, *, max_items: int = 100) -> list[dict[str, 
     return rows
 
 
+def _current_prompt_concepts(prompt_context: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return the deduplicated current Vontology prompt concepts."""
+
+    concepts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for key in (
+        "behaviour_prompt_concepts",
+        "narration_prompt_concepts",
+        "screen_prompt_concepts",
+        "prompt_concepts",
+    ):
+        for item in _coerce_mapping_list(prompt_context.get(key), max_items=50):
+            concept_id = _normalise_text(item.get("concept_id"))
+            if not concept_id or concept_id in seen:
+                continue
+            seen.add(concept_id)
+            concepts.append(item)
+    return concepts
+
+
+def _applied_prompt_snapshot_from_turn_execution(
+    turn_execution: Mapping[str, Any],
+    *,
+    expected_namespace: str | None,
+) -> dict[str, Any]:
+    """Resolve and integrity-check the snapshot retained for the target turn."""
+
+    from ...services.chat_auxiliary_prompt_service import (
+        normalise_applied_prompt_snapshot,
+    )
+
+    candidates: list[Any] = [turn_execution.get("applied_prompt_snapshot")]
+    for container_key in ("item", "record", "turn_execution_record", "result"):
+        container = turn_execution.get(container_key)
+        if isinstance(container, Mapping):
+            candidates.append(container.get("applied_prompt_snapshot"))
+    for candidate in candidates:
+        snapshot = normalise_applied_prompt_snapshot(
+            candidate,
+            expected_namespace=expected_namespace,
+        )
+        if snapshot is not None:
+            return snapshot
+    return {}
+
+
+def _applied_prompt_concepts(
+    applied_prompt_snapshot: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    concepts: list[dict[str, Any]] = []
+    for item in _coerce_mapping_list(
+        applied_prompt_snapshot.get("prompts"),
+        max_items=50,
+    ):
+        concept_id = _normalise_text(item.get("concept_id"))
+        content = _normalise_text(item.get("content"))
+        if not concept_id or not content:
+            continue
+        concepts.append(
+            {
+                "concept_id": concept_id,
+                "content": content,
+                "content_sha256": _normalise_text(item.get("content_sha256")),
+                "application_kind": _normalise_text(
+                    item.get("application_kind")
+                ),
+                "application_surface": _normalise_text(
+                    item.get("application_surface")
+                ),
+                "application_order": item.get("application_order"),
+            }
+        )
+    return concepts
+
+
 def _append_trace_event(
     context: Mapping[str, Any],
     *,
@@ -888,6 +963,10 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
                 "request_id": request_id,
             },
         )
+    applied_prompt_snapshot = _applied_prompt_snapshot_from_turn_execution(
+        turn_execution,
+        expected_namespace=namespace,
+    )
 
     selected_workflow_id = _normalise_text(context.get("selected_workflow_id"))
     if not selected_workflow_id:
@@ -967,12 +1046,17 @@ def _handle_assess_context(request: WorkflowActionRequest) -> WorkflowActionResu
             "github_error_count": len(github_evidence.get("errors", []))
             if isinstance(github_evidence.get("errors"), list)
             else 0,
+            "applied_prompt_snapshot_present": bool(applied_prompt_snapshot),
+            "applied_prompt_count": int(
+                applied_prompt_snapshot.get("prompt_count") or 0
+            ),
         },
     )
     maintenance_evidence = {
         "incident_text": _normalise_text(context.get("incident_text")),
         "workflow_definitions": workflow_definitions,
         "prompt_context": prompt_context,
+        "applied_prompt_snapshot": applied_prompt_snapshot,
         "episode_critique_memory": episode_critique_memory,
         "turn_execution": turn_execution,
         "workflow_concept": workflow_concept,
@@ -1000,7 +1084,20 @@ def _handle_diagnose_conflation(request: WorkflowActionRequest) -> WorkflowActio
         if isinstance(item, str) and item.strip()
     }
 
-    prompt_concepts = _coerce_mapping_list(prompt_context.get("behaviour_prompt_concepts"))
+    applied_prompt_snapshot = _coerce_mapping(
+        evidence.get("applied_prompt_snapshot")
+    )
+    applied_prompt_concepts = _applied_prompt_concepts(applied_prompt_snapshot)
+    prompt_concepts = (
+        applied_prompt_concepts
+        if applied_prompt_concepts
+        else _current_prompt_concepts(prompt_context)
+    )
+    prompt_evidence_source = (
+        "turn_applied_snapshot"
+        if applied_prompt_concepts
+        else "current_vontology_prompt_context"
+    )
     directives: list[dict[str, Any]] = []
     for concept in prompt_concepts:
         concept_id = _normalise_text(concept.get("concept_id"))
@@ -1170,6 +1267,10 @@ def _handle_diagnose_conflation(request: WorkflowActionRequest) -> WorkflowActio
         "selected_workflow_id": maintenance_context.get("selected_workflow_id"),
         "github_repository": github_evidence.get("repository"),
         "github_evidence_success": bool(github_evidence.get("success")),
+        "prompt_evidence_source": prompt_evidence_source,
+        "applied_prompt_snapshot_sha256": _normalise_text(
+            applied_prompt_snapshot.get("snapshot_sha256")
+        ),
     }
 
     trace = _append_trace_event(
@@ -1198,7 +1299,22 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
     diagnosis = _coerce_mapping(context.get("maintenance_diagnosis"))
     github_evidence = _coerce_mapping(evidence.get("github_evidence"))
     prompt_context = _coerce_mapping(evidence.get("prompt_context"))
-    prompt_concepts = _coerce_mapping_list(prompt_context.get("behaviour_prompt_concepts"))
+    current_prompt_concepts = _current_prompt_concepts(prompt_context)
+    current_prompt_by_id = {
+        concept_id: concept
+        for concept in current_prompt_concepts
+        if (concept_id := _normalise_text(concept.get("concept_id")))
+    }
+    applied_prompt_snapshot = _coerce_mapping(
+        evidence.get("applied_prompt_snapshot")
+    )
+    applied_prompt_concepts = _applied_prompt_concepts(applied_prompt_snapshot)
+    use_applied_prompt_evidence = bool(applied_prompt_concepts)
+    prompt_concepts = (
+        applied_prompt_concepts
+        if use_applied_prompt_evidence
+        else current_prompt_concepts
+    )
     directive_findings = _coerce_mapping_list(diagnosis.get("directive_findings"))
     implicated_prompt_ids = {
         str(item)
@@ -1207,6 +1323,7 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
     }
 
     operations: list[dict[str, Any]] = []
+    skipped_prompt_repairs: list[dict[str, Any]] = []
     for concept in prompt_concepts:
         concept_id = _normalise_text(concept.get("concept_id"))
         content = _normalise_text(concept.get("content"))
@@ -1221,6 +1338,35 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
         ]
         if not concept_findings:
             continue
+        if use_applied_prompt_evidence:
+            current_concept = current_prompt_by_id.get(concept_id)
+            current_content = _normalise_text(
+                current_concept.get("content")
+                if isinstance(current_concept, Mapping)
+                else None
+            )
+            if current_content != content:
+                skipped_prompt_repairs.append(
+                    {
+                        "concept_id": concept_id,
+                        "reason": (
+                            "current_prompt_missing"
+                            if current_content is None
+                            else "current_prompt_changed_since_target_turn"
+                        ),
+                        "applied_content_sha256": _normalise_text(
+                            concept.get("content_sha256")
+                        ),
+                        "current_content_sha256": (
+                            hashlib.sha256(
+                                current_content.encode("utf-8")
+                            ).hexdigest()
+                            if current_content is not None
+                            else None
+                        ),
+                    }
+                )
+                continue
         patched_text, patch_meta = _patch_prompt_content(
             original_content=content,
             findings=concept_findings,
@@ -1342,6 +1488,12 @@ def _handle_plan_repairs(request: WorkflowActionRequest) -> WorkflowActionResult
         "dry_run": bool(maintenance_context.get("dry_run", False)),
         "operation_count": len(operations),
         "operations": operations,
+        "prompt_evidence_source": (
+            "turn_applied_snapshot"
+            if use_applied_prompt_evidence
+            else "current_vontology_prompt_context"
+        ),
+        "skipped_prompt_repairs": skipped_prompt_repairs,
         "jira_remediation_skipped_reason": jira_remediation_skipped_reason,
     }
 

--- a/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
@@ -1,11 +1,16 @@
 {
   "family_id": "canonical_workflow_publication_seed_bundle",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "50",
+  "seed_version": "51",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#tool_calling_workflow": {
       "42": [
         "77e8896562063743a980c1700c43a5edf1d451b1a90c1e0b489f9c3838cc7b87"
+      ]
+    },
+    "#V#general_mail_review_workflow": {
+      "50": [
+        "3b1006be7892b4981511d7767b69f2de023c3c919da8883b050248ee4ae53674"
       ]
     }
   },
@@ -1860,6 +1865,20 @@
             "extractor": "identity",
             "required": false,
             "description": "Requested fields for each message row or item."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry bounded prior-turn messages for deictic mail-review requests."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry the server-projected shared situation for prior mailbox scope, requested fields, and named profiles."
           }
         ]
       },
@@ -2202,6 +2221,7 @@
               ],
               "required_tools": [],
               "max_tool_invocations": 6,
+              "context_messages_context_key": "augmented_context",
               "tool_argument_defaults": {
                 "find_relations_with_argument": {
                   "argument_index": "subject",
@@ -2222,6 +2242,10 @@
                 {
                   "context_key": "prompt",
                   "label": "Current mail-review request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation for prior mailbox scope, requested fields, and named profiles"
                 },
                 {
                   "context_key": "mail_review_profile_id",
@@ -2461,11 +2485,16 @@
               "allowed_tools": [],
               "required_tools": [],
               "max_tool_invocations": 0,
+              "context_messages_context_key": "augmented_context",
               "response_contract_text": "Return JSON with keys request_kind, requested_message_count, mail_query, label_ids, output_fields, include_body, and extraction_reason. Set request_kind to profile_status only when the user asks which Gmail/mail profile or account was used for a prior mail operation; otherwise set it to message_review. requested_message_count must be an integer from 1 to 25. Treat written number words from one through twenty-five as explicit counts. If the request says last 3, latest three, last four, or latest four, return 3 or 4 respectively. If no count is explicit and mail_review_limit is numeric, use that. Otherwise return 3. mail_query should be null unless the user explicitly supplied a Gmail search query or sender/topic filter. label_ids should be an empty array unless the user explicitly named Gmail labels. output_fields must be the compact per-message fields required to answer the user's requested output and may use only canonical Gmail result keys. Always include message_id for provenance. Canonicalise requests for received time, received date, or arrival time to the output key date; never emit received_date or received_time. Set include_body=true and include body and body_truncated in output_fields only when the user explicitly requests full message body text; otherwise set include_body=false and omit those fields. If the user explicitly requests fields such as subject and sender, return only message_id plus those requested canonical fields. If the request asks for a summary, digest, triage, comparison, or gist without naming fields, include message_id, subject, sender, date, and snippet.",
               "context_fields": [
                 {
                   "context_key": "prompt",
                   "label": "Current mail-review request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation for prior mailbox scope, requested fields, and named profiles"
                 },
                 {
                   "context_key": "mail_review_limit",

--- a/src/backend/workflows/repo_seed_bundles/concept_search_instance_retrieval_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/concept_search_instance_retrieval_workflow_seed_bundle.json
@@ -2,11 +2,14 @@
   "family_id": "concept_search_instance_retrieval_workflow_seed_bundle",
   "managed_by": "concept_search_instance_retrieval_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "3",
+  "seed_version": "4",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#concept_search_instance_retrieval_workflow": {
       "2": [
         "a5887e22fb952dbdc92312f1e325e6044a0365d29d319f38379000395125357c"
+      ],
+      "3": [
+        "3d008215ae98e89b3743a84795cc144292919e90df3acca5471e1e195cbe595c"
       ]
     }
   },
@@ -36,6 +39,20 @@
             "extractor": "identity",
             "required": true,
             "description": "Pass through the user's concept-profile request."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry bounded prior-turn messages for deictic concept-profile requests."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry the server-projected shared conversation situation for focal-concept continuity."
           }
         ]
       },
@@ -110,6 +127,10 @@
                 {
                   "context_key": "prompt",
                   "label": "Current turn request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation: prior referents, objectives, constraints, and unresolved questions"
                 },
                 {
                   "context_key": "user_concept_id",

--- a/src/backend/workflows/repo_seed_bundles/entity_information_retrieval_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/entity_information_retrieval_workflow_seed_bundle.json
@@ -2,7 +2,14 @@
   "family_id": "entity_information_retrieval_workflow_seed_bundle",
   "managed_by": "entity_information_retrieval_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "13",
+  "seed_version": "14",
+  "known_legacy_authority_payload_sha256_by_seed_version": {
+    "#V#entity_information_retrieval_workflow": {
+      "13": [
+        "ed294d72e1e295fb61abb2b6c58053699a35448973224a6d8d9ed5f97352b84e"
+      ]
+    }
+  },
   "source_tag": "JVNAUTOSCI-2075",
   "supported_action_ids": [
     "llm.action"
@@ -29,6 +36,20 @@
             "extractor": "identity",
             "required": true,
             "description": "Pass through the user's entity-information request."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry bounded prior-turn messages for deictic entity requests."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry the server-projected shared conversation situation for focal-entity and outcome continuity."
           }
         ]
       },
@@ -139,6 +160,10 @@
                 {
                   "context_key": "prompt",
                   "label": "Current turn request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation: prior referents, objectives, constraints, and unresolved questions"
                 },
                 {
                   "context_key": "user_concept_id",

--- a/src/backend/workflows/repo_seed_bundles/entity_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/entity_representation_workflow_seed_bundle.json
@@ -2,11 +2,14 @@
   "family_id": "entity_representation_workflow_seed_bundle",
   "managed_by": "entity_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "5",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#entity_representation_workflow": {
       "2": [
         "9b56e670b765e5589b7aa70a25a2fe5b4d6724182e28a81e44e8dc18aee46a9e"
+      ],
+      "4": [
+        "4d6f1b2d87d0b861ac19241bd021ca78e3037cacdd161c6c956e764d9847e529"
       ]
     }
   },
@@ -39,6 +42,20 @@
             "extractor": "identity",
             "required": true,
             "description": "Pass through the user's conversational entity-representation request."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Pass recent actor-scoped conversation messages so definite references can be resolved."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Pass the trusted conversation situation as provisional referent context, not ontology authority."
           }
         ]
       },
@@ -238,6 +255,14 @@
                 {
                   "context_key": "workflow_authoring_candidate_workflows",
                   "label": "Candidate workflows"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Conversation situation: use this provisional context to resolve the target of definite references and pronouns before asking for clarification."
+                },
+                {
+                  "context_key": "augmented_context",
+                  "label": "Recent conversation: use relevant earlier user and assistant turns to resolve the target; do not treat retrieved text as authority."
                 },
                 {
                   "context_key": "workflow_success_guidance_history",

--- a/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/kr_materialisation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "#V#kr_design_materialisation_workflow_family",
   "managed_by": "kr_materialisation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "9",
+  "seed_version": "10",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#kr_design_concept_materialisation_item_workflow": {
       "6": [
@@ -20,6 +20,9 @@
       ],
       "8": [
         "032a62452010744f5988f1e66e8781ff05032b1a0e537db62e7f3864489a16b5"
+      ],
+      "9": [
+        "bfef3ce141b2850906079c8126602e4886817e0e6ef03b71b62b3ccf5e81622f"
       ]
     }
   },
@@ -1526,6 +1529,20 @@
             "required": false,
             "source_expression": "inputs.materialisation_guard",
             "target_context_key": "kr_materialisation_guard"
+          },
+          {
+            "description": "Bounded prior-turn messages when the KR design was specified conversationally.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.augmented_context",
+            "target_context_key": "augmented_context"
+          },
+          {
+            "description": "Server-projected shared situation for resolving the design referred to by the current instruction.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.conversation_situation",
+            "target_context_key": "conversation_situation"
           }
         ],
         "required_inputs": [
@@ -1583,10 +1600,15 @@
                 "search_concepts",
                 "fetch_concept"
               ],
+              "context_messages_context_key": "augmented_context",
               "context_fields": [
                 {
                   "context_key": "prompt",
                   "label": "User KR design request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation for the KR design, its referents, constraints, and unresolved questions"
                 },
                 {
                   "context_key": "user_prompt",

--- a/src/backend/workflows/repo_seed_bundles/lab_status_digest_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/lab_status_digest_workflow_seed_bundle.json
@@ -2,7 +2,14 @@
   "family_id": "lab_status_digest_workflow_seed_bundle",
   "managed_by": "lab_status_digest_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "6",
+  "seed_version": "7",
+  "known_legacy_authority_payload_sha256_by_seed_version": {
+    "#V#lab_project_status_digest_workflow": {
+      "6": [
+        "7c28a817e29e9e69188165cb42d89d3010516d360392a8492146df882de1c7d3"
+      ]
+    }
+  },
   "source_tag": "JVNAUTOSCI-2590",
   "supported_action_ids": [
     "workflow_mcp.invoke_tool",
@@ -30,6 +37,20 @@
             "extractor": "identity",
             "required": true,
             "description": "The requested status-digest scope and reporting window."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry bounded prior-turn messages when the digest scope was established conversationally."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry the server-projected shared situation for project scope, obligations, and reporting-window continuity."
           }
         ]
       },
@@ -180,10 +201,15 @@
               "project_raw_response_to_final_response": true,
               "max_output_tokens": 4096,
               "response_contract_text": "Return status_digest_synthesis.v1 JSON with digest_markdown, work_product_id, evidence_window, and unavailable_source_classes. Use only the supplied prior-digest, Jira, and repository evidence. Every material claim must carry an issue key, commit, branch, or represented concept locator. Keep Jira Done, workflow completed, and capability passed distinct. Do not emit tool calls or claim persistence; represented deterministic states own persistence and read-back.",
+              "context_messages_context_key": "augmented_context",
               "context_fields": [
                 {
                   "context_key": "prompt",
                   "label": "Current status-digest request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation: selected project scope, obligations, constraints, and unresolved questions"
                 },
                 {
                   "context_key": "user_concept_id",

--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,11 +2,14 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "21",
+  "seed_version": "22",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
         "bfc761fc3407b0ffdbe7bb5a6662a0c49755ccd6c25df1d8eaede247bacbcfb1"
+      ],
+      "21": [
+        "73d2d1570351c56cfb98fbecb409a8dfc306cade830ff73b40c5d916868a6cb9"
       ]
     },
     "#V#source_neutral_paper_reference_ingestion_workflow": {
@@ -1708,6 +1711,20 @@
             "extractor": "arxiv_id_list",
             "required": false,
             "source_expression": "inputs.augmented_context",
+            "target_context_key": "arxiv_ids"
+          },
+          {
+            "description": "Resolve an arXiv identifier from the server-projected shared situation when the current request refers to an established paper.",
+            "extractor": "arxiv_id",
+            "required": false,
+            "source_expression": "inputs.conversation_situation",
+            "target_context_key": "arxiv_id"
+          },
+          {
+            "description": "Resolve all arXiv identifiers from the server-projected shared situation when the current request refers to an established paper set.",
+            "extractor": "arxiv_id_list",
+            "required": false,
+            "source_expression": "inputs.conversation_situation",
             "target_context_key": "arxiv_ids"
           },
           {

--- a/src/backend/workflows/repo_seed_bundles/represented_artefact_creation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/represented_artefact_creation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "represented_artefact_creation_workflow_seed_bundle",
   "managed_by": "represented_artefact_creation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "8",
+  "seed_version": "9",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#represented_artefact_creation_workflow": {
       "5": [
@@ -12,6 +12,9 @@
         "8d8667342c20b0f97b99ee48bfb9e875568b28ba5ea022d17fd8a69891f3d2db"
       ],
       "7": [
+        "76a561b09bf0e4ae165ffb25e775373ef8afb1d79a7cee0859aac2212a28d0f9"
+      ],
+      "8": [
         "76a561b09bf0e4ae165ffb25e775373ef8afb1d79a7cee0859aac2212a28d0f9"
       ]
     },
@@ -65,6 +68,20 @@
             "extractor": "identity",
             "required": false,
             "description": "Alias for prompts and replay tooling that use user_prompt."
+          },
+          {
+            "target_context_key": "augmented_context",
+            "source_expression": "inputs.augmented_context",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry bounded prior-turn messages when the represented artefact was specified conversationally."
+          },
+          {
+            "target_context_key": "conversation_situation",
+            "source_expression": "inputs.conversation_situation",
+            "extractor": "identity",
+            "required": false,
+            "description": "Carry the server-projected shared situation into the parent planning boundary only."
           }
         ]
       },
@@ -110,10 +127,15 @@
               "required_tools": [],
               "max_tool_invocations": 4,
               "policy_stage": "represented_artefact_set_extraction",
+              "context_messages_context_key": "augmented_context",
               "context_fields": [
                 {
                   "context_key": "prompt",
                   "label": "Current represented-artefact request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation for resolving prior artefact specifications and referents"
                 },
                 {
                   "context_key": "user_prompt",
@@ -242,10 +264,15 @@
                 "search_concepts",
                 "fetch_concept"
               ],
+              "context_messages_context_key": "augmented_context",
               "context_fields": [
                 {
                   "context_key": "prompt",
                   "label": "Current represented-artefact request"
+                },
+                {
+                  "context_key": "conversation_situation",
+                  "label": "Shared conversation situation for resolving prior artefact specifications and referents"
                 },
                 {
                   "context_key": "user_prompt",

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -3376,6 +3376,110 @@ def test_indeterminate_effect_stops_later_effect_but_allows_readback(
     assert blocked["error_code"] == "prior_effect_outcome_indeterminate"
 
 
+def test_exact_terminal_reconciliation_preserves_recovered_ontology_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    concept_id = "#V#nichola_raihani"
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "reconcile_governed_ontology_postcondition",
+        lambda **_kwargs: {
+            "success": True,
+            "verified": True,
+            "status": "verified",
+            "method_name": "create_concepts",
+            "receipt_id": "omr-nichola",
+            "intent_fingerprint": "intent-nichola",
+            "target_concept_ids": [concept_id],
+            "canonical_read_back": {"concepts": [{"concept_id": concept_id}]},
+        },
+    )
+
+    gateway = _effect_gateway(
+        lambda name, _arguments: (
+            {
+                "success": False,
+                "effect_status": "indeterminate",
+                "mutation_outcome": "unknown",
+                "outcome_finality": "requires_canonical_reconciliation",
+                "changed": None,
+                "error_code": "ontology_mutation_postcondition_failed",
+                "created_concept_ids": [concept_id],
+                "authority_receipt": {
+                    "receipt_id": "omr-nichola",
+                    "status": "indeterminate",
+                    "intent_fingerprint": "intent-nichola",
+                },
+                "postcondition_reconciliation": {
+                    "schema_version": (
+                        "ontology_mutation_postcondition_reconciliation.v1"
+                    )
+                },
+            }
+            if name == "create_concepts"
+            else {"success": True}
+        )
+    )
+    answer = f"I represented Nichola Raihani as {concept_id}."
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="create-nichola",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "concepts": [
+                                {
+                                    "concept_id": concept_id,
+                                    "name": "Nichola Raihani",
+                                }
+                            ]
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response=answer),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Represent her comprehensively.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-reconcile-nichola",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "completed"
+    assert result.effect_finality_fallback is False
+    assert result.response_text == answer
+    tool_messages = [
+        item
+        for item in client.calls[1]["context"]
+        if item.get("role") == "tool"
+    ]
+    model_receipt = json.loads(tool_messages[-1]["content"])
+    assert model_receipt["effect_status"] == "succeeded"
+    assert model_receipt["reconciliation_status"] == "canonically_verified"
+    assert model_receipt["result_target_ids"] == [concept_id]
+    invocation = result.tool_invocations[0]
+    assert invocation["effect_status"] == "succeeded"
+    assert invocation["initial_effect_status"] == "indeterminate"
+    assert invocation["reconciliation_status"] == "canonically_verified"
+    assert invocation["canonical_readback"]["verified"] is True
+    assert invocation["result_target_ids"] == [concept_id]
+
+
 def test_per_method_minimum_admits_sequential_effects_below_hard_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -8436,6 +8540,9 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
         user_concept_id="#V#real_user",
         org_concept_id="#V#real_org",
         workflow_launch_inputs={"authorised_record": "#V#request_record"},
+        conversation_situation=(
+            "The represented record currently under discussion is #V#record."
+        ),
         turn_id="turn-represented-workflow",
         turn_budget_seconds=20,
         final_synthesis_reserve_seconds=2,
@@ -8464,6 +8571,9 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
     assert seen_arguments["inputs"]["user_concept_id"] == "#V#real_user"
     assert seen_arguments["inputs"]["record_id"] == "#V#record"
     assert seen_arguments["inputs"]["authorised_record"] == "#V#request_record"
+    assert seen_arguments["inputs"]["conversation_situation"] == (
+        "The represented record currently under discussion is #V#record."
+    )
     assert seen_arguments["source_event_type"] == "conversation_turn"
     assert seen_arguments["source_event_id"] == "turn-represented-workflow"
     assert seen_arguments["timeout_seconds"] == 90.0

--- a/tests/backend/test_concept_search_instance_retrieval_workflow_vontology_service.py
+++ b/tests/backend/test_concept_search_instance_retrieval_workflow_vontology_service.py
@@ -87,6 +87,12 @@ def test_bootstrap_materialises_concept_search_instance_retrieval_workflow(
     assert isinstance(launch_contract, dict)
     assert launch_source.startswith("text_relation:")
     assert launch_contract.get("required_inputs") == ["prompt"]
+    launch_sources = {
+        mapping.get("source_expression")
+        for mapping in launch_contract.get("input_mappings") or []
+    }
+    assert "inputs.augmented_context" in launch_sources
+    assert "inputs.conversation_situation" in launch_sources
 
     required_effects_contract = definition.metadata.get("required_effects_contract")
     assert isinstance(required_effects_contract, dict)
@@ -129,6 +135,11 @@ def test_bootstrap_materialises_concept_search_instance_retrieval_workflow(
         "find_relations_with_argument",
     ]
     assert llm_policy.get("max_tool_invocations") == 6
+    assert llm_policy.get("context_messages_context_key") == "augmented_context"
+    assert "conversation_situation" in {
+        field.get("context_key")
+        for field in llm_policy.get("context_fields") or []
+    }
 def test_concept_search_instance_retrieval_prompt_support_seeds_content(
     _reset_mock_db: Any,
 ) -> None:

--- a/tests/backend/test_conversation_situation_turn_projection.py
+++ b/tests/backend/test_conversation_situation_turn_projection.py
@@ -253,6 +253,58 @@ def test_consent_turn_merges_model_sidecar_with_verified_effect_readback() -> No
     assert "private mail must never enter the situation" not in merged
 
 
+def test_later_canonical_reconciliation_supersedes_stale_indeterminate_state() -> None:
+    concept_id = "#V#nichola_raihani"
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-reconciled-create",
+        terminal_status="completed",
+        response_text=f"Represented Nichola Raihani as {concept_id}.",
+        tool_invocations=[
+            {
+                "tool": "create_concepts",
+                "status": "ok",
+                "effect_id": "effect-create-nichola",
+                "effect_status": "succeeded",
+                "initial_effect_status": "indeterminate",
+                "changed": True,
+                "reconciliation_status": "canonically_verified",
+                "result_target_ids": [concept_id],
+                "effective_payload": {
+                    "success": False,
+                    "effect_status": "indeterminate",
+                    "outcome_finality": "requires_canonical_reconciliation",
+                },
+            }
+        ],
+    )
+
+    assert projection is not None
+    assert projection["verified_concept_ids"] == [concept_id]
+    assert projection["effects"] == [
+        {
+            "tool": "create_concepts",
+            "status": "succeeded",
+            "effect_id": "effect-create-nichola",
+            "changed": True,
+            "reconciliation_status": "canonically_verified",
+            "target_ids": [concept_id],
+            "mode": "created",
+        }
+    ]
+
+    merged = merge_conversation_situation_turn_projection(
+        current_situation=(
+            "The Nichola Raihani mutation may not have completed and needs checking."
+        ),
+        model_situation=None,
+        projection=projection,
+    )
+
+    assert merged is not None
+    assert "reconciliation=canonically_verified" in merged
+    assert f"targets={concept_id}" in merged
+
+
 def test_mixed_partial_turn_preserves_stable_receipt_and_workflow_status_only() -> None:
     projection = build_conversation_situation_turn_projection(
         request_id="turn-partial",

--- a/tests/backend/test_entity_information_retrieval_workflow_vontology_service.py
+++ b/tests/backend/test_entity_information_retrieval_workflow_vontology_service.py
@@ -100,6 +100,12 @@ def test_bootstrap_materialises_entity_information_retrieval_workflow(
     assert isinstance(launch_contract, dict)
     assert launch_source.startswith("text_relation:")
     assert launch_contract.get("required_inputs") == ["prompt"]
+    launch_sources = {
+        mapping.get("source_expression")
+        for mapping in launch_contract.get("input_mappings") or []
+    }
+    assert "inputs.augmented_context" in launch_sources
+    assert "inputs.conversation_situation" in launch_sources
 
     required_effects_contract = definition.metadata.get("required_effects_contract")
     assert isinstance(required_effects_contract, dict)
@@ -174,6 +180,11 @@ def test_bootstrap_materialises_entity_information_retrieval_workflow(
         "list_uncertain_relationship_assertions",
     ]
     assert llm_policy.get("max_tool_invocations") == 5
+    assert llm_policy.get("context_messages_context_key") == "augmented_context"
+    assert "conversation_situation" in {
+        field.get("context_key")
+        for field in llm_policy.get("context_fields") or []
+    }
     response_contract = llm_policy.get("response_contract_text")
     assert isinstance(response_contract, str)
     assert "Once the five required evidence tools have succeeded" in response_contract

--- a/tests/backend/test_entity_representation_workflow_vontology_service.py
+++ b/tests/backend/test_entity_representation_workflow_vontology_service.py
@@ -79,6 +79,26 @@ def test_bootstrap_materialises_entity_representation_workflow_family(
     assert isinstance(launch_contract, dict)
     assert launch_source.startswith("text_relation:")
     assert launch_contract.get("required_inputs") == ["prompt"]
+    input_mappings = launch_contract.get("input_mappings") or []
+    assert {
+        mapping.get("target_context_key")
+        for mapping in input_mappings
+        if isinstance(mapping, dict)
+    } >= {"prompt", "augmented_context", "conversation_situation"}
+
+    preflight_state = next(
+        state
+        for state_id, state in definition.states.items()
+        if state_id.endswith("_decide_entity_path")
+    )
+    context_keys = {
+        item.get("context_key")
+        for item in (preflight_state.metadata.get("llm_policy") or {}).get(
+            "context_fields", []
+        )
+        if isinstance(item, dict)
+    }
+    assert {"augmented_context", "conversation_situation"}.issubset(context_keys)
 
     routing_profile, routing_source = resolve_workflow_routing_profile(
         ENTITY_REPRESENTATION_WORKFLOW_ID

--- a/tests/backend/test_episode_critic_evidence_service.py
+++ b/tests/backend/test_episode_critic_evidence_service.py
@@ -1,7 +1,22 @@
 from types import SimpleNamespace
 
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+)
+
 
 def _sample_llm_debug() -> dict:
+    applied_prompt_snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#user",
+        namespace="#V#user@org",
+        organisation_concept_id="#V#org",
+        turn_id="req-critic-1",
+        behaviour_fragments=[
+            {"concept_id": "#V#critic_prompt", "content": "Be precise."}
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
     return {
         "request_id": "req-critic-1",
         "model": "gpt-5.4-mini",
@@ -27,6 +42,7 @@ def _sample_llm_debug() -> dict:
         "llm_allowed_tools": ["search_concepts"],
         "allowed_write_tools": [],
         "aux_llm_calls": [{"model": "gpt-5.4-mini", "prompt": "x", "response": "y"}],
+        "applied_prompt_snapshot": applied_prompt_snapshot,
     }
 
 
@@ -96,9 +112,13 @@ def test_episode_critic_bundle_reconstructs_turn_record_and_emits_receipts(monke
         == "chat_history.reconstructed_turn_execution_record"
     )
     assert result["observed_evidence"]["turn_execution_record"]["request_id"] == "req-critic-1"
+    assert result["observed_evidence"]["applied_prompt_snapshot"]["prompts"][0][
+        "concept_id"
+    ] == "#V#critic_prompt"
     assert result["observed_evidence"]["tool_ledger"]["search_evidence_count"] == 1
     assert result["expected_context"]["allowed_tool_families"] == ["search"]
     assert result["receipts"]["turn_execution_record"]["present"] is True
+    assert result["receipts"]["applied_prompt_snapshot"]["present"] is True
     assert result["bundle_receipt"]["sha256"]
 
 

--- a/tests/backend/test_failure_case_intake_service.py
+++ b/tests/backend/test_failure_case_intake_service.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import hashlib
 from typing import Any, Mapping
 
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+)
 from src.backend.services.failure_case_intake_service import (
     FAILURE_CASE_INTAKE_COLLECT_ACTION_ID,
     FAILURE_CASE_INTAKE_SCHEMA_VERSION,
@@ -54,6 +57,20 @@ def test_collect_failure_case_intake_uses_canonical_sources_for_unsigned_ref() -
             "include_legacy": False,
         },
     }
+    applied_prompt_snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#michael_witbrock",
+        namespace=namespace,
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+        turn_id=request_id,
+        behaviour_fragments=[
+            {
+                "concept_id": "#V#gemma_failure_prompt_v1",
+                "content": "The exact prompt content used by the target turn.",
+            }
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
     invoker = RecordingInvoker(
         {
             "chat_history_get_segments": {
@@ -137,6 +154,7 @@ def test_collect_failure_case_intake_uses_canonical_sources_for_unsigned_ref() -
             "turn_execution_get": {
                 "success": True,
                 "request_id": request_id,
+                "applied_prompt_snapshot": applied_prompt_snapshot,
                 "final_response": {"text": "It produced an unhelpful answer."},
                 "workflow_selection": {
                     "selected_workflow_id": "prompt_improvement_failure",
@@ -184,6 +202,15 @@ def test_collect_failure_case_intake_uses_canonical_sources_for_unsigned_ref() -
     assert payload["model"]["target_model_matches_primary"] is True
     assert payload["workflow"]["selected_workflow_id"] == "prompt_improvement_failure"
     assert "#V#gemma_failure_prompt_v1" in payload["prompt_metadata"]["prompt_ids"]
+    assert payload["prompt_metadata"]["applied_prompt_ids"] == [
+        "#V#gemma_failure_prompt_v1"
+    ]
+    assert payload["applied_prompt_snapshot"]["source"] == (
+        "target_turn_applied_prompt_snapshot"
+    )
+    assert payload["applied_prompt_snapshot"]["prompts"][0]["content"] == (
+        "The exact prompt content used by the target turn."
+    )
     assert payload["tool_ledger"]["counts"] == {
         "total": 2,
         "success": 1,

--- a/tests/backend/test_failure_case_prompt_replay_experiment_service.py
+++ b/tests/backend/test_failure_case_prompt_replay_experiment_service.py
@@ -132,6 +132,23 @@ def test_prepare_failure_case_prompt_replay_experiment_builds_spec_inputs() -> N
     }
 
 
+def test_replay_uses_target_turn_applied_prompt_before_generic_prompt_metadata() -> (
+    None
+):
+    intake = _sample_failure_case_intake()
+    intake["prompt_metadata"]["applied_prompt_ids"] = [
+        "#V#historically_applied_prompt"
+    ]
+    intake["prompt_metadata"]["prompt_variant_selections"] = []
+
+    payload = prepare_failure_case_prompt_replay_experiment(
+        failure_case_intake=intake,
+        prompt_variant_ids=["#V#candidate_variant"],
+    )
+
+    assert payload["base_prompt_id"] == "#V#historically_applied_prompt"
+
+
 def test_prompt_replay_prepare_action_uses_accumulated_failure_context() -> None:
     registry = ActionRegistry()
     register_failure_case_prompt_improvement_actions(registry)

--- a/tests/backend/test_internal_mcp_chat_prompt_tools.py
+++ b/tests/backend/test_internal_mcp_chat_prompt_tools.py
@@ -5,6 +5,7 @@ basic handler behaviour.
 """
 
 from src.backend.integrations.internal_mcp.catalogue import (
+    _chat_get_applied_prompt_context,
     _chat_get_prompt_context,
     _chat_introspect,
     _settings_get_public,
@@ -12,6 +13,15 @@ from src.backend.integrations.internal_mcp.catalogue import (
 )
 from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
 from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.services.adaptive_turn_service import (
+    _model_visible_input_schema,
+    _trusted_tool_payload,
+    ordinary_turn_capability_delegation,
+)
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+    serialise_applied_prompt_snapshot,
+)
 
 _BEHAVIOUR_PROMPT_TYPES = (
     "#V#von_chat_behaviour_prompt",
@@ -65,8 +75,119 @@ def test_chat_prompt_tool_registered_in_catalogue():
     catalogue = build_default_catalogue()
     names = set(catalogue.list_methods())
     assert "chat_get_prompt_context" in names
+    assert "chat_get_applied_prompt_context" in names
     assert "chat_introspect" in names
     assert "settings_get_public" in names
+
+
+def _applied_prompt_snapshot_json(user_concept_id="#V#michael_witbrock"):
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id=user_concept_id,
+        namespace=f"{user_concept_id}@university_of_auckland_strong_ai_lab",
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+        turn_id="turn-123",
+        behaviour_fragments=[
+            {"concept_id": "#V#behaviour_prompt", "content": "Be precise."},
+        ],
+        narration_fragments=[
+            {"concept_id": "#V#narration_prompt", "content": "Speak plainly."},
+        ],
+        screen_fragments=[
+            {"concept_id": "#V#screen_prompt", "content": "Use Markdown."},
+        ],
+    )
+    return serialise_applied_prompt_snapshot(snapshot)
+
+
+def test_chat_get_applied_prompt_context_returns_exact_turn_snapshot():
+    result = _chat_get_applied_prompt_context(
+        applied_prompt_snapshot_json=_applied_prompt_snapshot_json(),
+        include_content=True,
+        namespace="#V#attempted_other_user",
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "server_bound_turn_snapshot"
+    assert result["turn_id"] == "turn-123"
+    assert result["actor"]["user_concept_id"] == "#V#michael_witbrock"
+    assert result["prompt_classes"] == ["behaviour", "narration", "screen"]
+    assert result["prompt_concept_ids"] == [
+        "#V#behaviour_prompt",
+        "#V#narration_prompt",
+        "#V#screen_prompt",
+    ]
+    assert [item["content"] for item in result["prompts"]] == [
+        "Be precise.",
+        "Speak plainly.",
+        "Use Markdown.",
+    ]
+    assert all(len(item["content_sha256"]) == 64 for item in result["prompts"])
+
+
+def test_chat_get_applied_prompt_context_requires_server_bound_snapshot():
+    result = _chat_get_applied_prompt_context(
+        applied_prompt_snapshot_json=None,
+        include_content=True,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "trusted_turn_snapshot_required"
+
+
+def test_chat_get_applied_prompt_context_rejects_modified_snapshot():
+    snapshot_json = _applied_prompt_snapshot_json().replace(
+        "Be precise.", "Read another user's prompt."
+    )
+    result = _chat_get_applied_prompt_context(
+        applied_prompt_snapshot_json=snapshot_json,
+        include_content=True,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_trusted_turn_snapshot"
+
+
+def test_applied_prompt_capability_is_delegated_only_with_trusted_snapshot():
+    gateway = _build_gateway()
+    definition = gateway.get_method_definition("chat_get_applied_prompt_context")
+    assert definition is not None
+    assert definition.ordinary_turn_excluded_reason is None
+    assert definition.ordinary_turn_trusted_argument_bindings == {
+        "applied_prompt_snapshot_json": "applied_prompt_snapshot"
+    }
+
+    without_snapshot = ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#michael_witbrock",
+        trusted_argument_values=None,
+    )
+    assert "chat_get_applied_prompt_context" not in without_snapshot
+
+    trusted_snapshot = _applied_prompt_snapshot_json()
+    with_snapshot = ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#michael_witbrock",
+        trusted_argument_values={"applied_prompt_snapshot": trusted_snapshot},
+    )
+    assert "chat_get_applied_prompt_context" in with_snapshot
+
+    visible_schema = _model_visible_input_schema(
+        definition,
+        {"applied_prompt_snapshot": trusted_snapshot},
+    )
+    assert "applied_prompt_snapshot_json" not in visible_schema["properties"]
+    assert "applied_prompt_snapshot_json" not in visible_schema.get("required", [])
+
+    payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="chat_get_applied_prompt_context",
+        model_payload={
+            "applied_prompt_snapshot_json": _applied_prompt_snapshot_json(
+                "#V#attempted_other_user"
+            ),
+            "include_content": False,
+        },
+        trusted_argument_values={"applied_prompt_snapshot": trusted_snapshot},
+    )
+    assert payload["applied_prompt_snapshot_json"] == trusted_snapshot
 
 
 def test_chat_get_prompt_context_requires_namespace():

--- a/tests/backend/test_kr_materialisation_workflow_vontology_service.py
+++ b/tests/backend/test_kr_materialisation_workflow_vontology_service.py
@@ -210,7 +210,7 @@ def test_kr_prompt_seed_assets_hold_operational_prompt_content() -> None:
 
 def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
     bundle = json.loads(_SEED_BUNDLE_PATH.read_text(encoding="utf-8"))
-    assert bundle["seed_version"] == "9"
+    assert bundle["seed_version"] == "10"
     assert bundle["known_legacy_authority_payload_sha256_by_seed_version"] == {
         mod.KR_DESIGN_CONCEPT_MATERIALISATION_ITEM_WORKFLOW_ID: {
             "6": [
@@ -228,6 +228,9 @@ def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
             ],
             "8": [
                 "032a62452010744f5988f1e66e8781ff05032b1a0e537db62e7f3864489a16b5"
+            ],
+            "9": [
+                "bfef3ce141b2850906079c8126602e4886817e0e6ef03b71b62b3ccf5e81622f"
             ]
         }
     }
@@ -253,6 +256,12 @@ def test_kr_seed_applies_optional_guard_before_each_write_phase() -> None:
         for row in bundle["workflows"]
         if row["workflow_id"] == mod.KR_DESIGN_MATERIALISATION_WORKFLOW_ID
     )
+    launch_sources = {
+        mapping.get("source_expression")
+        for mapping in workflow["launch_input_contract"]["input_mappings"]
+    }
+    assert "inputs.augmented_context" in launch_sources
+    assert "inputs.conversation_situation" in launch_sources
     states = {row["state_id"]: row for row in workflow["publication_spec"]["steps"]}
 
     assert workflow["launch_input_contract"]["excluded_ambient_input_keys"] == [

--- a/tests/backend/test_lab_status_digest_workflow_vontology_service.py
+++ b/tests/backend/test_lab_status_digest_workflow_vontology_service.py
@@ -80,6 +80,12 @@ def test_bootstrap_materialises_lab_status_digest_authority(
     )
     assert launch_source.startswith("text_relation:")
     assert (launch_contract or {}).get("required_inputs") == ["prompt"]
+    launch_sources = {
+        mapping.get("source_expression")
+        for mapping in (launch_contract or {}).get("input_mappings") or []
+    }
+    assert "inputs.augmented_context" in launch_sources
+    assert "inputs.conversation_situation" in launch_sources
 
     required_effects = (
         definition.metadata.get("required_effects_contract") or {}
@@ -124,6 +130,14 @@ def test_bootstrap_materialises_lab_status_digest_authority(
     assert synthesise_action.llm_policy["tool_mode"] == "none"
     assert synthesise_action.llm_policy["selection_policy"] == "active_only"
     assert synthesise_action.llm_policy["max_output_tokens"] == 4096
+    assert (
+        synthesise_action.llm_policy["context_messages_context_key"]
+        == "augmented_context"
+    )
+    assert "conversation_situation" in {
+        field.get("context_key")
+        for field in synthesise_action.llm_policy.get("context_fields") or []
+    }
     assert synthesise_action.validation_policy["output_format"] == "json_value"
 
     persist_state = state_for("persist_digest")

--- a/tests/backend/test_ontology_create_authority_containment.py
+++ b/tests/backend/test_ontology_create_authority_containment.py
@@ -413,6 +413,151 @@ def test_failed_create_readback_never_follows_an_existing_concept_id(
     assert readback["concepts"] == []
 
 
+def test_later_create_postcondition_reuses_the_original_immutable_intent(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    concept_id = "#V#nichola_raihani"
+    arguments = {
+        "instance_of_type": "#V#person",
+        "concepts": [
+            {
+                "concept_id": concept_id,
+                "name": "Nichola Raihani",
+                "description": "A behavioural scientist.",
+                "notes": "Represented from the conversation.",
+                "kind": "instance",
+            }
+        ],
+    }
+    governed_arguments = command.resolve_governed_ontology_arguments(
+        "create_concepts",
+        command.normalise_governed_ontology_arguments(
+            "create_concepts",
+            arguments,
+        ),
+    )
+    intent = authority.OntologyMutationIntent(
+        operation="concept.create",
+        publication_context=authority.PublicationContext.user("#V#person"),
+        target_concept_ids=(concept_id, "#V#person"),
+        tool_name="create_concepts",
+        delta={
+            "concepts": [
+                {
+                    "concept_id": concept_id,
+                    "name": "Nichola Raihani",
+                    "description": "A behavioural scientist.",
+                    "notes": "Represented from the conversation.",
+                    "kind": "instance",
+                    "instance_of_type": "#V#person",
+                    "vontology_path": None,
+                }
+            ],
+            "expected_concept_id": concept_id,
+            "parent_id": None,
+            "parent_concept_ids": [],
+            "instance_of_type": "#V#person",
+            "referenced_concept_ids": ["#V#person"],
+            "scope_mode": "user_only_default",
+            "stored_scope": {},
+            "maintain_parent_inverse": False,
+            "effect_arguments_sha256": command._effect_arguments_sha256(
+                governed_arguments
+            ),
+        },
+    )
+    canonical_state = {
+        "concepts": [
+            {
+                "concept_id": concept_id,
+                "exists": True,
+                "publication_context": authority.PublicationContext.user(
+                    "#V#person"
+                ).to_mapping(),
+                "forward_relationships": {
+                    "is_a_type_of": [],
+                    "is_an_instance_of": ["#V#person"],
+                    "linked_to": [],
+                },
+                "attributes": {},
+                "system_tags": [],
+                "user_tags": [],
+                "vontology_path": None,
+                "text_relations": [
+                    {
+                        "predicate": "hasName",
+                        "text": "Nichola Raihani",
+                        "context": {"name_type": "NL"},
+                    },
+                    {
+                        "predicate": "hasDescription",
+                        "text": "A behavioural scientist.",
+                        "context": {},
+                    },
+                    {
+                        "predicate": "hasNote",
+                        "text": "Represented from the conversation.",
+                        "context": {},
+                    },
+                ],
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        command,
+        "canonical_read_back_for_method",
+        lambda **_kwargs: canonical_state,
+    )
+    monkeypatch.setattr(
+        command,
+        "reconcile_indeterminate_mutation_receipt",
+        lambda **kwargs: {
+            "receipt_id": kwargs["receipt_id"],
+            "status": "succeeded",
+        },
+    )
+    original_result = {
+        "success": False,
+        "effect_status": "indeterminate",
+        "changed": None,
+        "outcome_finality": "requires_canonical_reconciliation",
+        "created_concept_ids": [concept_id],
+        "authority_receipt": {
+            "receipt_id": "omr-nichola",
+            "status": "indeterminate",
+            "intent_fingerprint": intent.fingerprint,
+        },
+        "postcondition_reconciliation": (
+            command._postcondition_reconciliation_contract(
+                method_name="create_concepts",
+                intent=intent,
+            )
+        ),
+    }
+
+    reconciled = command.reconcile_governed_ontology_postcondition(
+        method_name="create_concepts",
+        arguments=arguments,
+        original_result=original_result,
+    )
+
+    assert reconciled["verified"] is True
+    assert reconciled["target_concept_ids"] == [concept_id, "#V#person"]
+    assert reconciled["authority_receipt"]["status"] == "succeeded"
+
+    changed_arguments = {**arguments, "instance_of_type": "#V#other_type"}
+    rejected = command.reconcile_governed_ontology_postcondition(
+        method_name="create_concepts",
+        arguments=changed_arguments,
+        original_result=original_result,
+    )
+    assert rejected["verified"] is False
+    assert rejected["error_code"] == "ontology_reconciliation_contract_invalid"
+
+
 def test_inaccessible_create_collision_is_non_disclosing(monkeypatch) -> None:
     from src.backend.services import ontology_mutation_command_service as command
     from src.backend.services import ontology_publication_authority_service as authority

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -423,6 +423,44 @@ def test_mutation_receipt_reconciles_and_replays_idempotently(
     assert receipts.count_documents({}) == 1
 
 
+def test_indeterminate_receipt_can_be_finalised_by_exact_later_reconciliation(
+    authority_stores,
+) -> None:
+    service, _delegations, receipts = authority_stores
+    now = datetime.now(UTC)
+    receipts.insert_one(
+        {
+            "schema_version": service.RECEIPT_SCHEMA_VERSION,
+            "receipt_id": "omr-later-proof",
+            "actor_concept_id": "#V#admin",
+            "intent_fingerprint": "intent-proof-1",
+            "status": "indeterminate",
+            "mutation_outcome": "unknown",
+            "changed": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+
+    with service.override_current_actor("#V#admin", None):
+        reconciled = service.reconcile_indeterminate_mutation_receipt(
+            receipt_id="omr-later-proof",
+            intent_fingerprint="intent-proof-1",
+            canonical_read_back={"concepts": [{"concept_id": "#V#person_a"}]},
+            response_projection={
+                "success": True,
+                "effect_status": "succeeded",
+            },
+        )
+
+    assert reconciled is not None
+    assert reconciled["status"] == "succeeded"
+    assert reconciled["changed"] is True
+    stored = receipts.find_one({"receipt_id": "omr-later-proof"})
+    assert stored["reconciled_from_status"] == "indeterminate"
+    assert stored["response_effect_status"] == "succeeded"
+
+
 def test_agent_without_delegation_and_raw_payload_actor_fail_closed(
     authority_stores,
     monkeypatch,

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -961,6 +961,22 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
     assert any(
         isinstance(item, dict)
         and item.get("target_context_key") == "arxiv_id"
+        and item.get("source_expression") == "inputs.conversation_situation"
+        and item.get("extractor") == "arxiv_id"
+        and item.get("required") is False
+        for item in input_mappings
+    )
+    assert any(
+        isinstance(item, dict)
+        and item.get("target_context_key") == "arxiv_ids"
+        and item.get("source_expression") == "inputs.conversation_situation"
+        and item.get("extractor") == "arxiv_id_list"
+        and item.get("required") is False
+        for item in input_mappings
+    )
+    assert any(
+        isinstance(item, dict)
+        and item.get("target_context_key") == "arxiv_id"
         and item.get("source_expression")
         == "inputs.turn_expected_outcome_contract.summary"
         and item.get("extractor") == "arxiv_id"
@@ -1842,6 +1858,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
     assert {
         "inputs.arxiv_id",
         "inputs.augmented_context",
+        "inputs.conversation_situation",
         "inputs.turn_expected_outcome_contract.summary",
         "inputs.turn_expected_outcome_contract_state.fields.summary",
         "inputs.workflow_discovery_result.discovery_query_input",
@@ -1856,6 +1873,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         "inputs.arxiv_id",
         "inputs.prompt",
         "inputs.augmented_context",
+        "inputs.conversation_situation",
         "inputs.turn_expected_outcome_contract.summary",
         "inputs.turn_expected_outcome_contract_state.fields.summary",
         "inputs.workflow_discovery_result.discovery_query_input",
@@ -1871,7 +1889,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "21" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "22" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID

--- a/tests/backend/test_repo_seed_bundle_invariants.py
+++ b/tests/backend/test_repo_seed_bundle_invariants.py
@@ -223,6 +223,38 @@ def test_legacy_general_mail_review_is_not_an_ordinary_routing_candidate() -> No
     assert routing_profile["retained_for_explicit_durable_review_only"] is True
 
 
+def test_general_mail_review_receives_conversation_context_only_at_judgement_steps() -> (
+    None
+):
+    payload = json.loads(CANONICAL_BUNDLE_PATH.read_text(encoding="utf-8"))
+    workflow = next(
+        item
+        for item in payload.get("workflows", [])
+        if item.get("workflow_id") == "#V#general_mail_review_workflow"
+    )
+    launch_sources = {
+        mapping.get("source_expression")
+        for mapping in workflow["launch_input_contract"]["input_mappings"]
+    }
+    assert "inputs.augmented_context" in launch_sources
+    assert "inputs.conversation_situation" in launch_sources
+
+    steps = {
+        step["state_id"]: step for step in workflow["publication_spec"]["steps"]
+    }
+    for state_id in ("resolve_mail_profile", "extract_mail_review_request_parameters"):
+        policy = steps[state_id]["llm_policy"]
+        assert policy["context_messages_context_key"] == "augmented_context"
+        assert "conversation_situation" in {
+            field.get("context_key") for field in policy["context_fields"]
+        }
+    render_policy = steps["render_mail_review_response"]["llm_policy"]
+    assert render_policy.get("context_messages_context_key") is None
+    assert "conversation_situation" not in {
+        field.get("context_key") for field in render_policy["context_fields"]
+    }
+
+
 def test_repo_seeded_gmail_list_steps_use_semantic_mailbox_scope() -> None:
     canonical = json.loads(CANONICAL_BUNDLE_PATH.read_text(encoding="utf-8"))
     mail_review = next(

--- a/tests/backend/test_represented_artefact_creation_workflow_vontology_service.py
+++ b/tests/backend/test_represented_artefact_creation_workflow_vontology_service.py
@@ -16,6 +16,9 @@ from src.backend.services.represented_artefact_creation_workflow_vontology_servi
     _ensure_represented_artefact_creation_prompt_support,
     bootstrap_canonical_represented_artefact_creation_workflow,
 )
+from src.backend.services.workflow_repo_seed_bootstrap import (
+    bootstrap_repo_seed_workflow_bundle,
+)
 from src.backend.services.text_value_service import (
     get_texts_for_concept,
     upsert_singleton_text_relation,
@@ -114,6 +117,64 @@ def _workflow_step_id(workflow_id: str, state_id: str) -> str:
     )
 
 
+def _publish_exact_reviewed_v8_parent_authority(tmp_path: Path) -> None:
+    """Recreate the released v8 parent before exercising its v6 migration.
+
+    The current v9 seed adds launch/context fields.  Mutating only its lifecycle
+    and routing profile would produce a hybrid authority that was never reviewed
+    and must correctly be refused by the migration gate.
+    """
+
+    legacy_bundle = json.loads(_SEED_BUNDLE_PATH.read_text(encoding="utf-8"))
+    legacy_bundle["seed_version"] = "8"
+    legacy_versions = legacy_bundle[
+        "known_legacy_authority_payload_sha256_by_seed_version"
+    ][REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID]
+    legacy_versions.pop("8", None)
+
+    parent = next(
+        row
+        for row in legacy_bundle["workflows"]
+        if row["workflow_id"] == REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID
+    )
+    parent["launch_input_contract"]["input_mappings"] = [
+        mapping
+        for mapping in parent["launch_input_contract"]["input_mappings"]
+        if mapping.get("target_context_key")
+        not in {"augmented_context", "conversation_situation"}
+    ]
+    for state in parent["publication_spec"]["steps"]:
+        llm_policy = state.get("llm_policy")
+        if not isinstance(llm_policy, dict):
+            continue
+        llm_policy.pop("context_messages_context_key", None)
+        llm_policy["context_fields"] = [
+            field
+            for field in llm_policy.get("context_fields") or []
+            if field.get("context_key") != "conversation_situation"
+        ]
+
+    legacy_path = tmp_path / "represented_artefact_creation_v8.json"
+    legacy_path.write_text(
+        json.dumps(legacy_bundle, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    report = bootstrap_repo_seed_workflow_bundle(
+        asset_path=legacy_path,
+        force_republish=True,
+        target_workflow_ids=(REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID,),
+    )
+    adjudication = (
+        ((report.get("publication") or {}).get("repo_seed_version_gate") or {}).get(
+            "authority_adjudication_by_workflow"
+        )
+        or {}
+    ).get(REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID) or {}
+    assert adjudication["target_authority_payload_sha256"] == (
+        _REVIEWED_V7_PARENT_AUTHORITY_SHA256
+    )
+
+
 def _seed_existing_represented_artefact(
     *,
     concept_id: str,
@@ -165,12 +226,13 @@ def test_represented_artefact_workflow_family_has_reviewed_parent_only_routing()
 ):
     bundle = json.loads(_SEED_BUNDLE_PATH.read_text(encoding="utf-8"))
 
-    assert bundle["seed_version"] == "8"
+    assert bundle["seed_version"] == "9"
     assert bundle["known_legacy_authority_payload_sha256_by_seed_version"] == {
         REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID: {
             "5": ["2061801c8da0d8437f021ef49dd3af40d405f98fdc5388752d0b831ce689bb48"],
             "6": [_REVIEWED_V6_PARENT_AUTHORITY_SHA256],
             "7": [_REVIEWED_V7_PARENT_AUTHORITY_SHA256],
+            "8": [_REVIEWED_V7_PARENT_AUTHORITY_SHA256],
         },
         REPRESENTED_ARTEFACT_ITEM_CREATION_WORKFLOW_ID: {
             "5": ["cc17479ee5df029a7baed2b1d21a1f0c098979afcda730c91a2e7acce624771e"],
@@ -208,9 +270,27 @@ def test_represented_artefact_workflow_family_has_reviewed_parent_only_routing()
     assert item_lifecycle["review_state"] == "approved"
     assert item["publication_spec"]["initial_state"] == ("initialise_from_item_request")
 
+    parent_sources = {
+        mapping.get("source_expression")
+        for mapping in parent["launch_input_contract"]["input_mappings"]
+    }
+    assert "inputs.augmented_context" in parent_sources
+    assert "inputs.conversation_situation" in parent_sources
+    assert all(
+        "inputs.conversation_situation"
+        not in {
+            mapping.get("source_expression")
+            for mapping in row["launch_input_contract"]["input_mappings"]
+        }
+        for row in (item,)
+    )
 
-def test_normal_bootstrap_migrates_exact_reviewed_v6_parent_authority() -> None:
+
+def test_normal_bootstrap_migrates_exact_reviewed_v6_parent_authority(
+    tmp_path: Path,
+) -> None:
     bootstrap_canonical_represented_artefact_creation_workflow()
+    _publish_exact_reviewed_v8_parent_authority(tmp_path)
 
     upsert_singleton_text_relation(
         subject_concept_id=REPRESENTED_ARTEFACT_CREATION_WORKFLOW_ID,

--- a/tests/backend/test_turn_execution_record_actor_identity.py
+++ b/tests/backend/test_turn_execution_record_actor_identity.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+)
 from src.backend.services.turn_execution_record_service import build_turn_execution_record
 
 
@@ -49,3 +52,44 @@ def test_actor_identity_falls_back_to_namespace_user_component() -> None:
     assert record.get("actor_concept_id") == "#V#fallback_user"
     assert record.get("actor_identity_source") == "namespace_user_component"
 
+
+def test_turn_record_retains_integrity_checked_applied_prompt_snapshot() -> None:
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#alice",
+        namespace="#V#alice@test_org",
+        organisation_concept_id="#V#test_org",
+        turn_id="turn-actor-1",
+        behaviour_fragments=[
+            {"concept_id": "#V#behaviour_prompt", "content": "Be precise."}
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
+
+    record = _build_record(
+        actor_concept_id="#V#assistant_instance",
+        applied_prompt_snapshot=snapshot,
+    )
+
+    assert record["applied_prompt_snapshot"] == snapshot
+    assert record["applied_prompt_snapshot"]["prompts"][0]["content"] == (
+        "Be precise."
+    )
+
+
+def test_turn_record_rejects_cross_actor_applied_prompt_snapshot() -> None:
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#bob",
+        namespace="#V#bob@test_org",
+        organisation_concept_id="#V#test_org",
+        turn_id="turn-bob-1",
+        behaviour_fragments=[
+            {"concept_id": "#V#bob_prompt", "content": "Private Bob prompt."}
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
+
+    record = _build_record(applied_prompt_snapshot=snapshot)
+
+    assert record["applied_prompt_snapshot"] is None

--- a/tests/backend/test_von_generate_llm_debug_user_prompt.py
+++ b/tests/backend/test_von_generate_llm_debug_user_prompt.py
@@ -1,3 +1,4 @@
+import json
 
 import pytest
 from flask import Flask
@@ -38,6 +39,7 @@ def app(monkeypatch):
                 "user_concept_id": kwargs["user_concept_id"],
                 "org_concept_id": kwargs["org_concept_id"],
                 "user_namespace": kwargs["user_namespace"],
+                "trusted_argument_values": kwargs["trusted_argument_values"],
             }
         )
         return AdaptiveTurnResult(
@@ -79,21 +81,30 @@ def app(monkeypatch):
         lambda: "#V#test_user",
     )
 
-    monkeypatch.setattr(
-        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
-        lambda _user_id, **kwargs: (
-            [
+    def _prompt_fragments(_user_id, **kwargs):
+        prompt_types = kwargs.get("prompt_types")
+        if prompt_types == (
+            "#V#von_chat_behaviour_prompt",
+            "#V#von_chat_behavior_prompt",
+            "#V#von_llm_prompt",
+        ):
+            return [
                 {"concept_id": "#V#prompt1", "content": "First prompt."},
                 {"concept_id": "#V#prompt2", "content": "Second prompt."},
             ]
-            if kwargs.get("prompt_types")
-            == (
-                "#V#von_chat_behaviour_prompt",
-                "#V#von_chat_behavior_prompt",
-                "#V#von_llm_prompt",
-            )
-            else []
-        ),
+        if prompt_types == ("#V#von_chat_narration_prompt",):
+            return [
+                {"concept_id": "#V#narration_prompt", "content": "Speak briefly."}
+            ]
+        if prompt_types == ("#V#von_chat_screen_content_prompt",):
+            return [
+                {"concept_id": "#V#screen_prompt", "content": "Show evidence."}
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "src.backend.services.chat_auxiliary_prompt_service.get_user_specific_prompt_fragments",
+        _prompt_fragments,
     )
     monkeypatch.setattr(
         "src.backend.services.concept_service.get_concept_by_concept_id",
@@ -110,6 +121,10 @@ def app(monkeypatch):
     monkeypatch.setattr(
         "src.backend.server.routes.von_routes.chat_history_service.get_chat_history",
         lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes._load_conversation_session_state_fail_soft",
+        lambda **_kwargs: ([], None, None, 0, [], {}),
     )
     monkeypatch.setattr(
         "src.backend.server.routes.von_routes._ensure_generate_conversation_session",
@@ -228,6 +243,30 @@ def test_generate_includes_user_prompt_debug_metadata(app):
     )
     assert "First prompt." in injected_msg.get("content", "")
     assert "Second prompt." in injected_msg.get("content", "")
+
+    manifest_msg = next(
+        msg
+        for msg in sent_context
+        if msg.get("role") == "system"
+        and "APPLIED VONTOLOGY PROMPT MANIFEST" in msg.get("content", "")
+    )
+    assert "chat_get_applied_prompt_context" in manifest_msg["content"]
+    assert "#V#prompt1" in manifest_msg["content"]
+    assert "#V#narration_prompt" in manifest_msg["content"]
+    assert "#V#screen_prompt" in manifest_msg["content"]
+
+    trusted_values = llm_calls[0]["trusted_argument_values"]
+    snapshot = json.loads(trusted_values["applied_prompt_snapshot"])
+    assert snapshot["actor"]["user_concept_id"] == "#V#test_user"
+    assert [item["application_kind"] for item in snapshot["prompts"]] == [
+        "behaviour",
+        "behaviour",
+        "narration",
+        "screen",
+    ]
+    assert llm_debug["user_prompt"]["applied_prompt_snapshot_sha256"] == (
+        snapshot["snapshot_sha256"]
+    )
 
 
 def _messages_text(messages):

--- a/tests/backend/test_von_turn_execution_debug_info.py
+++ b/tests/backend/test_von_turn_execution_debug_info.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+)
+
 
 def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
     monkeypatch,
@@ -44,6 +48,17 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
         "preview_truncated": False,
         "sha256": "abc123",
     }
+    applied_prompt_snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#person",
+        namespace="#V#person@org",
+        organisation_concept_id="#V#org",
+        turn_id="req-adaptive-observation",
+        behaviour_fragments=[
+            {"concept_id": "#V#applied_prompt", "content": "Be precise."}
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
 
     result = von_routes._finalise_llm_debug_info(
         llm_debug_info={
@@ -102,6 +117,7 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
         org_id="#V#org",
         workflow_discovery=None,
         workflow_routing=None,
+        applied_prompt_snapshot=applied_prompt_snapshot,
     )
 
     record = result["turn_execution_record"]
@@ -115,6 +131,7 @@ def test_finalise_llm_debug_info_records_observations_without_rebuilding_a_gate(
     }
     assert record["terminal_status"] == "completed"
     assert record["response"]["present"] is True
+    assert record["applied_prompt_snapshot"] == applied_prompt_snapshot
     assert record["evidence_index"] == [evidence]
     summary = result["llm_usage_cost_summary"]
     assert summary["usage"]["total_tokens"] == 120

--- a/tests/backend/test_workflow_introspection_maintenance_workflow.py
+++ b/tests/backend/test_workflow_introspection_maintenance_workflow.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from src.backend.services.chat_auxiliary_prompt_service import (
+    build_applied_prompt_snapshot,
+)
 from src.backend.workflows.action_registry import WorkflowActionRequest, WorkflowEnvironment
 
 
@@ -77,6 +80,55 @@ def test_assess_prefers_user_namespace_for_prompt_lookup(monkeypatch):
     assert result.ok
     assert result.outputs["maintenance_context"]["prompt_lookup_namespace"] == "#V#user"
     assert lookup_calls[0] == "#V#user"
+
+
+def test_assess_retains_target_turn_applied_prompt_snapshot(monkeypatch):
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#user",
+        namespace="#V#user@org",
+        organisation_concept_id="#V#org",
+        turn_id="req-applied-1",
+        behaviour_fragments=[
+            {
+                "concept_id": "#V#historical_prompt",
+                "content": "Always use create_task.",
+            }
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
+
+    def _fake_invoke(tool_name: str, payload: dict):
+        if tool_name == "workflow_list_definitions":
+            return {"success": True, "count": 1, "definitions": []}
+        if tool_name == "chat_get_prompt_context":
+            return {"success": True, "behaviour_prompt_concepts": []}
+        if tool_name == "turn_execution_get":
+            return {
+                "success": True,
+                "selected_workflow_id": "#V#tool_calling_workflow",
+                "applied_prompt_snapshot": snapshot,
+            }
+        if tool_name == "fetch_concept":
+            return {"success": True, "concept_id": "#V#tool_calling_workflow"}
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_invoke_mcp_tool", _fake_invoke)
+    monkeypatch.setattr(mod, "_available_tool_names", lambda: ["task_create"])
+
+    result = mod._handle_assess_context(
+        _request(
+            action_id="workflow_introspection.assess_context",
+            data={"request_id": "req-applied-1"},
+        )
+    )
+
+    assert result.ok
+    retained = result.outputs["maintenance_evidence"]["applied_prompt_snapshot"]
+    assert retained["snapshot_sha256"] == snapshot["snapshot_sha256"]
+    assert retained["prompts"][0]["concept_id"] == "#V#historical_prompt"
 
 
 def test_assess_collects_github_evidence(monkeypatch):
@@ -239,6 +291,54 @@ def test_diagnose_detects_alias_scope_and_cross_domain_signals():
     assert "completion_gate_false_positive" in causes
 
 
+def test_diagnose_prefers_target_turn_applied_prompt_over_current_prompt():
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#user",
+        namespace="#V#user@org",
+        organisation_concept_id="#V#org",
+        turn_id="req-historical-prompt",
+        behaviour_fragments=[
+            {
+                "concept_id": "#V#general_prompt",
+                "content": "Always use create_task for every request.",
+            }
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
+    data = {
+        "maintenance_context": {
+            "namespace": "#V#user@org",
+            "selected_workflow_id": "#V#tool_calling_workflow",
+        },
+        "maintenance_evidence": {
+            "incident_text": "The turn created a task for an ontology request.",
+            "known_tool_names": ["task_create"],
+            "applied_prompt_snapshot": snapshot,
+            "prompt_context": {
+                "behaviour_prompt_concepts": [
+                    {
+                        "concept_id": "#V#general_prompt",
+                        "content": "Use tools only when they fit the request.",
+                    }
+                ]
+            },
+            "turn_execution": {},
+        },
+    }
+
+    result = mod._handle_diagnose_conflation(
+        _request(action_id="workflow_introspection.diagnose_conflation", data=data)
+    )
+
+    assert result.ok
+    diagnosis = result.outputs["maintenance_diagnosis"]
+    assert diagnosis["prompt_evidence_source"] == "turn_applied_snapshot"
+    assert diagnosis["implicated_prompt_concept_ids"] == ["#V#general_prompt"]
+
+
 def test_plan_repairs_builds_prompt_patch_and_workflow_note():
     from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
 
@@ -285,6 +385,80 @@ def test_plan_repairs_builds_prompt_patch_and_workflow_note():
     tools = {item["tool_name"] for item in repair_plan["operations"]}
     assert "upsert_singleton_text_relation" in tools
     assert "upsert_text_relation" in tools
+
+
+def test_plan_repairs_does_not_overwrite_prompt_changed_since_target_turn():
+    from src.backend.workflows.durable import workflow_introspection_maintenance_workflow as mod
+
+    snapshot = build_applied_prompt_snapshot(
+        user_concept_id="#V#user",
+        namespace="#V#user@org",
+        organisation_concept_id="#V#org",
+        turn_id="req-stale-prompt",
+        behaviour_fragments=[
+            {
+                "concept_id": "#V#general_prompt",
+                "content": "Always use create_task.",
+            }
+        ],
+        narration_fragments=[],
+        screen_fragments=[],
+    )
+    data = {
+        "maintenance_context": {
+            "namespace": "#V#user@org",
+            "request_id": "req-stale-prompt",
+            "selected_workflow_id": "#V#tool_calling_workflow",
+            "apply_repairs": True,
+            "dry_run": False,
+            "max_operations": 10,
+        },
+        "maintenance_evidence": {
+            "applied_prompt_snapshot": snapshot,
+            "prompt_context": {
+                "behaviour_prompt_concepts": [
+                    {
+                        "concept_id": "#V#general_prompt",
+                        "content": "Use task_create only for explicit task requests.",
+                    }
+                ]
+            },
+        },
+        "maintenance_diagnosis": {
+            "conflation_detected": True,
+            "root_causes": [{"cause_id": "prompt_scope_overreach"}],
+            "implicated_prompt_concept_ids": ["#V#general_prompt"],
+            "directive_findings": [
+                {
+                    "prompt_concept_id": "#V#general_prompt",
+                    "tool_name": "create_task",
+                    "canonical_tool_name": "task_create",
+                    "is_absolute": True,
+                    "scope_overreach": True,
+                }
+            ],
+        },
+    }
+
+    result = mod._handle_plan_repairs(
+        _request(action_id="workflow_introspection.plan_repairs", data=data)
+    )
+
+    assert result.ok
+    plan = result.outputs["maintenance_repair_plan"]
+    assert plan["prompt_evidence_source"] == "turn_applied_snapshot"
+    assert len(plan["skipped_prompt_repairs"]) == 1
+    skipped = plan["skipped_prompt_repairs"][0]
+    assert skipped["concept_id"] == "#V#general_prompt"
+    assert skipped["reason"] == "current_prompt_changed_since_target_turn"
+    assert skipped["applied_content_sha256"] == snapshot["prompts"][0][
+        "content_sha256"
+    ]
+    assert len(skipped["current_content_sha256"]) == 64
+    assert all(
+        operation["tool_name"] != "upsert_singleton_text_relation"
+        for operation in plan["operations"]
+    )
 
 
 def test_plan_repairs_adds_jira_remediation_operation_when_evidence_available():

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -249,12 +249,16 @@ def test_execution_arguments_bind_workflow_and_actor_server_side():
             "inputs": {
                 "record_id": "#V#record",
                 "user_concept_id": "#V#spoofed_user",
+                "conversation_situation": "Spoofed conversation situation.",
             },
             "await_terminal": "false",
             "timeout_seconds": 500,
         },
         prompt="Process this record.",
         context=[{"role": "user", "content": "Earlier context"}],
+        conversation_situation=(
+            "The record under discussion is the represented quarterly report."
+        ),
         request_workflow_launch_inputs={
             "file_copy_concept_id": "#V#authorised_file",
             "organisation_concept_id": "#V#spoofed_org",
@@ -279,12 +283,92 @@ def test_execution_arguments_bind_workflow_and_actor_server_side():
     assert effective["inputs"]["augmented_context"] == [
         {"role": "user", "content": "Earlier context"}
     ]
+    assert effective["inputs"]["conversation_situation"] == (
+        "The record under discussion is the represented quarterly report."
+    )
     assert diagnostic["ignored_model_arguments"] == [
         "namespace",
         "org_id",
         "user_id",
         "workflow_id",
     ]
+
+
+def test_completed_workflow_clarification_is_not_a_completed_semantic_effect():
+    from src.backend.services.workflow_turn_capability_service import (
+        normalise_workflow_effect_receipt,
+    )
+
+    clarified = normalise_workflow_effect_receipt(
+        {
+            "success": True,
+            "instance_id": "instance-clarification",
+            "created_new": True,
+            "final_status": "completed",
+            "workflow_execution": {
+                "outputs": {
+                    "requires_user_affirmation": True,
+                    "response_text": "Which person do you mean?",
+                }
+            },
+        },
+        capability=_capability(),
+    )
+
+    assert clarified["effect_status"] == "succeeded"
+    assert clarified["operational_state_effect"] is True
+    assert clarified["semantic_effect"] is False
+    assert clarified["semantic_outcome"] == "clarification_required"
+
+
+def test_workflow_can_report_a_typed_incomplete_semantic_outcome():
+    from src.backend.services.workflow_turn_capability_service import (
+        normalise_workflow_effect_receipt,
+    )
+
+    follow_up = normalise_workflow_effect_receipt(
+        {
+            "success": True,
+            "instance_id": "instance-follow-up",
+            "created_new": True,
+            "final_status": "completed",
+            "workflow_execution": {
+                "outputs": {"semantic_outcome": "follow_up_required"}
+            },
+        },
+        capability=_capability(),
+    )
+
+    assert follow_up["effect_status"] == "succeeded"
+    assert follow_up["semantic_effect"] is None
+    assert follow_up["semantic_outcome"] == "follow_up_required"
+
+
+@pytest.mark.parametrize("semantic_outcome", ["blocked", "failed", "not_completed"])
+def test_completed_workflow_hard_non_completion_is_not_a_semantic_effect(
+    semantic_outcome,
+):
+    from src.backend.services.workflow_turn_capability_service import (
+        normalise_workflow_effect_receipt,
+    )
+
+    incomplete = normalise_workflow_effect_receipt(
+        {
+            "success": True,
+            "instance_id": f"instance-{semantic_outcome}",
+            "created_new": True,
+            "final_status": "completed",
+            "workflow_execution": {
+                "outputs": {"semantic_outcome": semantic_outcome}
+            },
+        },
+        capability=_capability(),
+    )
+
+    assert incomplete["effect_status"] == "succeeded"
+    assert incomplete["operational_state_effect"] is True
+    assert incomplete["semantic_effect"] is False
+    assert incomplete["semantic_outcome"] == semantic_outcome
 
 
 def test_workflow_wait_is_one_bounded_observation_interval():
@@ -297,6 +381,7 @@ def test_workflow_wait_is_one_bounded_observation_interval():
         {"timeout_seconds": 180},
         prompt="Process this record.",
         context=None,
+        conversation_situation=None,
         request_workflow_launch_inputs=None,
         user_concept_id="#V#real_user",
         organisation_concept_id="#V#real_org",
@@ -329,6 +414,7 @@ def test_workflow_wait_rejects_nonfinite_observation_parameters(
             {field_name: invalid_value},
             prompt="Process this record.",
             context=None,
+            conversation_situation=None,
             request_workflow_launch_inputs=None,
             user_concept_id="#V#real_user",
             organisation_concept_id="#V#real_org",


### PR DESCRIPTION
## What changed

- retain the exact actor-scoped Vontology prompt snapshot applied to each turn
- expose the current snapshot through a trusted MCP capability and persist it in successful and failed turn records
- carry historical prompt provenance into critic evidence, failure-case intake/replay, and workflow-maintenance diagnosis
- prevent maintenance from overwriting prompts that changed after the target turn
- bind the conversation situation and bounded prior context into the conversation-facing judgement boundaries of the relevant represented workflows
- reconcile represented workflow and ontology-mutation outcomes before the outer turn claims success

## Why

The model could inspect the current Vontology prompt configuration but not reliably identify the exact prompt bodies applied to a historical turn. Several represented workflows also received the current request without the conversation situation needed to resolve prior referents and constraints. Finally, outer workflow completion could mask an inconclusive or partial represented effect.

## User and developer impact

Diagnostics and prompt improvement now use the exact target-turn evidence. Relevant workflows can resolve conversational references without propagating raw context into deterministic children or final renderers. Turn outcomes preserve partial/inconclusive state and recovery information instead of presenting it as completed work.

## Validation

- 418 tests passed across 21 affected backend suites
- 2 tests skipped
- JSON parsing for all changed seed bundles
- reviewed legacy authority digests recomputed exactly for every bumped workflow bundle
- Python compilation and Ruff fatal-error checks passed
- `git diff --check` passed

Five existing execution tests remain red. Each reproduces unchanged on clean `main`: two represented-artefact tests fail on `ambiguous_create_scope_mode`, and three paper-metadata tests enter an existing failed terminal state. They are not candidate regressions.