### PR TITLE
Add paginated Jira comment reads and compact MCP payloads

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -23294,6 +23294,24 @@ def _jira_get_issue_input_schema() -> Schema:
     )
 
 
+def _jira_get_comments_input_schema() -> Schema:
+    return Schema(
+        required={"issue_key": str},
+        optional={
+            "start_at": (int,),
+            "max_results": (int,),
+            "order_by": (str,),
+            "body_format": (str,),
+        },
+        allow_unknown=True,
+        description=(
+            "jira_get_comments input: issue_key (str, required) plus optional "
+            "start_at, max_results, order_by ('created' or '-created'), and "
+            "body_format ('text' default, or 'adf' for the raw node tree)."
+        ),
+    )
+
+
 def _jira_get_project_issue_types_input_schema() -> Schema:
     return Schema(
         required={"project_key": str},
@@ -29870,6 +29888,57 @@ def _jira_get_issue(**kwargs):
 
     try:
         return _run_async_compat(_async_get_issue)
+    except JiraProxyError as exc:
+        return make_error_response(
+            "jira_proxy_error",
+            str(exc),
+            details={"exception_type": "JiraProxyError"},
+            suggestions=["Check Jira connectivity and authentication"],
+        )
+
+
+def _jira_get_comments(**kwargs):
+    from .jira_proxy_mcp import get_jira_proxy, JiraProxyError
+
+    issue_key = kwargs.get("issue_key")
+    if not issue_key:
+        return make_error_response(
+            "missing_parameter",
+            "Missing required parameter: issue_key",
+            details={"missing": ["issue_key"]},
+            suggestions=["Provide a Jira issue key (e.g., PROJ-123)"],
+        )
+
+    body_format = kwargs.get("body_format")
+    if body_format is not None and body_format not in ("text", "adf"):
+        return make_error_response(
+            "invalid_parameter",
+            "Invalid body_format. Supported values: text, adf.",
+            details={"body_format": body_format},
+            suggestions=["Omit body_format for flattened text, or pass 'adf'"],
+        )
+
+    order_by = kwargs.get("order_by")
+    if order_by is not None and order_by not in ("created", "-created"):
+        return make_error_response(
+            "invalid_parameter",
+            "Invalid order_by. Supported values: created, -created.",
+            details={"order_by": order_by},
+            suggestions=["Use 'created' for oldest first or '-created' for newest"],
+        )
+
+    async def _async_get_comments():
+        proxy = await get_jira_proxy()
+        return await proxy.get_comments(
+            issue_key=issue_key,
+            start_at=kwargs.get("start_at"),
+            max_results=kwargs.get("max_results"),
+            order_by=order_by,
+            body_format=body_format,
+        )
+
+    try:
+        return _run_async_compat(_async_get_comments)
     except JiraProxyError as exc:
         return make_error_response(
             "jira_proxy_error",
@@ -38687,6 +38756,7 @@ def _build_default_catalogue_external_integration_definitions() -> List[
 ]:
     jira_search_output_schema = _jira_generic_output_schema("search")
     jira_get_issue_output_schema = _jira_generic_output_schema("get_issue")
+    jira_get_comments_output_schema = _jira_generic_output_schema("get_comments")
     jira_get_project_issue_types_output_schema = (
         _jira_get_project_issue_types_output_schema()
     )
@@ -38968,6 +39038,22 @@ def _build_default_catalogue_external_integration_definitions() -> List[
                 "Fetch full details for a Jira issue by key (e.g., JVNAUTOSCI-123). "
                 "Use when you need issue fields, summary, status, metadata, or "
                 "expanded sections such as changelog."
+            ),
+        ),
+        MethodDefinition(
+            name="jira_get_comments",
+            handler=_jira_get_comments,
+            input_schema=_jira_get_comments_input_schema(),
+            output_schema=jira_get_comments_output_schema,
+            category="read",
+            ordinary_turn_excluded_reason="deployment_global_account",
+            timeout_sec=15.0,
+            description=(
+                "Read comments on a Jira issue one page at a time, with "
+                "start_at/max_results pagination and comment bodies flattened to "
+                "text by default. Prefer this over jira_get_issue with "
+                "fields=['comment'], which returns every comment at once and can "
+                "exceed the response size limit on heavily commented issues."
             ),
         ),
         MethodDefinition(

--- a/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
@@ -137,6 +137,26 @@ class JiraMCPProxy:
             arguments["expand"] = expand
         return await self._call("jira_get_issue", arguments)
 
+    async def get_comments(
+        self,
+        *,
+        issue_key: str,
+        start_at: Optional[int] = None,
+        max_results: Optional[int] = None,
+        order_by: Optional[str] = None,
+        body_format: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        arguments: Dict[str, Any] = {"issue_key": issue_key}
+        if isinstance(start_at, int):
+            arguments["start_at"] = start_at
+        if isinstance(max_results, int):
+            arguments["max_results"] = max_results
+        if isinstance(order_by, str) and order_by.strip():
+            arguments["order_by"] = order_by.strip()
+        if isinstance(body_format, str) and body_format.strip():
+            arguments["body_format"] = body_format.strip()
+        return await self._call("jira_get_comments", arguments)
+
     async def get_watchers(self, *, issue_key: str) -> Dict[str, Any]:
         return await self._call("jira_get_watchers", {"issue_key": issue_key})
 

--- a/src/backend/mcp_server/mcp_server.py
+++ b/src/backend/mcp_server/mcp_server.py
@@ -792,6 +792,195 @@ def _ensure_adf(value: Any) -> Dict[str, Any] | Any:
     return value
 
 
+def _tool_json(payload: Any) -> str:
+    """Serialise tool output for the wire.
+
+    Compact separators only: this text is parsed by the calling proxy, never
+    read by a human, and indentation roughly doubles the byte count.
+    """
+    return json.dumps(payload, separators=(",", ":"), default=str)
+
+
+def _adf_marks_to_text(text: str, marks: Any) -> str:
+    """Re-apply ADF inline marks as Markdown so flattening stays faithful."""
+    if not isinstance(marks, list):
+        return text
+    for mark in marks:
+        if not isinstance(mark, dict):
+            continue
+        mark_type = mark.get("type")
+        if mark_type == "code":
+            text = f"`{text}`"
+        elif mark_type == "strong":
+            text = f"**{text}**"
+        elif mark_type == "em":
+            text = f"*{text}*"
+        elif mark_type == "link":
+            href = (mark.get("attrs") or {}).get("href")
+            if href:
+                text = f"[{text}]({href})"
+    return text
+
+
+def _adf_inline_to_text(nodes: Any) -> str:
+    """Render ADF inline nodes to a single line of Markdown-ish text."""
+    parts: List[str] = []
+    for node in nodes or []:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        attrs = node.get("attrs") or {}
+        if node_type == "text":
+            parts.append(
+                _adf_marks_to_text(str(node.get("text") or ""), node.get("marks"))
+            )
+        elif node_type == "hardBreak":
+            parts.append("\n")
+        elif node_type == "emoji":
+            parts.append(str(attrs.get("text") or attrs.get("shortName") or ""))
+        elif node_type == "mention":
+            parts.append(str(attrs.get("text") or attrs.get("id") or ""))
+        elif node_type == "inlineCard":
+            parts.append(str(attrs.get("url") or ""))
+        elif node_type == "date":
+            parts.append(str(attrs.get("timestamp") or ""))
+        elif node_type == "status":
+            parts.append(str(attrs.get("text") or ""))
+        else:
+            parts.append(_adf_inline_to_text(node.get("content")))
+    return "".join(parts)
+
+
+def _adf_table_to_text(rows: Any) -> List[str]:
+    """Render an ADF table as Markdown-style pipe rows."""
+    rendered: List[str] = []
+    for row in rows or []:
+        if not isinstance(row, dict) or row.get("type") != "tableRow":
+            continue
+        cells: List[str] = []
+        for cell in row.get("content") or []:
+            if not isinstance(cell, dict):
+                continue
+            cell_text = " ".join(
+                block.strip()
+                for block in _adf_blocks_to_text(cell.get("content"))
+                if block.strip()
+            )
+            cells.append(cell_text.replace("|", "\\|"))
+        if cells:
+            rendered.append("| " + " | ".join(cells) + " |")
+    return rendered
+
+
+def _adf_blocks_to_text(nodes: Any, *, depth: int = 0) -> List[str]:
+    """Render ADF block nodes to a list of Markdown-ish blocks."""
+    blocks: List[str] = []
+    pad = "  " * depth
+    for node in nodes or []:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        children = node.get("content") or []
+        attrs = node.get("attrs") or {}
+
+        if node_type == "paragraph":
+            blocks.append(pad + _adf_inline_to_text(children))
+        elif node_type == "heading":
+            level = attrs.get("level")
+            level = level if isinstance(level, int) and 1 <= level <= 6 else 1
+            blocks.append(f"{'#' * level} {_adf_inline_to_text(children)}")
+        elif node_type == "codeBlock":
+            language = attrs.get("language") or ""
+            blocks.append(f"```{language}\n{_adf_inline_to_text(children)}\n```")
+        elif node_type == "rule":
+            blocks.append("---")
+        elif node_type in ("bulletList", "orderedList"):
+            ordered = node_type == "orderedList"
+            for index, item in enumerate(children, start=1):
+                if not isinstance(item, dict):
+                    continue
+                marker = f"{index}." if ordered else "-"
+                item_blocks = _adf_blocks_to_text(item.get("content"), depth=depth + 1)
+                if item_blocks:
+                    blocks.append(f"{pad}{marker} {item_blocks[0].lstrip()}")
+                    blocks.extend(item_blocks[1:])
+                else:
+                    blocks.append(f"{pad}{marker}")
+        elif node_type == "blockquote":
+            quoted = "\n\n".join(_adf_blocks_to_text(children, depth=depth))
+            blocks.extend(f"> {line}" for line in quoted.split("\n"))
+        elif node_type == "table":
+            blocks.extend(_adf_table_to_text(children))
+        elif node_type in ("mediaGroup", "mediaSingle", "media"):
+            blocks.append(pad + "[media]")
+        else:
+            nested = _adf_blocks_to_text(children, depth=depth)
+            if nested:
+                blocks.extend(nested)
+            else:
+                inline = _adf_inline_to_text(children)
+                if inline:
+                    blocks.append(pad + inline)
+    return blocks
+
+
+def _adf_to_text(body: Any) -> str:
+    """Flatten an ADF document to Markdown-ish text.
+
+    Inverse of _markdown_to_adf. Jira returns comment and description bodies as
+    node trees costing roughly twice their prose size, so read paths that only
+    need the words flatten here rather than shipping the tree to the client.
+    """
+    if isinstance(body, str):
+        return body
+    if not isinstance(body, dict):
+        return ""
+    blocks = _adf_blocks_to_text(body.get("content"))
+    return "\n\n".join(block for block in blocks if block.strip())
+
+
+def _jira_author_summary(author: Any) -> Dict[str, Any] | None:
+    """Keep author identity but drop the avatar URL set, which dominates size."""
+    if not isinstance(author, dict):
+        return None
+    return {
+        "accountId": author.get("accountId"),
+        "displayName": author.get("displayName"),
+        "emailAddress": author.get("emailAddress"),
+        "active": author.get("active"),
+    }
+
+
+def _flatten_comment_page(page: Dict[str, Any]) -> Dict[str, Any]:
+    """Project a Jira comment page to text bodies and identity-only authors.
+
+    Visibility is preserved verbatim: it marks role-restricted comments and
+    must not be dropped by a size optimisation.
+    """
+    comments = page.get("comments")
+    if not isinstance(comments, list):
+        return page
+    return {
+        "startAt": page.get("startAt"),
+        "maxResults": page.get("maxResults"),
+        "total": page.get("total"),
+        "body_format": "text",
+        "comments": [
+            {
+                "id": comment.get("id"),
+                "author": _jira_author_summary(comment.get("author")),
+                "updateAuthor": _jira_author_summary(comment.get("updateAuthor")),
+                "created": comment.get("created"),
+                "updated": comment.get("updated"),
+                "visibility": comment.get("visibility"),
+                "body": _adf_to_text(comment.get("body")),
+            }
+            for comment in comments
+            if isinstance(comment, dict)
+        ],
+    }
+
+
 # ---------------------------------------------------------
 # MCP server
 # ---------------------------------------------------------
@@ -850,6 +1039,46 @@ async def list_tools() -> List[types.Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Optional Jira expand tokens (e.g. ['changelog']).",
+                    },
+                },
+                "required": ["issue_key"],
+            },
+        ),
+        types.Tool(
+            name="jira_get_comments",
+            description=(
+                "Read comments on a Jira issue, one page at a time. Prefer this "
+                "over jira_get_issue with fields=['comment'], which returns every "
+                "comment at once and can exceed the response size limit."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "issue_key": {
+                        "type": "string",
+                        "description": "Issue key, e.g. JVNAUTOSCI-371",
+                    },
+                    "start_at": {
+                        "type": "integer",
+                        "description": "Zero-based index of the first comment to return.",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum comments to return (default 50, Jira max 100).",
+                    },
+                    "order_by": {
+                        "type": "string",
+                        "enum": ["created", "-created"],
+                        "description": "Sort order: 'created' oldest first, '-created' newest first.",
+                    },
+                    "body_format": {
+                        "type": "string",
+                        "enum": ["text", "adf"],
+                        "description": (
+                            "'text' (default) flattens comment bodies to Markdown "
+                            "and omits avatar metadata; 'adf' returns the raw "
+                            "Atlassian Document Format node tree."
+                        ),
                     },
                 },
                 "required": ["issue_key"],
@@ -1115,7 +1344,7 @@ async def call_tool(
                 "success": False,
                 "error": "Deprecated pagination parameter: start_at. Use next_page_token instead.",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
 
         next_page_token = arguments.get("next_page_token")
         if isinstance(next_page_token, str) and next_page_token.strip():
@@ -1127,7 +1356,7 @@ async def call_tool(
 
         # Jira Cloud is deprecating GET /search?jql=... for some usage; prefer POST /search/jql.
         result = jira_post("search/jql", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_issue":
@@ -1142,13 +1371,32 @@ async def call_tool(
                 issue_params = {}
             issue_params["expand"] = ",".join(str(item) for item in expand)
         result = jira_get(f"issue/{issue_key}", params=issue_params)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
+        return [types.TextContent(type="text", text=text)]
+
+    elif name == "jira_get_comments":
+        issue_key = arguments["issue_key"]
+        comment_params: Dict[str, Any] = {}
+        max_results = arguments.get("max_results")
+        comment_params["maxResults"] = (
+            max_results if isinstance(max_results, int) and max_results > 0 else 50
+        )
+        start_at = arguments.get("start_at")
+        if isinstance(start_at, int) and start_at > 0:
+            comment_params["startAt"] = start_at
+        order_by = arguments.get("order_by")
+        if order_by in ("created", "-created"):
+            comment_params["orderBy"] = order_by
+        result = jira_get(f"issue/{issue_key}/comment", params=comment_params)
+        if arguments.get("body_format") != "adf":
+            result = _flatten_comment_page(result)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_watchers":
         issue_key = arguments["issue_key"]
         result = jira_get(f"issue/{issue_key}/watchers")
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_attachment_content":
@@ -1167,13 +1415,13 @@ async def call_tool(
             attachment_id=str(attachment_id),
             max_size_bytes=max_size_bytes,
         )
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_transitions":
         issue_key = arguments["issue_key"]
         result = jira_get(f"issue/{issue_key}/transitions")
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_add_comment":
@@ -1182,7 +1430,7 @@ async def call_tool(
         # Jira Cloud requires ADF for comment body
         payload = {"body": _ensure_adf(comment)}
         result = jira_post(f"issue/{issue_key}/comment", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_add_attachment":
@@ -1202,7 +1450,7 @@ async def call_tool(
                 "success": False,
                 "error": f"Missing required parameters: {', '.join(missing)}",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
 
         try:
             content_bytes = base64.b64decode(str(content_base64), validate=True)
@@ -1211,7 +1459,7 @@ async def call_tool(
                 "success": False,
                 "error": "Invalid content_base64 payload",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
 
         upload_result = jira_add_attachment(
             issue_key=str(issue_key).strip(),
@@ -1221,7 +1469,7 @@ async def call_tool(
         )
 
         if isinstance(upload_result, dict) and upload_result.get("success") is False:
-            text = json.dumps(upload_result, indent=2)
+            text = _tool_json(upload_result)
             return [types.TextContent(type="text", text=text)]
 
         attachments: List[Dict[str, Any]] = []
@@ -1250,7 +1498,7 @@ async def call_tool(
                 response["comment_added"] = True
                 response["comment_result"] = comment_result
 
-        text = json.dumps(response, indent=2)
+        text = _tool_json(response)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_transition":
@@ -1258,24 +1506,24 @@ async def call_tool(
         transition_id = arguments["transition_id"]
         payload = {"transition": {"id": transition_id}}
         result = jira_post(f"issue/{issue_key}/transitions", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_myself":
         result = jira_get("myself")
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_project_issue_types":
         project_key = arguments["project_key"]
         result = jira_get_project_issue_types(str(project_key))
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_get_bulk_operation_progress":
         task_id = arguments["task_id"]
         result = jira_get_bulk_operation_progress(str(task_id))
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_create_issue":
@@ -1285,7 +1533,7 @@ async def call_tool(
                 "success": False,
                 "error": "payload must be an object",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
         # Convert description to ADF if present and is a string
         if "fields" in payload and isinstance(payload["fields"], dict):
             if "description" in payload["fields"]:
@@ -1293,7 +1541,7 @@ async def call_tool(
                     payload["fields"]["description"]
                 )
         result = jira_post("issue", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_update_issue":
@@ -1304,7 +1552,7 @@ async def call_tool(
                 "success": False,
                 "error": "payload must be an object",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
         # Convert description to ADF if present and is a string
         if "fields" in payload and isinstance(payload["fields"], dict):
             if "description" in payload["fields"]:
@@ -1312,7 +1560,7 @@ async def call_tool(
                     payload["fields"]["description"]
                 )
         result = jira_put(f"issue/{issue_key}", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_move_issue":
@@ -1322,9 +1570,9 @@ async def call_tool(
                 "success": False,
                 "error": "payload must be an object",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
         result = jira_post("bulk/issues/move", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_link_issue":
@@ -1334,9 +1582,9 @@ async def call_tool(
                 "success": False,
                 "error": "payload must be an object",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
         result = jira_post("issueLink", payload)
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     elif name == "jira_delete_issue_link":
@@ -1346,9 +1594,9 @@ async def call_tool(
                 "success": False,
                 "error": "issue_link_id is required",
             }
-            return [types.TextContent(type="text", text=json.dumps(error, indent=2))]
+            return [types.TextContent(type="text", text=_tool_json(error))]
         result = jira_delete(f"issueLink/{issue_link_id}")
-        text = json.dumps(result, indent=2)
+        text = _tool_json(result)
         return [types.TextContent(type="text", text=text)]
 
     else:

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
         _jira_delete_issue_link,
         _jira_get_auth_config,
         _jira_get_bulk_operation_progress,
+        _jira_get_comments,
         _jira_get_issue,
         _jira_get_project_issue_types,
         _jira_get_myself,
@@ -322,6 +323,7 @@ _bind_imports(
         "_jira_delete_issue_link",
         "_jira_get_auth_config",
         "_jira_get_bulk_operation_progress",
+        "_jira_get_comments",
         "_jira_get_issue",
         "_jira_get_project_issue_types",
         "_jira_get_myself",
@@ -1220,7 +1222,9 @@ def _get_stdio_max_response_chars() -> int:
 
 
 def _json_text(payload: Any) -> TextContent:
-    text = json.dumps(payload, indent=2, default=str)
+    # Compact separators: indentation is pure transport cost on a machine-read
+    # channel and roughly doubles payload size against the guard below.
+    text = json.dumps(payload, separators=(",", ":"), default=str)
     max_response_chars = _get_stdio_max_response_chars()
     if len(text) <= max_response_chars:
         return TextContent(type="text", text=text)
@@ -1239,12 +1243,13 @@ def _json_text(payload: Any) -> TextContent:
         suggestions=[
             "For live turn progress, call turn_execution_get_live_progress without a section for the bounded snapshot.",
             "For live turn progress details, call turn_execution_get_live_progress with section, limit, and offset.",
+            "For Jira comments, call jira_get_comments with start_at and max_results instead of jira_get_issue with fields=['comment'].",
             "Use a narrower query or paginated detail tool for large read results.",
         ],
     )
     return TextContent(
         type="text",
-        text=json.dumps(guarded_payload, indent=2, default=str),
+        text=json.dumps(guarded_payload, separators=(",", ":"), default=str),
     )
 
 
@@ -3430,6 +3435,15 @@ async def _handle_jira_search(arguments: dict[str, Any]) -> list[TextContent]:
     )
 
 
+async def _handle_jira_get_comments(arguments: dict[str, Any]) -> list[TextContent]:
+    return _run_catalogue_proxy_handler(
+        _jira_get_comments,
+        arguments,
+        tool_family_label="Jira",
+        suggestions=["Check Jira authentication and network connectivity"],
+    )
+
+
 async def _handle_jira_get_issue(arguments: dict[str, Any]) -> list[TextContent]:
     return _run_catalogue_proxy_handler(
         _jira_get_issue,
@@ -4610,6 +4624,7 @@ _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]
     "turn_execution_backfill_from_chat_history": _handle_turn_execution_backfill_from_chat_history,
     "turn_execution_namespace_coverage_report": _handle_turn_execution_namespace_coverage_report,
     "jira_search": _handle_jira_search,
+    "jira_get_comments": _handle_jira_get_comments,
     "jira_get_issue": _handle_jira_get_issue,
     "jira_get_project_issue_types": _handle_jira_get_project_issue_types,
     "jira_get_bulk_operation_progress": _handle_jira_get_bulk_operation_progress,

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -3438,6 +3438,35 @@
             }
         },
         {
+            "name": "jira_get_comments",
+            "description": "Read comments on a Jira issue one page at a time, with start_at/max_results pagination and comment bodies flattened to text by default. Prefer this over jira_get_issue with fields=['comment'], which returns every comment at once and can exceed the response size limit on heavily commented issues.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "issue_key": {
+                        "type": "string"
+                    },
+                    "start_at": {
+                        "type": "integer"
+                    },
+                    "max_results": {
+                        "type": "integer"
+                    },
+                    "order_by": {
+                        "type": "string"
+                    },
+                    "body_format": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "issue_key"
+                ],
+                "additionalProperties": true,
+                "description": "jira_get_comments input: issue_key (str, required) plus optional start_at, max_results, order_by ('created' or '-created'), and body_format ('text' default, or 'adf' for the raw node tree)."
+            }
+        },
+        {
             "name": "jira_get_issue",
             "description": "Fetch full details for a Jira issue by key (e.g., JVNAUTOSCI-123). Use when you need issue fields, summary, status, metadata, or expanded sections such as changelog.",
             "inputSchema": {

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -550,6 +550,19 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "identifier_max_count": 1,
         "identifier_normalise": "upper",
     },
+    "jira_get_comments": {
+        "salience": "medium",
+        "category": "jira",
+        "display_template": "Comments: {issue_key}",
+        "dispatch_surface_family": "jira",
+        "evidence_surface_family": "jira",
+        "external_surface": True,
+        "identifier_argument_name": "issue_key",
+        "identifier_pattern": r"\b[A-Z][A-Z0-9]+-\d+\b",
+        "identifier_source": "user_text",
+        "identifier_max_count": 1,
+        "identifier_normalise": "upper",
+    },
     "jira_get_project_issue_types": {
         "salience": "medium",
         "category": "jira",
@@ -1200,6 +1213,7 @@ _DEFAULT_VONTOLOGY_STDIO_EXPOSED_TOOL_NAMES = {
     "jira_delete_issue_link",
     "jira_get_auth_config",
     "jira_get_bulk_operation_progress",
+    "jira_get_comments",
     "jira_get_issue",
     "jira_get_project_issue_types",
     "jira_get_myself",
@@ -1330,6 +1344,7 @@ _DEFAULT_VONRAG_STDIO_EXPOSED_TOOL_NAMES = {
 
 _DEFAULT_JIRA_FAMILY_SERVER_EXPOSED_TOOL_NAMES = {
     "jira_add_comment",
+    "jira_get_comments",
     "jira_get_issue",
     "jira_get_transitions",
     "jira_search",
@@ -1432,6 +1447,7 @@ _DEFAULT_VERIFICATION_READ_TOOL_NAMES = {
     "get_text_relations_summary",
     "get_tree",
     "issue_read",
+    "jira_get_comments",
     "jira_get_issue",
     "jira_get_bulk_operation_progress",
     "jira_get_project_issue_types",

--- a/tests/backend/test_jira_get_comments_and_compact_payloads.py
+++ b/tests/backend/test_jira_get_comments_and_compact_payloads.py
@@ -1,0 +1,602 @@
+"""Tests for paginated Jira comment reads and compact MCP payload encoding.
+
+Background: fetching a heavily commented issue through jira_get_issue with
+fields=['comment'] returned every comment at once as an ADF node tree inside a
+pretty-printed envelope. On JVNAUTOSCI-2615 that turned ~53K of prose into
+~296K of payload and tripped the 100K stdio guard, leaving the issue
+unreadable through MCP. These tests cover the two fixes: compact serialisation
+and a paginated, text-flattening comment reader.
+"""
+
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+os.environ.setdefault("ATLASSIAN_EMAIL", "agent@example.com")
+os.environ.setdefault("ATLASSIAN_API_TOKEN", "token-for-import")
+
+from src.backend.mcp_server import mcp_server  # noqa: E402
+from src.backend.mcp_server import mcp_stdio_server  # noqa: E402
+from src.backend.integrations.internal_mcp.catalogue import (  # noqa: E402
+    _jira_get_comments,
+)
+
+# ---------------------------------------------------------
+# ADF flattening
+# ---------------------------------------------------------
+
+
+def test_adf_to_text_renders_headings_lists_and_code_blocks():
+    body = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "heading",
+                "attrs": {"level": 2},
+                "content": [{"type": "text", "text": "Delivery phases"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Phase 0 is planning only."}],
+            },
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "classify data"}],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "measure Atlas"}],
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [{"type": "text", "text": "x = 1"}],
+            },
+        ],
+    }
+
+    text = mcp_server._adf_to_text(body)
+
+    assert "## Delivery phases" in text
+    assert "Phase 0 is planning only." in text
+    assert "- classify data" in text
+    assert "- measure Atlas" in text
+    assert "```python\nx = 1\n```" in text
+
+
+def test_adf_to_text_preserves_inline_marks_as_markdown():
+    body = {
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "bold",
+                        "marks": [{"type": "strong"}],
+                    },
+                    {"type": "text", "text": " and "},
+                    {"type": "text", "text": "code", "marks": [{"type": "code"}]},
+                    {"type": "text", "text": " and "},
+                    {"type": "text", "text": "italic", "marks": [{"type": "em"}]},
+                    {"type": "text", "text": " and "},
+                    {
+                        "type": "text",
+                        "text": "a link",
+                        "marks": [
+                            {"type": "link", "attrs": {"href": "https://example.com"}}
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+    text = mcp_server._adf_to_text(body)
+
+    assert "**bold**" in text
+    assert "`code`" in text
+    assert "*italic*" in text
+    assert "[a link](https://example.com)" in text
+
+
+def test_adf_to_text_round_trips_markdown_built_by_the_inverse():
+    """_adf_to_text is the inverse of _markdown_to_adf for supported syntax."""
+    source = "# Title\n\nSome prose here.\n\n- first\n- second"
+
+    text = mcp_server._adf_to_text(mcp_server._markdown_to_adf(source))
+
+    assert "# Title" in text
+    assert "Some prose here." in text
+    assert "- first" in text
+    assert "- second" in text
+
+
+def test_adf_to_text_renders_ordered_lists_and_nested_items():
+    body = {
+        "type": "doc",
+        "content": [
+            {
+                "type": "orderedList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "outer"}],
+                            },
+                            {
+                                "type": "bulletList",
+                                "content": [
+                                    {
+                                        "type": "listItem",
+                                        "content": [
+                                            {
+                                                "type": "paragraph",
+                                                "content": [
+                                                    {"type": "text", "text": "inner"}
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    text = mcp_server._adf_to_text(body)
+
+    assert "1. outer" in text
+    # Nested list keeps its own marker and is indented under the parent item.
+    assert "- inner" in text
+    assert "  - inner" in text
+
+
+def test_adf_to_text_renders_tables_as_pipe_rows():
+    body = {
+        "type": "doc",
+        "content": [
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [
+                                            {"type": "text", "text": "Dependency"}
+                                        ],
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "tableCell",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "Policy"}],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    text = mcp_server._adf_to_text(body)
+
+    assert "| Dependency | Policy |" in text
+
+
+@pytest.mark.parametrize("body", [None, "", 17, [], {"type": "doc"}])
+def test_adf_to_text_tolerates_missing_or_malformed_bodies(body):
+    """A malformed body must degrade to empty text, never raise."""
+    assert isinstance(mcp_server._adf_to_text(body), str)
+
+
+def test_adf_to_text_passes_through_plain_string_bodies():
+    """Older Jira REST versions return plain-text comment bodies."""
+    assert mcp_server._adf_to_text("already plain") == "already plain"
+
+
+# ---------------------------------------------------------
+# Comment page projection
+# ---------------------------------------------------------
+
+
+def _comment_page():
+    return {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": 2,
+        "comments": [
+            {
+                "id": "36692",
+                "self": "https://example.atlassian.net/rest/api/3/issue/1/comment/36692",
+                "author": {
+                    "accountId": "acc-1",
+                    "displayName": "Michael Witbrock",
+                    "emailAddress": "m@example.com",
+                    "active": True,
+                    "avatarUrls": {
+                        "48x48": "https://avatar.example/48",
+                        "24x24": "https://avatar.example/24",
+                        "16x16": "https://avatar.example/16",
+                        "32x32": "https://avatar.example/32",
+                    },
+                },
+                "updateAuthor": {
+                    "accountId": "acc-1",
+                    "displayName": "Michael Witbrock",
+                    "avatarUrls": {"48x48": "https://avatar.example/48"},
+                },
+                "created": "2026-07-30T20:54:55.347+1200",
+                "updated": "2026-07-30T20:54:55.347+1200",
+                "body": {
+                    "type": "doc",
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Part 2 of 4"}],
+                        }
+                    ],
+                },
+            },
+            {
+                "id": "36693",
+                "author": {"accountId": "acc-2", "displayName": "Reviewer"},
+                "created": "2026-07-30T20:55:53.310+1200",
+                "visibility": {"type": "role", "value": "Administrators"},
+                "body": {
+                    "type": "doc",
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Restricted note"}],
+                        }
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def test_flatten_comment_page_flattens_bodies_and_keeps_pagination():
+    flattened = mcp_server._flatten_comment_page(_comment_page())
+
+    assert flattened["startAt"] == 0
+    assert flattened["maxResults"] == 50
+    assert flattened["total"] == 2
+    assert flattened["body_format"] == "text"
+    assert flattened["comments"][0]["body"] == "Part 2 of 4"
+    assert flattened["comments"][0]["id"] == "36692"
+    assert flattened["comments"][0]["created"] == "2026-07-30T20:54:55.347+1200"
+
+
+def test_flatten_comment_page_drops_avatar_metadata_but_keeps_identity():
+    flattened = mcp_server._flatten_comment_page(_comment_page())
+
+    author = flattened["comments"][0]["author"]
+    assert author["displayName"] == "Michael Witbrock"
+    assert author["accountId"] == "acc-1"
+    assert "avatarUrls" not in author
+    assert "avatarUrls" not in flattened["comments"][0]["updateAuthor"]
+    assert "avatar" not in json.dumps(flattened)
+
+
+def test_flatten_comment_page_preserves_visibility_restrictions():
+    """Visibility marks role-restricted comments and is not a size optimisation."""
+    flattened = mcp_server._flatten_comment_page(_comment_page())
+
+    assert flattened["comments"][1]["visibility"] == {
+        "type": "role",
+        "value": "Administrators",
+    }
+
+
+def test_flatten_comment_page_passes_through_pages_without_comments():
+    page = {"error": "not found"}
+
+    assert mcp_server._flatten_comment_page(page) == page
+
+
+def _realistic_comment_page(count=3):
+    """A page whose bodies have the block structure real Jira comments carry.
+
+    Size assertions need this shape: ADF's cost is per node, so a fixture of
+    one-line bodies understates the overhead that motivated the change.
+    """
+    body = mcp_server._markdown_to_adf(
+        "## Delivery phases\n\n"
+        "Phase 0 is planning only.\n\n"
+        "- classify every data class\n"
+        "- measure a tuned Atlas baseline\n"
+        "- draft the decision record"
+    )
+    return {
+        "startAt": 0,
+        "maxResults": 50,
+        "total": count,
+        "comments": [
+            {
+                "id": str(index),
+                "self": f"https://example.atlassian.net/rest/api/3/issue/1/comment/{index}",
+                "author": {
+                    "accountId": "acc-1",
+                    "displayName": "Michael Witbrock",
+                    "avatarUrls": {
+                        size: f"https://avatar.example/{size}"
+                        for size in ("16x16", "24x24", "32x32", "48x48")
+                    },
+                },
+                "created": "2026-07-30T20:54:55.347+1200",
+                "body": body,
+            }
+            for index in range(count)
+        ],
+    }
+
+
+def test_flatten_comment_page_materially_shrinks_the_payload():
+    page = _realistic_comment_page()
+
+    raw = mcp_server._tool_json(page)
+    flattened = mcp_server._tool_json(mcp_server._flatten_comment_page(page))
+
+    assert len(flattened) < len(raw) / 2
+
+
+# ---------------------------------------------------------
+# Compact serialisation
+# ---------------------------------------------------------
+
+
+def test_tool_json_is_compact():
+    payload = {"a": 1, "b": [1, 2], "c": {"d": "e"}}
+
+    text = mcp_server._tool_json(payload)
+
+    assert text == '{"a":1,"b":[1,2],"c":{"d":"e"}}'
+    assert "\n" not in text
+    assert json.loads(text) == payload
+
+
+def test_stdio_json_text_is_compact_and_still_parses():
+    payload = {"success": True, "rows": [{"id": 1}, {"id": 2}]}
+
+    content = mcp_stdio_server._json_text(payload)
+
+    assert "\n" not in content.text
+    assert ": " not in content.text
+    assert json.loads(content.text) == payload
+
+
+def test_stdio_json_text_compaction_lowers_payload_against_the_guard():
+    """The guard measures serialised size, so indentation cost was real.
+
+    ADF is many small nodes rather than a few long strings, which is exactly
+    the shape where per-line indentation dominates.
+    """
+    payload = _realistic_comment_page(count=50)
+
+    compact = len(mcp_stdio_server._json_text(payload).text)
+    indented = len(json.dumps(payload, indent=2, default=str))
+
+    assert compact < indented / 2
+
+
+def test_stdio_json_text_still_guards_oversized_payloads(monkeypatch):
+    monkeypatch.setenv("VON_MCP_STDIO_MAX_RESPONSE_CHARS", "10000")
+    payload = {"rows": ["x" * 100 for _ in range(500)]}
+
+    content = mcp_stdio_server._json_text(payload)
+    decoded = json.loads(content.text)
+
+    assert decoded["error_code"] == "payload_too_large"
+    assert decoded["error_details"]["max_response_chars"] == 10000
+
+
+def test_payload_too_large_guidance_points_at_the_paginated_comment_tool(monkeypatch):
+    monkeypatch.setenv("VON_MCP_STDIO_MAX_RESPONSE_CHARS", "10000")
+    payload = {"rows": ["x" * 100 for _ in range(500)]}
+
+    decoded = json.loads(mcp_stdio_server._json_text(payload).text)
+
+    assert any(
+        "jira_get_comments" in suggestion
+        for suggestion in decoded.get("suggestions") or []
+    )
+
+
+# ---------------------------------------------------------
+# Catalogue handler contract
+# ---------------------------------------------------------
+
+
+def test_jira_get_comments_requires_issue_key():
+    result = _jira_get_comments()
+
+    assert result["success"] is False
+    assert result["error_code"] == "missing_parameter"
+
+
+@pytest.mark.parametrize("body_format", ["html", "markdown", "ADF"])
+def test_jira_get_comments_rejects_unknown_body_format(body_format):
+    result = _jira_get_comments(issue_key="JVNAUTOSCI-2615", body_format=body_format)
+
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_parameter"
+
+
+def test_jira_get_comments_rejects_unknown_order_by():
+    result = _jira_get_comments(issue_key="JVNAUTOSCI-2615", order_by="updated")
+
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_parameter"
+
+
+def test_jira_get_comments_forwards_pagination_to_the_proxy(monkeypatch):
+    captured = {}
+
+    class _FakeProxy:
+        async def get_comments(self, **kwargs):
+            captured.update(kwargs)
+            return {"total": 6, "comments": []}
+
+    async def _fake_get_jira_proxy():
+        return _FakeProxy()
+
+    monkeypatch.setattr(
+        "src.backend.integrations.internal_mcp.jira_proxy_mcp.get_jira_proxy",
+        _fake_get_jira_proxy,
+    )
+
+    result = _jira_get_comments(
+        issue_key="JVNAUTOSCI-2615",
+        start_at=100,
+        max_results=50,
+        order_by="created",
+    )
+
+    assert result == {"total": 6, "comments": []}
+    assert captured["issue_key"] == "JVNAUTOSCI-2615"
+    assert captured["start_at"] == 100
+    assert captured["max_results"] == 50
+    assert captured["order_by"] == "created"
+
+
+# ---------------------------------------------------------
+# Backing server request shaping
+# ---------------------------------------------------------
+
+
+def _call_backing_tool(monkeypatch, arguments, page=None):
+    captured = {}
+
+    def _fake_jira_get(endpoint, params=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return page if page is not None else _comment_page()
+
+    monkeypatch.setattr(mcp_server, "jira_get", _fake_jira_get)
+    import anyio
+
+    content = anyio.run(mcp_server.call_tool, "jira_get_comments", arguments)
+    return captured, json.loads(content[0].text)
+
+
+def test_backing_tool_requests_the_comment_endpoint_with_pagination(monkeypatch):
+    captured, _ = _call_backing_tool(
+        monkeypatch,
+        {
+            "issue_key": "JVNAUTOSCI-2615",
+            "start_at": 50,
+            "max_results": 25,
+            "order_by": "-created",
+        },
+    )
+
+    assert captured["endpoint"] == "issue/JVNAUTOSCI-2615/comment"
+    assert captured["params"]["startAt"] == 50
+    assert captured["params"]["maxResults"] == 25
+    assert captured["params"]["orderBy"] == "-created"
+
+
+def test_backing_tool_defaults_to_flattened_text_bodies(monkeypatch):
+    _, decoded = _call_backing_tool(monkeypatch, {"issue_key": "JVNAUTOSCI-2615"})
+
+    assert decoded["body_format"] == "text"
+    assert decoded["comments"][0]["body"] == "Part 2 of 4"
+
+
+def test_backing_tool_returns_raw_adf_on_request(monkeypatch):
+    _, decoded = _call_backing_tool(
+        monkeypatch,
+        {"issue_key": "JVNAUTOSCI-2615", "body_format": "adf"},
+    )
+
+    assert decoded["comments"][0]["body"]["type"] == "doc"
+
+
+def test_backing_tool_omits_start_at_when_not_requested(monkeypatch):
+    captured, _ = _call_backing_tool(monkeypatch, {"issue_key": "JVNAUTOSCI-2615"})
+
+    assert "startAt" not in captured["params"]
+    assert captured["params"]["maxResults"] == 50
+
+
+def test_backing_tool_emits_compact_json(monkeypatch):
+    import anyio
+
+    monkeypatch.setattr(mcp_server, "jira_get", lambda e, params=None: _comment_page())
+    content = anyio.run(mcp_server.call_tool, "jira_get_comments", {"issue_key": "X-1"})
+
+    assert "\n  " not in content[0].text
+    assert json.loads(content[0].text)["total"] == 2
+
+
+# ---------------------------------------------------------
+# Surface exposure
+# ---------------------------------------------------------
+
+
+def test_jira_get_comments_is_exposed_on_read_surfaces():
+    from src.backend.integrations.internal_mcp.tool_contract_registry import (
+        SURFACE_JIRA_FAMILY_SERVER,
+        SURFACE_MANIFEST,
+        SURFACE_VONTOLOGY_STDIO,
+        get_surface_tool_payloads,
+    )
+
+    for surface in (
+        SURFACE_VONTOLOGY_STDIO,
+        SURFACE_MANIFEST,
+        SURFACE_JIRA_FAMILY_SERVER,
+    ):
+        names = {tool["name"] for tool in get_surface_tool_payloads(surface)}
+        assert "jira_get_comments" in names, f"missing on {surface}"
+
+
+def test_jira_get_comments_is_registered_as_a_read_tool():
+    """A comment reader must not land in the write-tool set."""
+    from src.backend.services.tool_metadata_service import (
+        _DEFAULT_WRITE_TOOL_NAMES,
+        _DEFAULT_VERIFICATION_READ_TOOL_NAMES,
+    )
+
+    assert "jira_get_comments" not in _DEFAULT_WRITE_TOOL_NAMES
+    assert "jira_get_comments" in _DEFAULT_VERIFICATION_READ_TOOL_NAMES
+
+
+def test_stdio_server_dispatches_jira_get_comments():
+    assert "jira_get_comments" in mcp_stdio_server._TOOL_HANDLERS


### PR DESCRIPTION
## Problem

Heavily commented Jira issues were unreachable through MCP. Reading JVNAUTOSCI-2615 returned ~296K characters against the 100K stdio guard and failed with `payload_too_large`. The guard's advice to "request a bounded projection" was unfollowable: `jira_get_issue` has no pagination, and no comment-reading tool existed at all (only `jira_add_comment` for writing).

It was never a volume problem. The issue holds **six** comments and ~53K of prose. The rest was encoding overhead:

| Stage | Chars | Factor |
|---|---|---|
| Plain prose | 53,226 | — |
| ADF node-tree encoding | 109,284 | 2.1x |
| Author/avatar envelope | 121,589 | 1.1x |
| `indent=2` | 264,105 | 2.2x |
| Escaped into text content | 284,208 | 1.08x |

## Changes

**Compact serialisation.** Tool output now uses compact separators. Indentation is pure transport cost on a channel that is parsed and never read by a human, and the stdio guard measures serialised size. The on-disk diagnostics cache stays pretty-printed.

**`jira_get_comments`**, with the `start_at`/`max_results` pagination `jira_search` already had, plus `order_by`. Wired through the backing server, proxy, catalogue, and metadata registry; registered as a read tool on the three read surfaces and deliberately not in the write set.

**ADF flattening**, on by default (`body_format="text"`, `"adf"` for the raw tree). `_adf_to_text` is a true inverse of the existing `_markdown_to_adf`: headings, ordered/nested lists, code blocks, tables, and `strong`/`em`/`code`/`link` marks all survive. It drops per-author avatar URL sets but **preserves `visibility` verbatim**, since that marks role-restricted comments and must not be dropped by a size optimisation.

## Result

The read that previously failed:

| Path | Size | Result |
|---|---|---|
| `jira_get_issue` with `fields=['comment']`, indented | 296,345 | blocked by 100K guard |
| `jira_get_comments`, text, compact | 59,199 | passes, **5.0x** smaller |

Verified live against JVNAUTOSCI-2615: paging at `max_results=2` returns 6 unique comments across clean non-overlapping windows and terminates correctly; both sort orders behave; `body_format="adf"` returns the raw tree at 2.1x the text size.

## Tests

107 passing, including 35 new ones covering flattening fidelity, the round-trip against `_markdown_to_adf`, malformed-body tolerance, avatar stripping, visibility preservation, compaction, pagination forwarding, and surface exposure.

## Note on the manifest

The manifest entry is inserted **additively rather than regenerated**. Tool descriptions resolve through DB-backed `#V#mcp_tool` concepts, so `get_manifest_payload()` is not deterministic across processes — `scripts/regenerate_vontology_mcp_manifest.py` and `test_mcp_manifest_parity` disagreed within a single session, and regenerating swept live DB state for ~15 unrelated tools into the repo. The manifest diff here is 29 insertions, 0 deletions.

The 2 `test_mcp_manifest_parity` failures are **pre-existing** — confirmed red at a pristine HEAD worktree before this change. `jira_get_comments` matches canonical exactly and is not among the 15 drifting tools. Worth fixing separately, since it turns on whether the manifest should track the database at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)