### PR TITLE
Keep deployment controller out of server cleanup

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1207,11 +1207,9 @@ stop_python_processes_by_script() {
     local script_path="${ROOT}/${script_relative_path}"
     local killed
     killed="$("$py" -c 'import os,sys,psutil
-target=os.path.normcase(os.path.normpath(sys.argv[1]))
+target=os.path.normcase(os.path.realpath(sys.argv[1]))
 exclude=int(sys.argv[2]) if len(sys.argv) > 2 else 0
 current=os.getpid()
-fragment=target.lower().replace("\\\\","/")
-name=os.path.basename(target).lower()
 killed=[]
 for proc in psutil.process_iter(["pid","cmdline"]):
     try:
@@ -1221,9 +1219,23 @@ for proc in psutil.process_iter(["pid","cmdline"]):
         cmdline=[str(part) for part in (proc.info.get("cmdline") or [])]
         if not cmdline:
             continue
-        joined=" ".join(cmdline)
-        norm=joined.lower().replace("\\\\","/")
-        if fragment not in norm and name not in norm:
+        try:
+            cwd=proc.cwd()
+        except Exception:
+            cwd=None
+        matched=False
+        for part in cmdline:
+            if not part:
+                continue
+            candidate=part
+            if not os.path.isabs(candidate):
+                if not cwd:
+                    continue
+                candidate=os.path.join(cwd,candidate)
+            if os.path.normcase(os.path.realpath(candidate)) == target:
+                matched=True
+                break
+        if not matched:
             continue
         try:
             proc.terminate()

--- a/tests/test_run_sh_start_behaviour.py
+++ b/tests/test_run_sh_start_behaviour.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1013,6 +1014,42 @@ PY
     assert payload["takeovers"] == ["4242"]
     assert not any("Already running" in line for line in payload["logs"])
     assert "browser opened" not in payload["logs"]
+
+
+def test_stale_server_cleanup_does_not_match_deploy_local_main_by_basename(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "main.py"
+    controller = tmp_path / "deploy_local_main.py"
+    body = "import time\ntime.sleep(30)\n"
+    target.write_text(body, encoding="utf-8")
+    controller.write_text(body, encoding="utf-8")
+    target_process = subprocess.Popen([sys.executable, str(target)])
+    controller_process = subprocess.Popen([sys.executable, str(controller)])
+    try:
+        time.sleep(0.2)
+        command = f"""
+set -euo pipefail
+cd {shlex_quote(str(REPO_ROOT))}
+. ./run.sh help -NoBackupMigrate >/dev/null
+ROOT={shlex_quote(str(tmp_path))}
+python_cmd() {{ printf '%s' {shlex_quote(sys.executable)}; }}
+stop_python_processes_by_script main.py test-server
+""".strip()
+        cleanup = subprocess.run(
+            ["bash", "-c", command],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert "Stopped stale test-server process(es)" in cleanup.stdout
+        target_process.wait(timeout=5)
+        assert controller_process.poll() is None
+    finally:
+        for process in (target_process, controller_process):
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
 
 
 def test_run_sh_workflow_purity_check_respects_daily_success_ttl() -> None:


### PR DESCRIPTION
## What changed

- match stale Python processes by exact resolved script argument rather than basename substring
- add a regression proving cleanup stops `main.py` without stopping `deploy_local_main.py`

## Why

The first live `deploy-main` acceptance exposed a false match: server cleanup treated the basename `main.py` as a substring and terminated the deployment controller itself. The old server shut down cleanly and the runtime checkout was not changed.

## Validation

- `bash -n run.sh`
- `python -m pytest tests/test_deploy_local_main.py tests/test_run_sh_start_behaviour.py -q` — 39 passed
- `git diff --check`

No secrets or runtime data are included.