### PR TITLE
Allow Gmail batches without pagination metadata

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "15",
+  "seed_version": "16",
   "source_tag": "JVNAUTOSCI-2635",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
@@ -329,9 +329,7 @@
               "list_result",
               "messages",
               "effective_gmail_query",
-              "gmail_profile",
-              "gmail_next_page_token",
-              "gmail_result_size_estimate"
+              "gmail_profile"
             ]
           },
           {

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -783,6 +783,60 @@ def test_parent_batch_passes_prior_continuation_token_to_gmail_listing() -> None
     assert observed_arguments["page_token"] == "gmail-page-2"
 
 
+def test_parent_batch_allows_gmail_to_omit_optional_pagination_metadata() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[mod._REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID],
+    )[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
+    definition = replace(
+        definition,
+        initial_state="list_messages",
+        states={
+            state_id: definition.states[state_id]
+            for state_id in ("list_messages", "decide_messages", "done_no_messages")
+        },
+        termination_states=(),
+    )
+
+    def handler(request: WorkflowActionRequest) -> WorkflowActionResult:
+        assert request.inputs["tool_name"] == "gmail_list_messages"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "messages": [],
+                    "profile": "vonwitbrock-gmail",
+                    "effective_query": {"effective_query_string": "arxiv.org"},
+                }
+            },
+        )
+
+    registry = ActionRegistry()
+    register_control_flow_actions(registry)
+    registry.register(ActionSpec(action_id="workflow_mcp.invoke_tool", handler=handler))
+    result = WorkflowExecutor(registry=registry, max_transitions=4).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "gmail_profile": "vonwitbrock-gmail",
+            "gmail_query": "arxiv.org",
+            "gmail_max_results": 100,
+        },
+    )
+
+    assert result.completed is True
+    assert result.final_state == "done_no_messages"
+    assert "gmail_next_page_token" not in result.data
+    assert "gmail_result_size_estimate" not in result.data
+
+
 def test_parent_batch_result_is_lossless_across_durable_checkpoints() -> None:
     from src.backend.services import (
         email_source_representation_convergence_workflow_vontology_service as mod,


### PR DESCRIPTION
## What changed

- keep Gmail continuation-token and result-size mappings available when Gmail returns them
- stop declaring those optional response fields as mandatory workflow write effects
- bump the represented email-source workflow seed to version 16
- add the exact no-`nextPageToken`/no-`resultSizeEstimate` regression

## Root cause

The first live replay after PR #383 correctly selected one parent batch workflow, but Gmail returned no `nextPageToken` for the final page. The workflow had declared that optional mapping as a required write, so post-action metadata validation failed before the batch could reach its result projection.

## User impact

A final or single Gmail result page can now proceed normally. Pagination still works when a continuation token exists.

## Validation

- 311 affected-path tests passed
- exact omitted-pagination regression passed
- repository seed and workflow-affordance suites passed
- live failure receipt: parent instance `b4150790-7cbb-403f-8e2a-56ed8fda1e57`

Jira: JVNAUTOSCI-2635