### PR TITLE
Repair conversation workflow authority migration

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
@@ -1,16 +1,27 @@
 {
   "family_id": "canonical_workflow_publication_seed_bundle",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "51",
+  "seed_version": "52",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#tool_calling_workflow": {
       "42": [
         "77e8896562063743a980c1700c43a5edf1d451b1a90c1e0b489f9c3838cc7b87"
+      ],
+      "43": [
+        "696cdf1616304c533a448cf740cb97a94af7828be473de41c91793e627d52592"
       ]
     },
     "#V#general_mail_review_workflow": {
+      "43": [
+        "ff4639db4cfd620eede3ac9193feb537356b1f171a7ce386fa54dd99a413c008"
+      ],
       "50": [
         "3b1006be7892b4981511d7767b69f2de023c3c919da8883b050248ee4ae53674"
+      ]
+    },
+    "#V#gmail_message_detail_fetch_workflow": {
+      "43": [
+        "09970a529b9734e8ec989658157de51bb57d00484bf7a52bf8e18a8d7d23d770"
       ]
     }
   },
@@ -22,6 +33,7 @@
         "#V#workflow_model_policy"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Default stage-aware workflow model selection policy.",
       "system_tags": [
         "workflow-model-policy",
@@ -50,6 +62,7 @@
         "#V#workflow_stage"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Workflow model-policy stage for rendering grounded mail review answers.",
       "system_tags": [
         "workflow-model-policy",
@@ -71,6 +84,7 @@
         "#V#workflow_stage"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Workflow model-policy stage for planning executable tool calls.",
       "system_tags": [
         "workflow-model-policy",
@@ -92,6 +106,7 @@
         "#V#workflow_stage"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Workflow model-policy stage for retrying omitted executable tool calls.",
       "system_tags": [
         "workflow-model-policy",
@@ -113,6 +128,7 @@
         "#V#workflow_stage_configuration"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Default model-policy configuration for executable tool-call planning.",
       "system_tags": [
         "workflow-model-policy",
@@ -144,6 +160,7 @@
         "#V#workflow_stage_configuration"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Default model-policy configuration for retrying omitted executable tool calls.",
       "system_tags": [
         "workflow-model-policy",
@@ -175,6 +192,7 @@
         "#V#workflow_stage_configuration"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Default model-policy configuration for grounded mail review answer rendering.",
       "system_tags": [
         "workflow-model-policy",

--- a/tests/backend/test_repo_seed_bundle_invariants.py
+++ b/tests/backend/test_repo_seed_bundle_invariants.py
@@ -342,3 +342,41 @@ def test_explicit_workflow_experience_prelude_callers_keep_their_seed_definition
 
     assert callers
     assert prelude_id in canonical_workflow_ids
+
+
+def test_canonical_bundle_declares_reviewed_seed_43_migrations_without_claiming_shared_support_authority() -> (
+    None
+):
+    """Keep the live seed-43 recovery explicit and bounded.
+
+    The three digests are canonical read-backs of the reviewed live workflow
+    surfaces.  Shared model-policy concepts may be created on an empty
+    installation, but an existing represented concept has broader Vontology
+    authority and must not be rewritten merely to advance this workflow seed.
+    """
+
+    payload = json.loads(CANONICAL_BUNDLE_PATH.read_text(encoding="utf-8"))
+    assert payload["seed_version"] == "52"
+    reviewed_seed_43 = {
+        "#V#tool_calling_workflow": (
+            "696cdf1616304c533a448cf740cb97a94af7828be473de41c91793e627d52592"
+        ),
+        "#V#general_mail_review_workflow": (
+            "ff4639db4cfd620eede3ac9193feb537356b1f171a7ce386fa54dd99a413c008"
+        ),
+        "#V#gmail_message_detail_fetch_workflow": (
+            "09970a529b9734e8ec989658157de51bb57d00484bf7a52bf8e18a8d7d23d770"
+        ),
+    }
+    declared = payload[
+        "known_legacy_authority_payload_sha256_by_seed_version"
+    ]
+    for workflow_id, digest in reviewed_seed_43.items():
+        assert digest in declared[workflow_id]["43"]
+
+    support_concepts = payload["support_concepts"]
+    assert support_concepts
+    assert all(
+        support_concept.get("preserve_existing_authority") is True
+        for support_concept in support_concepts
+    )


### PR DESCRIPTION
## Outcome

Unblocks governed publication of the six canonical conversation-support workflows from the live seed-43 state to the reviewed seed-52 release.

## Root cause

The live tool-calling and mail workflow payloads were reviewed historical states, but their exact current digests were not declared as legacy migration sources. Shared model-policy support concepts also carried broader live Vontology representations than the repo seed and were incorrectly treated as seed-owned migration targets, so publication stopped with `workflow_seed_authority_blocked`.

## Changes

- bump the canonical workflow publication seed from 51 to 52
- declare the exact reviewed seed-43 digests for tool calling and the two mail workflows
- preserve existing Vontology authority for shared model-policy support concepts while retaining first-install creation
- lock the migration boundary with a structural regression test

## Validation

- `PYTHONPATH=src .venv/bin/pytest -q tests/backend/test_repo_seed_bundle_invariants.py tests/backend/test_workflow_repo_seed_affordances.py tests/backend/test_conversation_turn_workflow_vontology_service.py` — 113 passed
- Ruff, JSON parsing, seed-version bump check, and `git diff --check` passed
- live read-only provenance audit found every current mail-workflow component in reviewed repo seed history; tool-calling exactly matches reviewed seed 43

## Activation

After merge, publish through the canonical conversation workflow bootstrap, read back all six seed markers and authority payloads, then restart and verify live health. No force-republish bypass.