### PR TITLE
Make tool presentation metadata code-authoritative (JVNAUTOSCI-2652)

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -22839,6 +22839,22 @@ class InternalMCPChatOrchestrator:
             ans = str(payload["answer"])
             context["answer"] = ans[:50] + "..." if len(ans) > 50 else ans
 
+        # Generic fallback. The named mappings above cover common shapes but are
+        # an arbitrary list, and twenty-one templates referenced ordinary
+        # identifier fields it happened to omit, so they were silently discarded
+        # (JVNAUTOSCI-2652). A placeholder naming a scalar field the payload
+        # actually carries should resolve to it. Named mappings still win.
+        for payload_key, payload_value in payload.items():
+            if payload_key in context:
+                continue
+            if isinstance(payload_value, bool):
+                context[payload_key] = "Yes" if payload_value else "No"
+            elif isinstance(payload_value, (str, int, float)):
+                text_value = str(payload_value)
+                context[payload_key] = (
+                    text_value[:60] + "..." if len(text_value) > 60 else text_value
+                )
+
         # Try to apply the template
         try:
             # Find all placeholders

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -320,6 +320,11 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "display_template": "Renamed: {old_name} → {new_name}",
     },
     # Task tools (HIGH salience)
+    "create_task": {
+        "salience": "high",
+        "category": "task",
+        "display_template": "Created task: {task_id}",
+    },
     "task_create": {
         "salience": "high",
         "category": "task",
@@ -452,12 +457,12 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "finalise_cached_paper": {
         "salience": "high",
         "category": "arxiv",
-        "display_template": "Finalised: {arxiv_id}",
+        "display_template": "Finalised: {filename}",
     },
     "materialise_scholarly_representation_for_file_copy": {
         "salience": "high",
         "category": "arxiv",
-        "display_template": "Materialised paper: {paper_concept_id}",
+        "display_template": "Materialised paper representation",
     },
     # Owner-scoped LinkedIn export tools
     "linkedin_index_status": {
@@ -927,7 +932,7 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "read_paper": {
         "salience": "medium",
         "category": "arxiv",
-        "display_template": "Read: {arxiv_id}",
+        "display_template": "Read: {title}",
     },
     "context_search": {
         "salience": "medium",
@@ -1744,12 +1749,23 @@ def _refresh_cache_if_needed() -> None:
                 new_cache[tool_name] = ToolMetadata(
                     tool_name=tool_name,
                     concept_id=metadata.concept_id or default_metadata.concept_id,
-                    salience=metadata.salience or default_metadata.salience,
+                    # Presentation and planning metadata is code-authoritative
+                    # (JVNAUTOSCI-2652). These concepts record their values once at
+                    # bootstrap and are never refreshed, so a stored copy silently
+                    # outranked every later change in code. Vontology may still fill
+                    # a gap the code leaves; it no longer overrides one.
+                    salience=default_metadata.salience or metadata.salience,
                     display_template=(
-                        metadata.display_template or default_metadata.display_template
+                        default_metadata.display_template or metadata.display_template
                     ),
                     description=metadata.description or default_metadata.description,
-                    category=metadata.category or default_metadata.category,
+                    category=default_metadata.category or metadata.category,
+                    # planner_hint is deliberately NOT inverted. It is model-facing
+                    # guidance rather than presentation, so runtime curation is
+                    # defensible, and alias inheritance of represented hints is an
+                    # existing tested contract. The cost is recorded on
+                    # JVNAUTOSCI-2652: a stale represented hint still outranks a
+                    # better one in code, and correcting that needs a write route.
                     planner_hint=metadata.planner_hint or default_metadata.planner_hint,
                     dispatch_surface_family=(
                         metadata.dispatch_surface_family

--- a/tests/backend/test_tool_presentation_metadata_is_code_authoritative.py
+++ b/tests/backend/test_tool_presentation_metadata_is_code_authoritative.py
@@ -1,0 +1,178 @@
+"""Presentation and planning metadata resolves from code, not stored copies.
+
+JVNAUTOSCI-2652. #V#mcp_tool concepts record display_template, user_salience,
+category and planner_hint once at bootstrap and are never refreshed, so a stored
+copy silently outranked every later change in code. Twenty of thirty-nine named
+tools matched their code defaults exactly and nineteen had drifted, in both
+directions, with nothing recording which was intended.
+
+Reconciliation was decided on evidence rather than taste: a display template is
+only useful if the renderer can resolve its placeholders, and
+_apply_vontology_template discards a template outright when fewer than half
+resolve. Several templates on both sides referenced fields the resolver has no
+mapping for and were therefore dead.
+"""
+
+import os
+
+
+import pytest
+
+os.environ.setdefault("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+os.environ.setdefault("ATLASSIAN_EMAIL", "agent@example.com")
+os.environ.setdefault("ATLASSIAN_API_TOKEN", "token-for-import")
+
+import src.backend.services.tool_metadata_service as tms  # noqa: E402
+from src.backend.services.tool_metadata_service import (  # noqa: E402
+    _DEFAULT_TOOL_METADATA,
+    ToolMetadata,
+    get_tool_metadata,
+)
+
+
+def _render(template, payload):
+    from src.backend.integrations.internal_mcp.orchestrator import (
+        InternalMCPChatOrchestrator,
+    )
+
+    return InternalMCPChatOrchestrator._apply_vontology_template(template, payload)
+
+
+# ---------------------------------------------------------
+# Templates must actually render
+# ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "template,payload,expected",
+    [
+        ("Deleted: {concept_id}", {"concept_id": "#V#thing"}, "Deleted: thing"),
+        ("Comments: {issue_key}", {"issue_key": "PROJ-1"}, "Comments: PROJ-1"),
+        ("Downloaded: {arxiv_id}", {"arxiv_id": "2401.1"}, "Downloaded: 2401.1"),
+        (
+            "Renamed: {old_name} to {new_name}",
+            {"old_name": "a", "new_name": "b"},
+            "Renamed: a to b",
+        ),
+        ("Removed: {removed_count}", {"removed_count": 7}, "Removed: 7"),
+    ],
+)
+def test_a_placeholder_naming_a_payload_field_resolves(template, payload, expected):
+    """The named mappings are an arbitrary list; the payload is the real source.
+
+    Twenty-one code templates referenced ordinary identifier fields the mapping
+    happened to omit, so the renderer discarded them and fell through to a
+    hardcoded handler. That failure is invisible in the interface.
+    """
+    assert _render(template, payload) == expected
+
+
+def test_a_template_naming_absent_fields_is_still_discarded():
+    """The fallback must not make every template render regardless of payload."""
+    assert _render("Deleted: {concept_id}", {"unrelated": "value"}) is None
+
+
+def test_named_mappings_still_win_over_the_raw_payload():
+    """count is derived from several field names and must not be overwritten."""
+    rendered = _render("{count} found", {"results": [1, 2, 3]})
+
+    assert rendered == "3 found"
+
+
+@pytest.mark.parametrize(
+    "tool,expected",
+    [
+        ("read_paper", "Read: {title}"),
+        ("finalise_cached_paper", "Finalised: {filename}"),
+        (
+            "materialise_scholarly_representation_for_file_copy",
+            "Materialised paper representation",
+        ),
+        ("create_task", "Created task: {task_id}"),
+    ],
+)
+def test_reconciled_templates_are_the_resolvable_ones(tool, expected):
+    assert _DEFAULT_TOOL_METADATA[tool]["display_template"] == expected
+
+
+def test_create_task_has_its_own_entry():
+    """It does not alias to task_create, so the stored row was its only source."""
+    from src.backend.services.tool_metadata_service import (
+        preferred_tool_metadata_surface_name,
+    )
+
+    assert preferred_tool_metadata_surface_name("create_task") == "create_task"
+    assert "create_task" in _DEFAULT_TOOL_METADATA
+    assert _DEFAULT_TOOL_METADATA["create_task"]["salience"] == "high"
+
+
+# ---------------------------------------------------------
+# Precedence
+# ---------------------------------------------------------
+
+
+@pytest.fixture
+def stored_override(monkeypatch):
+    """Simulate a stale #V#mcp_tool row disagreeing with code."""
+
+    def _apply(tool_name, **fields):
+        stored = ToolMetadata(tool_name=tool_name, **fields)
+        monkeypatch.setattr(
+            tms, "_load_from_vontology", lambda: {tool_name: stored}
+        )
+        monkeypatch.setattr(tms, "_cache_loaded", False)
+        monkeypatch.setattr(tms, "_cache_timestamp", 0.0)
+        return stored
+
+    return _apply
+
+
+@pytest.mark.parametrize(
+    "field,stored_value",
+    [
+        ("display_template", "Stale: {name}"),
+        ("salience", "low"),
+        ("category", "stale_category"),
+    ],
+)
+def test_a_stored_value_cannot_override_code(stored_override, field, stored_value):
+    tool = "read_paper"
+    expected = _DEFAULT_TOOL_METADATA[tool].get(field)
+    assert expected, f"test needs a code value for {field}"
+
+    stored_override(tool, **{field: stored_value})
+
+    assert getattr(get_tool_metadata(tool), field) == expected
+
+
+def test_planner_hint_remains_represented_first_by_decision(stored_override):
+    """Deliberately outside the inversion, and asserted so it stays deliberate.
+
+    planner_hint is model-facing guidance rather than presentation, so runtime
+    curation is defensible, and alias inheritance of represented hints is an
+    existing tested contract. The cost, recorded on JVNAUTOSCI-2652, is that a
+    stale represented hint still outranks a better one in code.
+    """
+    stored_override("search_concepts", planner_hint="represented hint")
+
+    assert get_tool_metadata("search_concepts").planner_hint == "represented hint"
+
+
+def test_a_stored_value_still_fills_a_gap_code_leaves(stored_override, monkeypatch):
+    """Vontology remains a source for what code does not specify."""
+    tool = "read_paper"
+    monkeypatch.setitem(
+        _DEFAULT_TOOL_METADATA, tool, dict(_DEFAULT_TOOL_METADATA[tool])
+    )
+    _DEFAULT_TOOL_METADATA[tool].pop("planner_hint", None)
+
+    stored_override(tool, planner_hint="only the row has this")
+
+    assert get_tool_metadata(tool).planner_hint == "only the row has this"
+
+
+def test_description_precedence_is_unchanged(stored_override):
+    """Contract description is governed by PR #401 and out of scope here."""
+    stored_override("read_paper", description="from the row")
+
+    assert get_tool_metadata("read_paper").description == "from the row"


### PR DESCRIPTION
Same shape as #401, applied to presentation metadata instead of the contract.

## Problem

`display_template`, `user_salience` and `category` were recorded on `#V#mcp_tool` concepts once at bootstrap and never refreshed, so a stored copy silently outranked every later change in code. Of 39 named tools, **20 matched their code defaults exactly and 19 had drifted** — in both directions, with nothing recording which was intended.

## Reconciled on evidence, not taste

A display template only works if the renderer can resolve its placeholders, and `_apply_vontology_template` **discards one outright when fewer than half resolve**. That makes resolvability the deciding test rather than preference:

| Tool | Code | Stored | Winner |
|---|---|---|---|
| `get_tree`, `gmail_get_message`, `gmail_modify_labels`, `upsert_text_relation` | renders | discarded | code |
| `finalise_cached_paper`, `materialise_scholarly_…` | discarded | renders | **stored** |
| `read_paper` | discarded | discarded | **neither — both dead** |

## The bigger find

That test found more than it was asked to: **21 code templates were silently dead**, referencing ordinary identifier fields (`concept_id`, `issue_key`, `session_id`, `arxiv_id`, `request_id`…) that the resolver's named mapping happened to omit. Including `jira_get_comments`, which I added earlier the same day.

The fix belongs in the resolver, not in 21 configurations. A placeholder naming a scalar field the payload actually carries now resolves to it, with named mappings still winning. Rewriting 21 configs to satisfy a narrow validator would have been the wrong direction.

## Changes

Four values reconciled — `read_paper` and `finalise_cached_paper` adopt resolvable templates, `materialise_scholarly_representation_for_file_copy` adopts a static one, and `create_task` gains an entry at all (it had no code counterpart and does **not** alias to `task_create`, so the row was its only source).

Precedence inverted for `display_template`, `salience`, `category`: code wins, stored values still fill genuine gaps.

## One deliberate exclusion

`planner_hint` is **not** inverted. It's model-facing guidance rather than presentation, runtime curation of it is defensible, and alias inheritance of represented hints is an existing tested contract — `test_vontology_concept_search_alias_inherits_represented_metadata` failed when I first inverted it.

That test is protecting something real, so I narrowed the change rather than editing the test to make my change pass. The residual cost is recorded on the ticket: a stale represented hint still outranks a better one in code for `search_concepts`, and correcting the stored value needs the write route that JVNAUTOSCI-2653 is deciding.

147 tests passing across the touched suites; 18 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)