### PR TITLE
Preserve complete paper-ingestion batch results across follow-ups

### DIFF
--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -723,6 +723,7 @@ def list_messages(
     query: Optional[str] = None,
     label_ids: Optional[List[str]] = None,
     max_results: int = 25,
+    page_token: Optional[str] = None,
     include_metadata: Optional[List[str]] = None,
     profiles: Optional[Dict[str, GmailProfile]] = None,
     audit_context: Optional[Mapping[str, object]] = None,
@@ -740,6 +741,9 @@ def list_messages(
     ``include_metadata`` is an opt-in list-row projection. It performs at most
     one Gmail ``format=metadata`` read for each row returned by the list call
     and never requests or returns the message body or MIME payload.
+
+    ``page_token`` continues a prior Gmail listing without changing its query,
+    label, or profile scope.
     """
 
     profile = get_profile(profile_id, profiles)
@@ -761,12 +765,15 @@ def list_messages(
         composed_query = _compose_query(profile, query)
 
     messages_resource = service.users().messages()
-    request = messages_resource.list(
-        userId=profile.user_id,
-        q=composed_query,
-        labelIds=effective_label_ids,
-        maxResults=max_results,
-    )
+    list_arguments: Dict[str, object] = {
+        "userId": profile.user_id,
+        "q": composed_query,
+        "labelIds": effective_label_ids,
+        "maxResults": max_results,
+    }
+    if isinstance(page_token, str) and page_token.strip():
+        list_arguments["pageToken"] = page_token.strip()
+    request = messages_resource.list(**list_arguments)
     result = request.execute() or {}
 
     requested_fields = _normalise_list_message_metadata_fields(include_metadata)

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -17096,6 +17096,7 @@ _DELEGATED_TELEMETRY_PAGE_CONTEXT_FIELDS = (
     "namespace",
     "access_mode",
     "identifier_binding",
+    "history_coverage",
 )
 
 
@@ -17356,6 +17357,22 @@ def _chat_history_get_segments(**kwargs):
             "omitted_count": 0,
             "retention_limit": chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS,
         }
+    history_truncated = bool(meta_mapping.get("history_truncated", False))
+    history_coverage = {
+        "schema_version": "conversation_history_coverage.v1",
+        "status": "truncated" if history_truncated else "complete",
+        "history_truncated": history_truncated,
+        "exhaustive_answer_supported": not history_truncated,
+        "continuation_required_for_exhaustive_answer": history_truncated,
+    }
+    if history_truncated:
+        history_coverage["recovery"] = {
+            "tool_name": "chat_history_get_segments",
+            "instruction": (
+                "Repeat the active-conversation read without history_tail_limit "
+                "before answering an exhaustive list or count request."
+            ),
+        }
     payload = {
         "success": True,
         "session_id": access.get("session_id"),
@@ -17367,7 +17384,8 @@ def _chat_history_get_segments(**kwargs):
         "identifier_binding": access.get("identifier_binding"),
         "segments": segments,
         "segment_count": len(segments) if isinstance(segments, list) else 0,
-        "history_truncated": bool(meta_mapping.get("history_truncated", False)),
+        "history_truncated": history_truncated,
+        "history_coverage": history_coverage,
         "conversation_situation": conversation_situation,
         "conversation_observations": conversation_observations,
         "conversation_observation_state": conversation_observation_state,
@@ -26814,19 +26832,23 @@ def _gmail_list_messages(**kwargs):
             max_results = kwargs.get("maxResults")
         if max_results is None:
             max_results = kwargs.get("limit")
-        result = gs.list_messages(
-            profile_id=profile,
-            query=caller_query,
-            label_ids=caller_label_ids,
-            max_results=max_results or 25,
-            include_metadata=kwargs.get("include_metadata"),
-            audit_context={
+        list_arguments: dict[str, Any] = {
+            "profile_id": profile,
+            "query": caller_query,
+            "label_ids": caller_label_ids,
+            "max_results": max_results or 25,
+            "include_metadata": kwargs.get("include_metadata"),
+            "audit_context": {
                 "namespace": profile_authority.audit_namespace,
                 "source": kwargs.get("_audit_source") or "internal_mcp_gateway",
                 "tool": "gmail_list_messages",
             },
-            bypass_profile_query_prefix=bypass_profile_query_prefix,
-        )
+            "bypass_profile_query_prefix": bypass_profile_query_prefix,
+        }
+        requested_page_token = kwargs.get("page_token") or kwargs.get("pageToken")
+        if isinstance(requested_page_token, str) and requested_page_token.strip():
+            list_arguments["page_token"] = requested_page_token.strip()
+        result = gs.list_messages(**list_arguments)
 
         # Resolve the profile to surface the effective query info to callers.
         try:
@@ -37276,6 +37298,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "label_ids": list,
             "max_results": (int, type(None)),
             "maxResults": (int, type(None)),
+            "page_token": (str, type(None)),
             "order_by": str,
             "order": str,
             "scope": str,
@@ -37303,7 +37326,9 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "up to one metadata read per returned row, so set max_results to the "
             "candidate cardinality the request actually needs. A narrow query plus "
             "max_results and include_metadata can normally identify candidate "
-            "messages in one tool call. The 'limit' alias maps to max_results; "
+            "messages in one tool call. Pass a returned nextPageToken as "
+            "page_token to continue the same Gmail result set. The 'limit' "
+            "alias maps to max_results; "
             "order/order_by/sort remain compatibility hints and are ignored."
         ),
         aliases={
@@ -37311,6 +37336,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "identity": "profile",
             "user_id": "profile",
             "q": "query",
+            "pageToken": "page_token",
             "limit": "max_results",
             "sort": "order_by",
             "sort_by": "order_by",
@@ -38941,7 +38967,10 @@ def _build_default_catalogue_diagnostics_and_research_definitions() -> List[
                 "session or supply a conversation reference. Direct diagnostic "
                 "callers may still use an authoritative conversation_ref and "
                 "history_location locators. Use offset/limit when a delegated "
-                "response is paged."
+                "response is paged. For exhaustive list or count questions, "
+                "inspect history_coverage: if it reports truncated, repeat the "
+                "active-conversation read without history_tail_limit before "
+                "answering, or state explicitly that only a lower bound is known."
             ),
         ),
         MethodDefinition(
@@ -41726,6 +41755,7 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                     "step_index": int,
                     "inputs": dict,
                     "outputs": (dict, type(None)),
+                    "workflow_data": dict,
                     "error": (str, type(None)),
                     "error_code": (str, type(None)),
                     "await_terminal": bool,
@@ -41738,7 +41768,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                     "hard_timeout_seconds": (int, float, type(None)),
                 },
                 allow_unknown=True,
-                description="Full workflow instance details.",
+                description=(
+                    "Full workflow instance details, including persisted workflow_data "
+                    "and any declared batch or item result projection."
+                ),
             ),
             category="read",
             timeout_sec=None,
@@ -41746,7 +41779,9 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             hard_timeout_enabled=False,
             description=(
                 "Get detailed status of a durable workflow instance including current state, "
-                "inputs, outputs, and any errors. Set await_terminal=true to make a "
+                "inputs, outputs, persisted workflow_data, declared batch/item results, "
+                "and any errors. Use workflow_data from a retained parent instance locator "
+                "for later exhaustive list or count follow-ups. Set await_terminal=true to make a "
                 "advisory observation wait on an existing instance; crossing returns its "
                 "current state to the model and never cancels or retries the workflow."
             ),

--- a/src/backend/services/email_source_representation_convergence_workflow_vontology_service.py
+++ b/src/backend/services/email_source_representation_convergence_workflow_vontology_service.py
@@ -43,7 +43,7 @@ _GMAIL_COMPLETION_HINT_SEED_ASSET_PATH = (
     / "gmail_get_message_terminal_completion_hint_seed.json"
 )
 _MANAGED_BY = "email_source_representation_convergence_workflow_vontology_service"
-_SOURCE_TAG = "JVNAUTOSCI-2335"
+_SOURCE_TAG = "JVNAUTOSCI-2635"
 
 
 def _load_gmail_completion_hint_seed() -> dict[str, Any]:

--- a/src/backend/workflows/durable/control_flow_actions.py
+++ b/src/backend/workflows/durable/control_flow_actions.py
@@ -826,16 +826,20 @@ def _build_for_each_handler(
             and isinstance((result_payload := item.get("result")), Mapping)
             and result_payload
         ]
-        iteration_errors = [
-            {
+        iteration_errors: list[dict[str, Any]] = []
+        for item in iteration_results:
+            if item["completed"]:
+                continue
+            failure: dict[str, Any] = {
                 "index": item.get("index"),
                 "item": item.get("item"),
                 "final_state": item.get("final_state"),
                 "error": item.get("error"),
             }
-            for item in iteration_results
-            if not item["completed"]
-        ]
+            declared_failure_result = item.get("result")
+            if isinstance(declared_failure_result, Mapping) and declared_failure_result:
+                failure["result"] = dict(declared_failure_result)
+            iteration_errors.append(failure)
         final_state_counts: dict[str, int] = {}
         for item in iteration_results:
             final_state = _normalise_text(item.get("final_state")) or "unknown"

--- a/src/backend/workflows/execution_contracts.py
+++ b/src/backend/workflows/execution_contracts.py
@@ -427,16 +427,24 @@ def workflow_final_state_is_failure_like(final_state: Any) -> bool:
     text = str(final_state or "").strip().lower()
     if not text:
         return False
-    return text in {"failed", "failure", "error", "cancelled", "canceled"} or any(
-        text.endswith(suffix)
-        for suffix in (
-            "_failed",
-            "_failure",
-            "_error",
-            "_cancelled",
-            "_canceled",
-        )
+    exact_tokens = {"failed", "failure", "error", "cancelled", "canceled"}
+    failure_tokens = (
+        "failed",
+        "failure",
+        "error",
+        "cancelled",
+        "canceled",
     )
+    if text in exact_tokens:
+        return True
+
+    # Represented workflows may qualify a terminal failure on either side of
+    # the token (for example ``failed_unmarked`` or
+    # ``workflow_step_x_failed_gmail_state``).  Keep the match token-bounded so
+    # neutral states such as ``completed_with_errors`` retain their represented
+    # partial-success semantics.
+    parts = tuple(part for part in text.replace("#v#", "").split("_") if part)
+    return any(part in failure_tokens for part in parts)
 
 
 def build_arxiv_ingestion_completion_report(

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,8 +2,8 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "14",
-  "source_tag": "JVNAUTOSCI-2335",
+  "seed_version": "15",
+  "source_tag": "JVNAUTOSCI-2635",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
     "extract_signals_from_tool_result",
@@ -19,11 +19,11 @@
     {
       "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
       "display_name": "Zhan Gmail Arxiv Ingestion Workflow",
-      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. It selects newest Inbox messages that are neither represented nor dispositioned, represents each supported arXiv reference, records current source-processing evidence, then atomically applies the represented label and removes INBOX with canonical Gmail read-back. Messages with no supported reference instead receive one actor-scoped review task and VON/PAPER/NEEDS_REVIEW while remaining in Inbox.",
+      "description": "Explicit batch workflow for recurring Gmail-to-arXiv paper representation convergence. It selects newest Inbox messages that are neither represented nor dispositioned, represents each supported arXiv reference, records current source-processing evidence, then atomically applies the represented label and removes INBOX with canonical Gmail read-back. Messages with no supported reference instead receive one actor-scoped review task and VON/PAPER/NEEDS_REVIEW while remaining in Inbox. The parent instance preserves one complete result row for every message discovered in its bounded page and completes with retryable failure details when some independently useful items fail.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-          "text": "{\"examples\": [\"Keep scanning Gmail for arXiv paper links, represent every returned unrepresented paper, label each verified source message VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Run the recurring email-to-representation convergence workflow for arXiv paper notifications.\"], \"keywords\": [\"batch email messages about arxiv papers\", \"represent arxiv papers from email\", \"gmail arxiv paper representation\", \"source email to paper representation convergence\", \"represented source processing marker\", \"recurring arxiv gmail ingestion workflow\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\", \"messages\", \"mailbox\", \"inbox\", \"sender\", \"label\"], \"excluded_query_cues\": [\"which gmail profile\", \"what gmail profile\", \"profile did you use\", \"which mail profile\", \"what mail profile\", \"account did you use\"], \"routing_notes\": [\"This is an explicit batch convergence workflow: every Gmail message returned up to gmail_max_results, and every supported arXiv reference in each message, may produce representation and message-level Gmail label effects.\", \"Do not route a singular newest or best request here; discover and select the exact source item read-only, then invoke its matching representation capability.\", \"Do not choose this workflow for a question about which Gmail profile or account was used by a prior mail operation.\", \"Do not choose this workflow for source-neutral paper references or conversation-context paper lookups unless an email/Gmail/mail source cue is present.\", \"Only label and archive a source message after current represented-marker and artefact read-back succeeds.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
+          "text": "{\"examples\": [\"Keep scanning Gmail for arXiv paper links, represent every returned unrepresented paper, label each verified source message VON/PAPER/REPRESENTED, and remove it from Inbox.\", \"Represent recent papers from email messages and report every paper or failure discovered in the bounded batch.\", \"Run the recurring email-to-representation convergence workflow for arXiv paper notifications.\"], \"keywords\": [\"batch email messages about arxiv papers\", \"represent recent papers from email messages\", \"represent arxiv papers from email\", \"gmail arxiv paper representation\", \"source email to paper representation convergence\", \"represented source processing marker\", \"recurring arxiv gmail ingestion workflow\"], \"required_query_cues\": [\"gmail\", \"email\", \"mail\", \"message\", \"messages\", \"mailbox\", \"inbox\", \"sender\", \"label\"], \"excluded_query_cues\": [\"which gmail profile\", \"what gmail profile\", \"profile did you use\", \"which mail profile\", \"what mail profile\", \"account did you use\"], \"routing_notes\": [\"This is the reusable batch convergence workflow for broad email-paper representation requests: every Gmail message returned up to gmail_max_results, and every supported arXiv reference in each message, may produce representation and message-level Gmail label effects.\", \"Use one parent instance rather than independently launching the exact-message child for each discovered message; the parent result is the durable locator for later list and count questions.\", \"One item failure does not invalidate independently verified successes: preserve the failed row and retry evidence and complete the parent with retryable failures.\", \"Do not route a singular newest or best request here; discover and select the exact source item read-only, then invoke its matching representation capability.\", \"Do not choose this workflow for a question about which Gmail profile or account was used by a prior mail operation.\", \"Do not choose this workflow for source-neutral paper references or conversation-context paper lookups unless an email/Gmail/mail source cue is present.\", \"Only label and archive a source message after current represented-marker and artefact read-back succeeds.\"], \"schema_version\": \"workflow_discovery_exemplars.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -33,7 +33,7 @@
         },
         {
           "predicate": "#V#hasWorkflowRoutingProfileJson",
-          "text": "{\"authoring_intent_required\": false, \"execution_mode\": \"tool_pipeline\", \"explicit_workflow_context_required\": true, \"prefer_existing_capability\": false, \"role\": \"execution\", \"routing_eligible\": true, \"schema_version\": \"workflow_routing_profile.v1\"}",
+          "text": "{\"authoring_intent_required\": false, \"execution_mode\": \"tool_pipeline\", \"explicit_workflow_context_required\": false, \"prefer_existing_capability\": true, \"role\": \"execution\", \"routing_eligible\": true, \"schema_version\": \"workflow_routing_profile.v1\"}",
           "lang": "en-NZ"
         },
         {
@@ -85,6 +85,20 @@
             "required": false,
             "source_expression": "inputs.max_results",
             "target_context_key": "gmail_max_results"
+          },
+          {
+            "description": "Optional continuation token returned by a prior parent batch.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.gmail_page_token",
+            "target_context_key": "gmail_page_token"
+          },
+          {
+            "description": "Alias for callers that pass the prior batch next_page_token directly.",
+            "extractor": "identity",
+            "required": false,
+            "source_expression": "inputs.next_page_token",
+            "target_context_key": "gmail_page_token"
           }
         ],
         "required_inputs": [],
@@ -266,6 +280,9 @@
                   "profile": {
                     "$context_key": "gmail_profile"
                   },
+                  "page_token": {
+                    "$context_key": "gmail_page_token"
+                  },
                   "query": {
                     "$context_key": "gmail_query"
                   }
@@ -296,13 +313,25 @@
                 "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_list_messages_result_profile_to_gmail_profile",
                 "context_key": "gmail_profile",
                 "tool_output_field": "result.profile"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_list_messages_result_next_page_token_to_gmail_next_page_token",
+                "context_key": "gmail_next_page_token",
+                "tool_output_field": "result.nextPageToken"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_list_messages_result_size_estimate_to_gmail_result_size_estimate",
+                "context_key": "gmail_result_size_estimate",
+                "tool_output_field": "result.resultSizeEstimate"
               }
             ],
             "writes_context_keys": [
               "list_result",
               "messages",
               "effective_gmail_query",
-              "gmail_profile"
+              "gmail_profile",
+              "gmail_next_page_token",
+              "gmail_result_size_estimate"
             ]
           },
           {
@@ -337,67 +366,6 @@
           },
           {
             "action_id": "workflow_control.for_each",
-            "conditional_transitions": [
-              {
-                "condition_spec": {
-                  "conditions": [
-                    {
-                      "key": "message_final_state_counts.#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review",
-                      "kind": "context_compare",
-                      "operator": "gt",
-                      "value": 0
-                    },
-                    {
-                      "key": "message_error_count",
-                      "kind": "context_compare",
-                      "operator": "eq",
-                      "value": 0
-                    }
-                  ],
-                  "kind": "all"
-                },
-                "reason": "batch_completed_with_human_review_dispositions",
-                "to_state": "done_with_review_required"
-              },
-              {
-                "condition_spec": {
-                  "conditions": [
-                    {
-                      "key": "message_success_count",
-                      "kind": "context_compare",
-                      "operator": "gt",
-                      "value": 0
-                    },
-                    {
-                      "key": "message_error_count",
-                      "kind": "context_compare",
-                      "operator": "eq",
-                      "value": 0
-                    }
-                  ],
-                  "kind": "all"
-                },
-                "reason": "all_messages_succeeded",
-                "to_state": "done"
-              },
-              {
-                "condition_spec": {
-                  "key": "message_error_count",
-                  "kind": "context_compare",
-                  "operator": "gt",
-                  "value": 0
-                },
-                "reason": "message_batch_had_failures_for_retry",
-                "to_state": "failed"
-              },
-              {
-                "condition_spec": {
-                  "kind": "always"
-                },
-                "reason": "message_batch_produced_no_success",
-                "to_state": "failed"
-              }
-            ],
             "context_input_mapping_specs": [
               {
                 "concept_id": "#V#workflow_mapping_zhan_gmail_arxiv_ingestion_workflow_process_messages_gmail_max_results_to_max_items_parameter",
@@ -407,6 +375,8 @@
               }
             ],
             "execution_mode": "deterministic",
+            "next_state": "project_batch_result",
+            "on_failure_state": "failed",
             "state_id": "process_messages",
             "static_input_bindings": [
               [
@@ -464,6 +434,21 @@
                 "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_for_each_final_state_counts_to_message_final_state_counts",
                 "context_key": "message_final_state_counts",
                 "tool_output_field": "for_each_final_state_counts"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_for_each_selected_item_count_to_message_selected_item_count",
+                "context_key": "message_selected_item_count",
+                "tool_output_field": "for_each_selected_item_count"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_for_each_unattempted_count_to_message_unattempted_count",
+                "context_key": "message_unattempted_count",
+                "tool_output_field": "for_each_unattempted_count"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_process_messages_iteration_errors_to_message_iteration_errors",
+                "context_key": "message_iteration_errors",
+                "tool_output_field": "iteration_errors"
               }
             ],
             "writes_context_keys": [
@@ -472,19 +457,210 @@
               "message_success_count",
               "message_error_count",
               "message_partial_success",
-              "message_item_count"
+              "message_item_count",
+              "message_selected_item_count",
+              "message_unattempted_count",
+              "message_iteration_errors"
             ]
           },
           {
+            "action_id": "workflow_control.context_project",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
+                      "key": "message_success_count",
+                      "kind": "context_compare",
+                      "operator": "gt",
+                      "value": 0
+                    },
+                    {
+                      "key": "message_error_count",
+                      "kind": "context_compare",
+                      "operator": "gt",
+                      "value": 0
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "batch_completed_with_retryable_item_failures",
+                "to_state": "done_with_retryable_failures"
+              },
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
+                      "key": "message_final_state_counts.#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review",
+                      "kind": "context_compare",
+                      "operator": "gt",
+                      "value": 0
+                    },
+                    {
+                      "key": "message_error_count",
+                      "kind": "context_compare",
+                      "operator": "eq",
+                      "value": 0
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "batch_completed_with_human_review_dispositions",
+                "to_state": "done_with_review_required"
+              },
+              {
+                "condition_spec": {
+                  "conditions": [
+                    {
+                      "key": "message_success_count",
+                      "kind": "context_compare",
+                      "operator": "gt",
+                      "value": 0
+                    },
+                    {
+                      "key": "message_error_count",
+                      "kind": "context_compare",
+                      "operator": "eq",
+                      "value": 0
+                    }
+                  ],
+                  "kind": "all"
+                },
+                "reason": "all_messages_succeeded",
+                "to_state": "done"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "message_batch_produced_no_success",
+                "to_state": "failed"
+              }
+            ],
+            "execution_mode": "deterministic",
+            "on_failure_state": "failed",
+            "state_id": "project_batch_result",
+            "static_input_bindings": [
+              [
+                "field_sources",
+                {
+                  "schema_version": "gmail_arxiv_batch_result.v1",
+                  "source_system": "gmail",
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "effective_query": {
+                    "$context_key": "effective_gmail_query"
+                  },
+                  "requested_max_items": {
+                    "$context_key": "gmail_max_results"
+                  },
+                  "result_size_estimate": {
+                    "$context_key": "gmail_result_size_estimate"
+                  },
+                  "page_token_used": {
+                    "$context_key": "gmail_page_token"
+                  },
+                  "next_page_token": {
+                    "$context_key": "gmail_next_page_token"
+                  },
+                  "discovered_message_count": {
+                    "$context_key": "message_item_count"
+                  },
+                  "selected_message_count": {
+                    "$context_key": "message_selected_item_count"
+                  },
+                  "unattempted_message_count": {
+                    "$context_key": "message_unattempted_count"
+                  },
+                  "successful_message_count": {
+                    "$context_key": "message_success_count"
+                  },
+                  "failed_message_count": {
+                    "$context_key": "message_error_count"
+                  },
+                  "partial_success": {
+                    "$context_key": "message_partial_success"
+                  },
+                  "final_state_counts": {
+                    "$context_key": "message_final_state_counts"
+                  },
+                  "items": {
+                    "$context_key": "message_iteration_results"
+                  },
+                  "failures": {
+                    "$context_key": "message_iteration_errors"
+                  }
+                }
+              ],
+              [
+                "required_fields",
+                [
+                  "schema_version",
+                  "source_system",
+                  "source_profile",
+                  "effective_query",
+                  "requested_max_items",
+                  "result_size_estimate",
+                  "page_token_used",
+                  "next_page_token",
+                  "discovered_message_count",
+                  "selected_message_count",
+                  "unattempted_message_count",
+                  "successful_message_count",
+                  "failed_message_count",
+                  "partial_success",
+                  "final_state_counts",
+                  "items",
+                  "failures"
+                ]
+              ],
+              [
+                "include_empty_fields",
+                true
+              ],
+              [
+                "include_missing_fields",
+                true
+              ],
+              [
+                "include_null_fields",
+                true
+              ],
+              [
+                "target_key",
+                "batch_result"
+              ]
+            ],
+            "writes_context_keys": [
+              "batch_result"
+            ]
+          },
+          {
+            "reads_context_keys": [
+              "batch_result"
+            ],
             "state_id": "done"
           },
           {
+            "reads_context_keys": [
+              "batch_result"
+            ],
+            "state_id": "done_with_retryable_failures"
+          },
+          {
+            "reads_context_keys": [
+              "batch_result"
+            ],
             "state_id": "done_with_review_required"
           },
           {
             "state_id": "done_no_messages"
           },
           {
+            "reads_context_keys": [
+              "batch_result"
+            ],
             "state_id": "failed"
           }
         ]
@@ -878,7 +1054,7 @@
               "schema_version": "workflow_step_mutation_authority.v1"
             },
             "next_state": "verify_done_marker",
-            "on_failure_state": "failed_unmarked",
+            "on_failure_state": "project_unmarked_result",
             "state_id": "upgrade_legacy_marker",
             "static_input_bindings": [
               [
@@ -1377,14 +1553,14 @@
                   "value": 0
                 },
                 "reason": "arxiv_ingestion_had_failures_keep_message_unmarked",
-                "to_state": "failed_unmarked"
+                "to_state": "project_unmarked_result"
               },
               {
                 "condition_spec": {
                   "kind": "always"
                 },
                 "reason": "arxiv_ingestion_produced_no_success_keep_message_unmarked",
-                "to_state": "failed_unmarked"
+                "to_state": "project_unmarked_result"
               }
             ],
             "execution_mode": "deterministic",
@@ -1444,6 +1620,11 @@
                 "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_ingest_arxiv_resources_iteration_results_to_arxiv_iteration_results",
                 "context_key": "arxiv_iteration_results",
                 "tool_output_field": "iteration_results"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_ingest_arxiv_resources_iteration_errors_to_arxiv_iteration_errors",
+                "context_key": "arxiv_iteration_errors",
+                "tool_output_field": "iteration_errors"
               }
             ],
             "writes_context_keys": [
@@ -1451,7 +1632,8 @@
               "arxiv_success_count",
               "arxiv_error_count",
               "arxiv_partial_success",
-              "arxiv_item_count"
+              "arxiv_item_count",
+              "arxiv_iteration_errors"
             ]
           },
           {
@@ -1463,7 +1645,7 @@
               "schema_version": "workflow_step_mutation_authority.v1"
             },
             "next_state": "verify_done_marker",
-            "on_failure_state": "failed_unmarked",
+            "on_failure_state": "project_unmarked_result",
             "retry_policy": {
               "backoff_policy": "fixed",
               "initial_delay_ms": 1000,
@@ -1533,6 +1715,21 @@
                 "tool_output_field": "result.arxiv_id"
               },
               {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_done_result_paper_concept_ids_to_paper_concept_ids",
+                "context_key": "paper_concept_ids",
+                "tool_output_field": "result.paper_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_done_result_file_copy_concept_ids_to_file_copy_concept_ids",
+                "context_key": "file_copy_concept_ids",
+                "tool_output_field": "result.file_copy_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_done_result_arxiv_ids_to_arxiv_ids",
+                "context_key": "arxiv_ids",
+                "tool_output_field": "result.arxiv_ids"
+              },
+              {
                 "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_mark_done_result_to_mark_done_result",
                 "context_key": "mark_done_result",
                 "tool_output_field": "result"
@@ -1542,8 +1739,11 @@
               "message_processing_marker",
               "processed_message_id",
               "paper_concept_id",
+              "paper_concept_ids",
               "file_copy_concept_id",
+              "file_copy_concept_ids",
               "arxiv_id",
+              "arxiv_ids",
               "mark_done_result"
             ]
           },
@@ -1561,8 +1761,8 @@
               }
             ],
             "execution_mode": "deterministic",
-            "next_state": "failed_unmarked",
-            "on_failure_state": "failed_unmarked",
+            "next_state": "project_unmarked_result",
+            "on_failure_state": "project_unmarked_result",
             "state_id": "verify_done_marker",
             "static_input_bindings": [
               [
@@ -1621,6 +1821,21 @@
                 "tool_output_field": "result.arxiv_id"
               },
               {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_paper_concept_ids_to_paper_concept_ids",
+                "context_key": "paper_concept_ids",
+                "tool_output_field": "result.paper_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_file_copy_concept_ids_to_file_copy_concept_ids",
+                "context_key": "file_copy_concept_ids",
+                "tool_output_field": "result.file_copy_concept_ids"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_arxiv_ids_to_arxiv_ids",
+                "context_key": "arxiv_ids",
+                "tool_output_field": "result.arxiv_ids"
+              },
+              {
                 "concept_id": "#V#workflow_mapping_tool_field_email_arxiv_ingestion_from_message_workflow_verify_done_marker_result_source_processing_current_to_source_processing_current",
                 "context_key": "source_processing_current",
                 "tool_output_field": "result.source_processing_current"
@@ -1636,8 +1851,11 @@
               "message_processing_marker",
               "processed_message_id",
               "paper_concept_id",
+              "paper_concept_ids",
               "file_copy_concept_id",
+              "file_copy_concept_ids",
               "arxiv_id",
+              "arxiv_ids",
               "source_processing_current",
               "represented_artifacts_exist"
             ]
@@ -1652,7 +1870,7 @@
                   "kind": "context_flag"
                 },
                 "reason": "represented_label_present_and_inbox_absent",
-                "to_state": "done"
+                "to_state": "project_done_result"
               }
             ],
             "execution_mode": "deterministic",
@@ -1661,8 +1879,8 @@
               "reason_code": "verified_represented_message_label_and_archive",
               "schema_version": "workflow_step_mutation_authority.v1"
             },
-            "next_state": "failed_gmail_state",
-            "on_failure_state": "failed_gmail_state",
+            "next_state": "project_gmail_unverified_result",
+            "on_failure_state": "project_gmail_unverified_result",
             "retry_policy": {
               "backoff_policy": "fixed",
               "initial_delay_ms": 1000,
@@ -1723,6 +1941,336 @@
               "gmail_label_state_verified",
               "gmail_readback_label_ids",
               "gmail_modify_reconciled_after_error"
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_project",
+            "execution_mode": "deterministic",
+            "next_state": "done",
+            "on_failure_state": "failed",
+            "state_id": "project_done_result",
+            "static_input_bindings": [
+              [
+                "field_sources",
+                {
+                  "schema_version": "gmail_arxiv_message_result.v1",
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_subject": {
+                    "$context_key": "message_subject"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "disposition": "represented",
+                  "message_processing_marker": {
+                    "$context_key": "message_processing_marker"
+                  },
+                  "paper_concept_id": {
+                    "$context_key": "paper_concept_id"
+                  },
+                  "paper_concept_ids": {
+                    "$context_key": "paper_concept_ids"
+                  },
+                  "file_copy_concept_id": {
+                    "$context_key": "file_copy_concept_id"
+                  },
+                  "file_copy_concept_ids": {
+                    "$context_key": "file_copy_concept_ids"
+                  },
+                  "arxiv_id": {
+                    "$context_key": "arxiv_id"
+                  },
+                  "arxiv_ids": {
+                    "$context_key": "arxiv_ids"
+                  },
+                  "represented_artifacts_exist": {
+                    "$context_key": "represented_artifacts_exist"
+                  },
+                  "source_processing_current": {
+                    "$context_key": "source_processing_current"
+                  },
+                  "gmail_label_state_verified": {
+                    "$context_key": "gmail_label_state_verified"
+                  },
+                  "gmail_readback_label_ids": {
+                    "$context_key": "gmail_readback_label_ids"
+                  },
+                  "gmail_modify_reconciled_after_error": {
+                    "$context_key": "gmail_modify_reconciled_after_error"
+                  },
+                  "arxiv_iteration_results": {
+                    "$context_key": "arxiv_iteration_results"
+                  }
+                }
+              ],
+              [
+                "required_fields",
+                [
+                  "schema_version",
+                  "source_item_id",
+                  "source_subject",
+                  "source_profile",
+                  "disposition",
+                  "message_processing_marker",
+                  "paper_concept_id",
+                  "paper_concept_ids",
+                  "file_copy_concept_id",
+                  "file_copy_concept_ids",
+                  "arxiv_id",
+                  "arxiv_ids",
+                  "represented_artifacts_exist",
+                  "source_processing_current",
+                  "gmail_label_state_verified",
+                  "gmail_readback_label_ids",
+                  "gmail_modify_reconciled_after_error",
+                  "arxiv_iteration_results"
+                ]
+              ],
+              [
+                "include_empty_fields",
+                true
+              ],
+              [
+                "include_missing_fields",
+                true
+              ],
+              [
+                "include_null_fields",
+                true
+              ],
+              [
+                "target_key",
+                "result"
+              ]
+            ],
+            "writes_context_keys": [
+              "result"
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_project",
+            "execution_mode": "deterministic",
+            "next_state": "failed_unmarked",
+            "on_failure_state": "failed_unmarked",
+            "state_id": "project_unmarked_result",
+            "static_input_bindings": [
+              [
+                "field_sources",
+                {
+                  "schema_version": "gmail_arxiv_message_result.v1",
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_subject": {
+                    "$context_key": "message_subject"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "disposition": "failed_unmarked",
+                  "message_processing_marker": {
+                    "$context_key": "message_processing_marker"
+                  },
+                  "paper_concept_id": {
+                    "$context_key": "paper_concept_id"
+                  },
+                  "paper_concept_ids": {
+                    "$context_key": "paper_concept_ids"
+                  },
+                  "file_copy_concept_id": {
+                    "$context_key": "file_copy_concept_id"
+                  },
+                  "file_copy_concept_ids": {
+                    "$context_key": "file_copy_concept_ids"
+                  },
+                  "arxiv_id": {
+                    "$context_key": "arxiv_id"
+                  },
+                  "arxiv_ids": {
+                    "$context_key": "arxiv_ids"
+                  },
+                  "represented_artifacts_exist": {
+                    "$context_key": "represented_artifacts_exist"
+                  },
+                  "source_processing_current": {
+                    "$context_key": "source_processing_current"
+                  },
+                  "arxiv_success_count": {
+                    "$context_key": "arxiv_success_count"
+                  },
+                  "arxiv_error_count": {
+                    "$context_key": "arxiv_error_count"
+                  },
+                  "arxiv_iteration_results": {
+                    "$context_key": "arxiv_iteration_results"
+                  },
+                  "arxiv_iteration_errors": {
+                    "$context_key": "arxiv_iteration_errors"
+                  },
+                  "failure_action_id": {
+                    "$context_key": "last_action_id"
+                  },
+                  "failure_reason": {
+                    "$context_key": "last_action_error"
+                  }
+                }
+              ],
+              [
+                "required_fields",
+                [
+                  "schema_version",
+                  "source_item_id",
+                  "source_subject",
+                  "source_profile",
+                  "disposition",
+                  "message_processing_marker",
+                  "paper_concept_id",
+                  "paper_concept_ids",
+                  "file_copy_concept_id",
+                  "file_copy_concept_ids",
+                  "arxiv_id",
+                  "arxiv_ids",
+                  "represented_artifacts_exist",
+                  "source_processing_current",
+                  "arxiv_success_count",
+                  "arxiv_error_count",
+                  "arxiv_iteration_results",
+                  "arxiv_iteration_errors",
+                  "failure_action_id",
+                  "failure_reason"
+                ]
+              ],
+              [
+                "include_empty_fields",
+                true
+              ],
+              [
+                "include_missing_fields",
+                true
+              ],
+              [
+                "include_null_fields",
+                true
+              ],
+              [
+                "target_key",
+                "result"
+              ]
+            ],
+            "writes_context_keys": [
+              "result"
+            ]
+          },
+          {
+            "action_id": "workflow_control.context_project",
+            "execution_mode": "deterministic",
+            "next_state": "failed_gmail_state",
+            "on_failure_state": "failed_gmail_state",
+            "state_id": "project_gmail_unverified_result",
+            "static_input_bindings": [
+              [
+                "field_sources",
+                {
+                  "schema_version": "gmail_arxiv_message_result.v1",
+                  "source_item_id": {
+                    "$context_key": "message_id"
+                  },
+                  "source_subject": {
+                    "$context_key": "message_subject"
+                  },
+                  "source_profile": {
+                    "$context_key": "gmail_profile"
+                  },
+                  "disposition": "represented_gmail_unverified",
+                  "message_processing_marker": {
+                    "$context_key": "message_processing_marker"
+                  },
+                  "paper_concept_id": {
+                    "$context_key": "paper_concept_id"
+                  },
+                  "paper_concept_ids": {
+                    "$context_key": "paper_concept_ids"
+                  },
+                  "file_copy_concept_id": {
+                    "$context_key": "file_copy_concept_id"
+                  },
+                  "file_copy_concept_ids": {
+                    "$context_key": "file_copy_concept_ids"
+                  },
+                  "arxiv_id": {
+                    "$context_key": "arxiv_id"
+                  },
+                  "arxiv_ids": {
+                    "$context_key": "arxiv_ids"
+                  },
+                  "represented_artifacts_exist": {
+                    "$context_key": "represented_artifacts_exist"
+                  },
+                  "source_processing_current": {
+                    "$context_key": "source_processing_current"
+                  },
+                  "gmail_label_state_verified": {
+                    "$context_key": "gmail_label_state_verified"
+                  },
+                  "gmail_readback_label_ids": {
+                    "$context_key": "gmail_readback_label_ids"
+                  },
+                  "gmail_modify_reconciled_after_error": {
+                    "$context_key": "gmail_modify_reconciled_after_error"
+                  },
+                  "failure_action_id": {
+                    "$context_key": "last_action_id"
+                  },
+                  "failure_reason": {
+                    "$context_key": "last_action_error"
+                  }
+                }
+              ],
+              [
+                "required_fields",
+                [
+                  "schema_version",
+                  "source_item_id",
+                  "source_subject",
+                  "source_profile",
+                  "disposition",
+                  "message_processing_marker",
+                  "paper_concept_id",
+                  "paper_concept_ids",
+                  "file_copy_concept_id",
+                  "file_copy_concept_ids",
+                  "arxiv_id",
+                  "arxiv_ids",
+                  "represented_artifacts_exist",
+                  "source_processing_current",
+                  "gmail_label_state_verified",
+                  "gmail_readback_label_ids",
+                  "gmail_modify_reconciled_after_error",
+                  "failure_action_id",
+                  "failure_reason"
+                ]
+              ],
+              [
+                "include_empty_fields",
+                true
+              ],
+              [
+                "include_missing_fields",
+                true
+              ],
+              [
+                "include_null_fields",
+                true
+              ],
+              [
+                "target_key",
+                "result"
+              ]
+            ],
+            "writes_context_keys": [
+              "result"
             ]
           },
           {

--- a/tests/backend/test_control_flow_actions.py
+++ b/tests/backend/test_control_flow_actions.py
@@ -460,7 +460,11 @@ def test_for_each_action_respects_partial_success_policy() -> None:
 
     def _conditionally_fail(request):
         if request.data.get("current_item") == "bad":
-            return WorkflowActionResult(status="failed", error="child_failed")
+            return WorkflowActionResult(
+                status="failed",
+                error="child_failed",
+                outputs={"failure_reason": "source read-back failed"},
+            )
         return WorkflowActionResult(outputs={"item_value": request.data.get("current_item")})
 
     registry.register(
@@ -500,6 +504,7 @@ def test_for_each_action_respects_partial_success_policy() -> None:
             "item": "bad",
             "final_state": "start",
             "error": "child_failed",
+            "result": {"failure_reason": "source read-back failed"},
         }
     ]
 

--- a/tests/backend/test_conversation_situation_turn_projection.py
+++ b/tests/backend/test_conversation_situation_turn_projection.py
@@ -353,6 +353,51 @@ def test_mixed_partial_turn_preserves_stable_receipt_and_workflow_status_only() 
     assert "verified_concept_ids" not in projection
 
 
+def test_parent_batch_projects_one_durable_locator_for_all_item_results() -> None:
+    item_results = [
+        {
+            "source_item_id": f"gmail-message-{index + 1}",
+            "disposition": "represented" if index < 21 else "failed_unmarked",
+        }
+        for index in range(22)
+    ]
+    projection = build_conversation_situation_turn_projection(
+        request_id="turn-paper-batch",
+        terminal_status="completed",
+        response_text="Represented 21 messages; one can be retried.",
+        tool_invocations=[
+            {
+                "tool": "workflow_execute",
+                "status": "ok",
+                "effect_id": "effect-paper-batch",
+                "effect_status": "succeeded",
+                "changed": True,
+                "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
+                "instance_id": "workflow-paper-batch-123",
+                "effective_payload": {
+                    "success": True,
+                    "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
+                    "instance_id": "workflow-paper-batch-123",
+                    "status": "completed",
+                    "batch_result": {
+                        "schema_version": "gmail_arxiv_batch_result.v1",
+                        "items": item_results,
+                    },
+                },
+            }
+        ],
+    )
+
+    assert projection is not None
+    assert projection["workflow_instances"] == [
+        {
+            "instance_id": "workflow-paper-batch-123",
+            "status": "completed",
+            "workflow_id": "#V#zhan_gmail_arxiv_ingestion_workflow",
+        }
+    ]
+
+
 def test_simple_chat_without_tool_records_does_not_create_runtime_situation() -> None:
     projection = build_conversation_situation_turn_projection(
         request_id="turn-simple-chat",

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -353,15 +353,17 @@ def test_email_source_seed_requires_current_markers_before_verified_gmail_writes
     ]
     assert "message_processing_marker" in mark_done["writes_context_keys"]
     assert mark_done["next_state"] == "verify_done_marker"
-    assert mark_done["on_failure_state"] == "failed_unmarked"
+    assert mark_done["on_failure_state"] == "project_unmarked_result"
 
     verify_done_marker = steps["verify_done_marker"]
     assert verify_done_marker["static_input_bindings"][1] == [
         "tool_name",
         "get_source_processing_marker",
     ]
-    assert verify_done_marker["on_failure_state"] == "failed_unmarked"
-    assert verify_done_marker["next_state"] == "failed_unmarked"
+    assert verify_done_marker["on_failure_state"] == (
+        "project_unmarked_result"
+    )
+    assert verify_done_marker["next_state"] == "project_unmarked_result"
     assert verify_done_marker["conditional_transitions"][0]["condition_spec"] == {
         "expected": True,
         "key": "source_processing_current",
@@ -385,6 +387,11 @@ def test_email_source_seed_requires_current_markers_before_verified_gmail_writes
     ]
     assert gmail_arguments["remove_labels"] == ["INBOX"]
     assert gmail_arguments["verify_after"] is True
+    assert converge["conditional_transitions"][0]["to_state"] == (
+        "project_done_result"
+    )
+    assert converge["next_state"] == "project_gmail_unverified_result"
+    assert converge["on_failure_state"] == "project_gmail_unverified_result"
 
 
 def test_email_source_seed_dispositions_non_converging_mail_for_human_review() -> None:
@@ -576,7 +583,12 @@ def test_parent_batch_surfaces_human_review_disposition_count() -> None:
         for item in process["tool_output_mapping_specs"]
     }
     assert mappings["message_final_state_counts"] == "for_each_final_state_counts"
-    review_transition = process["conditional_transitions"][0]
+    project = next(
+        step
+        for step in parent["publication_spec"]["steps"]
+        if step.get("state_id") == "project_batch_result"
+    )
+    review_transition = project["conditional_transitions"][1]
     assert review_transition["to_state"] == "done_with_review_required"
     assert review_transition["condition_spec"]["conditions"][0]["key"] == (
         "message_final_state_counts.#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done_needs_review"
@@ -591,6 +603,227 @@ def test_parent_batch_surfaces_human_review_disposition_count() -> None:
         },
         condition_spec=review_transition["condition_spec"],
     )
+
+
+def test_parent_batch_preserves_all_22_item_results_and_one_retryable_failure() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID],
+    )[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
+    definition = replace(
+        definition,
+        initial_state="project_batch_result",
+        states={
+            state_id: definition.states[state_id]
+            for state_id in ("project_batch_result", "done_with_retryable_failures")
+        },
+        termination_states=(),
+    )
+
+    unique_arxiv_ids = [f"2606.{index:05d}" for index in range(1, 20)]
+    successful_arxiv_ids = [*unique_arxiv_ids, unique_arxiv_ids[0], unique_arxiv_ids[1]]
+    successful_items = [
+        {
+            "index": index,
+            "item": {"id": f"gmail-message-{index + 1}"},
+            "completed": True,
+            "final_state": "done",
+            "error": None,
+            "result": {
+                "result": {
+                    "schema_version": "gmail_arxiv_message_result.v1",
+                    "source_item_id": f"gmail-message-{index + 1}",
+                    "disposition": "represented",
+                    "arxiv_ids": [arxiv_id],
+                    "paper_concept_ids": [f"#V#paper_{arxiv_id.replace('.', '_')}"],
+                    "gmail_label_state_verified": True,
+                }
+            },
+        }
+        for index, arxiv_id in enumerate(successful_arxiv_ids)
+    ]
+    failed_item = {
+        "index": 21,
+        "item": {"id": "gmail-message-22"},
+        "completed": False,
+        "final_state": "failed_unmarked",
+        "error": "workflow_failed_terminal_state",
+        "result": {
+            "result": {
+                "schema_version": "gmail_arxiv_message_result.v1",
+                "source_item_id": "gmail-message-22",
+                "disposition": "failed_unmarked",
+                "arxiv_ids": ["2606.99999"],
+            }
+        },
+    }
+    iteration_results = [*successful_items, failed_item]
+    iteration_errors = [
+        {
+            "index": 21,
+            "item": {"id": "gmail-message-22"},
+            "final_state": "failed_unmarked",
+            "error": "workflow_failed_terminal_state",
+            "result": failed_item["result"],
+        }
+    ]
+
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    result = WorkflowExecutor(registry=registry, max_transitions=4).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "gmail_profile": "vonwitbrock-gmail",
+            "effective_gmail_query": "newer_than:30d arxiv",
+            "gmail_max_results": 100,
+            "gmail_result_size_estimate": 22,
+            "gmail_page_token": None,
+            "gmail_next_page_token": None,
+            "message_item_count": 22,
+            "message_selected_item_count": 22,
+            "message_unattempted_count": 0,
+            "message_success_count": 21,
+            "message_error_count": 1,
+            "message_partial_success": True,
+            "message_final_state_counts": {
+                "#V#workflow_step_email_arxiv_ingestion_from_message_workflow_done": 21,
+                "#V#workflow_step_email_arxiv_ingestion_from_message_workflow_failed_unmarked": 1,
+            },
+            "message_iteration_results": iteration_results,
+            "message_iteration_errors": iteration_errors,
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done_with_retryable_failures"
+    batch_result = result.data["batch_result"]
+    assert batch_result["schema_version"] == "gmail_arxiv_batch_result.v1"
+    assert batch_result["discovered_message_count"] == 22
+    assert batch_result["page_token_used"] is None
+    assert batch_result["successful_message_count"] == 21
+    assert batch_result["failed_message_count"] == 1
+    assert batch_result["partial_success"] is True
+    assert batch_result["items"] == iteration_results
+    assert batch_result["failures"] == iteration_errors
+    represented_ids = {
+        arxiv_id
+        for item in batch_result["items"]
+        if item["completed"]
+        for arxiv_id in item["result"]["result"]["arxiv_ids"]
+    }
+    assert len(represented_ids) == 19
+    assert batch_result["items"][-1]["result"]["result"]["disposition"] == (
+        "failed_unmarked"
+    )
+
+
+def test_parent_batch_passes_prior_continuation_token_to_gmail_listing() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID],
+    )[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
+    definition = replace(
+        definition,
+        initial_state="list_messages",
+        states={
+            state_id: definition.states[state_id]
+            for state_id in ("list_messages", "decide_messages", "done_no_messages")
+        },
+        termination_states=(),
+    )
+    observed_arguments: dict[str, object] = {}
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        assert request.inputs["tool_name"] == "gmail_list_messages"
+        observed_arguments.update(request.inputs["tool_arguments"])
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "messages": [],
+                    "profile": "vonwitbrock-gmail",
+                    "effective_query": {"effective_query_string": "arxiv.org"},
+                    "nextPageToken": None,
+                    "resultSizeEstimate": 22,
+                }
+            },
+        )
+
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    registry.register(ActionSpec(action_id="workflow_mcp.invoke_tool", handler=handler))
+    result = WorkflowExecutor(registry=registry, max_transitions=4).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "gmail_profile": "vonwitbrock-gmail",
+            "gmail_query": "arxiv.org",
+            "gmail_max_results": 100,
+            "gmail_page_token": "gmail-page-2",
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done_no_messages"
+    assert observed_arguments["page_token"] == "gmail-page-2"
+
+
+def test_parent_batch_result_is_lossless_across_durable_checkpoints() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.durable.checkpoint_context_projection import (
+        project_workflow_context_for_checkpoint,
+    )
+    from src.backend.workflows.durable.durable_executor import (
+        _execution_required_checkpoint_context_keys,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID],
+    )[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
+    lossless_keys = _execution_required_checkpoint_context_keys(definition)
+    assert "batch_result" in lossless_keys
+
+    batch_result = {
+        "schema_version": "gmail_arxiv_batch_result.v1",
+        "items": [
+            {
+                "index": index,
+                "source_item_id": f"gmail-message-{index + 1}",
+                "paper_concept_ids": [f"#V#paper_{index + 1}"],
+                "evidence": "x" * 200,
+            }
+            for index in range(100)
+        ],
+    }
+    projected = project_workflow_context_for_checkpoint(
+        {"batch_result": batch_result},
+        max_value_bson_bytes=512,
+        lossless_keys=lossless_keys,
+    )
+
+    assert projected["batch_result"] == batch_result
+    assert len(projected["batch_result"]["items"]) == 100
 
 
 def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> None:
@@ -624,8 +857,8 @@ def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> Non
 
     assert parent_lifecycle["routing_eligible"] is True
     assert parent_routing["routing_eligible"] is True
-    assert parent_routing["explicit_workflow_context_required"] is True
-    assert parent_routing["prefer_existing_capability"] is False
+    assert parent_routing["explicit_workflow_context_required"] is False
+    assert parent_routing["prefer_existing_capability"] is True
 
     assert child_lifecycle["routing_eligible"] is True
     assert child_lifecycle["postconditions_verified"] is True
@@ -699,6 +932,7 @@ def _exact_message_definition(*state_ids: str, initial_state: str):
 
 def _run_exact_message_slice(definition, handler):
     registry = ActionRegistry()
+    register_control_flow_actions(registry)
     registry.register(ActionSpec(action_id="workflow_mcp.invoke_tool", handler=handler))
     return WorkflowExecutor(registry=registry, max_transitions=8).run(
         definition,
@@ -732,8 +966,11 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
                         "message_processing_marker": "#V#marker_1",
                         "processed_message_id": "gmail-message-1",
                         "paper_concept_id": "#V#paper_2606_12345",
+                        "paper_concept_ids": ["#V#paper_2606_12345"],
                         "file_copy_concept_id": "#V#file_2606_12345",
+                        "file_copy_concept_ids": ["#V#file_2606_12345"],
                         "arxiv_id": "2606.12345",
+                        "arxiv_ids": ["2606.12345"],
                     }
                 },
             )
@@ -757,8 +994,11 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
                     "message_processing_marker": "#V#marker_1",
                     "processed_message_id": "gmail-message-1",
                     "paper_concept_id": "#V#paper_2606_12345",
+                    "paper_concept_ids": ["#V#paper_2606_12345"],
                     "file_copy_concept_id": "#V#file_2606_12345",
+                    "file_copy_concept_ids": ["#V#file_2606_12345"],
                     "arxiv_id": "2606.12345",
+                    "arxiv_ids": ["2606.12345"],
                     "source_processing_current": True,
                     "represented_artifacts_exist": True,
                 }
@@ -769,6 +1009,9 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
         "mark_done",
         "verify_done_marker",
         "converge_gmail_labels",
+        "project_done_result",
+        "project_unmarked_result",
+        "project_gmail_unverified_result",
         "done",
         "failed_unmarked",
         "failed_gmail_state",
@@ -785,6 +1028,12 @@ def test_exact_message_workflow_records_then_reads_back_marker_before_success() 
     ]
     assert result.data["source_processing_marker_exists"] is True
     assert result.data["message_processing_marker"] == "#V#marker_1"
+    assert result.data["result"]["disposition"] == "represented"
+    assert result.data["result"]["paper_concept_id"] == (
+        "#V#paper_2606_12345"
+    )
+    assert result.data["result"]["arxiv_id"] == "2606.12345"
+    assert result.data["result"]["gmail_label_state_verified"] is True
 
 
 @pytest.mark.parametrize("failure_mode", ["write_failed", "readback_missing"])
@@ -806,8 +1055,11 @@ def test_exact_message_workflow_never_claims_success_without_verified_marker(
                         "message_processing_marker": "#V#marker_1",
                         "processed_message_id": "gmail-message-1",
                         "paper_concept_id": "#V#paper_2606_12345",
+                        "paper_concept_ids": ["#V#paper_2606_12345"],
                         "file_copy_concept_id": "#V#file_2606_12345",
+                        "file_copy_concept_ids": ["#V#file_2606_12345"],
                         "arxiv_id": "2606.12345",
+                        "arxiv_ids": ["2606.12345"],
                     }
                 },
             )
@@ -820,8 +1072,11 @@ def test_exact_message_workflow_never_claims_success_without_verified_marker(
                     "message_processing_marker": None,
                     "processed_message_id": None,
                     "paper_concept_id": None,
+                    "paper_concept_ids": [],
                     "file_copy_concept_id": None,
+                    "file_copy_concept_ids": [],
                     "arxiv_id": None,
+                    "arxiv_ids": [],
                     "source_processing_current": False,
                     "represented_artifacts_exist": False,
                 }
@@ -831,14 +1086,16 @@ def test_exact_message_workflow_never_claims_success_without_verified_marker(
     definition = _exact_message_definition(
         "mark_done",
         "verify_done_marker",
+        "project_unmarked_result",
         "done",
         "failed_unmarked",
         initial_state="mark_done",
     )
     result = _run_exact_message_slice(definition, handler)
 
-    assert result.completed is True
+    assert result.completed is False
     assert result.final_state == "failed_unmarked"
+    assert result.data["result"]["disposition"] == "failed_unmarked"
     assert calls == (
         ["record_source_processing_marker", "record_source_processing_marker"]
         if failure_mode == "write_failed"
@@ -886,6 +1143,8 @@ def test_exact_message_workflow_reuses_current_marker_then_converges_gmail() -> 
     definition = _exact_message_definition(
         "check_processed_marker",
         "converge_gmail_labels",
+        "project_done_result",
+        "project_gmail_unverified_result",
         "done",
         "failed_gmail_state",
         "failed",
@@ -948,6 +1207,9 @@ def test_exact_message_workflow_upgrades_legacy_marker_before_gmail() -> None:
         "upgrade_legacy_marker",
         "verify_done_marker",
         "converge_gmail_labels",
+        "project_done_result",
+        "project_unmarked_result",
+        "project_gmail_unverified_result",
         "done",
         "failed",
         "failed_unmarked",
@@ -975,14 +1237,18 @@ def test_exact_message_workflow_does_not_succeed_when_gmail_readback_fails() -> 
 
     definition = _exact_message_definition(
         "converge_gmail_labels",
+        "project_gmail_unverified_result",
         "done",
         "failed_gmail_state",
         initial_state="converge_gmail_labels",
     )
     result = _run_exact_message_slice(definition, handler)
 
-    assert result.completed is True
+    assert result.completed is False
     assert result.final_state == "failed_gmail_state"
+    assert result.data["result"]["disposition"] == (
+        "represented_gmail_unverified"
+    )
     assert calls == ["gmail_modify_labels", "gmail_modify_labels"]
 
 
@@ -1001,6 +1267,9 @@ def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() ->
                 "for_each_partial_success": False,
                 "for_each_success_count": 0,
                 "iteration_results": [{"status": "failed"}],
+                "iteration_errors": [
+                    {"item_index": 0, "error": "paper representation failed"}
+                ],
             },
         )
 
@@ -1011,6 +1280,7 @@ def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() ->
         "ingest_arxiv_resources",
         "mark_done",
         "verify_done_marker",
+        "project_unmarked_result",
         "done",
         "failed_unmarked",
         initial_state="ingest_arxiv_resources",
@@ -1019,6 +1289,7 @@ def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() ->
     registry.register(
         ActionSpec(action_id="workflow_control.for_each", handler=failed_ingestion)
     )
+    register_control_flow_actions(registry)
     registry.register(
         ActionSpec(action_id="workflow_mcp.invoke_tool", handler=marker_must_not_run)
     )
@@ -1028,7 +1299,7 @@ def test_exact_message_workflow_does_not_mark_after_arxiv_ingestion_failure() ->
         data={"arxiv_resource_references": [{"identifier": "2606.12345"}]},
     )
 
-    assert result.completed is True
+    assert result.completed is False
     assert result.final_state == "failed_unmarked"
     assert calls == ["workflow_control.for_each"]
 
@@ -1049,12 +1320,16 @@ def test_zhan_seed_launch_contract_can_narrow_from_prior_arxiv_evidence() -> Non
     resolution = resolve_workflow_launch_inputs(
         workflow_id=mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID,
         contract=workflow["launch_input_contract"],
-        inputs={"arxiv_id": "2606.30544"},
+        inputs={
+            "arxiv_id": "2606.30544",
+            "next_page_token": "gmail-page-2",
+        },
         contract_source="repo_seed_test",
     )
 
     assert resolution.resolved_inputs["base_gmail_query"] == "2606.30544"
     assert resolution.resolved_inputs["arxiv_id"] == "2606.30544"
+    assert resolution.resolved_inputs["gmail_page_token"] == "gmail-page-2"
     assert resolution.diagnostics["status"] == "resolved"
 
 

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -293,6 +293,43 @@ def test_list_and_get_message(mock_get_profile, mock_get_service):
 
 @patch("src.backend.integrations.google.gmail_service.get_service")
 @patch("src.backend.integrations.google.gmail_service.get_profile")
+def test_list_messages_passes_continuation_token_to_gmail(
+    mock_get_profile, mock_get_service
+):
+    mock_get_profile.return_value = SimpleNamespace(
+        profile_id="test",
+        user_id="me",
+        label_filter=None,
+        query_prefix=None,
+    )
+    messages_mock = MagicMock()
+    mock_get_service.return_value.users.return_value.messages.return_value = (
+        messages_mock
+    )
+    messages_mock.list.return_value.execute.return_value = {
+        "messages": [{"id": "message-26"}],
+        "nextPageToken": "page-3",
+    }
+
+    result = gs.list_messages(
+        "test",
+        query="arxiv.org",
+        max_results=25,
+        page_token=" page-2 ",
+    )
+
+    assert result["nextPageToken"] == "page-3"
+    messages_mock.list.assert_called_once_with(
+        userId="me",
+        q="arxiv.org",
+        labelIds=None,
+        maxResults=25,
+        pageToken="page-2",
+    )
+
+
+@patch("src.backend.integrations.google.gmail_service.get_service")
+@patch("src.backend.integrations.google.gmail_service.get_profile")
 def test_list_messages_projects_requested_metadata_without_body(
     mock_get_profile, mock_get_service
 ):

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -270,6 +270,8 @@ def test_workflow_instance_await_is_a_model_visible_soft_checkpoint():
     assert definition.hard_timeout_enabled is False
     assert definition.resolved_timeout(InternalMCPTransport()) is None
     assert "await_terminal" in definition.input_schema.optional
+    assert "workflow_data" in definition.output_schema.optional
+    assert "exhaustive list or count" in definition.description
     assert "never cancels or retries" in definition.description
 
 
@@ -757,6 +759,12 @@ def test_internal_mcp_gmail_list_messages_accepts_max_results_aliases():
     )
     assert ok, errors
 
+    ok, errors = validate_payload(
+        method.input_schema,
+        {"profile": "zhan-gmail", "page_token": "page-2"},
+    )
+    assert ok, errors
+
     assert method.output_schema is not None
     assert "gmail_get_message" in (method.description or "")
     assert "message_id" in (method.description or "")
@@ -1160,7 +1168,10 @@ def test_gmail_list_messages_surfaces_effective_query_and_warns_on_prefix(
     monkeypatch.setattr(gs, "list_messages", fake_list_messages)
     monkeypatch.setattr(gs, "get_profile", lambda *_a, **_kw: fake_profile)
 
-    payload = catalogue_module._gmail_list_messages(profile="vonwitbrock-gmail")
+    payload = catalogue_module._gmail_list_messages(
+        profile="vonwitbrock-gmail",
+        page_token="gmail-page-2",
+    )
 
     assert "effective_query" in payload
     eq = payload["effective_query"]
@@ -1178,6 +1189,7 @@ def test_gmail_list_messages_surfaces_effective_query_and_warns_on_prefix(
 
     # The handler did not pass bypass through unless asked.
     assert captured_kwargs.get("bypass_profile_query_prefix") is False
+    assert captured_kwargs["page_token"] == "gmail-page-2"
 
 
 def test_gmail_list_messages_reports_grouped_profile_and_caller_query(

--- a/tests/backend/test_internal_mcp_locator_tools.py
+++ b/tests/backend/test_internal_mcp_locator_tools.py
@@ -103,11 +103,64 @@ def test_chat_history_get_segments_returns_provenanced_payload(monkeypatch):
     assert result["chat_session_id"] == "chat-1"
     assert result["segment_count"] == 1
     assert result["history_truncated"] is False
+    assert result["history_coverage"] == {
+        "schema_version": "conversation_history_coverage.v1",
+        "status": "complete",
+        "history_truncated": False,
+        "exhaustive_answer_supported": True,
+        "continuation_required_for_exhaustive_answer": False,
+    }
     assert result["conversation_situation"] == situation
     assert result["conversation_observations"] == observations
     assert result["conversation_observation_state"] == observation_state
     assert result["identifier_binding"]["mode"] == "raw_parameters"
     assert result["provenance"]["item_kind"] == "chat_history_segments"
+
+
+def test_chat_history_get_segments_marks_truncation_as_non_exhaustive(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    monkeypatch.setattr(
+        cat,
+        "_resolve_chat_history_read_target",
+        lambda _kwargs: {
+            "success": True,
+            "session_id": "chat-1",
+            "chat_session_id": "chat-1",
+            "read_user_id": "#V#user",
+            "requested_user_id": "#V#user",
+            "read_namespace": "#V#user@org",
+            "access_mode": "owner",
+            "identifier_binding": {"mode": "raw_parameters"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_history_segments",
+        lambda *_args, **_kwargs: (
+            [{"segment_index": 0, "history": [{"role": "user", "content": "tail"}]}],
+            {"history_truncated": True},
+        ),
+    )
+
+    result = cat._chat_history_get_segments(
+        session_id="chat-1",
+        namespace="#V#user@org",
+        history_tail_limit=50,
+    )
+
+    assert result["history_truncated"] is True
+    assert result["history_coverage"]["status"] == "truncated"
+    assert result["history_coverage"]["exhaustive_answer_supported"] is False
+    assert (
+        result["history_coverage"]["continuation_required_for_exhaustive_answer"]
+        is True
+    )
+    assert result["history_coverage"]["recovery"]["tool_name"] == (
+        "chat_history_get_segments"
+    )
+    assert "without history_tail_limit" in result["history_coverage"]["recovery"][
+        "instruction"
+    ]
 
 
 def test_chat_history_get_debug_entry_returns_history_location(monkeypatch):

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -1441,6 +1441,43 @@ def test_workflow_get_instance_exposes_failed_outputs(monkeypatch):
     }
 
 
+def test_workflow_get_instance_exposes_persisted_batch_result(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as catalogue_module
+
+    manager = _StubWorkflowManager()
+    instance_id = manager.create_instance(
+        "#V#zhan_gmail_arxiv_ingestion_workflow",
+        user_id="#V#user",
+        org_id="#V#org",
+        namespace="#V#user@org",
+    )
+    instance = manager.get_instance(instance_id)
+    assert instance is not None
+    instance.workflow_data["batch_result"] = {
+        "schema_version": "gmail_arxiv_batch_result.v1",
+        "successful_message_count": 21,
+        "failed_message_count": 1,
+    }
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        catalogue_module,
+        "_workflow_persisted_record_matches_internal_actor",
+        lambda _record: True,
+    )
+
+    detail = catalogue_module._workflow_get_instance(instance_id=instance_id)
+
+    assert detail["success"] is True
+    assert detail["workflow_data"]["batch_result"] == {
+        "schema_version": "gmail_arxiv_batch_result.v1",
+        "successful_message_count": 21,
+        "failed_message_count": 1,
+    }
+
+
 def test_workflow_instance_tools_are_exactly_scoped_to_preexisting_actor(
     monkeypatch,
 ):

--- a/tests/backend/test_workflow_execution_contracts.py
+++ b/tests/backend/test_workflow_execution_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from src.backend.workflows.action_registry import (
     ActionRegistry,
     ActionSpec,
@@ -15,6 +17,25 @@ from src.backend.workflows.engine import (
     WorkflowTransitionSpec,
     resolve_action_inputs_from_context,
 )
+from src.backend.workflows.execution_contracts import (
+    workflow_final_state_is_failure_like,
+)
+
+
+@pytest.mark.parametrize(
+    ("final_state", "expected"),
+    [
+        ("failed_unmarked", True),
+        ("failed_gmail_state", True),
+        ("#V#workflow_step_email_ingestion_failed_unmarked", True),
+        ("done_with_retryable_failures", False),
+        ("completed_with_errors", False),
+    ],
+)
+def test_workflow_failure_like_terminal_states_are_token_bounded(
+    final_state: str, expected: bool
+) -> None:
+    assert workflow_final_state_is_failure_like(final_state) is expected
 
 
 def test_static_context_bindings_resolve_shared_dotted_paths() -> None:


### PR DESCRIPTION
## What changed

- route broad Gmail/arXiv requests through one durable parent workflow with paginated Gmail discovery
- retain a lossless batch result containing every attempted item, successful representation, mailbox completion read-back, and per-item failure
- expose persisted parent workflow data and explicit conversation-history coverage for exhaustive follow-ups
- preserve child failure details in generic `for_each` results and classify partial-success terminal states correctly

## Why

The original request launched each email as an unrelated workflow. Conversation compaction retained only a subset of receipts, so later questions could enumerate fewer represented papers and could not explain the failed item reliably.

## User impact

The initial answer and later questions in the same conversation can use the same authoritative parent batch result. Successful papers remain successful when another item fails; the answer can enumerate the full represented set, confirm which source messages were marked complete, and name retryable failures with their causes.

## Validation

- 310 affected-path backend tests passed
- exact 22-message contract: 21 successful messages, 19 unique papers, one explained failure
- forced 512-byte checkpoint compaction retained a 100-item batch losslessly
- Gmail pagination, workflow-data read-back, truncation signalling, parent locator retention, and partial-failure classification covered
- JSON parse, Python compile, and `git diff --check` passed

Jira: JVNAUTOSCI-2635