### PR TITLE
Add verified local main deployment

### DIFF
--- a/docs/engineering/operational_engineering_guide.md
+++ b/docs/engineering/operational_engineering_guide.md
@@ -63,7 +63,31 @@ Prefer:
 If a simple read stalls, retry a smaller probe. If that also stalls, inspect the
 tool host or transport before blaming repository code.
 
-### 3.2 Start Von through the repository launcher
+### 3.2 Deploy and start Von through the repository launcher
+
+For the normal local deployed instance, run this from the clean primary
+checkout on `main`:
+
+```sh
+./run.sh deploy-main
+```
+
+This is the canonical local deployment operation. It fetches `origin/main`,
+fast-forwards a clean primary `main`, checks out the exact commit detached in
+the dedicated sibling `Von-runtime-main` worktree, restarts that runtime, and
+verifies the running commit, clean-build marker, durable workflow services,
+and both background indexing workers. It refuses a dirty, divergent, wrong-
+branch, or unrelated runtime checkout. Set `VON_RUNTIME_WORKTREE` or pass
+`-RuntimeWorktree <path>` only when the runtime worktree intentionally lives
+elsewhere.
+
+The primary checkout owns the local `main` branch. The runtime worktree is
+deliberately detached at the deployed commit; it must not maintain a second
+long-lived local branch. A detached runtime is therefore expected, whereas a
+detached primary checkout is not.
+
+Use a direct restart only when the runtime checkout is already intentionally
+selected and no Git deployment is required:
 
 Normal local restart:
 

--- a/run.sh
+++ b/run.sh
@@ -56,6 +56,7 @@ DISABLE_LOG_READY=0
 HEALTH_DEBUG=0
 SHOW_RELATION_COVERAGE=0
 STATUS_RUN_MAINTENANCE=0
+RUNTIME_WORKTREE_PATH=""
 BACKUP_FLAGS_SET=0
 READY_LOG_PATTERNS=("Running with Waitress" "Press CTRL+C to quit" "Flask app running")
 
@@ -99,6 +100,7 @@ while [ $# -gt 0 ]; do
         -HealthDebug) HEALTH_DEBUG=1; shift ;;
         -ShowRelationCoverage) SHOW_RELATION_COVERAGE=1; shift ;;
         -StatusRunMaintenance) STATUS_RUN_MAINTENANCE=1; shift ;;
+        -RuntimeWorktree|--RuntimeWorktree|--runtime-worktree) RUNTIME_WORKTREE_PATH="$2"; shift 2 ;;
         -BackupDryRun) BACKUP_DRY_RUN=1; BACKUP_FLAGS_SET=1; shift ;;
         -BackupTag) BACKUP_TAG="$2"; BACKUP_FLAGS_SET=1; shift 2 ;;
         -BackupOutDir) BACKUP_OUT_DIR="$2"; BACKUP_FLAGS_SET=1; shift 2 ;;
@@ -1413,8 +1415,8 @@ start_rag_worker_bg() {
 
     log "Starting RAG Indexing Worker..."
     rm -f "$RAG_LOG_FILE" "$RAG_ERR_LOG_FILE" 2>/dev/null || true
-    nohup "$py" -u "${ROOT}/src/backend/utilities/rag_indexing_worker.py" >> "$RAG_LOG_FILE" 2>> "$RAG_ERR_LOG_FILE" &
-    local pid=$!
+    local pid=""
+    pid="$(start_python_worker_detached "$py" "${ROOT}/src/backend/utilities/rag_indexing_worker.py" "$RAG_LOG_FILE" "$RAG_ERR_LOG_FILE")" || return 1
     printf 'PID=%s\nSTART=%s\n' "$pid" "$(date -Iseconds 2>/dev/null || date)" > "$RAG_PID_FILE"
     log "RAG Worker started (PID=$pid). Logs: $RAG_LOG_FILE, $RAG_ERR_LOG_FILE"
 }
@@ -1465,8 +1467,8 @@ start_concept_index_worker_bg() {
 
     log "Starting Concept Index Worker..."
     rm -f "$CONCEPT_INDEX_LOG_FILE" "$CONCEPT_INDEX_ERR_LOG_FILE" 2>/dev/null || true
-    nohup "$py" -u "$script_path" >> "$CONCEPT_INDEX_LOG_FILE" 2>> "$CONCEPT_INDEX_ERR_LOG_FILE" &
-    local pid=$!
+    local pid=""
+    pid="$(start_python_worker_detached "$py" "$script_path" "$CONCEPT_INDEX_LOG_FILE" "$CONCEPT_INDEX_ERR_LOG_FILE")" || return 1
     printf 'PID=%s\nSTART=%s\n' "$pid" "$(date -Iseconds 2>/dev/null || date)" > "$CONCEPT_INDEX_PID_FILE"
     log "Concept Index Worker started (PID=$pid). Logs: $CONCEPT_INDEX_LOG_FILE, $CONCEPT_INDEX_ERR_LOG_FILE"
 }
@@ -3556,11 +3558,56 @@ run_autoupdate() {
     done
 }
 
+start_python_worker_detached() {
+    local py="$1"
+    local script_path="$2"
+    local stdout_path="$3"
+    local stderr_path="$4"
+    "$py" - "$py" "$script_path" "$ROOT" "$stdout_path" "$stderr_path" <<'PY'
+import os
+import subprocess
+import sys
+
+python, script, cwd, stdout_path, stderr_path = sys.argv[1:]
+with open(stdout_path, "ab", buffering=0) as stdout_handle, open(
+    stderr_path, "ab", buffering=0
+) as stderr_handle:
+    process = subprocess.Popen(
+        [python, "-u", script],
+        cwd=cwd,
+        env=os.environ.copy(),
+        stdin=subprocess.DEVNULL,
+        stdout=stdout_handle,
+        stderr=stderr_handle,
+        start_new_session=True,
+        close_fds=True,
+    )
+print(process.pid)
+PY
+}
+
+deploy_main() {
+    local py=""
+    py="$(python_cmd)"
+    if [ -z "$py" ]; then
+        log "ERROR: No Python executable found for deploy-main."
+        return 1
+    fi
+    local runtime_path="$RUNTIME_WORKTREE_PATH"
+    if [ -z "$runtime_path" ]; then
+        runtime_path="${VON_RUNTIME_WORKTREE:-$(dirname "$ROOT")/Von-runtime-main}"
+    fi
+    "$py" "${ROOT}/scripts/deploy_local_main.py" \
+        --primary-root "$ROOT" \
+        --runtime-worktree "$runtime_path" \
+        --health-timeout-seconds "$HEALTH_TIMEOUT_SEC"
+}
+
 show_help() {
     cat <<'TXT'
 Von Launcher Help
     Usage: ./run.sh [action] [options]
-    Actions: start | foreground | stop | status | restart | logs | check | backup | scheduled-backup | restore-backup | autoupdate | rag-worker | help
+    Actions: start | foreground | stop | status | restart | deploy-main | logs | check | backup | scheduled-backup | restore-backup | autoupdate | rag-worker | help
     Options:
         -Port <int>            Server port (default 5001 on macOS, 5000 elsewhere; -AgentTest defaults to 5010)
         -AgentTest             Isolated coding-agent test instance mode
@@ -3579,6 +3626,7 @@ Von Launcher Help
         -DisableLogReady
         -HealthDebug
         -StatusRunMaintenance
+        -RuntimeWorktree <path> Dedicated runtime worktree for deploy-main
         -ShowRelationCoverage
         -NoBackupMigrate
 
@@ -3608,6 +3656,7 @@ Von Launcher Help
         ./run.sh start
         ./run.sh restart -ForceBrowser
         ./run.sh restart -AgentTest -HealthTimeoutSec 180
+        ./run.sh deploy-main
         ./run.sh logs -Tail 200 -Follow
         ./run.sh backup -BackupDryRun
         ./run.sh scheduled-backup -NoBackupMigrate
@@ -3636,6 +3685,9 @@ case "$ACTION" in
     restart)
         stop_server
         start_server 1
+        ;;
+    deploy-main)
+        deploy_main
         ;;
     logs)
         show_logs

--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Deploy origin/main into the dedicated local Von runtime worktree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+class DeploymentError(RuntimeError):
+    """A deployment precondition or verification failed."""
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    primary_root: Path
+    runtime_root: Path
+    commit: str
+    server_pid: int
+    rag_worker_pid: int
+    concept_index_worker_pid: int
+
+
+def _run(
+    args: Sequence[str | os.PathLike[str]],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    command = [os.fspath(value) for value in args]
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=capture_output,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = ((result.stderr or result.stdout) if capture_output else "").strip()
+        if detail:
+            raise DeploymentError(f"Command failed: {' '.join(command)}: {detail}")
+        raise DeploymentError(
+            f"Command failed with exit {result.returncode}: {' '.join(command)}"
+        )
+    return result
+
+
+def _git(root: Path, *args: str, check: bool = True) -> str:
+    return _run(["git", "-C", root, *args], check=check).stdout.strip()
+
+
+def _require_clean(root: Path, label: str) -> None:
+    status = _git(root, "status", "--porcelain=v1", "--untracked-files=all")
+    if status:
+        first_entries = ", ".join(status.splitlines()[:5])
+        raise DeploymentError(
+            f"Refusing to deploy: {label} worktree is not clean ({first_entries})"
+        )
+
+
+def _git_common_dir(root: Path) -> Path:
+    raw = Path(_git(root, "rev-parse", "--git-common-dir"))
+    if not raw.is_absolute():
+        raw = root / raw
+    return raw.resolve()
+
+
+def _prepare_primary(
+    primary_root: Path,
+    *,
+    remote: str,
+    branch: str,
+) -> str:
+    actual_root = Path(_git(primary_root, "rev-parse", "--show-toplevel")).resolve()
+    if actual_root != primary_root:
+        raise DeploymentError(
+            f"Primary path resolves to {actual_root}, expected {primary_root}"
+        )
+
+    current_branch = _git(primary_root, "symbolic-ref", "--short", "HEAD", check=False)
+    if current_branch != branch:
+        shown = current_branch or "detached HEAD"
+        raise DeploymentError(
+            f"Refusing to deploy: primary worktree must be on {branch}, found {shown}"
+        )
+    _require_clean(primary_root, "primary")
+
+    _run(["git", "-C", primary_root, "fetch", remote, branch])
+    local_commit = _git(primary_root, "rev-parse", "HEAD")
+    remote_ref = f"{remote}/{branch}"
+    target_commit = _git(primary_root, "rev-parse", remote_ref)
+    if local_commit != target_commit:
+        merge_base = _git(primary_root, "merge-base", local_commit, target_commit)
+        if merge_base != local_commit:
+            raise DeploymentError(
+                "Refusing to deploy: primary branch is ahead of or diverged from "
+                f"{remote_ref} (local={local_commit}, remote={target_commit})"
+            )
+        _run(["git", "-C", primary_root, "merge", "--ff-only", remote_ref])
+        local_commit = _git(primary_root, "rev-parse", "HEAD")
+
+    if local_commit != target_commit:
+        raise DeploymentError(
+            f"Primary checkout did not reach {remote_ref} ({local_commit} != {target_commit})"
+        )
+    _require_clean(primary_root, "primary")
+    return target_commit
+
+
+def _validate_runtime(primary_root: Path, runtime_root: Path) -> None:
+    if runtime_root == primary_root:
+        raise DeploymentError("Runtime worktree must be distinct from the primary checkout")
+    if not runtime_root.is_dir():
+        raise DeploymentError(
+            "Dedicated runtime worktree does not exist or is not a directory: "
+            f"{runtime_root}"
+        )
+    actual_root = Path(_git(runtime_root, "rev-parse", "--show-toplevel")).resolve()
+    if actual_root != runtime_root:
+        raise DeploymentError(
+            f"Runtime path resolves to {actual_root}, expected {runtime_root}"
+        )
+    if _git_common_dir(runtime_root) != _git_common_dir(primary_root):
+        raise DeploymentError(
+            "Runtime path is a checkout of a different Git repository: "
+            f"{runtime_root}"
+        )
+    _require_clean(runtime_root, "runtime")
+
+
+def _prepare_runtime(
+    primary_root: Path,
+    runtime_root: Path,
+    target_commit: str,
+) -> None:
+    _validate_runtime(primary_root, runtime_root)
+    _run(["git", "-C", runtime_root, "switch", "--detach", target_commit])
+
+    _require_clean(runtime_root, "runtime")
+    runtime_commit = _git(runtime_root, "rev-parse", "HEAD")
+    if runtime_commit != target_commit:
+        raise DeploymentError(
+            f"Runtime checkout is at {runtime_commit}, expected {target_commit}"
+        )
+    if _git(runtime_root, "symbolic-ref", "-q", "HEAD", check=False):
+        raise DeploymentError("Runtime checkout must be detached, but it is on a branch")
+
+
+def _read_health(url: str) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            payload = json.load(response)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise DeploymentError(f"Health read failed: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DeploymentError("Health response was not a JSON object")
+    return payload
+
+
+def _health_error(payload: dict[str, Any], target_commit: str) -> str | None:
+    if payload.get("status") != "healthy":
+        return f"status={payload.get('status')!r}"
+
+    version = payload.get("version_details")
+    if not isinstance(version, dict):
+        return "version_details missing"
+    if version.get("git_commit") != target_commit:
+        return (
+            f"running commit={version.get('git_commit')!r}, expected={target_commit!r}"
+        )
+    if version.get("git_dirty") is not False:
+        return f"running git_dirty={version.get('git_dirty')!r}"
+
+    authority = payload.get("runtime_authority")
+    durable = authority.get("durable_workflows") if isinstance(authority, dict) else None
+    if not isinstance(durable, dict):
+        return "durable workflow health missing"
+    required = ("database_connected", "worker_running", "scheduler_running")
+    missing = [name for name in required if durable.get(name) is not True]
+    if missing:
+        return f"durable workflow readiness false: {', '.join(missing)}"
+    return None
+
+
+def _wait_for_verified_health(
+    url: str,
+    target_commit: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "health endpoint not read"
+    while time.monotonic() < deadline:
+        try:
+            payload = _read_health(url)
+            last_error = _health_error(payload, target_commit) or ""
+            if not last_error:
+                return payload
+        except DeploymentError as exc:
+            last_error = str(exc)
+        time.sleep(1)
+    raise DeploymentError(
+        f"Runtime did not pass exact health verification within {timeout_seconds}s: "
+        f"{last_error}"
+    )
+
+
+def _pid_from_file(path: Path, label: str) -> int:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise DeploymentError(f"{label} PID file unavailable: {path}: {exc}") from exc
+    for line in lines:
+        if line.startswith("PID=") and line[4:].isdigit():
+            return int(line[4:])
+    raise DeploymentError(f"{label} PID file has no valid PID: {path}")
+
+
+def _verify_worker(pid_file: Path, script_name: str, label: str) -> int:
+    pid = _pid_from_file(pid_file, label)
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        raise DeploymentError(f"{label} PID {pid} is not alive") from exc
+
+    command = _run(["ps", "-o", "command=", "-p", str(pid)]).stdout.strip()
+    if script_name not in command.replace("\\", "/"):
+        raise DeploymentError(
+            f"{label} PID {pid} does not run {script_name}: {command or '<empty>'}"
+        )
+    return pid
+
+
+def _verify_workers(runtime_root: Path) -> tuple[int, int]:
+    # A short second observation catches helpers that only survived the launcher.
+    time.sleep(2)
+    rag_pid = _verify_worker(
+        runtime_root / ".run" / "rag_worker.pid",
+        "src/backend/utilities/rag_indexing_worker.py",
+        "RAG worker",
+    )
+    concept_pid = _verify_worker(
+        runtime_root / ".run" / "concept_index_worker.pid",
+        "src/backend/utilities/concept_index_worker.py",
+        "concept-index worker",
+    )
+    return rag_pid, concept_pid
+
+
+def deploy(
+    *,
+    primary_root: Path,
+    runtime_root: Path,
+    remote: str = "origin",
+    branch: str = "main",
+    health_url: str = "http://127.0.0.1:5001/health",
+    health_timeout_seconds: int = 180,
+) -> DeploymentResult:
+    primary_root = primary_root.resolve()
+    runtime_root = runtime_root.resolve()
+    target_commit = _prepare_primary(primary_root, remote=remote, branch=branch)
+    launcher = runtime_root / "run.sh"
+    if not launcher.is_file():
+        raise DeploymentError(f"Runtime launcher missing: {launcher}")
+
+    # Validate before stopping, then change code only while the server is down.
+    _validate_runtime(primary_root, runtime_root)
+    _run(
+        ["bash", launcher, "stop", "-NoBrowser"],
+        cwd=runtime_root,
+        capture_output=False,
+    )
+    _prepare_runtime(primary_root, runtime_root, target_commit)
+    launcher = runtime_root / "run.sh"
+    _run(
+        [
+            "bash",
+            launcher,
+            "start",
+            "-NoBrowser",
+            "-HealthTimeoutSec",
+            str(health_timeout_seconds),
+        ],
+        cwd=runtime_root,
+        capture_output=False,
+    )
+
+    health = _wait_for_verified_health(
+        health_url,
+        target_commit,
+        health_timeout_seconds,
+    )
+    rag_pid, concept_pid = _verify_workers(runtime_root)
+    server_pid = health.get("pid")
+    if not isinstance(server_pid, int) or server_pid <= 0:
+        raise DeploymentError(f"Health response has invalid server PID: {server_pid!r}")
+
+    return DeploymentResult(
+        primary_root=primary_root,
+        runtime_root=runtime_root,
+        commit=target_commit,
+        server_pid=server_pid,
+        rag_worker_pid=rag_pid,
+        concept_index_worker_pid=concept_pid,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fast-forward the primary main checkout, detach the dedicated runtime "
+            "worktree at the exact origin/main commit, restart Von, and verify it."
+        )
+    )
+    parser.add_argument("--primary-root", type=Path, required=True)
+    parser.add_argument("--runtime-worktree", type=Path, required=True)
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--health-url", default="http://127.0.0.1:5001/health")
+    parser.add_argument("--health-timeout-seconds", type=int, default=180)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.health_timeout_seconds <= 0:
+        print("deploy-main: health timeout must be positive", file=sys.stderr)
+        return 2
+    try:
+        result = deploy(
+            primary_root=args.primary_root,
+            runtime_root=args.runtime_worktree,
+            remote=args.remote,
+            branch=args.branch,
+            health_url=args.health_url,
+            health_timeout_seconds=args.health_timeout_seconds,
+        )
+    except DeploymentError as exc:
+        print(f"deploy-main: ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("deploy-main: VERIFIED")
+    print(f"  primary: {result.primary_root} ({result.commit})")
+    print(f"  runtime: {result.runtime_root} (detached at {result.commit})")
+    print(f"  server: PID {result.server_pid}, healthy exact build")
+    print(f"  RAG worker: PID {result.rag_worker_pid}")
+    print(f"  concept-index worker: PID {result.concept_index_worker_pid}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_local_main.py
+++ b/tests/test_deploy_local_main.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.deploy_local_main import (
+    DeploymentError,
+    _health_error,
+    _prepare_primary,
+    _prepare_runtime,
+)
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(root), *args],
+        text=True,
+    ).strip()
+
+
+def _setup_repositories(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    primary = tmp_path / "Von"
+    runtime = tmp_path / "Von-runtime-main"
+
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True)
+    subprocess.run(["git", "init", "-b", "main", str(seed)], check=True)
+    _git(seed, "config", "user.email", "tests@example.invalid")
+    _git(seed, "config", "user.name", "Von Tests")
+    (seed / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "initial")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    _git(remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+    subprocess.run(["git", "clone", str(remote), str(primary)], check=True)
+    _git(primary, "worktree", "add", "-b", "runtime/main", str(runtime), "HEAD")
+    return remote, seed, primary, runtime
+
+
+def test_prepare_fast_forwards_primary_and_detaches_runtime(tmp_path: Path) -> None:
+    _, seed, primary, runtime = _setup_repositories(tmp_path)
+    (seed / "tracked.txt").write_text("two\n", encoding="utf-8")
+    _git(seed, "add", "tracked.txt")
+    _git(seed, "commit", "-m", "second")
+    _git(seed, "push", "origin", "main")
+    target = _git(seed, "rev-parse", "HEAD")
+
+    prepared = _prepare_primary(primary.resolve(), remote="origin", branch="main")
+    _prepare_runtime(primary.resolve(), runtime.resolve(), prepared)
+
+    assert prepared == target
+    assert _git(primary, "rev-parse", "HEAD") == target
+    assert _git(runtime, "rev-parse", "HEAD") == target
+    detached = subprocess.run(
+        ["git", "-C", str(runtime), "symbolic-ref", "-q", "HEAD"],
+        check=False,
+    )
+    assert detached.returncode != 0
+
+
+def test_prepare_refuses_dirty_runtime_without_changing_its_branch(
+    tmp_path: Path,
+) -> None:
+    _, _, primary, runtime = _setup_repositories(tmp_path)
+    (runtime / "tracked.txt").write_text("local work\n", encoding="utf-8")
+    original_commit = _git(runtime, "rev-parse", "HEAD")
+
+    target = _prepare_primary(primary.resolve(), remote="origin", branch="main")
+    with pytest.raises(DeploymentError, match="runtime worktree is not clean"):
+        _prepare_runtime(primary.resolve(), runtime.resolve(), target)
+
+    assert _git(runtime, "rev-parse", "HEAD") == original_commit
+    assert _git(runtime, "symbolic-ref", "--short", "HEAD") == "runtime/main"
+
+
+def test_prepare_refuses_primary_that_is_not_main(tmp_path: Path) -> None:
+    _, _, primary, _ = _setup_repositories(tmp_path)
+    _git(primary, "switch", "-c", "feature")
+
+    with pytest.raises(DeploymentError, match="primary worktree must be on main"):
+        _prepare_primary(primary.resolve(), remote="origin", branch="main")
+
+
+def test_health_verification_requires_exact_clean_durable_build() -> None:
+    commit = "a" * 40
+    payload = {
+        "status": "healthy",
+        "version_details": {"git_commit": commit, "git_dirty": False},
+        "runtime_authority": {
+            "durable_workflows": {
+                "database_connected": True,
+                "worker_running": True,
+                "scheduler_running": True,
+            }
+        },
+    }
+    assert _health_error(payload, commit) is None
+
+    dirty = json.loads(json.dumps(payload))
+    dirty["version_details"]["git_dirty"] = True
+    assert _health_error(dirty, commit) == "running git_dirty=True"
+
+    wrong_commit = json.loads(json.dumps(payload))
+    wrong_commit["version_details"]["git_commit"] = "b" * 40
+    assert "running commit=" in (_health_error(wrong_commit, commit) or "")
+
+    no_scheduler = json.loads(json.dumps(payload))
+    no_scheduler["runtime_authority"]["durable_workflows"][
+        "scheduler_running"
+    ] = False
+    assert _health_error(no_scheduler, commit) == (
+        "durable workflow readiness false: scheduler_running"
+    )
+
+
+def test_run_sh_detached_worker_helper_starts_a_new_session(tmp_path: Path) -> None:
+    worker = tmp_path / "worker.py"
+    worker.write_text(
+        "import time\ntime.sleep(30)\n",
+        encoding="utf-8",
+    )
+    stdout_path = tmp_path / "worker.out"
+    stderr_path = tmp_path / "worker.err"
+    command = f"""
+set -euo pipefail
+cd {str(Path(__file__).resolve().parents[1])!r}
+. ./run.sh help -NoBackupMigrate >/dev/null
+start_python_worker_detached \
+  "$(command -v python3)" \
+  {str(worker)!r} \
+  {str(stdout_path)!r} \
+  {str(stderr_path)!r}
+""".strip()
+    result = subprocess.run(
+        ["bash", "-c", command],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    pid = int(result.stdout.strip())
+    try:
+        os.kill(pid, 0)
+        assert os.getsid(pid) == pid
+    finally:
+        try:
+            os.kill(pid, 15)
+        except ProcessLookupError:
+            pass


### PR DESCRIPTION
## What changed

- add `./run.sh deploy-main` as the canonical local deployment command
- keep the primary checkout on `main` while detaching the dedicated runtime worktree at the exact fetched `origin/main` commit
- refuse dirty, divergent, wrong-branch, or unrelated checkout state before deployment
- restart from the runtime worktree and verify the exact clean commit, durable workflow readiness, and both indexing workers
- launch background indexing workers in independent OS sessions so they survive automation-terminal closure
- document the primary/runtime ownership rule in the operational guide

## Why

The prior `runtime/main` branch convention required people and agents to remember which checkout and branch represented the deployed server. This replaces that convention with a deterministic, verified operation.

## Validation

- `bash -n run.sh`
- `python -m ruff check scripts/deploy_local_main.py tests/test_deploy_local_main.py --select E9,F`
- `python -m pytest tests/test_deploy_local_main.py tests/test_run_sh_start_behaviour.py -q` — 38 passed
- real command refusal from a non-`main` primary: stopped before runtime mutation
- `git diff --check`

No secrets or runtime data are included.