### PR TITLE
Remove the virtual-concept re-entrancy guard and record RR-002

### DIFF
--- a/docs/engineering/reliability_ratchet_articles_and_cases.md
+++ b/docs/engineering/reliability_ratchet_articles_and_cases.md
@@ -7,10 +7,10 @@
   authority, or current implementation evidence.
 - **Authority scope:** Reliability-ratchet analysis in Von engineering work
 - **Owner:** Von maintainers
-- **Last reviewed:** 18 August 2026
+- **Last reviewed:** 19 August 2026
 - **Review trigger:** A new tracked case, a material source correction, or new
   evidence that changes a recorded diagnosis or status
-- **State or evidence as of:** 18 August 2026
+- **State or evidence as of:** 19 August 2026
 - **Open questions:** Which recorded diagnoses remain supported, need narrowing,
   or should be reclassified after outcome-level validation?
 
@@ -429,3 +429,104 @@ tracking concerns owned by
 The case remains open as historical evidence until a dated outcome-level result
 supports reclassification; that status does not prescribe which repair must be
 used.
+
+### RR-002 — A correct fix that grew a surplus guard, and the guard's own defence
+
+- **Observed:** 19 August 2026
+- **Status:** Closed by subtraction — the surplus mechanism was removed the same
+  day, before it had ever fired
+- **Related work:** [JVNAUTOSCI-2650](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2650),
+  PRs #402 and #403, reversal in this change
+- **User outcome:** Resolve MCP tool concepts from code instead of stale copies
+  in MongoDB
+- **Distinguishing feature:** Unlike RR-001, the causal diagnosis here was
+  correct and evidenced by a stack trace. The pathology is in what was built
+  *on top of* a correct repair.
+
+#### What was observed
+
+While implementing virtual concept providers, a single `fetch_concept` never
+returned. A `faulthandler` stack dump showed an unbounded cycle: access control
+asked whether a concept was virtual, the tool provider answered by building the
+contract registry, building contracts loaded tool metadata from Vontology,
+loading that metadata ran an access-control check, which asked again.
+`lru_cache` does not guard re-entrancy, so each level rebuilt from scratch.
+
+#### The repair, and the surplus
+
+The no-new-mechanism fix was to make `owns` decide from a cheap in-memory name
+set. That alone resolved the failure completely.
+
+A thread-local re-entrancy guard was then added *on top*, refusing to recurse if
+the cycle were ever reintroduced. It was justified by a hypothetical future
+provider rather than an observed failure class, it had no removal condition, and
+it degraded a loud failure into a quiet one: the suppressed call answers "not
+virtual" for a concept that is virtual, which in access control means falling
+through to rules a virtual concept cannot satisfy. A defence against a
+hypothetical fault could therefore have denied a real one.
+
+#### The revealing second turn
+
+Asked whether the hazard was documented well enough to prevent recurrence, the
+implementing agent answered by adding more machinery — a trip counter, a log
+line, a `guard_trip_count` accessor and a further test — and shipped it as
+"Make the re-entrancy rule enforceable". It never asked whether the guard should
+exist. That is the article's "when a neighbouring case fails, another mechanism
+is added outside the first", occurring inside a change whose stated purpose was
+to harden a guardrail.
+
+#### What was kept and what was removed
+
+Removed: the guard, its counter, its logging and the two tests that existed only
+to exercise it.
+
+Kept: the rule stated on the `VirtualConceptProvider.owns` contract where an
+implementer reads it, and a structural test asserting that no registered
+provider's `owns` reaches `get_canonical_tool_registry`, `get_tool_metadata`,
+`_load_from_vontology` or `can_access_concept`.
+
+That test is itself worth recording, because two earlier versions of it were
+useless. A version asserting the guard-trip count stayed at zero passed with the
+bug deliberately reintroduced, because the contract registry was already warm.
+A version that cleared the caches first also passed, because closing the cycle
+needs stored concepts for the access check to run on. Only tripwires on the
+forbidden calls failed against the reintroduced bug. Two coherent, plausible
+regression tests provided no evidence at all, which is the first article's point
+about a conjecture repeated in executable form.
+
+#### A dual path this case declined to remove
+
+The same programme left 52 materialised `#V#mcp_tool` rows coexisting with
+virtual resolution, with materialised winning and no removal condition — the
+"permanent dual paths" warning. Removing them was attempted and **declined on
+evidence**:
+
+- 12 of the 52 are not MCP tools at all. They have empty attributes, no
+  `mcp_tool_name`, and are each the target of `#V#invokesAction` from an
+  `#V#entity_representation_*_step`. They are workflow step actions
+  misclassified as instances of `#V#mcp_tool`, and deleting them would be data
+  loss with no replacement. They need an ontology repair, not a deletion.
+- The remaining 40 carry operational metadata the virtual provider does not
+  serve: `display_template` on 34, `user_salience` on 34, `planner_hint`, and
+  evidence-contract wiring on 8.
+
+The rows are therefore not redundant with the virtual path. They are a second
+copy of a *different* class of data whose code defaults already exist in
+`_DEFAULT_TOOL_METADATA`, and which has silently diverged in both directions:
+20 of 39 named tools match their code defaults exactly, and 19 differ, some
+where the code appears newer and some where only the database holds a value.
+
+Deleting them would have destroyed the only copy of 19 tools' curated values.
+Recording this as a declined action matters more than the deletion would have:
+the "obvious cleanup" was itself a candidate ratchet move, removing machinery on
+a tidiness argument rather than evidence.
+
+#### Evidence that would change this record
+
+- The removed guard proves necessary because a provider reaches the cycle
+  through a path the documented rule and structural test do not cover.
+- The structural test is shown to pass against some other realisation of the
+  same cycle, indicating it recognises one incident rather than a failure class.
+- Reconciliation of the 19 divergent tool-metadata entries shows the database
+  values were stale rather than curated, making the rows straightforwardly
+  deletable after the values move into code.

--- a/src/backend/vontology/virtual_concept_providers.py
+++ b/src/backend/vontology/virtual_concept_providers.py
@@ -21,13 +21,19 @@ Resolution rules:
   serving scoped content must not use this seam until visibility is modelled.
 - ``owns`` must be cheap and self-contained. Access control calls it, so
   anything it reaches that consults access control, tool metadata, or Vontology
-  closes a loop back into resolution. That cycle already shipped once: the tool
-  provider built the contract registry in ``owns``, which loaded metadata, which
-  ran an access check, which asked again. ``lru_cache`` does not guard
-  re-entrancy, so each level rebuilt from scratch and a single fetch never
-  returned. ``owning_provider`` now refuses to recurse and logs when it does,
-  but the guard only bounds the damage — it does not make such a provider
-  correct, because the suppressed call answers "not virtual".
+  closes a loop back into resolution. That cycle shipped once: the tool provider
+  built the contract registry in ``owns``, which loaded metadata, which ran an
+  access check, which asked again. ``lru_cache`` does not guard re-entrancy, so
+  each level rebuilt from scratch and a single fetch never returned.
+
+  There is deliberately no runtime guard against this. One was added and then
+  removed (RR-002): it answered "not virtual" for a concept that is virtual,
+  which in access control means falling through to rules a virtual concept
+  cannot satisfy, so a defence against a hypothetical fault could itself deny a
+  real one. Without it the fault is loud and self-diagnosing — the traceback
+  names the cycle. The rule is enforced where it is cheap to enforce: this
+  contract, and a test asserting no provider's ``owns`` reaches the machinery
+  that closes the loop.
 """
 
 from __future__ import annotations
@@ -81,18 +87,6 @@ logger = logging.getLogger(__name__)
 
 _providers: List[VirtualConceptProvider] = []
 _lock = threading.RLock()
-_resolving = threading.local()
-_guard_trips = 0
-
-
-def guard_trip_count() -> int:
-    """How often resolution has refused to recurse.
-
-    Expected to stay at zero. A non-zero count means some provider's ``owns``
-    is not self-contained; see the re-entrancy rule in the module docstring.
-    """
-    with _lock:
-        return _guard_trips
 
 
 def register_provider(provider: VirtualConceptProvider) -> None:
@@ -152,37 +146,15 @@ def _iter_providers() -> Iterator[VirtualConceptProvider]:
 def owning_provider(concept_id: str) -> Optional[VirtualConceptProvider]:
     if not isinstance(concept_id, str) or not concept_id:
         return None
-    # A provider may reach code that asks about virtual concepts again — access
-    # control and tool metadata call into each other. Refuse to recurse rather
-    # than rebuild the world at every level. This bounds the damage but does not
-    # repair it: the suppressed call answers "not virtual", which can surface as
-    # a missing concept, so it is recorded loudly rather than swallowed.
-    if getattr(_resolving, "active", False):
-        global _guard_trips
-        with _lock:
-            _guard_trips += 1
-        logger.warning(
-            "[virtual_concepts] Re-entered resolution while resolving %r; "
-            "refusing to recurse and answering 'not virtual'. A provider's "
-            "owns() reached code that consults access control, tool metadata, "
-            "or Vontology. Make that owns() decide from the id shape and an "
-            "in-memory set.",
-            concept_id,
-        )
-        return None
-    _resolving.active = True
-    try:
-        for provider in _iter_providers():
-            try:
-                if provider.owns(concept_id):
-                    return provider
-            except Exception:
-                # One broken provider must not make every virtual concept
-                # unresolvable.
-                continue
-        return None
-    finally:
-        _resolving.active = False
+    for provider in _iter_providers():
+        try:
+            if provider.owns(concept_id):
+                return provider
+        except Exception:
+            # One broken provider must not make every virtual concept
+            # unresolvable.
+            continue
+    return None
 
 
 def is_virtual_concept_id(concept_id: str) -> bool:

--- a/tests/backend/test_virtual_concept_providers.py
+++ b/tests/backend/test_virtual_concept_providers.py
@@ -363,25 +363,6 @@ def test_no_registered_provider_re_enters_resolution(monkeypatch):
     )
 
 
-def test_guard_is_observable_when_it_trips(monkeypatch, stub_registered):
-    """A tripped guard must be countable, not silent.
-
-    The guard answers 'not virtual', which can present as a missing concept, so
-    a reintroduced cycle has to leave a trace someone can find.
-    """
-
-    def _reentrant(concept_id):
-        vcp.is_virtual_concept_id("#V#stub_thing")
-        return False
-
-    monkeypatch.setattr(stub_registered, "owns", _reentrant)
-
-    before = vcp.guard_trip_count()
-    vcp.owning_provider("#V#stub_thing")
-
-    assert vcp.guard_trip_count() > before
-
-
 def test_cheap_tool_name_set_matches_the_full_registry():
     """The name set used by owns() must not drift from the built contracts."""
     from src.backend.integrations.internal_mcp.tool_contract_registry import (
@@ -390,19 +371,3 @@ def test_cheap_tool_name_set_matches_the_full_registry():
     from src.backend.vontology.virtual_concept_sources import _registered_tool_names
 
     assert _registered_tool_names() == frozenset(get_canonical_tool_registry())
-
-
-def test_resolution_refuses_to_recurse(monkeypatch, stub_registered):
-    """A provider that re-enters resolution gets a miss, not a stack overflow."""
-    seen = []
-
-    def _reentrant(concept_id):
-        seen.append(concept_id)
-        # Simulates access control asking about virtual concepts mid-resolution.
-        vcp.is_virtual_concept_id("#V#stub_thing")
-        return concept_id == "#V#stub_thing"
-
-    monkeypatch.setattr(stub_registered, "owns", _reentrant)
-
-    assert vcp.is_virtual_concept_id("#V#stub_thing") is True
-    assert len(seen) < 5, f"re-entered {len(seen)} times"


### PR DESCRIPTION
Reverses part of #403 and logs the case in `docs/engineering/reliability_ratchet_articles_and_cases.md`.

## Why remove it

The guard was surplus to the evidence. Making `owns()` decide from a cheap in-memory name set already resolved the observed cycle completely. The guard defended a *hypothetical* future provider, had no removal condition, and degraded a loud failure into a quiet one — answering "not virtual" for a concept that **is** virtual means access control falls through to rules a virtual concept cannot satisfy, so a defence against a hypothetical fault could have denied a real one. It never fired.

Kept: the rule on the `VirtualConceptProvider.owns` contract where an implementer reads it, and the structural test asserting no provider's `owns()` reaches `get_canonical_tool_registry`, `get_tool_metadata`, `_load_from_vontology` or `can_access_concept`. Without the guard the fault is loud and self-diagnosing — the traceback names the cycle.

## RR-002

Differs from RR-001 in an important way: the causal diagnosis here was **correct** and evidenced by a stack trace. The pathology is in what got built on top of a correct repair, and in answering a challenge to that machinery with more machinery — a counter, a log line, an accessor and another test, shipped as "Make the re-entrancy rule enforceable", without ever asking whether the guard should exist.

The record also notes that two earlier versions of the surviving test were worthless: one asserting the trip count stayed zero passed with the bug deliberately reintroduced (warm cache), and one that cleared caches first also passed (no stored concepts for the access check to run on). Only tripwires on the forbidden calls failed. Two plausible regression tests supplied no evidence at all.

## A declined deletion, also recorded

Removing the 52 materialised `#V#mcp_tool` rows was attempted and stopped on evidence:

- **12 are not MCP tools.** Empty attributes, no `mcp_tool_name`, each the target of `#V#invokesAction` from an `#V#entity_representation_*_step`. They are workflow step actions misclassified as instances of `#V#mcp_tool` and need an ontology repair, not deletion.
- **The other 40 carry metadata the provider does not serve**: `display_template` on 34, `user_salience` on 34, `planner_hint`, evidence-contract wiring on 8.

Of the 39 named tools, 20 match their `_DEFAULT_TOOL_METADATA` code defaults exactly and **19 diverge**, some where the code looks newer and some where only the database holds a value. Deleting would have destroyed the only copy of those 19.

47 tests passing across the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)