### PR TITLE
Reclassify mistyped workflow actions, and add ontology repair plans

### DIFF
--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -134,6 +134,7 @@ human acceptance and promotion into a current public authority surface.
 | [Automated policy learning](engineering/automated_policy_learning_design.md) | Design with partial substrate | Use as a proposed learning architecture, not proof of a closed operational loop |
 | [Testing workflows and ephemeral theories](engineering/testing_workflows_ephemeral_theories_design.md) | Research/design proposal with partial substrate | Use for design intent and explicit hypotheses; verify implemented surfaces |
 | [Reliability Ratchet articles and case log](engineering/reliability_ratchet_articles_and_cases.md) | Active advisory source copy and evidence log | Use as a revisable diagnostic lens and dated case record; not as standing policy, repair authority, or proof of current behaviour |
+| [Ontology repair plans](engineering/ontology_repair_plan_design.md) | Design with implemented substrate | Use for the plan/approve/execute shape and its affordance argument; it adds no authority route, and agent-reachable ontology mutation remains an open decision |
 | [Multi-agent coordination](engineering/multi_agent_coordination_design.md) | Early design proposal | Use as a direction to evaluate, not implemented architecture |
 | [Vontology tooling from KA/KR literature](engineering/vontology_tooling_from_ka_kcap_kr_literature.md) | Research-backed advisory roadmap | Use for alternatives and research uptake, not present capability claims |
 

--- a/docs/engineering/ontology_repair_plan_design.md
+++ b/docs/engineering/ontology_repair_plan_design.md
@@ -1,0 +1,140 @@
+# Ontology repair plans
+
+- **Kind:** Design and implemented substrate
+- **Lifecycle:** Active
+- **Authority:** Describes `src/backend/services/ontology_repair_plan_service.py`
+  as implemented. It adds no authority route and no principal; the open decision
+  about agent-reachable ontology mutation remains
+  [JVNAUTOSCI-2653](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2653).
+- **Authority scope:** Structural ontology repair proposals in Von engineering work
+- **Owner:** Von maintainers
+- **Last reviewed:** 20 August 2026
+- **Review trigger:** A new operation type, a persistence or transport decision,
+  or evidence that the affordance argument below no longer holds
+- **State or evidence as of:** 20 August 2026
+- **Open questions:** Should plans be persisted and executed by name; should
+  non-structural operations be supported; does the propose-without-authority mode
+  actually change what Von does in practice?
+
+## What this is
+
+A repair plan is an ordered list of structural ontology changes, each carrying a
+precondition and a rationale, identified by a stable digest over its step
+content. Building and validating a plan touch no authority and mutate nothing.
+Executing one requires an approval bound to that exact digest.
+
+The implementation is `ontology_repair_plan_service.py`. Its operations are
+deliberately two: `assert_structural` and `retract_structural`.
+
+## Where the design came from
+
+JVNAUTOSCI-2651 reclassified twelve concepts recorded as instances of
+`#V#mcp_tool` that were actually workflow action contracts. That repair was done
+by hand, and doing it by hand is what produced this design rather than the
+reverse. Four things emerged that the existing single-shot mutation tools cannot
+express.
+
+**Ordering is semantic.** Each concept had to gain its correct type before
+losing the wrong one, so it was never momentarily untyped. This was not
+theoretical: the first execution run had all twelve assertions succeed and all
+twelve retractions refused, and the ordering is the only reason that left a
+benign both-types state rather than twelve untyped concepts.
+
+**Preconditions decouple proposal from execution.** A plan may be built now and
+approved later. Without a precondition per step, a delayed execution acts on a
+stale assumption.
+
+**Partial failure safety is a property of order, not of the executor.** No
+amount of executor cleverness recovers from a plan whose steps are sequenced
+badly. Conversely a well-sequenced plan is safe under an executor that simply
+stops.
+
+**The weakest sufficient primitive should be the default.** That run asked for a
+hard delete it did not need and was correctly refused for lacking
+`operator_override`. `soft_delete` removes the edge identically and additionally
+records a tombstone and undo token, which is also what JVNAUTOSCI-2615 requires:
+retraction is a lifecycle event, not silent physical deletion. The service now
+uses `soft_delete` unconditionally for retraction.
+
+## The affordance argument
+
+The test proposed for this design was that if it offers nothing beyond the
+current tools, the design is wrong. Six affordances are genuinely new.
+
+**Propose precisely without authority.** This is the central one. Today an agent
+either holds mutation authority and acts, or lacks it and can only describe in
+prose. A plan is a third mode: a precise, machine-checkable, executable proposal
+produced with no authority at all. `validate_repair_plan` is read-only and
+reports exactly which steps would change what, so the proposal carries its own
+evidence.
+
+**Approval binds to content, not to capability.** Granting write access
+authorises every future write. Approving a digest authorises exactly twenty-four
+named edges and nothing else. Substituting, reordering, adding, or removing any
+step invalidates the approval, and `execute_repair_plan` refuses outright on a
+mismatch. This is a materially different security object from a permission.
+
+**Drift is detected rather than assumed away.** Every step is re-validated
+immediately before it runs, so a plan approved yesterday cannot act on a world
+that has since moved.
+
+**Idempotent and resumable.** Steps already satisfied are skipped, so an
+interrupted run resumes by rerunning the same plan. The hand-written repair
+needed this within an hour of being written.
+
+**One reviewable unit.** A plan is diffable, attachable to a ticket, and
+reviewable as a whole. Reviewing one plan of twenty-four changes is a different
+activity from approving twenty-four operations.
+
+**A reversal record.** Retraction receipts carry undo tokens, so the reversal
+path is part of the execution artefact rather than reconstructed afterwards.
+
+## Why this matters for Von
+
+The propose-without-authority mode is the part that changes what Von can be
+asked to do. Von can run ontology consistency audits, of exactly the kind that
+found the twelve misclassified concepts, and emit plans rather than either
+requesting write authority or filing prose. A human reviews and approves a batch.
+
+That scales oversight in the direction that matters: the reviewer's effort grows
+with the number of *decisions*, not the number of *edits*. Twelve
+misclassifications with one shared rationale is one decision.
+
+It also gives rejection somewhere to land. A refused plan is a precise record of
+a change a human did not want, which is far better learning signal than a
+refused tool call.
+
+For the federation direction in JVNAUTOSCI-2615, a plan is a proposal that can
+cross an authority boundary as ordinary data. It carries its own preconditions
+and needs no ambient trust to be transmitted, inspected, or rejected.
+
+## What this deliberately does not do
+
+It adds no route and no principal. Execution calls the same canonical services
+an operator maintenance script already calls, so it runs at exactly the
+authority that already existed. Nothing here pre-empts JVNAUTOSCI-2653.
+
+It does not persist plans. A plan is currently built in process or committed to
+the repository as a script. Persisting plans and executing them by name is the
+shape "execute server-stored canonical arguments" would need, and this format is
+intended to be that shape, but the decision and its threat model belong to 2653.
+
+It supports structural predicates only. Text relations, concept creation, and
+merges are out of scope until a case demands them.
+
+## Honest limits
+
+The digest binds step content, not the world. Two plans with identical steps
+have identical digests, which is intended, but it means an approval is
+transferable between contexts where those steps mean different things. If plans
+are ever persisted or transmitted, the digest should be bound to an issuer and
+scope as well.
+
+`already_satisfied` is treated as success. A plan that has been fully applied and
+one that was never applicable both report `executable` with zero pending
+changes. Callers wanting to distinguish those should read `changes_pending`.
+
+The precondition model knows only about structural predicate arrays. It does not
+understand inferred types, cross-concept invariants, or workflow-level
+consequences, so a plan can be locally valid and still semantically wrong. It
+narrows the class of mistakes; it does not eliminate review.

--- a/scripts/repair_mcp_tool_action_reclassification.py
+++ b/scripts/repair_mcp_tool_action_reclassification.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Reclassify workflow action contracts wrongly typed as MCP tools.
+
+JVNAUTOSCI-2651. Twelve concepts are recorded as instances of #V#mcp_tool but
+are workflow action contracts: empty attributes, no mcp_tool_name, and (for
+seven) targets of #V#invokesAction from entity-representation workflow steps.
+The established type is #V#workflow_action_contract.
+
+Each concept gets the correct type ADDED before the wrong one is REMOVED, so no
+concept is ever momentarily untyped.
+
+Route note (JVNAUTOSCI-2653): this script calls the canonical relationship
+services directly, the established maintenance-script pattern of this
+repository, because no governed agent-reachable route exists for an authorised
+operator ontology repair. It is deliberately shaped as a stored, verifiable
+plan — explicit steps, per-step preconditions, a captured inverse, and
+postconditions — because that shape is the specification for the general
+governed repair capability that should replace this pattern.
+
+Usage:
+    python scripts/repair_mcp_tool_action_reclassification.py           # dry run
+    python scripts/repair_mcp_tool_action_reclassification.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.backend.db.repositories.concepts_repository import (  # noqa: E402
+    ConceptsRepository,
+)
+from src.backend.services.relationship_write_service import (  # noqa: E402
+    add_structural_relationship,
+)
+from src.backend.services.relationship_removal_service import (  # noqa: E402
+    remove_relationship,
+)
+
+WRONG_TYPE = "#V#mcp_tool"
+CORRECT_TYPE = "#V#workflow_action_contract"
+TICKET = "JVNAUTOSCI-2651"
+
+CONCEPT_IDS = [
+    "#V#test_org_exists_tool",
+    "#V#test_org_type_membership_tool",
+    "#V#test_org_evidence_tool",
+    "#V#create_org_tool",
+    "#V#add_org_type_tool",
+    "#V#attach_org_evidence_tool",
+    "#V#fail_workflow_tool",
+    "#V#test_person_exists_tool",
+    "#V#test_affiliation_exists_tool",
+    "#V#add_affiliation_tool",
+    "#V#attach_affiliation_evidence_tool",
+    "#V#test_affiliation_evidence_tool",
+]
+
+
+def _instance_of(concept_id: str) -> list[str]:
+    doc = ConceptsRepository.find_one(
+        {"concept_id": concept_id}, {"relationships.is_an_instance_of": 1}
+    )
+    if not isinstance(doc, dict):
+        return []
+    values = (doc.get("relationships") or {}).get("is_an_instance_of") or []
+    return values if isinstance(values, list) else [values]
+
+
+def _check_preconditions(concept_id: str) -> str | None:
+    """Return None when the concept matches the diagnosed state, else why not."""
+    doc = ConceptsRepository.find_one({"concept_id": concept_id}, {})
+    if not isinstance(doc, dict):
+        return "concept_not_found"
+    types = _instance_of(concept_id)
+    if WRONG_TYPE not in types:
+        return f"expected {WRONG_TYPE} in is_an_instance_of, found {types}"
+    attributes = doc.get("attributes") or {}
+    if attributes.get("mcp_tool_name"):
+        return "has mcp_tool_name; this is a real tool row, not a misclassification"
+    return None
+
+
+def run(execute: bool) -> int:
+    started = datetime.now(timezone.utc).isoformat()
+    log: dict = {
+        "ticket": TICKET,
+        "started": started,
+        "execute": execute,
+        "wrong_type": WRONG_TYPE,
+        "correct_type": CORRECT_TYPE,
+        "steps": [],
+    }
+
+    extent_before = ConceptsRepository.collection().count_documents(
+        {"relationships.is_an_instance_of": WRONG_TYPE}
+    )
+    log["extent_before"] = extent_before
+
+    target = ConceptsRepository.find_one({"concept_id": CORRECT_TYPE}, {"concept_id": 1})
+    if not target:
+        print(f"ABORT: {CORRECT_TYPE} does not exist")
+        return 1
+
+    failures = 0
+    for concept_id in CONCEPT_IDS:
+        entry: dict = {"concept_id": concept_id, "prior_types": _instance_of(concept_id)}
+        problem = _check_preconditions(concept_id)
+        if problem:
+            entry["skipped"] = problem
+            log["steps"].append(entry)
+            # Already-repaired concepts are an expected rerun state, not an error.
+            if "expected" in problem and CORRECT_TYPE in entry["prior_types"]:
+                print(f"  ~ {concept_id}: already reclassified")
+            else:
+                print(f"  ! {concept_id}: precondition failed: {problem}")
+                failures += 1
+            continue
+
+        if not execute:
+            entry["would"] = [
+                f"add is_an_instance_of {CORRECT_TYPE}",
+                f"remove is_an_instance_of {WRONG_TYPE}",
+            ]
+            print(f"  - {concept_id}: would reclassify")
+            log["steps"].append(entry)
+            continue
+
+        added = add_structural_relationship(
+            concept_id, "is_an_instance_of", CORRECT_TYPE
+        )
+        entry["add_result"] = {
+            k: added.get(k) for k in ("success", "error", "already_exists")
+        }
+        if not added.get("success"):
+            print(f"  ! {concept_id}: add failed: {added.get('error')}")
+            failures += 1
+            log["steps"].append(entry)
+            continue  # wrong type is left in place; concept is never untyped
+
+        # soft_delete, deliberately. It removes the edge exactly as hard_delete
+        # does but also persists a tombstone and undo token. A misclassification
+        # is a retraction, which JVNAUTOSCI-2615 requires be a semantic lifecycle
+        # event rather than silent physical deletion, and the weaker primitive
+        # is the one this repair actually needs.
+        removed = remove_relationship(
+            source_id=concept_id,
+            predicate="is_an_instance_of",
+            target=WRONG_TYPE,
+            mode="soft_delete",
+            confirmed=True,
+            reason=f"{TICKET}: workflow action contract misclassified as MCP tool",
+            request_id=f"{TICKET}-{concept_id}",
+        )
+        entry["remove_result"] = {
+            k: removed.get(k)
+            for k in ("success", "error", "error_code", "status", "undo_token")
+        }
+        if not removed.get("success"):
+            print(f"  ! {concept_id}: remove failed: {removed}")
+            failures += 1
+            log["steps"].append(entry)
+            continue
+
+        entry["final_types"] = _instance_of(concept_id)
+        ok = (
+            CORRECT_TYPE in entry["final_types"]
+            and WRONG_TYPE not in entry["final_types"]
+        )
+        entry["verified"] = ok
+        if ok:
+            print(f"  + {concept_id}: reclassified and read back")
+        else:
+            print(f"  ! {concept_id}: read-back mismatch: {entry['final_types']}")
+            failures += 1
+        log["steps"].append(entry)
+
+    extent_after = ConceptsRepository.collection().count_documents(
+        {"relationships.is_an_instance_of": WRONG_TYPE}
+    )
+    log["extent_after"] = extent_after
+    log["failures"] = failures
+
+    print(f"\n{WRONG_TYPE} extent: {extent_before} -> {extent_after}"
+          f" ({'dry run' if not execute else 'executed'}), failures: {failures}")
+
+    out = REPO_ROOT.parent / "Von-Private" / (
+        f"repair_{TICKET}_{'execute' if execute else 'dryrun'}_"
+        f"{started.replace(':', '').split('.')[0]}.json"
+    )
+    try:
+        out.write_text(json.dumps(log, indent=2, default=str), encoding="utf-8")
+        print(f"log: {out}")
+    except OSError:
+        print(json.dumps(log, indent=2, default=str))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true",
+                        help="apply the changes; default is a dry run")
+    sys.exit(run(execute=parser.parse_args().execute))

--- a/src/backend/services/ontology_repair_plan_service.py
+++ b/src/backend/services/ontology_repair_plan_service.py
@@ -1,0 +1,426 @@
+"""Proposable, verifiable ontology repair plans.
+
+A repair plan is a declarative, ordered list of structural ontology changes with
+a per-step precondition and a stable digest. It can be built and validated
+without any mutation authority, and executed only against an approval bound to
+that exact digest.
+
+Why this exists, from JVNAUTOSCI-2651. Reclassifying twelve misclassified
+concepts by hand established what a repair actually needs, and none of it is
+expressible in the single-shot mutation tools:
+
+- Ordering is semantic. Each concept had to gain its correct type before losing
+  the wrong one so it was never momentarily untyped. That ordering earned its
+  keep on the first run, where every add succeeded and every retraction was
+  refused, leaving a benign both-types state instead of a broken one.
+- Preconditions make a plan safe to propose now and execute later. A step that
+  finds the world already changed reports drift rather than acting on a stale
+  assumption.
+- Partial failure must be safe by construction, which is a property of the step
+  order, not of the executor.
+- The weakest sufficient primitive should be the default. That run asked for a
+  hard delete it did not need and was correctly refused.
+
+The affordance this adds is a third mode between acting and describing:
+**propose precisely, with evidence, verifiably, without authority.** An agent
+that cannot mutate the ontology can still produce a plan a human can read,
+diff, approve, and execute, and the approval names those exact changes rather
+than granting standing write access.
+
+Authority note (JVNAUTOSCI-2653). This module adds no route and no principal.
+Building and validating a plan are read-only. Execution calls the same
+canonical services an operator maintenance script calls today and therefore
+runs at exactly the authority it already had. The plan object is deliberately
+the shape that "execute server-stored canonical arguments" would need, so that
+decision becomes cheaper to implement without being pre-empted here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Literal, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+PLAN_FORMAT_VERSION = "ontology_repair_plan.v1"
+
+# Operations are deliberately few. Each maps to one canonical service call and
+# uses the weakest primitive that achieves it.
+Operation = Literal["assert_structural", "retract_structural"]
+
+StepStatus = Literal["ready", "already_satisfied", "drifted", "blocked"]
+
+
+class OntologyRepairPlanError(Exception):
+    """Raised when a plan is malformed or executed without a matching approval."""
+
+
+@dataclass(frozen=True)
+class RepairStep:
+    """One structural change, with the condition that makes it meaningful."""
+
+    operation: Operation
+    source_id: str
+    predicate: str
+    target_id: str
+    rationale: str = ""
+
+    def canonical(self) -> dict[str, str]:
+        """The content the digest covers. Rationale is prose and excluded."""
+        return {
+            "operation": self.operation,
+            "source_id": self.source_id,
+            "predicate": self.predicate,
+            "target_id": self.target_id,
+        }
+
+
+@dataclass(frozen=True)
+class RepairPlan:
+    """An ordered set of steps proposed as one reviewable unit."""
+
+    plan_id: str
+    rationale: str
+    steps: tuple[RepairStep, ...]
+    ticket: str | None = None
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "format": PLAN_FORMAT_VERSION,
+            "plan_id": self.plan_id,
+            "steps": [step.canonical() for step in self.steps],
+        }
+
+    @property
+    def digest(self) -> str:
+        """Stable hash of plan identity and ordered step content.
+
+        Approval binds to this. Reordering, adding, removing, or altering any
+        step changes it, so an approval cannot survive an edit to what it
+        approved. Prose does not affect it, so a plan can be re-explained
+        without invalidating review.
+        """
+        payload = json.dumps(self.canonical(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["steps"] = [asdict(step) for step in self.steps]
+        data["format"] = PLAN_FORMAT_VERSION
+        data["digest"] = self.digest
+        return data
+
+
+def build_repair_plan(
+    *,
+    plan_id: str,
+    rationale: str,
+    steps: Iterable[Mapping[str, Any] | RepairStep],
+    ticket: str | None = None,
+) -> RepairPlan:
+    """Assemble a plan. Pure: touches no database."""
+    built: list[RepairStep] = []
+    for raw in steps:
+        step = raw if isinstance(raw, RepairStep) else RepairStep(**dict(raw))
+        if step.operation not in ("assert_structural", "retract_structural"):
+            raise OntologyRepairPlanError(f"unsupported operation: {step.operation}")
+        if not (step.source_id and step.predicate and step.target_id):
+            raise OntologyRepairPlanError("each step needs source, predicate and target")
+        built.append(step)
+    if not built:
+        raise OntologyRepairPlanError("a plan needs at least one step")
+    return RepairPlan(
+        plan_id=plan_id,
+        rationale=rationale,
+        steps=tuple(built),
+        ticket=ticket,
+    )
+
+
+def _structural_targets(source_id: str, predicate: str, repo: Any) -> list[str]:
+    doc = repo.find_one({"concept_id": source_id}, {f"relationships.{predicate}": 1})
+    if not isinstance(doc, dict):
+        return []
+    values = (doc.get("relationships") or {}).get(predicate) or []
+    if isinstance(values, str):
+        return [values]
+    return [v for v in values if isinstance(v, str)]
+
+
+def _step_status(step: RepairStep, repo: Any) -> tuple[StepStatus, str]:
+    """Classify a step against live state without changing anything."""
+    source = repo.find_one({"concept_id": step.source_id}, {"concept_id": 1})
+    if not source:
+        return "blocked", f"source concept {step.source_id} not found"
+
+    present = step.target_id in _structural_targets(step.source_id, step.predicate, repo)
+
+    if step.operation == "assert_structural":
+        target = repo.find_one({"concept_id": step.target_id}, {"concept_id": 1})
+        if not target:
+            return "blocked", f"target concept {step.target_id} not found"
+        if present:
+            return "already_satisfied", "edge already present"
+        return "ready", "edge absent and both concepts exist"
+
+    if not present:
+        return "already_satisfied", "edge already absent"
+    # A retraction must not strand the concept without any value for a
+    # structural predicate that carries its classification.
+    remaining = [
+        value
+        for value in _structural_targets(step.source_id, step.predicate, repo)
+        if value != step.target_id
+    ]
+    if not remaining:
+        return (
+            "drifted",
+            f"retracting would leave {step.source_id} with no {step.predicate}; "
+            "order an assertion before it",
+        )
+    return "ready", "edge present and another value remains"
+
+
+def validate_repair_plan(plan: RepairPlan, *, repo: Any = None) -> dict[str, Any]:
+    """Check every step against live state. Read-only.
+
+    Steps are evaluated in order against a simulated projection, so an
+    assertion earlier in the plan satisfies a retraction that depends on it.
+    That is what lets add-before-remove validate as safe rather than reporting
+    a false stranding.
+    """
+    if repo is None:
+        from ..db.repositories.concepts_repository import ConceptsRepository
+
+        repo = ConceptsRepository
+
+    simulated: dict[tuple[str, str], list[str]] = {}
+
+    def _targets(source_id: str, predicate: str) -> list[str]:
+        key = (source_id, predicate)
+        if key not in simulated:
+            simulated[key] = list(_structural_targets(source_id, predicate, repo))
+        return simulated[key]
+
+    results: list[dict[str, Any]] = []
+    for index, step in enumerate(plan.steps):
+        current = _targets(step.source_id, step.predicate)
+        source_exists = bool(repo.find_one({"concept_id": step.source_id}, {"concept_id": 1}))
+
+        if not source_exists:
+            status, detail = "blocked", f"source concept {step.source_id} not found"
+        elif step.operation == "assert_structural":
+            if not repo.find_one({"concept_id": step.target_id}, {"concept_id": 1}):
+                status, detail = "blocked", f"target concept {step.target_id} not found"
+            elif step.target_id in current:
+                status, detail = "already_satisfied", "edge already present"
+            else:
+                status, detail = "ready", "edge absent and both concepts exist"
+                current.append(step.target_id)
+        else:
+            if step.target_id not in current:
+                status, detail = "already_satisfied", "edge already absent"
+            elif len([v for v in current if v != step.target_id]) == 0:
+                status, detail = (
+                    "drifted",
+                    f"retracting would leave {step.source_id} with no "
+                    f"{step.predicate}; order an assertion before it",
+                )
+            else:
+                status, detail = "ready", "edge present and another value remains"
+                current.remove(step.target_id)
+
+        results.append(
+            {
+                "index": index,
+                "step": step.canonical(),
+                "status": status,
+                "detail": detail,
+                "rationale": step.rationale,
+            }
+        )
+
+    counts: dict[str, int] = {}
+    for row in results:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+
+    return {
+        "plan_id": plan.plan_id,
+        "digest": plan.digest,
+        "format": PLAN_FORMAT_VERSION,
+        "steps": results,
+        "counts": counts,
+        "executable": counts.get("blocked", 0) == 0 and counts.get("drifted", 0) == 0,
+        "changes_pending": counts.get("ready", 0),
+    }
+
+
+def execute_repair_plan(
+    plan: RepairPlan,
+    *,
+    approved_digest: str,
+    repo: Any = None,
+) -> dict[str, Any]:
+    """Apply a plan whose digest matches an explicit approval.
+
+    Refuses outright unless ``approved_digest`` equals the plan digest, so an
+    approval can never apply to changes other than the ones reviewed.
+
+    Every step is re-validated immediately before it runs, because a plan may be
+    approved long after it was built. Steps reported ``already_satisfied`` are
+    skipped, which makes execution idempotent and safe to resume.
+    """
+    if approved_digest != plan.digest:
+        raise OntologyRepairPlanError(
+            "approval does not match this plan; approved "
+            f"{approved_digest[:12]}… but plan is {plan.digest[:12]}…"
+        )
+
+    if repo is None:
+        from ..db.repositories.concepts_repository import ConceptsRepository
+
+        repo = ConceptsRepository
+
+    from .relationship_removal_service import remove_relationship
+    from .relationship_write_service import add_structural_relationship
+
+    receipts: list[dict[str, Any]] = []
+    applied = failed = skipped = 0
+
+    for index, step in enumerate(plan.steps):
+        status, detail = _step_status(step, repo)
+        receipt: dict[str, Any] = {
+            "index": index,
+            "step": step.canonical(),
+            "precondition": status,
+        }
+
+        if status in ("blocked", "drifted"):
+            receipt["outcome"] = "refused"
+            receipt["detail"] = detail
+            failed += 1
+            receipts.append(receipt)
+            continue
+
+        if status == "already_satisfied":
+            receipt["outcome"] = "skipped"
+            receipt["detail"] = detail
+            skipped += 1
+            receipts.append(receipt)
+            continue
+
+        if step.operation == "assert_structural":
+            result = add_structural_relationship(
+                step.source_id, step.predicate, step.target_id
+            )
+            receipt["result"] = {k: result.get(k) for k in ("success", "error")}
+            ok = bool(result.get("success"))
+        else:
+            # soft_delete is the weakest primitive that removes the edge, and it
+            # records a tombstone and undo token. Retraction is a lifecycle
+            # event, not a physical deletion.
+            result = remove_relationship(
+                source_id=step.source_id,
+                predicate=step.predicate,
+                target=step.target_id,
+                mode="soft_delete",
+                confirmed=True,
+                reason=f"{plan.plan_id}: {step.rationale or plan.rationale}",
+                request_id=f"{plan.plan_id}-{index}",
+            )
+            receipt["result"] = {
+                k: result.get(k)
+                for k in ("success", "error", "error_code", "undo_token")
+            }
+            ok = bool(result.get("success"))
+
+        # Canonical read-back per step, not once at the end.
+        observed = _structural_targets(step.source_id, step.predicate, repo)
+        expected = (
+            step.target_id in observed
+            if step.operation == "assert_structural"
+            else step.target_id not in observed
+        )
+        receipt["read_back"] = observed
+        receipt["verified"] = bool(ok and expected)
+        receipt["outcome"] = "applied" if receipt["verified"] else "failed"
+        if receipt["verified"]:
+            applied += 1
+        else:
+            failed += 1
+        receipts.append(receipt)
+
+    return {
+        "plan_id": plan.plan_id,
+        "digest": plan.digest,
+        "format": PLAN_FORMAT_VERSION,
+        "applied": applied,
+        "skipped": skipped,
+        "failed": failed,
+        "complete": failed == 0,
+        "receipts": receipts,
+        "executed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def plan_reclassification(
+    *,
+    plan_id: str,
+    concept_ids: Sequence[str],
+    from_type: str,
+    to_type: str,
+    predicate: str = "is_an_instance_of",
+    rationale: str = "",
+    ticket: str | None = None,
+) -> RepairPlan:
+    """Build the add-before-remove reclassification shape.
+
+    Generalised directly from JVNAUTOSCI-2651. The ordering is the point: every
+    assertion precedes its matching retraction, so an interrupted run leaves
+    concepts carrying both types rather than none.
+    """
+    steps: list[RepairStep] = []
+    for concept_id in concept_ids:
+        steps.append(
+            RepairStep(
+                operation="assert_structural",
+                source_id=concept_id,
+                predicate=predicate,
+                target_id=to_type,
+                rationale=f"adopt correct type {to_type}",
+            )
+        )
+        steps.append(
+            RepairStep(
+                operation="retract_structural",
+                source_id=concept_id,
+                predicate=predicate,
+                target_id=from_type,
+                rationale=f"retract incorrect type {from_type}",
+            )
+        )
+    return build_repair_plan(
+        plan_id=plan_id,
+        rationale=rationale or f"reclassify {from_type} -> {to_type}",
+        steps=steps,
+        ticket=ticket,
+    )
+
+
+__all__ = [
+    "PLAN_FORMAT_VERSION",
+    "OntologyRepairPlanError",
+    "RepairStep",
+    "RepairPlan",
+    "build_repair_plan",
+    "validate_repair_plan",
+    "execute_repair_plan",
+    "plan_reclassification",
+]

--- a/tests/backend/test_ontology_repair_plan_service.py
+++ b/tests/backend/test_ontology_repair_plan_service.py
@@ -1,0 +1,433 @@
+"""Repair plans are proposable without authority and executable only on approval.
+
+The properties pinned here are the ones the manual JVNAUTOSCI-2651 repair showed
+were needed and that the single-shot mutation tools cannot express: ordering,
+preconditions, drift detection, exact-plan approval, and safe partial failure.
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+os.environ.setdefault("ATLASSIAN_EMAIL", "agent@example.com")
+os.environ.setdefault("ATLASSIAN_API_TOKEN", "token-for-import")
+
+from src.backend.services.ontology_repair_plan_service import (  # noqa: E402
+    OntologyRepairPlanError,
+    RepairStep,
+    build_repair_plan,
+    execute_repair_plan,
+    plan_reclassification,
+    validate_repair_plan,
+)
+
+
+class _FakeRepo:
+    """In-memory stand-in shaped like ConceptsRepository for these calls."""
+
+    def __init__(self, concepts):
+        self.concepts = {cid: dict(rels) for cid, rels in concepts.items()}
+
+    def find_one(self, query, projection=None):
+        cid = query.get("concept_id")
+        if cid not in self.concepts:
+            return None
+        return {"concept_id": cid, "relationships": self.concepts[cid]}
+
+
+def _repo_with_misclassification(n=2):
+    concepts = {"#V#wrong_type": {}, "#V#right_type": {}}
+    for i in range(n):
+        concepts[f"#V#thing_{i}"] = {"is_an_instance_of": ["#V#wrong_type"]}
+    return _FakeRepo(concepts)
+
+
+# ---------------------------------------------------------
+# Plan construction and identity
+# ---------------------------------------------------------
+
+
+def test_plan_orders_every_assertion_before_its_retraction():
+    """Safe partial failure is a property of ordering, not of the executor."""
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#a", "#V#b"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+
+    ops = [(s.operation, s.source_id) for s in plan.steps]
+    assert ops == [
+        ("assert_structural", "#V#a"),
+        ("retract_structural", "#V#a"),
+        ("assert_structural", "#V#b"),
+        ("retract_structural", "#V#b"),
+    ]
+
+
+def test_digest_is_stable_across_rebuilds():
+    kwargs = dict(
+        plan_id="p1",
+        concept_ids=["#V#a"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    assert plan_reclassification(**kwargs).digest == plan_reclassification(**kwargs).digest
+
+
+def test_digest_ignores_prose_so_review_survives_re_explanation():
+    a = build_repair_plan(
+        plan_id="p1",
+        rationale="first wording",
+        steps=[RepairStep("assert_structural", "#V#a", "is_an_instance_of", "#V#t", "why")],
+    )
+    b = build_repair_plan(
+        plan_id="p1",
+        rationale="different wording",
+        steps=[RepairStep("assert_structural", "#V#a", "is_an_instance_of", "#V#t", "other")],
+    )
+    assert a.digest == b.digest
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda ids: ids + ["#V#extra"],
+        lambda ids: list(reversed(ids)),
+    ],
+)
+def test_digest_changes_when_the_steps_change(mutate):
+    base = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#a", "#V#b"],
+        from_type="#V#w",
+        to_type="#V#r",
+    )
+    other = plan_reclassification(
+        plan_id="p1",
+        concept_ids=mutate(["#V#a", "#V#b"]),
+        from_type="#V#w",
+        to_type="#V#r",
+    )
+    assert base.digest != other.digest
+
+
+def test_malformed_plans_are_refused():
+    with pytest.raises(OntologyRepairPlanError):
+        build_repair_plan(plan_id="p", rationale="", steps=[])
+    with pytest.raises(OntologyRepairPlanError):
+        build_repair_plan(
+            plan_id="p",
+            rationale="",
+            steps=[RepairStep("delete_everything", "#V#a", "p", "#V#b")],
+        )
+
+
+# ---------------------------------------------------------
+# Validation is read-only and order-aware
+# ---------------------------------------------------------
+
+
+def test_validation_does_not_mutate_anything():
+    repo = _repo_with_misclassification()
+    before = {cid: dict(rels) for cid, rels in repo.concepts.items()}
+
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    validate_repair_plan(plan, repo=repo)
+
+    assert repo.concepts == before
+
+
+def test_add_before_remove_validates_as_ready_not_stranded():
+    """Order-aware simulation is what stops a false stranding report."""
+    repo = _repo_with_misclassification()
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+
+    report = validate_repair_plan(plan, repo=repo)
+
+    assert report["executable"] is True
+    assert [s["status"] for s in report["steps"]] == ["ready", "ready"]
+
+
+def test_a_retraction_that_would_stranded_a_concept_is_drifted():
+    repo = _repo_with_misclassification()
+    plan = build_repair_plan(
+        plan_id="p1",
+        rationale="retract without replacing",
+        steps=[
+            RepairStep(
+                "retract_structural", "#V#thing_0", "is_an_instance_of", "#V#wrong_type"
+            )
+        ],
+    )
+
+    report = validate_repair_plan(plan, repo=repo)
+
+    assert report["executable"] is False
+    assert report["steps"][0]["status"] == "drifted"
+    assert "no is_an_instance_of" in report["steps"][0]["detail"]
+
+
+def test_missing_concepts_block_rather_than_fail_at_execution():
+    repo = _repo_with_misclassification()
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#does_not_exist"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+
+    report = validate_repair_plan(plan, repo=repo)
+
+    assert report["executable"] is False
+    assert report["steps"][0]["status"] == "blocked"
+
+
+def test_an_already_repaired_world_reports_no_pending_changes():
+    repo = _FakeRepo(
+        {
+            "#V#wrong_type": {},
+            "#V#right_type": {},
+            "#V#thing_0": {"is_an_instance_of": ["#V#right_type"]},
+        }
+    )
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+
+    report = validate_repair_plan(plan, repo=repo)
+
+    assert report["changes_pending"] == 0
+    assert report["executable"] is True
+    assert all(s["status"] == "already_satisfied" for s in report["steps"])
+
+
+# ---------------------------------------------------------
+# Approval binds to the exact plan
+# ---------------------------------------------------------
+
+
+def test_execution_refuses_an_approval_for_different_steps():
+    approved = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#a"],
+        from_type="#V#w",
+        to_type="#V#r",
+    )
+    substituted = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#a", "#V#victim"],
+        from_type="#V#w",
+        to_type="#V#r",
+    )
+
+    with pytest.raises(OntologyRepairPlanError, match="does not match"):
+        execute_repair_plan(substituted, approved_digest=approved.digest)
+
+
+def test_execution_refuses_an_empty_or_wrong_digest():
+    plan = plan_reclassification(
+        plan_id="p1", concept_ids=["#V#a"], from_type="#V#w", to_type="#V#r"
+    )
+    for bad in ("", "0" * 64):
+        with pytest.raises(OntologyRepairPlanError):
+            execute_repair_plan(plan, approved_digest=bad)
+
+
+# ---------------------------------------------------------
+# Execution behaviour
+# ---------------------------------------------------------
+
+
+@pytest.fixture
+def patched_mutations(monkeypatch):
+    """Route the canonical services at the fake repo."""
+    calls = {"asserts": [], "retracts": []}
+
+    def _add(source_id, predicate, target_id, **_kw):
+        calls["asserts"].append((source_id, predicate, target_id))
+        rels = _add.repo.concepts.setdefault(source_id, {})
+        rels.setdefault(predicate, [])
+        if target_id not in rels[predicate]:
+            rels[predicate].append(target_id)
+        return {"success": True}
+
+    def _remove(*, source_id, predicate, target, mode, **_kw):
+        calls["retracts"].append((source_id, predicate, target, mode))
+        rels = _remove.repo.concepts.get(source_id, {})
+        if target in rels.get(predicate, []):
+            rels[predicate].remove(target)
+        return {"success": True, "undo_token": f"undo:{source_id}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service.add_structural_relationship",
+        _add,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_removal_service.remove_relationship",
+        _remove,
+    )
+    return calls, _add, _remove
+
+
+def test_execution_applies_in_order_and_reads_back(patched_mutations):
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=2)
+    _add.repo = _remove.repo = repo
+
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0", "#V#thing_1"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    result = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    assert result["complete"] is True
+    assert result["applied"] == 4
+    assert all(r["verified"] for r in result["receipts"])
+    for cid in ("#V#thing_0", "#V#thing_1"):
+        assert repo.concepts[cid]["is_an_instance_of"] == ["#V#right_type"]
+
+
+def test_retraction_uses_the_weakest_primitive(patched_mutations):
+    """soft_delete removes the edge and leaves a tombstone; nothing needs more."""
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=1)
+    _add.repo = _remove.repo = repo
+
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    assert all(mode == "soft_delete" for *_rest, mode in calls["retracts"])
+
+
+def test_execution_captures_undo_tokens(patched_mutations):
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=1)
+    _add.repo = _remove.repo = repo
+
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    result = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    retraction = [r for r in result["receipts"] if r["step"]["operation"] == "retract_structural"]
+    assert retraction[0]["result"]["undo_token"] == "undo:#V#thing_0"
+
+
+def test_execution_is_idempotent_and_resumable(patched_mutations):
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=1)
+    _add.repo = _remove.repo = repo
+
+    plan = plan_reclassification(
+        plan_id="p1",
+        concept_ids=["#V#thing_0"],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+    )
+    execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+    second = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    assert second["applied"] == 0
+    assert second["skipped"] == 2
+    assert second["complete"] is True
+
+
+def test_drift_since_approval_is_refused_not_applied(patched_mutations):
+    """A plan approved earlier must not act on an assumption that has expired."""
+    calls, _add, _remove = patched_mutations
+    repo = _FakeRepo(
+        {
+            "#V#wrong_type": {},
+            "#V#right_type": {},
+            # Someone else already removed the wrong type and left nothing else.
+            "#V#thing_0": {"is_an_instance_of": []},
+        }
+    )
+    _add.repo = _remove.repo = repo
+
+    plan = build_repair_plan(
+        plan_id="p1",
+        rationale="retract only",
+        steps=[
+            RepairStep(
+                "retract_structural", "#V#thing_0", "is_an_instance_of", "#V#wrong_type"
+            )
+        ],
+    )
+    result = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    # Already absent, so nothing to do and nothing broken.
+    assert result["receipts"][0]["outcome"] == "skipped"
+    assert calls["retracts"] == []
+
+
+def test_a_blocked_step_does_not_stop_the_rest_from_being_reported(patched_mutations):
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=1)
+    _add.repo = _remove.repo = repo
+
+    plan = build_repair_plan(
+        plan_id="p1",
+        rationale="one good, one impossible",
+        steps=[
+            RepairStep("assert_structural", "#V#ghost", "is_an_instance_of", "#V#right_type"),
+            RepairStep("assert_structural", "#V#thing_0", "is_an_instance_of", "#V#right_type"),
+        ],
+    )
+    result = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+
+    assert result["receipts"][0]["outcome"] == "refused"
+    assert result["receipts"][1]["outcome"] == "applied"
+    assert result["complete"] is False
+
+
+def test_the_2651_shape_reproduces_the_manual_repair(patched_mutations):
+    """The plan form must express what the hand-written repair did."""
+    calls, _add, _remove = patched_mutations
+    repo = _repo_with_misclassification(n=12)
+    _add.repo = _remove.repo = repo
+
+    plan = plan_reclassification(
+        plan_id="JVNAUTOSCI-2651",
+        concept_ids=[f"#V#thing_{i}" for i in range(12)],
+        from_type="#V#wrong_type",
+        to_type="#V#right_type",
+        ticket="JVNAUTOSCI-2651",
+    )
+
+    report = validate_repair_plan(plan, repo=repo)
+    assert report["executable"] is True
+    assert report["changes_pending"] == 24
+
+    result = execute_repair_plan(plan, approved_digest=plan.digest, repo=repo)
+    assert result["applied"] == 24
+    assert result["complete"] is True
+    assert all(
+        repo.concepts[f"#V#thing_{i}"]["is_an_instance_of"] == ["#V#right_type"]
+        for i in range(12)
+    )


### PR DESCRIPTION
Closes JVNAUTOSCI-2651 and adds the general capability it was used to design.

## The repair (executed)

Twelve concepts were instances of `#V#mcp_tool` but are workflow action contracts — empty attributes, no `mcp_tool_name`, seven of them targets of `#V#invokesAction` from entity-representation steps. They inflated the extent by a quarter and entered the tool metadata cache as nameless tools.

**Verified:** extent 52 → 40, every remaining row resolvable as a registered tool, none carrying both types, all 7 live `invokesAction` references intact, Vontology metadata load down to 39 clean entries.

Two things the run taught, both now encoded in the capability:

- **Ordering earned its keep.** The first execute attempt had all 12 assertions succeed and all 12 retractions refused. Because assertions precede retractions, that left a benign both-types state rather than 12 untyped concepts.
- **I reached for too strong a primitive.** I asked for `hard_delete` without needing it and was correctly refused for lacking `operator_override`. `soft_delete` removes the edge identically *and* records a tombstone and undo token — and matches JVNAUTOSCI-2615's rule that retraction is a lifecycle event, not silent deletion.

## The capability

`ontology_repair_plan_service.py`: an ordered list of structural changes, each with a precondition and rationale, identified by a stable digest over step content. Build and validate are read-only; execute requires an approval bound to that exact digest and re-validates each step immediately before running it.

## The affordance argument

The test set for this design was that if it offers nothing beyond the current tools, the design is wrong. The central one:

**Propose precisely without authority.** Today an agent either holds mutation authority and acts, or lacks it and writes prose. A plan is a third mode — a machine-checkable, executable proposal carrying its own evidence, produced with no authority at all.

Then: **approval binds to content, not capability** (approving a digest authorises exactly 24 named edges, and any substitution or reordering invalidates it); **drift is detected** rather than assumed away; execution is **idempotent and resumable**; a plan is **one reviewable unit**, so reviewer effort scales with decisions rather than edits; and retraction receipts **carry undo tokens**.

For Von specifically: it can run consistency audits of the kind that found these twelve, and emit plans instead of requesting write authority. A refused plan is also a far better learning signal than a refused tool call.

## Scope discipline

Adds **no route and no principal**. Execution calls the same canonical services an operator script already calls, at exactly the authority that already existed. The plan format is deliberately the shape "execute server-stored canonical arguments" would need, so JVNAUTOSCI-2653 is left open rather than pre-empted.

Honest limits are documented: the digest binds step content but not issuer or scope; `already_satisfied` and never-applicable both read as executable with zero pending; and preconditions understand structural arrays only, so a plan can be locally valid and semantically wrong. It narrows the class of mistakes; it does not remove review.

20 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)