### PR TITLE
Decouple deployment stop from old runtime code

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${VON_LAUNCHER_ROOT:-$SCRIPT_ROOT}"
+if [ ! -d "$ROOT" ]; then
+    echo "ERROR: VON_LAUNCHER_ROOT is not a directory: $ROOT" >&2
+    exit 2
+fi
+ROOT="$(cd "$ROOT" && pwd -P)"
 
 log() {
     # Match run.ps1: lightweight timestamped console logs.

--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -36,6 +36,7 @@ def _run(
     cwd: Path | None = None,
     check: bool = True,
     capture_output: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     command = [os.fspath(value) for value in args]
     result = subprocess.run(
@@ -43,6 +44,7 @@ def _run(
         cwd=cwd,
         text=True,
         capture_output=capture_output,
+        env=env,
         check=False,
     )
     if check and result.returncode != 0:
@@ -268,19 +270,24 @@ def deploy(
     primary_root = primary_root.resolve()
     runtime_root = runtime_root.resolve()
     target_commit = _prepare_primary(primary_root, remote=remote, branch=branch)
-    launcher = runtime_root / "run.sh"
-    if not launcher.is_file():
-        raise DeploymentError(f"Runtime launcher missing: {launcher}")
+    current_launcher = primary_root / "run.sh"
+    if not current_launcher.is_file():
+        raise DeploymentError(f"Current launcher missing: {current_launcher}")
 
     # Validate before stopping, then change code only while the server is down.
     _validate_runtime(primary_root, runtime_root)
+    stop_environment = os.environ.copy()
+    stop_environment["VON_LAUNCHER_ROOT"] = str(runtime_root)
     _run(
-        ["bash", launcher, "stop", "-NoBrowser"],
+        ["bash", current_launcher, "stop", "-NoBrowser"],
         cwd=runtime_root,
         capture_output=False,
+        env=stop_environment,
     )
     _prepare_runtime(primary_root, runtime_root, target_commit)
     launcher = runtime_root / "run.sh"
+    if not launcher.is_file():
+        raise DeploymentError(f"Runtime launcher missing after checkout: {launcher}")
     _run(
         [
             "bash",

--- a/tests/test_run_sh_start_behaviour.py
+++ b/tests/test_run_sh_start_behaviour.py
@@ -76,6 +76,42 @@ PY
     assert payload == {"health_timeout_seconds": 180}
 
 
+def test_run_sh_accepts_an_explicit_existing_launcher_root(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is required for run.sh launcher-path tests")
+    env = os.environ.copy()
+    env["VON_LAUNCHER_ROOT"] = str(tmp_path)
+    result = subprocess.run(
+        [bash, "-c", ". ./run.sh help -NoBackupMigrate >/dev/null; printf '%s' \"$ROOT\""],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert result.stdout == str(tmp_path.resolve())
+
+
+def test_run_sh_rejects_a_missing_launcher_root(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is required for run.sh launcher-path tests")
+    missing = tmp_path / "missing"
+    env = os.environ.copy()
+    env["VON_LAUNCHER_ROOT"] = str(missing)
+    result = subprocess.run(
+        [bash, "./run.sh", "help", "-NoBackupMigrate"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "VON_LAUNCHER_ROOT is not a directory" in result.stderr
+
+
 def test_run_sh_labels_ssh_tunnel_fallback_as_remote_atlas() -> None:
     output = _run_bash_text_probe(r"""
 curl() {


### PR DESCRIPTION
## What changed

- allow the current launcher to operate against an explicit, existing runtime root
- use the newly merged launcher for the deployment stop phase, then switch the runtime and start from the new checkout
- reject missing runtime-root overrides

## Why

The first deployment after introducing `deploy-main` must not depend on the old runtime launcher being able to stop itself correctly. The live acceptance exposed that bootstrap dependency after the old broad process matcher terminated the deployment controller.

## Validation

- `bash -n run.sh`
- `python -m ruff check scripts/deploy_local_main.py tests/test_deploy_local_main.py --select E9,F`
- `python -m pytest tests/test_deploy_local_main.py tests/test_run_sh_start_behaviour.py -q` — 41 passed
- `git diff --check`

No secrets or runtime data are included.