### PR TITLE
Retain complete paper-batch inputs before final projection

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "16",
+  "seed_version": "17",
   "source_tag": "JVNAUTOSCI-2635",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
@@ -537,6 +537,20 @@
             ],
             "execution_mode": "deterministic",
             "on_failure_state": "failed",
+            "reads_context_keys": [
+              "gmail_profile",
+              "effective_gmail_query",
+              "gmail_max_results",
+              "message_item_count",
+              "message_selected_item_count",
+              "message_unattempted_count",
+              "message_success_count",
+              "message_error_count",
+              "message_partial_success",
+              "message_final_state_counts",
+              "message_iteration_results",
+              "message_iteration_errors"
+            ],
             "state_id": "project_batch_result",
             "static_input_bindings": [
               [

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -857,27 +857,42 @@ def test_parent_batch_result_is_lossless_across_durable_checkpoints() -> None:
     )[mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID]
     lossless_keys = _execution_required_checkpoint_context_keys(definition)
     assert "batch_result" in lossless_keys
+    assert "message_iteration_results" in lossless_keys
+    assert "message_iteration_errors" in lossless_keys
 
-    batch_result = {
-        "schema_version": "gmail_arxiv_batch_result.v1",
-        "items": [
-            {
-                "index": index,
-                "source_item_id": f"gmail-message-{index + 1}",
-                "paper_concept_ids": [f"#V#paper_{index + 1}"],
-                "evidence": "x" * 200,
-            }
-            for index in range(100)
-        ],
-    }
+    iteration_results = [
+        {
+            "index": index,
+            "source_item_id": f"gmail-message-{index + 1}",
+            "paper_concept_ids": [f"#V#paper_{index + 1}"],
+            "evidence": "x" * 200,
+        }
+        for index in range(100)
+    ]
+    iteration_errors = [
+        {
+            "index": 99,
+            "source_item_id": "gmail-message-100",
+            "error": "file_copy_type_not_visible_to_actor",
+            "details": {"stage": "file_copy_typing", "retryable": True},
+        }
+    ]
     projected = project_workflow_context_for_checkpoint(
-        {"batch_result": batch_result},
+        {
+            "message_iteration_results": iteration_results,
+            "message_iteration_errors": iteration_errors,
+        },
         max_value_bson_bytes=512,
+        max_total_bson_bytes=512,
         lossless_keys=lossless_keys,
     )
 
-    assert projected["batch_result"] == batch_result
-    assert len(projected["batch_result"]["items"]) == 100
+    assert projected["message_iteration_results"] == iteration_results
+    assert len(projected["message_iteration_results"]) == 100
+    assert projected["message_iteration_errors"] == iteration_errors
+    assert projected["message_iteration_errors"][0]["error"] == (
+        "file_copy_type_not_visible_to_actor"
+    )
 
 
 def test_email_source_seed_routes_exact_message_unit_and_explicit_batch() -> None:


### PR DESCRIPTION
## What changed

- declare the final batch projector's mandatory input keys as represented durable reads
- preserve `message_iteration_results` and `message_iteration_errors` losslessly across the checkpoint before `batch_result` is constructed
- retain optional pagination fields as optional
- bump the email-source workflow seed to version 17
- strengthen the checkpoint regression to preserve 100 rows and nested specific error detail under a 512-byte total budget

## Root cause

Seed v16 preserved `batch_result` once it existed, but the source arrays were compacted immediately after `process_messages`. The next state therefore built an already-truncated batch result: at most eight item rows and depth summaries instead of failure causes.

## Live evidence

Instance `00072b84-fd69-40b3-9b56-3bcc6d34a9c9` completed as `done_with_retryable_failures` with 10 selected, 8 review dispositions, and 2 failures. A same-conversation follow-up found the retained parent under a 27-to-20 history projection and accounted for all messages, but explicitly reported the item-array and nested-error truncation. This PR fixes that boundary for the larger 22-item general case.

## Validation

- 311 affected-path tests passed
- 100 item rows and nested error details survive a forced 512-byte checkpoint budget
- no optional-pagination regression

Jira: JVNAUTOSCI-2635