### PR TITLE
Repair display templates that name fields their tools never return

### DIFF
--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -292,7 +292,7 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "remove_relationships_bulk": {
         "salience": "high",
         "category": "vontology",
-        "display_template": "Bulk removed relationships: {removed_count}",
+        "display_template": "Bulk relationships removed",
     },
     "undo_relationship_removal": {
         "salience": "high",
@@ -312,12 +312,12 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "delete_concept": {
         "salience": "high",
         "category": "vontology",
-        "display_template": "Deleted: {concept_id}",
+        "display_template": "Concept deleted",
     },
     "rename_concept": {
         "salience": "high",
         "category": "vontology",
-        "display_template": "Renamed: {old_name} → {new_name}",
+        "display_template": "Renamed: {old_id} → {new_id}",
     },
     # Task tools (HIGH salience)
     "create_task": {
@@ -344,7 +344,7 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "task_assign": {
         "salience": "high",
         "category": "task",
-        "display_template": "Assigned to: {assignee}",
+        "display_template": "Task assigned",
         "dispatch_surface_family": "task",
         "evidence_surface_family": "task",
         "external_surface": False,
@@ -352,7 +352,7 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "task_delete": {
         "salience": "high",
         "category": "task",
-        "display_template": "Deleted task: {task_id}",
+        "display_template": "Task deleted",
         "dispatch_surface_family": "task",
         "evidence_surface_family": "task",
         "external_surface": False,
@@ -558,7 +558,7 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "jira_get_comments": {
         "salience": "medium",
         "category": "jira",
-        "display_template": "Comments: {issue_key}",
+        "display_template": "{count} comments",
         "dispatch_surface_family": "jira",
         "evidence_surface_family": "jira",
         "external_surface": True,

--- a/tests/backend/test_tool_presentation_metadata_is_code_authoritative.py
+++ b/tests/backend/test_tool_presentation_metadata_is_code_authoritative.py
@@ -176,3 +176,55 @@ def test_description_precedence_is_unchanged(stored_override):
     stored_override("read_paper", description="from the row")
 
     assert get_tool_metadata("read_paper").description == "from the row"
+
+
+# ---------------------------------------------------------
+# Templates must name fields their tool actually returns
+# ---------------------------------------------------------
+
+
+def test_no_template_names_a_field_absent_from_its_output_schema():
+    """A template naming an input argument or an invented field is dead.
+
+    The renderer discards a template when fewer than half its placeholders
+    resolve, and falls through to a hardcoded handler, so the failure never
+    surfaces. Six templates were dead this way, including one naming
+    ``issue_key`` — an argument the result payload never carries.
+
+    Only schemas specific enough to judge are checked; a generic
+    success/error schema cannot disprove a field.
+    """
+    import re
+
+    from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+    from src.backend.integrations.internal_mcp.tool_contract_registry import (
+        schema_to_json_schema,
+    )
+
+    # Names the renderer derives rather than reading directly from the payload.
+    derived = {
+        "count", "name", "title", "query", "query_label", "names", "action",
+        "exists", "target", "source", "predicate", "key", "status", "url",
+        "answer", "subject", "filename",
+    }
+
+    definitions = build_default_catalogue()._definitions
+    offenders = []
+    for tool, entry in _DEFAULT_TOOL_METADATA.items():
+        template = entry.get("display_template")
+        placeholders = set(re.findall(r"\{(\w+)\}", template or ""))
+        definition = definitions.get(tool)
+        if not placeholders or definition is None or definition.output_schema is None:
+            continue
+        properties = set(
+            (schema_to_json_schema(definition.output_schema).get("properties") or {})
+        )
+        if len(properties) <= 3:
+            continue  # generic envelope; not specific enough to judge
+        unknown = placeholders - properties - derived
+        if unknown:
+            offenders.append(f"{tool} {template!r} missing={sorted(unknown)}")
+
+    assert not offenders, "display templates naming absent fields: " + "; ".join(
+        offenders
+    )


### PR DESCRIPTION
Follow-up to #408, which fixed the *resolver*; this fixes templates the resolver still can't rescue.

## The distinction that matters

#408 made a placeholder resolve to any scalar field the payload carries, which revived 21 templates naming real result fields. It cannot help a template naming a field that was **never in the result**.

`jira_get_comments` was the giveaway: its template named `{issue_key}` — an *input argument*. The comment-page payload carries `startAt`, `maxResults`, `total`, `comments`. Still discarded after #408. I added that template the previous day, which is how fast this appears when nothing checks it.

## Evidence-based, via output schemas

214 of 277 methods declare an output schema, which makes this decidable rather than a guess. Six templates named fields absent from theirs:

| Tool | Was | Now |
|---|---|---|
| `jira_get_comments` | `Comments: {issue_key}` | `{count} comments` → renders "6 comments" |
| `rename_concept` | `Renamed: {old_name} → {new_name}` | `Renamed: {old_id} → {new_id}` (schema has both) |
| `delete_concept` | `Deleted: {concept_id}` | `Concept deleted` |
| `remove_relationships_bulk` | `Bulk removed relationships: {removed_count}` | `Bulk relationships removed` |
| `task_assign` | `Assigned to: {assignee}` | `Task assigned` |
| `task_delete` | `Deleted task: {task_id}` | `Task deleted` |

A test now asserts no template names a field absent from its output schema, checking only schemas specific enough to judge — a generic `success`/`error` envelope cannot disprove a field.

## Left alone deliberately

`task_assign` and `task_delete` declare list-shaped schemas (`count`, `limit`, `offset`) that look wrong for those operations, and **63 methods declare no output schema at all**, so their templates stay unverifiable. Both belong to the template-authoring work rather than to this repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)