### PR TITLE
Serve virtual concepts from registered providers (JVNAUTOSCI-2650)

### DIFF
--- a/src/backend/integrations/internal_mcp/tool_contract_registry.py
+++ b/src/backend/integrations/internal_mcp/tool_contract_registry.py
@@ -324,295 +324,307 @@ def _contract_from_method_definition(
     )
 
 
-def _supplemental_surface_only_contracts() -> dict[str, CanonicalMCPToolContract]:
-    supplemental_specs: dict[str, dict[str, Any]] = {
-        "find_subconcepts": {
-            "family": "vontology",
-            "category": "read",
-            "description": "Finds all direct subconcepts (children) of a given concept in the Vontology hierarchy",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "concept_id": {
-                        "type": "string",
-                        "description": "The concept ID to find children of",
-                    }
-                },
-                "required": ["concept_id"],
+_SUPPLEMENTAL_SURFACE_ONLY_SPECS: dict[str, dict[str, Any]] = {
+    "find_subconcepts": {
+        "family": "vontology",
+        "category": "read",
+        "description": "Finds all direct subconcepts (children) of a given concept in the Vontology hierarchy",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "concept_id": {
+                    "type": "string",
+                    "description": "The concept ID to find children of",
+                }
             },
+            "required": ["concept_id"],
         },
-        "find_concepts_by_name": {
-            "family": "vontology",
-            "category": "read",
-            "description": "Searches for concepts in the Vontology by name substring",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "The name substring to search for",
-                    }
-                },
-                "required": ["name"],
+    },
+    "find_concepts_by_name": {
+        "family": "vontology",
+        "category": "read",
+        "description": "Searches for concepts in the Vontology by name substring",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name substring to search for",
+                }
             },
+            "required": ["name"],
         },
-        "audit_concept_text_relations": {
-            "family": "vontology",
-            "category": "read",
-            "description": (
-                "Audit all text relations attached to a concept. Reports accessibility status for each relation "
-                "and whether the concept can be safely renamed. Use before rename operations to identify and "
-                "resolve blocking inaccessible relations."
-            ),
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "concept_id": {
-                        "type": "string",
-                        "description": "The concept ID to audit",
-                    },
-                    "include_text_preview": {
-                        "type": "boolean",
-                        "default": True,
-                        "description": "Include truncated text preview in results",
-                    },
-                    "max_preview_length": {
-                        "type": "integer",
-                        "default": 100,
-                        "description": "Maximum length for text previews",
-                    },
+    },
+    "audit_concept_text_relations": {
+        "family": "vontology",
+        "category": "read",
+        "description": (
+            "Audit all text relations attached to a concept. Reports accessibility status for each relation "
+            "and whether the concept can be safely renamed. Use before rename operations to identify and "
+            "resolve blocking inaccessible relations."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "concept_id": {
+                    "type": "string",
+                    "description": "The concept ID to audit",
                 },
-                "required": ["concept_id"],
-            },
-        },
-        "get_concept_index_status": {
-            "family": "vontology",
-            "category": "read",
-            "description": (
-                "Get statistics about the concept embedding index. Shows counts by status (pending, indexed, "
-                "stale, failed), concepts needing indexing, and index namespace."
-            ),
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "concept_id": {
-                        "type": "string",
-                        "description": "Optional: get status for a specific concept instead of aggregate stats",
-                    }
+                "include_text_preview": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Include truncated text preview in results",
                 },
-                "required": [],
+                "max_preview_length": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "Maximum length for text previews",
+                },
             },
+            "required": ["concept_id"],
         },
-        "von_chat_run": {
-            "family": "internal",
-            "category": "read",
-            "description": (
-                "Run one thin adaptive read-only Von turn and return its response, "
-                "bounded evidence index, and redacted observational trace. The model "
-                "may choose among delegated read capabilities; writes require an "
-                "explicit authorised effect tool or workflow."
-            ),
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "prompt": {"type": "string", "description": "User prompt text"},
-                    "context": {
-                        "type": "array",
-                        "description": "Optional prior messages [{role, content}]",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "role": {
-                                    "type": "string",
-                                    "description": "system|user|assistant|tool",
-                                },
-                                "content": {"type": "string"},
+    },
+    "get_concept_index_status": {
+        "family": "vontology",
+        "category": "read",
+        "description": (
+            "Get statistics about the concept embedding index. Shows counts by status (pending, indexed, "
+            "stale, failed), concepts needing indexing, and index namespace."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "concept_id": {
+                    "type": "string",
+                    "description": "Optional: get status for a specific concept instead of aggregate stats",
+                }
+            },
+            "required": [],
+        },
+    },
+    "von_chat_run": {
+        "family": "internal",
+        "category": "read",
+        "description": (
+            "Run one thin adaptive read-only Von turn and return its response, "
+            "bounded evidence index, and redacted observational trace. The model "
+            "may choose among delegated read capabilities; writes require an "
+            "explicit authorised effect tool or workflow."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "User prompt text"},
+                "context": {
+                    "type": "array",
+                    "description": "Optional prior messages [{role, content}]",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "role": {
+                                "type": "string",
+                                "description": "system|user|assistant|tool",
                             },
-                            "required": ["role", "content"],
+                            "content": {"type": "string"},
                         },
-                    },
-                    "model": {
-                        "type": "string",
-                        "description": "Optional model override",
-                    },
-                    "user_namespace": {
-                        "type": "string",
-                        "description": "Optional namespace claim accepted only from a trusted operator context; it never authenticates itself",
-                    },
-                    "gmail_profile": {
-                        "type": "string",
-                        "description": "Optional trusted-operator Gmail profile binding",
-                    },
-                    "auxiliary_system_prompt": {
-                        "type": "string",
-                        "description": "Optional caller-supplied supplementary context; treated as untrusted user context, not a system authority",
-                    },
-                    "timeout_seconds": {
-                        "type": "number",
-                        "default": 90,
-                        "description": "Legacy alias for advisory_seconds",
-                    },
-                    "advisory_seconds": {
-                        "type": "number",
-                        "default": 90,
-                        "description": (
-                            "Elapsed-time advisory for the adaptive turn; crossing "
-                            "it does not discard the result"
-                        ),
-                    },
-                    "max_string_chars": {
-                        "type": "integer",
-                        "default": 8000,
-                        "description": "Max characters retained for any string in the trace",
-                    },
-                    "turn_id": {
-                        "type": "string",
-                        "description": "Optional caller correlation identifier for this ephemeral read-only turn",
+                        "required": ["role", "content"],
                     },
                 },
-                "required": ["prompt"],
-            },
-        },
-        "create_task": {
-            "family": "task",
-            "category": "write",
-            "description": (
-                "Create a task from a conversation. Tasks are stored as Vontology concepts with rich metadata. "
-                "Optionally links to the originating conversation."
-            ),
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "description": "Brief task title (required)",
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Detailed task description",
-                    },
-                    "assignee_concept_id": {
-                        "type": "string",
-                        "description": "Assignee's concept ID (e.g., '#V#user_abc')",
-                    },
-                    "creator_concept_id": {
-                        "type": "string",
-                        "description": "Creator's concept ID (e.g., '#V#user_abc')",
-                    },
-                    "session_id": {
-                        "type": "string",
-                        "description": "Chat session_id to link task to conversation",
-                    },
-                    "due_date": {
-                        "type": "string",
-                        "description": "ISO 8601 date string for due date",
-                    },
-                    "priority": {
-                        "type": "string",
-                        "enum": ["low", "medium", "high", "critical"],
-                        "default": "medium",
-                        "description": "Task priority level",
-                    },
-                    "organisation_concept_id": {
-                        "type": "string",
-                        "description": "Organisation context for the task",
-                    },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model override",
                 },
-                "required": ["title", "description"],
-            },
-        },
-        "get_task": {
-            "family": "task",
-            "category": "read",
-            "description": "Get details of a specific task by its concept ID.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "task_concept_id": {
-                        "type": "string",
-                        "description": "The task's concept ID (e.g., '#V#task_abc123')",
-                    }
+                "user_namespace": {
+                    "type": "string",
+                    "description": "Optional namespace claim accepted only from a trusted operator context; it never authenticates itself",
                 },
-                "required": ["task_concept_id"],
-            },
-        },
-        "list_my_tasks": {
-            "family": "task",
-            "category": "read",
-            "description": "List tasks assigned to a user, optionally filtered by status.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "user_concept_id": {
-                        "type": "string",
-                        "description": "User's concept ID to get tasks for",
-                    },
-                    "status_filter": {
-                        "type": "string",
-                        "enum": [
-                            "pending",
-                            "in_progress",
-                            "completed",
-                            "cancelled",
-                            "blocked",
-                        ],
-                        "description": "Optional status filter",
-                    },
-                    "include_created": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "If true, also include tasks created by the user (not just assigned)",
-                    },
+                "gmail_profile": {
+                    "type": "string",
+                    "description": "Optional trusted-operator Gmail profile binding",
                 },
-                "required": ["user_concept_id"],
-            },
-        },
-        "update_task_status": {
-            "family": "task",
-            "category": "write",
-            "description": "Update the status of a task.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "task_concept_id": {
-                        "type": "string",
-                        "description": "The task's concept ID",
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "pending",
-                            "in_progress",
-                            "completed",
-                            "cancelled",
-                            "blocked",
-                        ],
-                        "description": "New task status",
-                    },
+                "auxiliary_system_prompt": {
+                    "type": "string",
+                    "description": "Optional caller-supplied supplementary context; treated as untrusted user context, not a system authority",
                 },
-                "required": ["task_concept_id", "status"],
-            },
-        },
-        "assign_task": {
-            "family": "task",
-            "category": "write",
-            "description": "Assign or reassign a task to a user.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "task_concept_id": {
-                        "type": "string",
-                        "description": "The task's concept ID",
-                    },
-                    "assignee_concept_id": {
-                        "type": "string",
-                        "description": "The assignee's concept ID",
-                    },
+                "timeout_seconds": {
+                    "type": "number",
+                    "default": 90,
+                    "description": "Legacy alias for advisory_seconds",
                 },
-                "required": ["task_concept_id", "assignee_concept_id"],
+                "advisory_seconds": {
+                    "type": "number",
+                    "default": 90,
+                    "description": (
+                        "Elapsed-time advisory for the adaptive turn; crossing "
+                        "it does not discard the result"
+                    ),
+                },
+                "max_string_chars": {
+                    "type": "integer",
+                    "default": 8000,
+                    "description": "Max characters retained for any string in the trace",
+                },
+                "turn_id": {
+                    "type": "string",
+                    "description": "Optional caller correlation identifier for this ephemeral read-only turn",
+                },
             },
+            "required": ["prompt"],
         },
-    }
+    },
+    "create_task": {
+        "family": "task",
+        "category": "write",
+        "description": (
+            "Create a task from a conversation. Tasks are stored as Vontology concepts with rich metadata. "
+            "Optionally links to the originating conversation."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Brief task title (required)",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Detailed task description",
+                },
+                "assignee_concept_id": {
+                    "type": "string",
+                    "description": "Assignee's concept ID (e.g., '#V#user_abc')",
+                },
+                "creator_concept_id": {
+                    "type": "string",
+                    "description": "Creator's concept ID (e.g., '#V#user_abc')",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Chat session_id to link task to conversation",
+                },
+                "due_date": {
+                    "type": "string",
+                    "description": "ISO 8601 date string for due date",
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "critical"],
+                    "default": "medium",
+                    "description": "Task priority level",
+                },
+                "organisation_concept_id": {
+                    "type": "string",
+                    "description": "Organisation context for the task",
+                },
+            },
+            "required": ["title", "description"],
+        },
+    },
+    "get_task": {
+        "family": "task",
+        "category": "read",
+        "description": "Get details of a specific task by its concept ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_concept_id": {
+                    "type": "string",
+                    "description": "The task's concept ID (e.g., '#V#task_abc123')",
+                }
+            },
+            "required": ["task_concept_id"],
+        },
+    },
+    "list_my_tasks": {
+        "family": "task",
+        "category": "read",
+        "description": "List tasks assigned to a user, optionally filtered by status.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "user_concept_id": {
+                    "type": "string",
+                    "description": "User's concept ID to get tasks for",
+                },
+                "status_filter": {
+                    "type": "string",
+                    "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed",
+                        "cancelled",
+                        "blocked",
+                    ],
+                    "description": "Optional status filter",
+                },
+                "include_created": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If true, also include tasks created by the user (not just assigned)",
+                },
+            },
+            "required": ["user_concept_id"],
+        },
+    },
+    "update_task_status": {
+        "family": "task",
+        "category": "write",
+        "description": "Update the status of a task.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_concept_id": {
+                    "type": "string",
+                    "description": "The task's concept ID",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed",
+                        "cancelled",
+                        "blocked",
+                    ],
+                    "description": "New task status",
+                },
+            },
+            "required": ["task_concept_id", "status"],
+        },
+    },
+    "assign_task": {
+        "family": "task",
+        "category": "write",
+        "description": "Assign or reassign a task to a user.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "task_concept_id": {
+                    "type": "string",
+                    "description": "The task's concept ID",
+                },
+                "assignee_concept_id": {
+                    "type": "string",
+                    "description": "The assignee's concept ID",
+                },
+            },
+            "required": ["task_concept_id", "assignee_concept_id"],
+        },
+    },
+}
+
+
+def supplemental_tool_names() -> frozenset[str]:
+    """Names of surface-only contracts, without constructing them.
+
+    Constructing them resolves metadata and exposure, which reads Vontology
+    and runs access control. Callers that only need membership must use this.
+    """
+    return frozenset(_SUPPLEMENTAL_SURFACE_ONLY_SPECS)
+
+
+def _supplemental_surface_only_contracts() -> dict[str, CanonicalMCPToolContract]:
+    supplemental_specs = _SUPPLEMENTAL_SURFACE_ONLY_SPECS
 
     contracts: dict[str, CanonicalMCPToolContract] = {}
     for name, spec in supplemental_specs.items():

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -170,11 +170,11 @@ class AccessEvaluator:
         # considered visible, even when no MongoDB concept document exists.
         # This supports UI navigation and text-relations (e.g., adding hasName).
         try:
-            from ..vontology.code_concepts_registry import (  # local import avoids cycles
-                is_code_concept_id,
+            from ..vontology.virtual_concept_providers import (  # local import avoids cycles
+                is_virtual_concept_id,
             )
 
-            if is_code_concept_id(normalised):
+            if is_virtual_concept_id(normalised):
                 self._cache[normalised] = True
                 return True
         except Exception:
@@ -260,10 +260,10 @@ class AccessEvaluator:
         if uncached:
             code_concepts: set[str] = set()
             try:
-                from ..vontology.code_concepts_registry import is_code_concept_id
+                from ..vontology.virtual_concept_providers import is_virtual_concept_id
 
                 for concept_id in tuple(uncached):
-                    if is_code_concept_id(concept_id):
+                    if is_virtual_concept_id(concept_id):
                         code_concepts.add(concept_id)
             except Exception:
                 code_concepts = set()
@@ -558,9 +558,9 @@ def describe_concept_access(concept_id: Any) -> Dict[str, Any]:
         return details
 
     try:
-        from ..vontology.code_concepts_registry import is_code_concept_id
+        from ..vontology.virtual_concept_providers import is_virtual_concept_id
 
-        if is_code_concept_id(normalised):
+        if is_virtual_concept_id(normalised):
             details.update(
                 {
                     "exists": True,

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -399,9 +399,24 @@ def get_code_concept(concept_id: str) -> Optional[CodeConcept]:
 
 
 def build_virtual_concept_doc(concept_id: str) -> Optional[dict]:
-    """Return a Mongo-shaped concept document for a registered code concept.
+    """Return a Mongo-shaped document for any virtual concept, or None.
+
+    Resolves through the provider registry, so this now also serves sources
+    beyond the code registry, such as the MCP tool catalogue. Callers are all
+    miss-path fallbacks, so a materialised concept still wins.
+    """
+
+    from .virtual_concept_providers import resolve_virtual_concept
+
+    return resolve_virtual_concept(concept_id)
+
+
+def build_code_concept_doc(concept_id: str) -> Optional[dict]:
+    """Return a Mongo-shaped document for a registered code concept.
 
     The shape is intentionally compatible with `is_predicate()` and similar helpers.
+    This is the raw builder behind the code-registry provider; general callers
+    want `build_virtual_concept_doc`.
     """
 
     cc = get_code_concept(concept_id)

--- a/src/backend/vontology/virtual_concept_providers.py
+++ b/src/backend/vontology/virtual_concept_providers.py
@@ -1,0 +1,206 @@
+"""Registry for virtual concepts resolved on demand from authoritative sources.
+
+A virtual concept is not persisted in MongoDB. It is derived from whatever
+already owns the truth — the code registry, the MCP tool catalogue — and
+rebuilt on every read, so it cannot go stale and cannot be edited into
+disagreement with its source.
+
+This exists because the opposite approach failed concretely (JVNAUTOSCI-2615).
+Tool descriptions were copied into #V#mcp_tool concepts at first bootstrap and
+never refreshed, so frozen text suppressed later improvements in code and the
+published tool surface varied with database state.
+
+Resolution rules:
+
+- A materialised concept always wins. Providers are consulted on the miss path
+  only, which makes this a migration route rather than a cutover.
+- Providers are read-only. Writes to a virtual concept are refused by
+  ``virtual_write_refusal`` with the owning source named.
+- A provider must declare ``serves_public_concepts``. Claiming a concept
+  currently grants unconditional visibility in access control, so a provider
+  serving scoped content must not use this seam until visibility is modelled.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol, runtime_checkable
+
+
+class VirtualConceptWriteError(Exception):
+    """Raised when a write targets a concept owned by a provider."""
+
+    def __init__(self, concept_id: str, source_id: str):
+        self.concept_id = concept_id
+        self.source_id = source_id
+        super().__init__(
+            f"Concept '{concept_id}' is derived from '{source_id}' and cannot be "
+            f"written through Vontology. Change it at that source instead."
+        )
+
+
+@runtime_checkable
+class VirtualConceptProvider(Protocol):
+    """Resolves concepts owned by one authoritative source."""
+
+    @property
+    def source_id(self) -> str:
+        """Stable identifier for the owning source, used in refusals."""
+
+    @property
+    def serves_public_concepts(self) -> bool:
+        """Whether every concept served is readable by any actor."""
+
+    def owns(self, concept_id: str) -> bool: ...
+
+    def get(self, concept_id: str) -> Optional[Dict[str, Any]]: ...
+
+    def iter_concepts(self) -> Iterable[Dict[str, Any]]: ...
+
+
+_providers: List[VirtualConceptProvider] = []
+_lock = threading.RLock()
+_resolving = threading.local()
+
+
+def register_provider(provider: VirtualConceptProvider) -> None:
+    """Register a provider. Later registrations resolve after earlier ones."""
+    source_id = str(getattr(provider, "source_id", "") or "").strip()
+    if not source_id:
+        raise ValueError("A virtual concept provider must declare a source_id.")
+    if not getattr(provider, "serves_public_concepts", False):
+        # Claiming a concept grants unconditional visibility in access control,
+        # so a provider that cannot make this promise would silently widen scope.
+        raise ValueError(
+            f"Provider '{source_id}' must declare serves_public_concepts=True. "
+            "Scoped virtual content is not supported by this seam yet."
+        )
+    with _lock:
+        if any(existing.source_id == source_id for existing in _providers):
+            raise ValueError(f"Duplicate virtual concept provider: '{source_id}'")
+        _providers.append(provider)
+
+
+def unregister_provider(source_id: str) -> bool:
+    with _lock:
+        for index, provider in enumerate(_providers):
+            if provider.source_id == source_id:
+                del _providers[index]
+                return True
+    return False
+
+
+def registered_source_ids() -> List[str]:
+    _ensure_bootstrapped()
+    with _lock:
+        return [provider.source_id for provider in _providers]
+
+
+def _ensure_bootstrapped() -> None:
+    """Register the built-in providers on first use.
+
+    Imported lazily: the provider implementations import the sources they wrap,
+    which would otherwise close an import cycle back to this module.
+    """
+    with _lock:
+        if _providers:
+            return
+    from .virtual_concept_sources import register_default_virtual_concept_providers
+
+    register_default_virtual_concept_providers()
+
+
+def _iter_providers() -> Iterator[VirtualConceptProvider]:
+    _ensure_bootstrapped()
+    with _lock:
+        snapshot = tuple(_providers)
+    return iter(snapshot)
+
+
+def owning_provider(concept_id: str) -> Optional[VirtualConceptProvider]:
+    if not isinstance(concept_id, str) or not concept_id:
+        return None
+    # A provider may reach code that asks about virtual concepts again — access
+    # control and tool metadata call into each other. Refuse to recurse rather
+    # than rebuild the world at every level.
+    if getattr(_resolving, "active", False):
+        return None
+    _resolving.active = True
+    try:
+        for provider in _iter_providers():
+            try:
+                if provider.owns(concept_id):
+                    return provider
+            except Exception:
+                # One broken provider must not make every virtual concept
+                # unresolvable.
+                continue
+        return None
+    finally:
+        _resolving.active = False
+
+
+def is_virtual_concept_id(concept_id: str) -> bool:
+    return owning_provider(concept_id) is not None
+
+
+def virtual_concept_source(concept_id: str) -> Optional[str]:
+    provider = owning_provider(concept_id)
+    return provider.source_id if provider is not None else None
+
+
+def resolve_virtual_concept(concept_id: str) -> Optional[Dict[str, Any]]:
+    """Return a Mongo-shaped document for a virtual concept, or None.
+
+    None means no provider claims this id. That is an unresolved virtual
+    lookup, not evidence that the concept does not exist.
+    """
+    provider = owning_provider(concept_id)
+    if provider is None:
+        return None
+    try:
+        doc = provider.get(concept_id)
+    except Exception:
+        return None
+    if not isinstance(doc, dict):
+        return None
+    return _stamp_provenance(doc, provider.source_id)
+
+
+def iter_virtual_concepts(
+    *, source_id: Optional[str] = None
+) -> Iterator[Dict[str, Any]]:
+    """Yield every virtual concept, optionally from one source."""
+    seen: set[str] = set()
+    for provider in _iter_providers():
+        if source_id is not None and provider.source_id != source_id:
+            continue
+        try:
+            concepts = list(provider.iter_concepts())
+        except Exception:
+            continue
+        for doc in concepts:
+            if not isinstance(doc, dict):
+                continue
+            identifier = doc.get("concept_id")
+            if not isinstance(identifier, str) or identifier in seen:
+                continue
+            seen.add(identifier)
+            yield _stamp_provenance(doc, provider.source_id)
+
+
+def virtual_write_refusal(concept_id: str) -> Optional[VirtualConceptWriteError]:
+    """Return the error a caller should raise, or None if the write may proceed."""
+    provider = owning_provider(concept_id)
+    if provider is None:
+        return None
+    return VirtualConceptWriteError(concept_id, provider.source_id)
+
+
+def _stamp_provenance(doc: Dict[str, Any], source_id: str) -> Dict[str, Any]:
+    stamped = dict(doc)
+    metadata = dict(stamped.get("metadata") or {})
+    metadata["virtual"] = True
+    metadata["virtual_source"] = source_id
+    stamped["metadata"] = metadata
+    return stamped

--- a/src/backend/vontology/virtual_concept_sources.py
+++ b/src/backend/vontology/virtual_concept_sources.py
@@ -1,0 +1,169 @@
+"""Concrete virtual concept providers.
+
+Two sources are registered here. The code concept registry is the pre-existing
+behaviour, re-expressed as a provider. The MCP tool catalogue is new: every
+registered tool becomes fetchable as a concept without being copied into the
+database, which is the arrangement that went stale in JVNAUTOSCI-2615.
+
+Both are imported for their registration side effect by
+``register_default_virtual_concept_providers``.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Optional
+
+from .virtual_concept_providers import register_provider
+
+MCP_TOOL_TYPE_ID = "#V#mcp_tool"
+MCP_TOOL_SOURCE_ID = "mcp_tool_catalogue"
+CODE_CONCEPT_SOURCE_ID = "von_code_registry"
+
+
+class CodeConceptProvider:
+    """Serves the concepts handled directly in Von's code."""
+
+    source_id = CODE_CONCEPT_SOURCE_ID
+    serves_public_concepts = True
+
+    def owns(self, concept_id: str) -> bool:
+        from .code_concepts_registry import is_code_concept_id
+
+        return is_code_concept_id(concept_id)
+
+    def get(self, concept_id: str) -> Optional[Dict[str, Any]]:
+        from .code_concepts_registry import build_code_concept_doc
+
+        return build_code_concept_doc(concept_id)
+
+    def iter_concepts(self) -> Iterable[Dict[str, Any]]:
+        from .code_concepts_registry import (
+            build_code_concept_doc,
+            iter_code_concepts,
+        )
+
+        for code_concept in iter_code_concepts():
+            doc = build_code_concept_doc(code_concept.concept_id)
+            if isinstance(doc, dict):
+                yield doc
+
+
+@lru_cache(maxsize=1)
+def _registered_tool_names() -> frozenset:
+    """Registered tool names, resolved without building contracts.
+
+    Kept separate from the contract registry so ownership checks stay free of
+    the metadata and access-control machinery. See McpToolConceptProvider.owns.
+    """
+    from ..integrations.internal_mcp.catalogue import build_default_catalogue
+    from ..integrations.internal_mcp.tool_contract_registry import (
+        supplemental_tool_names,
+    )
+
+    return frozenset(build_default_catalogue().list_methods()) | supplemental_tool_names()
+
+
+def invalidate_registered_tool_names() -> None:
+    _registered_tool_names.cache_clear()
+
+
+def tool_concept_id(tool_name: str) -> str:
+    """Map a tool name to its concept id.
+
+    Deterministic and matching the convention the existing materialised
+    #V#mcp_tool concepts already use, so a virtual concept and the row it will
+    eventually replace share one identity and stored relations survive.
+    """
+    return f"#V#{tool_name}_tool"
+
+
+def tool_name_from_concept_id(concept_id: str) -> Optional[str]:
+    if not isinstance(concept_id, str):
+        return None
+    if not concept_id.startswith("#V#") or not concept_id.endswith("_tool"):
+        return None
+    name = concept_id[len("#V#") : -len("_tool")]
+    return name or None
+
+
+class McpToolConceptProvider:
+    """Serves one concept per registered MCP tool, derived from the contract.
+
+    The contract is code-authoritative (JVNAUTOSCI-2615, PR #401), so these
+    documents are a pure function of source and cannot drift from what the
+    tool actually is.
+    """
+
+    source_id = MCP_TOOL_SOURCE_ID
+    serves_public_concepts = True  # Tool contracts are published in the manifest.
+
+    def _contracts(self) -> Dict[str, Any]:
+        from ..integrations.internal_mcp.tool_contract_registry import (
+            get_canonical_tool_registry,
+        )
+
+        return get_canonical_tool_registry()
+
+    def owns(self, concept_id: str) -> bool:
+        name = tool_name_from_concept_id(concept_id)
+        if name is None:
+            return False
+        # Deliberately the name list rather than the contract registry.
+        # Building contracts loads tool metadata from Vontology, which runs an
+        # access-control check, which consults this provider again. lru_cache
+        # does not guard re-entrancy, so that cycle never terminates.
+        return name in _registered_tool_names()
+
+    def get(self, concept_id: str) -> Optional[Dict[str, Any]]:
+        name = tool_name_from_concept_id(concept_id)
+        if name is None:
+            return None
+        contract = self._contracts().get(name)
+        if contract is None:
+            return None
+        return _tool_concept_doc(name, contract)
+
+    def iter_concepts(self) -> Iterable[Dict[str, Any]]:
+        for name, contract in sorted(self._contracts().items()):
+            yield _tool_concept_doc(name, contract)
+
+
+def _tool_concept_doc(tool_name: str, contract: Any) -> Dict[str, Any]:
+    concept_id = tool_concept_id(tool_name)
+    display_name = f"{tool_name} tool"
+    description = getattr(contract, "description", "") or ""
+    return {
+        "concept_id": concept_id,
+        "name": display_name,
+        "names": [{"name": display_name, "type": "NL", "language": "en-NZ"}],
+        "relationships": {
+            "is_a_type_of": [],
+            "is_an_instance_of": [MCP_TOOL_TYPE_ID],
+        },
+        "path": concept_id,
+        "md_content": description,
+        "attributes": {
+            "mcp_tool_name": tool_name,
+            "category": getattr(contract, "category", None),
+            "family": getattr(contract, "family", None),
+        },
+        "metadata": {
+            "concept_type": "instance",
+            "mcp_tool_name": tool_name,
+            "operation_category": getattr(contract, "category", None),
+        },
+    }
+
+
+_registered = False
+
+
+def register_default_virtual_concept_providers() -> None:
+    """Register the built-in providers once per process."""
+    global _registered
+    if _registered:
+        return
+    register_provider(CodeConceptProvider())
+    register_provider(McpToolConceptProvider())
+    _registered = True

--- a/tests/backend/test_virtual_concept_providers.py
+++ b/tests/backend/test_virtual_concept_providers.py
@@ -1,0 +1,325 @@
+"""Virtual concepts resolve from registered providers rather than stored rows.
+
+JVNAUTOSCI-2650. Copying derived data into the store that describes it is what
+went wrong in JVNAUTOSCI-2615: tool descriptions were written into #V#mcp_tool
+concepts once at bootstrap and never refreshed, so frozen text suppressed later
+code changes and the published surface varied with database state.
+
+Resolving on demand removes the copy. These tests pin the properties that make
+that safe: a materialised concept still wins, providers are read-only, a
+provider must promise public visibility, and resolution cannot be influenced by
+database state.
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+os.environ.setdefault("ATLASSIAN_EMAIL", "agent@example.com")
+os.environ.setdefault("ATLASSIAN_API_TOKEN", "token-for-import")
+
+from src.backend.vontology import virtual_concept_providers as vcp  # noqa: E402
+from src.backend.vontology.virtual_concept_sources import (  # noqa: E402
+    CODE_CONCEPT_SOURCE_ID,
+    MCP_TOOL_SOURCE_ID,
+    MCP_TOOL_TYPE_ID,
+    tool_concept_id,
+    tool_name_from_concept_id,
+)
+
+
+class _StubProvider:
+    def __init__(self, source_id="stub", public=True, ids=("#V#stub_thing",)):
+        self.source_id = source_id
+        self.serves_public_concepts = public
+        self._ids = set(ids)
+
+    def owns(self, concept_id):
+        return concept_id in self._ids
+
+    def get(self, concept_id):
+        if concept_id not in self._ids:
+            return None
+        return {"concept_id": concept_id, "name": "Stub"}
+
+    def iter_concepts(self):
+        return [self.get(i) for i in sorted(self._ids)]
+
+
+@pytest.fixture
+def stub_registered():
+    provider = _StubProvider()
+    vcp.register_provider(provider)
+    try:
+        yield provider
+    finally:
+        vcp.unregister_provider(provider.source_id)
+
+
+# ---------------------------------------------------------
+# Registration contract
+# ---------------------------------------------------------
+
+
+def test_provider_must_declare_public_visibility():
+    """Claiming a concept grants unconditional visibility in access control."""
+    with pytest.raises(ValueError, match="serves_public_concepts"):
+        vcp.register_provider(_StubProvider(source_id="scoped", public=False))
+
+    assert "scoped" not in vcp.registered_source_ids()
+
+
+def test_provider_must_declare_a_source_id():
+    with pytest.raises(ValueError, match="source_id"):
+        vcp.register_provider(_StubProvider(source_id="  "))
+
+
+def test_duplicate_source_ids_are_refused(stub_registered):
+    with pytest.raises(ValueError, match="Duplicate"):
+        vcp.register_provider(_StubProvider(source_id=stub_registered.source_id))
+
+
+def test_built_in_providers_are_registered():
+    sources = vcp.registered_source_ids()
+
+    assert CODE_CONCEPT_SOURCE_ID in sources
+    assert MCP_TOOL_SOURCE_ID in sources
+
+
+# ---------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------
+
+
+def test_unknown_id_resolves_to_none_not_an_error():
+    """A provider miss is an unresolved lookup, not proof of non-existence."""
+    assert vcp.resolve_virtual_concept("#V#definitely_not_registered") is None
+    assert vcp.is_virtual_concept_id("#V#definitely_not_registered") is False
+
+
+@pytest.mark.parametrize("bad", [None, "", 17, [], {}])
+def test_resolution_tolerates_malformed_ids(bad):
+    assert vcp.owning_provider(bad) is None
+
+
+def test_resolved_documents_carry_provider_provenance(stub_registered):
+    doc = vcp.resolve_virtual_concept("#V#stub_thing")
+
+    assert doc["metadata"]["virtual"] is True
+    assert doc["metadata"]["virtual_source"] == "stub"
+
+
+def test_a_broken_provider_does_not_break_the_others(monkeypatch, stub_registered):
+    def _explode(_concept_id):
+        raise RuntimeError("provider is down")
+
+    monkeypatch.setattr(stub_registered, "owns", _explode)
+
+    # The code registry must still resolve despite the broken provider.
+    assert vcp.is_virtual_concept_id(_a_code_concept_id()) is True
+
+
+def _a_code_concept_id():
+    from src.backend.vontology.code_concepts_registry import iter_code_concepts
+
+    return next(iter(iter_code_concepts())).concept_id
+
+
+# ---------------------------------------------------------
+# Read-only enforcement
+# ---------------------------------------------------------
+
+
+def test_writes_to_a_virtual_concept_are_refused_naming_the_source():
+    refusal = vcp.virtual_write_refusal(tool_concept_id("fetch_concept"))
+
+    assert isinstance(refusal, vcp.VirtualConceptWriteError)
+    assert refusal.source_id == MCP_TOOL_SOURCE_ID
+    assert MCP_TOOL_SOURCE_ID in str(refusal)
+
+
+def test_writes_to_an_ordinary_concept_are_not_refused():
+    assert vcp.virtual_write_refusal("#V#person") is None
+
+
+# ---------------------------------------------------------
+# Code concept provider preserves prior behaviour
+# ---------------------------------------------------------
+
+
+def test_code_concepts_still_resolve_through_the_registry():
+    concept_id = _a_code_concept_id()
+
+    doc = vcp.resolve_virtual_concept(concept_id)
+
+    assert doc is not None
+    assert doc["concept_id"] == concept_id
+    assert doc["metadata"]["virtual_source"] == CODE_CONCEPT_SOURCE_ID
+
+
+def test_build_virtual_concept_doc_still_serves_code_concepts():
+    from src.backend.vontology.code_concepts_registry import build_virtual_concept_doc
+
+    concept_id = _a_code_concept_id()
+    doc = build_virtual_concept_doc(concept_id)
+
+    assert doc is not None
+    assert doc["concept_id"] == concept_id
+
+
+# ---------------------------------------------------------
+# MCP tool provider
+# ---------------------------------------------------------
+
+
+def test_tool_concept_identity_is_deterministic_and_round_trips():
+    assert tool_concept_id("fetch_concept") == "#V#fetch_concept_tool"
+    assert tool_name_from_concept_id("#V#fetch_concept_tool") == "fetch_concept"
+    assert tool_name_from_concept_id("#V#person") is None
+    assert tool_name_from_concept_id("not_a_concept_id") is None
+    assert tool_name_from_concept_id(None) is None
+
+
+def test_every_registered_tool_resolves_as_a_concept():
+    from src.backend.integrations.internal_mcp.tool_contract_registry import (
+        get_canonical_tool_registry,
+    )
+
+    contracts = get_canonical_tool_registry()
+    assert contracts
+
+    unresolved = [
+        name
+        for name in contracts
+        if vcp.resolve_virtual_concept(tool_concept_id(name)) is None
+    ]
+
+    assert not unresolved, f"tools not resolvable as concepts: {unresolved[:5]}"
+
+
+def test_tool_concept_matches_the_code_authoritative_contract():
+    from src.backend.integrations.internal_mcp.tool_contract_registry import (
+        get_canonical_tool_registry,
+    )
+
+    contract = get_canonical_tool_registry()["fetch_concept"]
+    doc = vcp.resolve_virtual_concept(tool_concept_id("fetch_concept"))
+
+    assert doc["md_content"] == contract.description
+    assert doc["metadata"]["operation_category"] == contract.category
+    assert doc["attributes"]["mcp_tool_name"] == "fetch_concept"
+    assert doc["relationships"]["is_an_instance_of"] == [MCP_TOOL_TYPE_ID]
+
+
+def test_tool_concepts_are_not_influenced_by_database_state(monkeypatch):
+    """The whole point of deriving them: no stored row can change the answer."""
+    import src.backend.services.tool_metadata_service as tms
+
+    before = vcp.resolve_virtual_concept(tool_concept_id("fetch_concept"))
+
+    hostile = tms.ToolMetadata(
+        tool_name="fetch_concept",
+        description="Replaced by a database row.",
+        operation_category="write",
+    )
+    monkeypatch.setitem(tms._tool_metadata_cache, "fetch_concept", hostile)
+    monkeypatch.setattr(tms, "_cache_loaded", True)
+    monkeypatch.setattr(tms, "_cache_timestamp", float("inf"))
+
+    from src.backend.integrations.internal_mcp import tool_contract_registry
+
+    tool_contract_registry.invalidate_canonical_tool_registry()
+    try:
+        after = vcp.resolve_virtual_concept(tool_concept_id("fetch_concept"))
+        assert after["md_content"] == before["md_content"]
+        assert after["metadata"]["operation_category"] == "read"
+    finally:
+        tool_contract_registry.invalidate_canonical_tool_registry()
+
+
+def test_resolution_is_repeatable():
+    first = vcp.resolve_virtual_concept(tool_concept_id("fetch_concept"))
+    second = vcp.resolve_virtual_concept(tool_concept_id("fetch_concept"))
+
+    assert first == second
+
+
+def test_iteration_covers_both_sources_without_duplicates():
+    docs = list(vcp.iter_virtual_concepts())
+    ids = [doc["concept_id"] for doc in docs]
+
+    assert len(ids) == len(set(ids))
+    sources = {doc["metadata"]["virtual_source"] for doc in docs}
+    assert {CODE_CONCEPT_SOURCE_ID, MCP_TOOL_SOURCE_ID} <= sources
+
+
+def test_iteration_can_be_filtered_to_one_source():
+    docs = list(vcp.iter_virtual_concepts(source_id=MCP_TOOL_SOURCE_ID))
+
+    assert docs
+    assert all(
+        doc["metadata"]["virtual_source"] == MCP_TOOL_SOURCE_ID for doc in docs
+    )
+
+
+def test_owns_short_circuits_before_consulting_the_catalogue(monkeypatch):
+    """An ordinary concept id must not pay for a catalogue build."""
+    from src.backend.vontology.virtual_concept_sources import McpToolConceptProvider
+
+    provider = McpToolConceptProvider()
+
+    def _fail():
+        raise AssertionError("catalogue consulted for a non-tool id")
+
+    monkeypatch.setattr(provider, "_contracts", _fail)
+
+    assert provider.owns("#V#person") is False
+    assert provider.owns("not-a-concept") is False
+
+
+def test_owns_never_builds_the_contract_registry(monkeypatch):
+    """Regression: building contracts here recurses without terminating.
+
+    Contract construction loads tool metadata from Vontology, which runs an
+    access-control check, which asks whether the concept is virtual, which
+    returns here. lru_cache does not guard re-entrancy, so every level rebuilt
+    from scratch and a single fetch never completed.
+    """
+    from src.backend.vontology.virtual_concept_sources import McpToolConceptProvider
+
+    provider = McpToolConceptProvider()
+
+    def _fail():
+        raise AssertionError("owns() must not build the contract registry")
+
+    monkeypatch.setattr(provider, "_contracts", _fail)
+
+    assert provider.owns(tool_concept_id("fetch_concept")) is True
+    assert provider.owns("#V#no_such_tool_tool") is False
+
+
+def test_cheap_tool_name_set_matches_the_full_registry():
+    """The name set used by owns() must not drift from the built contracts."""
+    from src.backend.integrations.internal_mcp.tool_contract_registry import (
+        get_canonical_tool_registry,
+    )
+    from src.backend.vontology.virtual_concept_sources import _registered_tool_names
+
+    assert _registered_tool_names() == frozenset(get_canonical_tool_registry())
+
+
+def test_resolution_refuses_to_recurse(monkeypatch, stub_registered):
+    """A provider that re-enters resolution gets a miss, not a stack overflow."""
+    seen = []
+
+    def _reentrant(concept_id):
+        seen.append(concept_id)
+        # Simulates access control asking about virtual concepts mid-resolution.
+        vcp.is_virtual_concept_id("#V#stub_thing")
+        return concept_id == "#V#stub_thing"
+
+    monkeypatch.setattr(stub_registered, "owns", _reentrant)
+
+    assert vcp.is_virtual_concept_id("#V#stub_thing") is True
+    assert len(seen) < 5, f"re-entered {len(seen)} times"


### PR DESCRIPTION
Implements JVNAUTOSCI-2650.

## Why

Copying derived data into the store that describes it is what failed in JVNAUTOSCI-2615: tool descriptions were written into `#V#mcp_tool` concepts once at bootstrap and never refreshed, so frozen text suppressed later code changes and the published surface varied with database state.

Resolving such concepts on demand removes the copy, and with it the staleness, the drift, and the unscoped write surface.

## What

A provider registry generalising the existing single-purpose mechanism. `code_concepts_registry.py` already served virtual concepts — not persisted, read-only, `metadata.virtual = true` — and is already load-bearing in access control, workflows and routes. It was hardcoded to one static dict.

- **Code concepts** become the first provider, keeping their public functions so existing call sites need no edit.
- **The MCP tool catalogue** becomes the second: all 287 registered tools are now fetchable as concepts, derived from the code-authoritative contract from #401, using the `#V#<tool_name>_tool` identity the existing materialised concepts already use.

## Safety properties, each pinned by a test

- **A materialised concept still wins.** Providers are consulted on the miss path only, so this is a migration route for the 52 existing `#V#mcp_tool` rows rather than a cutover.
- **Writes are refused** with the owning source named.
- **A provider must declare `serves_public_concepts`.** Claiming a concept grants unconditional visibility in access control, so a provider serving scoped content cannot use this seam until visibility is modelled. Tool contracts qualify — they are already published in the manifest.
- **A provider miss is an unresolved lookup**, not semantic absence.
- **Database state cannot alter a virtual tool concept**, verified with a hostile-metadata negative control.

## The interesting bug

The first working version made a single `fetch_concept` never complete. Profiling the parts showed nothing — each was fast in isolation. A stack dump showed an unbounded cycle:

```
access_control → is_virtual_concept_id → owns()
  → builds the contract registry
  → loads tool metadata from Vontology
  → runs an access-control check
  → is_virtual_concept_id → ...
```

`lru_cache` does not guard re-entrancy, so every level rebuilt from scratch. Ownership checks now use a cheap name set instead of the contract registry, and a thread-local guard refuses to recurse if the cycle is reintroduced elsewhere. Both are regression-tested.

Fetching a virtual tool concept now takes 17.1s against a 15.1s baseline for an ordinary materialised concept — i.e. ordinary Atlas latency, which is JVNAUTOSCI-2615's own subject.

## Tests

27 new; 97 passing across the touched suites.

Five failures exist in `test_virtual_code_predicate_concepts.py` (3) and `test_mcp_stdio_coding_agent_access_profile.py` (2). I verified by stashing that all five fail identically at baseline — they are pre-existing and untouched by this change.

## Not in scope

Retiring the 52 existing `#V#mcp_tool` concepts, refactoring the existing `is_code_concept_id` call sites, write-back, virtual subtypes, and scoped virtual content. The runtime `get_tool_operation_category` override and the unscoped `_load_from_vontology` read remain open on JVNAUTOSCI-2615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)