### PR TITLE
JVNAUTOSCI-2657: widen tabs and add bounded panel resizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,10 +450,23 @@ For substantial Jira implementation work:
 6. Before another patch, wider campaign, or delay prompted by a material new
    observation, state explicitly whether it changes the merge decision and act
    accordingly.
-7. At the current decision boundary, leave the branch, Jira issue, and any live
-   state consistent with reality. Commit, publish, merge, release, comment, or
-   transition only when current task authority permits it and the action helps
-   the work. A provisional branch, experiment, or human-gated Jira programme
+7. A request to implement, fully implement, finish, or finish up Jira-backed
+   repository work authorises the ordinary publication lifecycle once
+   proportionate acceptance evidence supports delivery. Unless the user
+   explicitly requests a local-only, draft, no-publication, provisional, or
+   human-gated boundary, do not stop at a local commit, a ready-to-push state,
+   or a draft PR and do not ask for a separate publication confirmation.
+8. The ordinary publication lifecycle is: commit only the intended files, push
+   the task branch, open a non-draft PR, wait for required CI, repair in-scope
+   failures, merge, verify the intended result on `origin/main`, update or
+   transition Jira and read it back, return the primary checkout to the current
+   default branch, and remove only merged, unused task branches or worktrees
+   while preserving unrelated or dirty work.
+9. Repository publication does not by itself authorise deployment or activation
+   of a running system unless that effect is part of the requested outcome or an
+   applicable standing deployment workflow. At every decision boundary, leave
+   the branch, Jira issue, and any live state consistent with reality. A
+   provisional branch, experiment, or explicitly human-gated Jira programme
    must stop at its stated boundary even when implementation and tests are
    complete.
 

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -27,6 +27,7 @@ import {
     getSessionScopedNamespace,
     getSessionScopedOrgId
 } from './utils/sessionScopedStorage.js';
+import { initialiseResizableViewport } from './utils/resizableViewport.js';
 import { getKeyConceptIds, updateTabHeaderStarButtons, updateTreeKeyConceptBadge } from './vontology.js';
 
 // Track dynamically created concept tabs
@@ -42,6 +43,9 @@ const CONCEPT_TAB_BUCKET_ORDER = ['type', 'individual', 'predicate'];
 const CONCEPT_TAB_KIND_CLASS_NAMES = ['type-tab', 'individual-tab', 'predicate-tab'];
 const CONCEPT_TAB_LOADING_CLASS = 'concept-tab-loading';
 const CONCEPT_TAB_BUTTON_LOADING_CLASS = 'is-loading';
+const CONCEPT_PAGE_MIN_WIDTH_PX = 640;
+const CONCEPT_PAGE_WIDTH_STEP_PX = 120;
+const CONCEPT_PAGE_NARROW_BREAKPOINT_PX = 760;
 // Singleton context menu element for tab operations (created lazily)
 let tabContextMenu = null;
 let currentContextMenuTarget = null; // The tab button element for which menu opened
@@ -51,6 +55,216 @@ let suppressConceptTabPersistence = false;
 let dynamicConceptTabRecencyCounter = 0;
 let conceptTabLoadingSequence = 0;
 const expandedConceptTabBuckets = new Set();
+
+export function clampConceptPageWidthPx(requestedWidthPx, availableWidthPx) {
+    const available = Number(availableWidthPx);
+    const safeAvailable = Number.isFinite(available) && available > 0
+        ? available
+        : CONCEPT_PAGE_MIN_WIDTH_PX;
+    const minimum = Math.min(CONCEPT_PAGE_MIN_WIDTH_PX, safeAvailable);
+    const requested = Number(requestedWidthPx);
+    const safeRequested = Number.isFinite(requested) && requested > 0
+        ? requested
+        : safeAvailable;
+    return Math.round(Math.min(safeAvailable, Math.max(minimum, safeRequested)));
+}
+
+function getConceptPageAvailableWidthPx(tabContent) {
+    const parent = tabContent?.parentElement;
+    let available = Number(parent?.getBoundingClientRect?.().width) || Number(parent?.clientWidth);
+    if (!Number.isFinite(available) || available <= 0) {
+        available = Number(globalThis?.window?.innerWidth) || CONCEPT_PAGE_MIN_WIDTH_PX;
+    }
+    try {
+        const styles = globalThis?.window?.getComputedStyle?.(parent);
+        const horizontalPadding = (Number.parseFloat(styles?.paddingLeft || '') || 0)
+            + (Number.parseFloat(styles?.paddingRight || '') || 0);
+        available -= horizontalPadding;
+    } catch (_) { /* use the unadjusted parent width */ }
+    return Math.max(1, Math.round(available));
+}
+
+function isNarrowConceptPageViewport(availableWidthPx) {
+    const viewportWidth = Number(globalThis?.window?.innerWidth);
+    return (Number.isFinite(viewportWidth) && viewportWidth <= CONCEPT_PAGE_NARROW_BREAKPOINT_PX)
+        || availableWidthPx < CONCEPT_PAGE_MIN_WIDTH_PX;
+}
+
+function hasCoarsePrimaryPointer() {
+    try {
+        return !!globalThis?.window?.matchMedia?.('(pointer: coarse)')?.matches;
+    } catch (_) {
+        return false;
+    }
+}
+
+function getConceptPagePreferredWidthPx(tabContent, availableWidthPx) {
+    const stored = Number.parseFloat(tabContent?.dataset?.conceptPageWidthPx || '');
+    return clampConceptPageWidthPx(stored, availableWidthPx);
+}
+
+function updateConceptPageResizeControls(tabContent) {
+    const controls = tabContent?.querySelector?.('.concept-page-resize-controls');
+    if (!controls) return;
+    const availableWidthPx = getConceptPageAvailableWidthPx(tabContent);
+    const currentWidthPx = getConceptPagePreferredWidthPx(tabContent, availableWidthPx);
+    const narrowViewport = isNarrowConceptPageViewport(availableWidthPx);
+    const decreaseButton = controls.querySelector('[data-concept-width-action="decrease"]');
+    const increaseButton = controls.querySelector('[data-concept-width-action="increase"]');
+    const fitButton = controls.querySelector('[data-concept-width-action="fit"]');
+    const handle = controls.querySelector('.concept-page-resize-handle');
+
+    if (decreaseButton) {
+        decreaseButton.disabled = narrowViewport || currentWidthPx <= Math.min(CONCEPT_PAGE_MIN_WIDTH_PX, availableWidthPx);
+    }
+    if (increaseButton) {
+        increaseButton.disabled = narrowViewport || currentWidthPx >= availableWidthPx;
+    }
+    if (fitButton) {
+        fitButton.disabled = narrowViewport
+            || (tabContent.dataset.conceptPageWidthUserSet !== 'true' && currentWidthPx >= availableWidthPx);
+    }
+    controls.setAttribute('aria-disabled', narrowViewport ? 'true' : 'false');
+
+    if (handle) {
+        const directResizeEnabled = !narrowViewport && !hasCoarsePrimaryPointer();
+        handle.tabIndex = directResizeEnabled ? 0 : -1;
+        handle.setAttribute('aria-hidden', directResizeEnabled ? 'false' : 'true');
+        handle.setAttribute('aria-valuemin', String(Math.min(CONCEPT_PAGE_MIN_WIDTH_PX, availableWidthPx)));
+        handle.setAttribute('aria-valuemax', String(availableWidthPx));
+        handle.setAttribute('aria-valuenow', String(currentWidthPx));
+    }
+}
+
+function applyConceptPageWidthPx(tabContent, requestedWidthPx, { userSet = true } = {}) {
+    const availableWidthPx = getConceptPageAvailableWidthPx(tabContent);
+    const widthPx = clampConceptPageWidthPx(requestedWidthPx, availableWidthPx);
+    tabContent.dataset.conceptPageWidthPx = String(widthPx);
+    tabContent.dataset.conceptPageWidthUserSet = userSet ? 'true' : 'false';
+    tabContent.style.setProperty('--von-concept-page-width', `${widthPx}px`);
+    updateConceptPageResizeControls(tabContent);
+    return widthPx;
+}
+
+export function destroyConceptTabResizeUI(tabContent) {
+    if (!tabContent) return;
+    try {
+        tabContent.__vonConceptPageResizeCleanup?.();
+    } catch (_) { /* continue cleaning child controllers */ }
+    tabContent.querySelectorAll?.('.von-resizable-viewport')?.forEach((viewport) => {
+        try {
+            viewport.__vonResizableViewportController?.destroy?.();
+        } catch (_) { /* best-effort cleanup for a removed tab/template */ }
+    });
+}
+
+export function initialiseConceptPageResizeUI(tabContent) {
+    if (!tabContent?.classList?.contains('dynamic-concept-tab')) return null;
+    const controls = tabContent.querySelector('.concept-page-resize-controls');
+    if (!controls) return null;
+    if (tabContent.__vonConceptPageResizeCleanup) {
+        if (tabContent.__vonConceptPageResizeControls === controls && controls.isConnected) {
+            return tabContent.__vonConceptPageResizeCleanup;
+        }
+        destroyConceptTabResizeUI(tabContent);
+    }
+
+    controls.querySelectorAll('button, .concept-page-resize-handle').forEach((control) => {
+        if (tabContent.id) control.setAttribute('aria-controls', tabContent.id);
+    });
+    applyConceptPageWidthPx(tabContent, getConceptPageAvailableWidthPx(tabContent), { userSet: false });
+
+    const adjustWidth = (deltaPx) => {
+        const availableWidthPx = getConceptPageAvailableWidthPx(tabContent);
+        const currentWidthPx = getConceptPagePreferredWidthPx(tabContent, availableWidthPx);
+        applyConceptPageWidthPx(tabContent, currentWidthPx + deltaPx);
+    };
+    const onDecrease = () => adjustWidth(-CONCEPT_PAGE_WIDTH_STEP_PX);
+    const onIncrease = () => adjustWidth(CONCEPT_PAGE_WIDTH_STEP_PX);
+    const onFit = () => applyConceptPageWidthPx(
+        tabContent,
+        getConceptPageAvailableWidthPx(tabContent),
+        { userSet: false }
+    );
+    const decreaseButton = controls.querySelector('[data-concept-width-action="decrease"]');
+    const increaseButton = controls.querySelector('[data-concept-width-action="increase"]');
+    const fitButton = controls.querySelector('[data-concept-width-action="fit"]');
+    const handle = controls.querySelector('.concept-page-resize-handle');
+    decreaseButton?.addEventListener('click', onDecrease);
+    increaseButton?.addEventListener('click', onIncrease);
+    fitButton?.addEventListener('click', onFit);
+
+    let pointerStartX = null;
+    let pointerStartWidthPx = null;
+    const onPointerDown = (event) => {
+        if (event.button !== undefined && event.button !== 0) return;
+        if (isNarrowConceptPageViewport(getConceptPageAvailableWidthPx(tabContent)) || hasCoarsePrimaryPointer()) return;
+        pointerStartX = Number(event.clientX) || 0;
+        pointerStartWidthPx = getConceptPagePreferredWidthPx(
+            tabContent,
+            getConceptPageAvailableWidthPx(tabContent)
+        );
+        handle?.setPointerCapture?.(event.pointerId);
+        event.preventDefault();
+    };
+    const onPointerMove = (event) => {
+        if (pointerStartX === null || pointerStartWidthPx === null) return;
+        applyConceptPageWidthPx(tabContent, pointerStartWidthPx + ((Number(event.clientX) || 0) - pointerStartX));
+        event.preventDefault();
+    };
+    const onPointerEnd = (event) => {
+        if (pointerStartX === null) return;
+        pointerStartX = null;
+        pointerStartWidthPx = null;
+        handle?.releasePointerCapture?.(event.pointerId);
+    };
+    const onHandleKeyDown = (event) => {
+        if (event.key === 'ArrowLeft') {
+            event.preventDefault();
+            onDecrease();
+        } else if (event.key === 'ArrowRight') {
+            event.preventDefault();
+            onIncrease();
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            applyConceptPageWidthPx(tabContent, CONCEPT_PAGE_MIN_WIDTH_PX);
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            onFit();
+        }
+    };
+    handle?.addEventListener('pointerdown', onPointerDown);
+    handle?.addEventListener('pointermove', onPointerMove);
+    handle?.addEventListener('pointerup', onPointerEnd);
+    handle?.addEventListener('pointercancel', onPointerEnd);
+    handle?.addEventListener('keydown', onHandleKeyDown);
+
+    const onWindowResize = () => {
+        if (tabContent.dataset.conceptPageWidthUserSet !== 'true') {
+            applyConceptPageWidthPx(tabContent, getConceptPageAvailableWidthPx(tabContent), { userSet: false });
+        } else {
+            updateConceptPageResizeControls(tabContent);
+        }
+    };
+    globalThis?.window?.addEventListener?.('resize', onWindowResize);
+
+    const cleanup = () => {
+        decreaseButton?.removeEventListener('click', onDecrease);
+        increaseButton?.removeEventListener('click', onIncrease);
+        fitButton?.removeEventListener('click', onFit);
+        handle?.removeEventListener('pointerdown', onPointerDown);
+        handle?.removeEventListener('pointermove', onPointerMove);
+        handle?.removeEventListener('pointerup', onPointerEnd);
+        handle?.removeEventListener('pointercancel', onPointerEnd);
+        handle?.removeEventListener('keydown', onHandleKeyDown);
+        globalThis?.window?.removeEventListener?.('resize', onWindowResize);
+        delete tabContent.__vonConceptPageResizeCleanup;
+        delete tabContent.__vonConceptPageResizeControls;
+    };
+    tabContent.__vonConceptPageResizeCleanup = cleanup;
+    tabContent.__vonConceptPageResizeControls = controls;
+    return cleanup;
+}
 
 function getOpenConceptTabsStorageKey(namespace = null) {
     return buildNamespaceScopedStorageKey(OPEN_CONCEPT_TABS_STORAGE_PREFIX, namespace);
@@ -1743,7 +1957,7 @@ function createTabButton(tabId, displayName, conceptId, kind, opts = {}) {
 function createTabContent(tabId, conceptId, kind) {
     const tabContent = document.createElement('div');
     tabContent.id = tabId;
-    tabContent.className = 'tab-content';
+    tabContent.className = 'tab-content dynamic-concept-tab';
     tabContent.dataset.conceptId = conceptId;
     applyConceptTabKindPresentation(tabContent, kind);
 
@@ -1813,6 +2027,8 @@ export function closeDynamicConceptTab(conceptId, options = {}) {
             tabInfo.namesObserver.disconnect();
         }
     } catch (_) { /* ignore */ }
+
+    destroyConceptTabResizeUI(tabInfo.content);
 
     // Clean up predicate view if present
     try {
@@ -1983,7 +2199,9 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
         const headerSpanRegex = new RegExp(`(<span[^>]*id="${headerIdWithSuffix}")`);
         modifiedHtml = modifiedHtml.replace(headerSpanRegex, `$1 data-concept-id="${conceptId}"`);
 
+        destroyConceptTabResizeUI(tabInfo.content);
         tabInfo.content.innerHTML = modifiedHtml;
+        initialiseConceptPageResizeUI(tabInfo.content);
 
         // Add a small kind badge and an ID copy chip to the header if available.
         // Fallback inference: if tabInfo.kind is absent (regression / legacy dispatch), infer from node content.
@@ -2119,6 +2337,7 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
 
     } catch (error) {
         console.error(`[dynamicTabs] Error loading content for ${tabId}:`, error);
+        destroyConceptTabResizeUI(tabInfo.content);
         tabInfo.content.innerHTML = `<div class="error">Error loading concept tab content. Please try again.</div>`;
     } finally {
         delete tabInfo.loadingPromise;
@@ -5737,6 +5956,24 @@ function setRelationshipExtentUiState(conceptId, suffix, patch = {}) {
     return state;
 }
 
+function setRelationshipExtentResizeEnabled(content, suffix, enabled) {
+    if (!content) return null;
+    const section = document.getElementById(`relationshipsSection_${suffix}`)
+        || content.closest?.('.concept-list-subsection');
+    const controls = section?.querySelector?.('.von-resize-controls') || null;
+    const controller = initialiseResizableViewport(content, controls, {
+        defaultHeightPx: 440,
+        minHeightPx: 180,
+        maxHeightPx: 800,
+        stepPx: 80,
+        viewportOffsetPx: 180,
+        resizeAxis: 'vertical',
+        enabled
+    });
+    controller?.setEnabled(enabled);
+    return controller;
+}
+
 export function deriveRelationshipExtentQuery(uncertaintyFilter = 'all') {
     const selected = RELATIONSHIP_UNCERTAINTY_FILTERS[String(uncertaintyFilter || 'all')] || RELATIONSHIP_UNCERTAINTY_FILTERS.all;
     return {
@@ -5886,6 +6123,7 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
         const content = document.getElementById(`relationshipsContent_${suffix}`) || document.getElementById('relationshipsContent');
         if (content) {
             content.innerHTML = '<div class="relationships-loading">Loading relationships...</div>';
+            setRelationshipExtentResizeEnabled(content, suffix, false);
         }
 
         const container = document.getElementById(`relationshipsSection_${suffix}`) || document.getElementById('relationshipsSection');
@@ -6989,6 +7227,7 @@ async function renderRelationships(conceptId, suffix, kind) {
         }
         if (!rows.length) {
             content.innerHTML = '<i>No relationships yet.</i>';
+            setRelationshipExtentResizeEnabled(content, suffix, false);
             return;
         }
         rows = sortRelationshipExtentRows(rows, uiState.sortBy);
@@ -7298,8 +7537,10 @@ async function renderRelationships(conceptId, suffix, kind) {
         tableContainer.appendChild(table);
         content.innerHTML = '';
         content.appendChild(tableContainer);
+        setRelationshipExtentResizeEnabled(content, suffix, true);
     } catch (e) {
         content.innerHTML = `<span class="relationships-error">Failed to load relationships (${e.message})</span>`;
+        setRelationshipExtentResizeEnabled(content, suffix, false);
     }
 }
 // Helper: Add analysis and relationship buttons next to JSON button

--- a/src/frontend/web/von_interface/static/js/utils/resizableViewport.js
+++ b/src/frontend/web/von_interface/static/js/utils/resizableViewport.js
@@ -1,0 +1,371 @@
+const DEFAULT_MIN_HEIGHT_PX = 180;
+const DEFAULT_HEIGHT_PX = 440;
+const DEFAULT_MAX_HEIGHT_PX = 800;
+const DEFAULT_STEP_PX = 80;
+const DEFAULT_VIEWPORT_OFFSET_PX = 180;
+const DEFAULT_MIN_WIDTH_PX = 320;
+const DEFAULT_WIDTH_STEP_PX = 120;
+
+function finitePositiveNumber(value, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getViewportHeightPx(explicitHeight = null) {
+    const parsed = Number(explicitHeight);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+    }
+    const liveHeight = Number(globalThis?.window?.innerHeight);
+    return Number.isFinite(liveHeight) && liveHeight > 0 ? liveHeight : null;
+}
+
+export function getResizableViewportHeightBounds(options = {}) {
+    const minHeightPx = finitePositiveNumber(options.minHeightPx, DEFAULT_MIN_HEIGHT_PX);
+    const configuredMaxHeightPx = Math.max(
+        minHeightPx,
+        finitePositiveNumber(options.maxHeightPx, DEFAULT_MAX_HEIGHT_PX)
+    );
+    const viewportOffsetPx = Math.max(
+        0,
+        Number.isFinite(Number(options.viewportOffsetPx))
+            ? Number(options.viewportOffsetPx)
+            : DEFAULT_VIEWPORT_OFFSET_PX
+    );
+    const viewportHeightPx = getViewportHeightPx(options.viewportHeightPx);
+    const viewportMaxHeightPx = viewportHeightPx === null
+        ? configuredMaxHeightPx
+        : Math.max(minHeightPx, viewportHeightPx - viewportOffsetPx);
+
+    return {
+        minHeightPx: Math.round(minHeightPx),
+        maxHeightPx: Math.round(Math.min(configuredMaxHeightPx, viewportMaxHeightPx))
+    };
+}
+
+export function clampResizableViewportHeightPx(requestedHeightPx, options = {}) {
+    const { minHeightPx, maxHeightPx } = getResizableViewportHeightBounds(options);
+    const defaultHeightPx = finitePositiveNumber(options.defaultHeightPx, DEFAULT_HEIGHT_PX);
+    const requested = finitePositiveNumber(requestedHeightPx, defaultHeightPx);
+    return Math.round(Math.min(maxHeightPx, Math.max(minHeightPx, requested)));
+}
+
+function getMeasuredHeightPx(viewport) {
+    const rectHeight = Number(viewport?.getBoundingClientRect?.().height);
+    if (Number.isFinite(rectHeight) && rectHeight > 0) {
+        return rectHeight;
+    }
+    const clientHeight = Number(viewport?.clientHeight);
+    if (Number.isFinite(clientHeight) && clientHeight > 0) {
+        return clientHeight;
+    }
+    const inlineHeight = Number.parseFloat(viewport?.style?.height || '');
+    return Number.isFinite(inlineHeight) && inlineHeight > 0 ? inlineHeight : null;
+}
+
+function getMeasuredWidthPx(viewport) {
+    const rectWidth = Number(viewport?.getBoundingClientRect?.().width);
+    if (Number.isFinite(rectWidth) && rectWidth > 0) {
+        return rectWidth;
+    }
+    const clientWidth = Number(viewport?.clientWidth);
+    if (Number.isFinite(clientWidth) && clientWidth > 0) {
+        return clientWidth;
+    }
+    const inlineWidth = Number.parseFloat(viewport?.style?.width || '');
+    return Number.isFinite(inlineWidth) && inlineWidth > 0 ? inlineWidth : null;
+}
+
+function getAvailableWidthPx(viewport) {
+    const parentWidth = Number(viewport?.parentElement?.clientWidth);
+    if (Number.isFinite(parentWidth) && parentWidth > 0) {
+        return parentWidth;
+    }
+    const viewportWidth = Number(globalThis?.window?.innerWidth);
+    return Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : null;
+}
+
+/**
+ * Add bounded sizing to a stable scroll viewport.
+ *
+ * Native resize remains available to fine pointers. Buttons in the supplied
+ * control group provide equivalent decrease/increase/reset paths for keyboard
+ * and coarse-pointer users. Width is opt-in through resizeAxis: "both" and
+ * resets to the responsive full-width CSS default.
+ */
+export function initialiseResizableViewport(viewport, controls, options = {}) {
+    if (!viewport || typeof viewport.addEventListener !== 'function') {
+        return null;
+    }
+    if (viewport.__vonResizableViewportController) {
+        return viewport.__vonResizableViewportController;
+    }
+
+    const config = {
+        minHeightPx: finitePositiveNumber(options.minHeightPx, DEFAULT_MIN_HEIGHT_PX),
+        defaultHeightPx: finitePositiveNumber(options.defaultHeightPx, DEFAULT_HEIGHT_PX),
+        maxHeightPx: finitePositiveNumber(options.maxHeightPx, DEFAULT_MAX_HEIGHT_PX),
+        stepPx: finitePositiveNumber(options.stepPx, DEFAULT_STEP_PX),
+        minWidthPx: finitePositiveNumber(options.minWidthPx, DEFAULT_MIN_WIDTH_PX),
+        maxWidthPx: finitePositiveNumber(options.maxWidthPx, Number.POSITIVE_INFINITY),
+        widthStepPx: finitePositiveNumber(options.widthStepPx, DEFAULT_WIDTH_STEP_PX),
+        viewportOffsetPx: Number.isFinite(Number(options.viewportOffsetPx))
+            ? Math.max(0, Number(options.viewportOffsetPx))
+            : DEFAULT_VIEWPORT_OFFSET_PX
+    };
+    const resizeAxis = options.resizeAxis === 'both' ? 'both' : 'vertical';
+    const storedHeightPx = Number.parseFloat(viewport.dataset.vonResizeHeightPx || '');
+    let preferredHeightPx = Number.isFinite(storedHeightPx) && storedHeightPx > 0
+        ? storedHeightPx
+        : config.defaultHeightPx;
+    const storedWidthPx = Number.parseFloat(viewport.dataset.vonResizeWidthPx || '');
+    let preferredWidthPx = Number.isFinite(storedWidthPx) && storedWidthPx > 0
+        ? storedWidthPx
+        : null;
+    let enabled = options.enabled !== false;
+    let resizeObserver = null;
+    let lastAppliedInlineHeight = viewport.style.height || '';
+    let lastAppliedInlineWidth = viewport.style.width || '';
+
+    const decreaseButton = controls?.querySelector?.('[data-resize-action="decrease"]') || null;
+    const increaseButton = controls?.querySelector?.('[data-resize-action="increase"]') || null;
+    const resetButton = controls?.querySelector?.('[data-resize-action="reset"]') || null;
+    const decreaseWidthButton = controls?.querySelector?.('[data-resize-action="decrease-width"]') || null;
+    const increaseWidthButton = controls?.querySelector?.('[data-resize-action="increase-width"]') || null;
+    const resetWidthButton = controls?.querySelector?.('[data-resize-action="reset-width"]') || null;
+    const buttons = [
+        decreaseButton,
+        increaseButton,
+        resetButton,
+        decreaseWidthButton,
+        increaseWidthButton,
+        resetWidthButton
+    ].filter(Boolean);
+
+    viewport.classList.add('von-resizable-viewport');
+    viewport.dataset.resizeAxis = resizeAxis;
+    if (controls) {
+        controls.classList.add('von-resize-controls');
+        if (viewport.id) {
+            controls.setAttribute('aria-controls', viewport.id);
+            buttons.forEach((button) => button.setAttribute('aria-controls', viewport.id));
+        }
+    }
+
+    const boundsOptions = () => ({
+        ...config,
+        viewportHeightPx: getViewportHeightPx()
+    });
+
+    const getRenderedHeightPx = () => clampResizableViewportHeightPx(preferredHeightPx, boundsOptions());
+
+    const getWidthBounds = () => {
+        const availableWidthPx = getAvailableWidthPx(viewport);
+        const configuredMaxWidthPx = config.maxWidthPx;
+        const maxWidthPx = Math.max(
+            config.minWidthPx,
+            Math.min(configuredMaxWidthPx, availableWidthPx ?? configuredMaxWidthPx)
+        );
+        return { minWidthPx: config.minWidthPx, maxWidthPx };
+    };
+
+    const clampWidth = (requestedWidthPx) => {
+        const { minWidthPx, maxWidthPx } = getWidthBounds();
+        const measuredWidthPx = getMeasuredWidthPx(viewport);
+        const fallbackWidthPx = measuredWidthPx ?? maxWidthPx;
+        const requested = finitePositiveNumber(requestedWidthPx, fallbackWidthPx);
+        return Math.round(Math.min(maxWidthPx, Math.max(minWidthPx, requested)));
+    };
+
+    const getRenderedWidthPx = () => preferredWidthPx === null
+        ? null
+        : clampWidth(preferredWidthPx);
+
+    const updateControls = () => {
+        const { minHeightPx, maxHeightPx } = getResizableViewportHeightBounds(boundsOptions());
+        const renderedHeightPx = getRenderedHeightPx();
+        if (decreaseButton) {
+            decreaseButton.disabled = !enabled || renderedHeightPx <= minHeightPx;
+        }
+        if (increaseButton) {
+            increaseButton.disabled = !enabled || renderedHeightPx >= maxHeightPx;
+        }
+        if (resetButton) {
+            resetButton.disabled = !enabled || Math.abs(preferredHeightPx - config.defaultHeightPx) < 1;
+        }
+        const { minWidthPx, maxWidthPx } = getWidthBounds();
+        const renderedWidthPx = getRenderedWidthPx();
+        const currentWidthPx = renderedWidthPx ?? clampWidth(getMeasuredWidthPx(viewport));
+        if (decreaseWidthButton) {
+            decreaseWidthButton.disabled = !enabled || resizeAxis !== 'both' || currentWidthPx <= minWidthPx;
+        }
+        if (increaseWidthButton) {
+            increaseWidthButton.disabled = !enabled || resizeAxis !== 'both' || currentWidthPx >= maxWidthPx;
+        }
+        if (resetWidthButton) {
+            resetWidthButton.disabled = !enabled || resizeAxis !== 'both' || preferredWidthPx === null;
+        }
+        if (controls) {
+            controls.setAttribute('aria-disabled', enabled ? 'false' : 'true');
+        }
+    };
+
+    const applyPreferredHeight = ({ notify = true } = {}) => {
+        const renderedHeightPx = getRenderedHeightPx();
+        viewport.dataset.vonResizeHeightPx = String(Math.round(preferredHeightPx));
+        if (enabled) {
+            viewport.style.height = `${renderedHeightPx}px`;
+            lastAppliedInlineHeight = viewport.style.height;
+        }
+        updateControls();
+        if (notify && typeof options.onHeightChange === 'function') {
+            options.onHeightChange(renderedHeightPx);
+        }
+        return renderedHeightPx;
+    };
+
+    const setHeight = (nextHeightPx, { notify = true } = {}) => {
+        preferredHeightPx = clampResizableViewportHeightPx(nextHeightPx, boundsOptions());
+        return applyPreferredHeight({ notify });
+    };
+
+    const applyPreferredWidth = ({ notify = true } = {}) => {
+        if (resizeAxis !== 'both') return null;
+        const renderedWidthPx = getRenderedWidthPx();
+        if (preferredWidthPx === null) {
+            delete viewport.dataset.vonResizeWidthPx;
+            viewport.style.removeProperty('width');
+        } else {
+            viewport.dataset.vonResizeWidthPx = String(Math.round(preferredWidthPx));
+            viewport.style.width = `${Math.round(preferredWidthPx)}px`;
+        }
+        lastAppliedInlineWidth = viewport.style.width;
+        updateControls();
+        if (notify && typeof options.onWidthChange === 'function') {
+            options.onWidthChange(renderedWidthPx);
+        }
+        return renderedWidthPx;
+    };
+
+    const setWidth = (nextWidthPx, { notify = true } = {}) => {
+        if (resizeAxis !== 'both') return null;
+        preferredWidthPx = clampWidth(nextWidthPx);
+        return applyPreferredWidth({ notify });
+    };
+
+    const resetWidth = () => {
+        if (resizeAxis !== 'both') return null;
+        preferredWidthPx = null;
+        return applyPreferredWidth();
+    };
+
+    const setEnabled = (nextEnabled) => {
+        enabled = nextEnabled !== false;
+        viewport.classList.toggle('von-resizable-viewport-active', enabled);
+        if (enabled) {
+            applyPreferredHeight({ notify: false });
+            applyPreferredWidth({ notify: false });
+        } else {
+            viewport.style.removeProperty('height');
+            viewport.style.removeProperty('width');
+            lastAppliedInlineHeight = '';
+            lastAppliedInlineWidth = '';
+            updateControls();
+        }
+    };
+
+    const persistMeasuredHeight = () => {
+        if (!enabled) return;
+        const inlineHeight = viewport.style.height || '';
+        if (!inlineHeight || inlineHeight === lastAppliedInlineHeight) return;
+        const measuredHeightPx = getMeasuredHeightPx(viewport);
+        if (!Number.isFinite(measuredHeightPx) || measuredHeightPx <= 0) return;
+        const clampedHeightPx = clampResizableViewportHeightPx(measuredHeightPx, boundsOptions());
+        if (Math.abs(clampedHeightPx - preferredHeightPx) < 1) {
+            lastAppliedInlineHeight = inlineHeight;
+            return;
+        }
+        preferredHeightPx = clampedHeightPx;
+        viewport.dataset.vonResizeHeightPx = String(clampedHeightPx);
+        if (Math.abs(clampedHeightPx - measuredHeightPx) >= 1) {
+            viewport.style.height = `${clampedHeightPx}px`;
+        }
+        lastAppliedInlineHeight = viewport.style.height;
+        updateControls();
+        if (typeof options.onHeightChange === 'function') {
+            options.onHeightChange(clampedHeightPx);
+        }
+    };
+
+    const decrease = () => setHeight(getRenderedHeightPx() - config.stepPx);
+    const increase = () => setHeight(getRenderedHeightPx() + config.stepPx);
+    const reset = () => {
+        preferredHeightPx = config.defaultHeightPx;
+        return applyPreferredHeight();
+    };
+    const decreaseWidth = () => setWidth((getRenderedWidthPx() ?? getMeasuredWidthPx(viewport)) - config.widthStepPx);
+    const increaseWidth = () => setWidth((getRenderedWidthPx() ?? getMeasuredWidthPx(viewport)) + config.widthStepPx);
+    const persistMeasuredWidth = () => {
+        if (!enabled || resizeAxis !== 'both') return;
+        const inlineWidth = viewport.style.width || '';
+        if (!inlineWidth || inlineWidth === lastAppliedInlineWidth) return;
+        const inlineWidthPx = Number.parseFloat(inlineWidth);
+        if (!Number.isFinite(inlineWidthPx) || inlineWidthPx <= 0) return;
+        setWidth(inlineWidthPx);
+    };
+    const persistNativeSize = () => {
+        persistMeasuredHeight();
+        persistMeasuredWidth();
+    };
+    const onWindowResize = () => {
+        if (!enabled) return;
+        applyPreferredHeight({ notify: false });
+        applyPreferredWidth({ notify: false });
+    };
+
+    decreaseButton?.addEventListener('click', decrease);
+    increaseButton?.addEventListener('click', increase);
+    resetButton?.addEventListener('click', reset);
+    decreaseWidthButton?.addEventListener('click', decreaseWidth);
+    increaseWidthButton?.addEventListener('click', increaseWidth);
+    resetWidthButton?.addEventListener('click', resetWidth);
+    ['pointerup', 'mouseup', 'touchend'].forEach((eventName) => {
+        viewport.addEventListener(eventName, persistNativeSize);
+    });
+    globalThis?.window?.addEventListener?.('resize', onWindowResize);
+
+    if (typeof globalThis.ResizeObserver === 'function') {
+        resizeObserver = new globalThis.ResizeObserver(() => {
+            persistMeasuredHeight();
+            persistMeasuredWidth();
+        });
+        resizeObserver.observe(viewport);
+    }
+
+    const controller = {
+        destroy() {
+            decreaseButton?.removeEventListener('click', decrease);
+            increaseButton?.removeEventListener('click', increase);
+            resetButton?.removeEventListener('click', reset);
+            decreaseWidthButton?.removeEventListener('click', decreaseWidth);
+            increaseWidthButton?.removeEventListener('click', increaseWidth);
+            resetWidthButton?.removeEventListener('click', resetWidth);
+            ['pointerup', 'mouseup', 'touchend'].forEach((eventName) => {
+                viewport.removeEventListener(eventName, persistNativeSize);
+            });
+            globalThis?.window?.removeEventListener?.('resize', onWindowResize);
+            resizeObserver?.disconnect?.();
+            delete viewport.__vonResizableViewportController;
+        },
+        getHeight: getRenderedHeightPx,
+        getWidth: getRenderedWidthPx,
+        reset,
+        resetWidth,
+        setEnabled,
+        setHeight,
+        setWidth
+    };
+    viewport.__vonResizableViewportController = controller;
+    setEnabled(enabled);
+    return controller;
+}

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -16,6 +16,7 @@ import {
   vontologyTreeData
 } from './state.js';
 import { finishBackgroundTask, startBackgroundTask } from './backgroundTaskTracker.js';
+import { initialiseResizableViewport } from './utils/resizableViewport.js';
 import { createAnnotatedFragment, createVontologyCartouche, normalisePotentialConceptId } from './utils/textDecorator.js';
 
 // Search configuration constants
@@ -4253,6 +4254,20 @@ export function initializeVontologyTab() {
 
   // Initialize DOM elements since the tab content is loaded dynamically
   initializeVontologyTabDomElements();
+  initialiseResizableViewport(
+    elements.vontologyTreeContainer,
+    document.getElementById('vontologyTreeResizeControls'),
+    {
+      defaultHeightPx: 420,
+      minHeightPx: 180,
+      maxHeightPx: 900,
+      stepPx: 80,
+      minWidthPx: 320,
+      widthStepPx: 120,
+      viewportOffsetPx: 160,
+      resizeAxis: 'both'
+    }
+  );
   const loadTreeButton = document.getElementById('loadVontologyTreeButton');
 
   // Wire up show only key concepts checkbox

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -565,7 +565,8 @@ body {
 
 /* Annotation Advanced Layout */
 .annotation-layout {
-    max-width: 1200px;
+    max-width: none;
+    width: 100%;
 }
 
 .annotation-toolbar {
@@ -1032,6 +1033,12 @@ body {
 @media (max-width: 1100px) {
     .annotation-columns {
         flex-direction: column;
+    }
+
+    .annotation-left,
+    .annotation-right {
+        min-width: 0;
+        width: 100%;
     }
 
     .annotation-right {
@@ -6598,10 +6605,10 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     /* Force display */
 }
 
-/* --- Tab Content General Styles (for Chat, Vontology, Entity, Settings) --- */
+/* --- Tab Content General Styles --- */
 .tab-content {
-    max-width: 900px;
-    /* Center content with max width */
+    max-width: none;
+    /* Work surfaces use the available width; readable inner content opts into its own measure. */
     margin-left: auto;
     /* Center horizontally */
     margin-right: auto;
@@ -6617,6 +6624,25 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     min-height: 400px !important;
     /* Force minimum height */
     position: relative;
+}
+
+.tab-content.dynamic-concept-tab {
+    width: min(100%, var(--von-concept-page-width, 100%)) !important;
+}
+
+/* Keep description actions inside a full-width concept surface. The legacy
+ * placement used left: 100%, which was only safe while the whole tab was
+ * artificially capped and caused body-level overflow once that cap was
+ * removed. Reserve the action strip's desktop width so it never covers text. */
+.dynamic-concept-tab .type-description-wrapper {
+    box-sizing: border-box;
+    padding-right: 172px;
+}
+
+.dynamic-concept-tab .type-description-wrapper > .desc-actions {
+    left: auto;
+    right: 0;
+    margin-left: 0;
 }
 
 .tab-content.concept-tab-loading {
@@ -6730,6 +6756,30 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     min-height: 0 !important;
 }
 
+@media (max-width: 760px) {
+    .tab-content-area {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+
+    .tab-content {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+
+    .tab-content.dynamic-concept-tab {
+        width: 100% !important;
+    }
+
+    .dynamic-concept-tab .type-description-wrapper {
+        padding-right: 40px;
+    }
+
+    .dynamic-concept-tab .type-description-wrapper > .desc-actions {
+        flex-direction: column;
+    }
+}
+
 /* Concept interaction panel: ensure follow-up question wraps and does not overflow */
 #followUpQuestion {
     word-break: break-word;
@@ -6752,10 +6802,9 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     /* Text aligns to top by default. Padding and min-height are inherited or can be set. */
 }
 
-/* Constrain the overall width of the tab content and center it */
+/* Vontology uses the shared full-width work surface. */
 #vontologyTab {
-    max-width: 800px;
-    /* Adjust as needed */
+    max-width: none;
     margin-left: auto;
     margin-right: auto;
     padding: 15px;
@@ -6900,20 +6949,110 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     min-width: 200px;
     height: 300px;
     /* Initial height */
-    max-height: 600px;
+    max-height: 900px;
     width: 100%;
-    max-width: 1000px;
+    max-width: 100%;
     overflow: auto;
     margin-bottom: 15px;
     background-color: #fff;
     /* White background for the tree */
-    resize: both;
-    /* Allow user to resize vertically and horizontally */
     box-sizing: border-box;
     display: block !important;
     /* Force display */
     position: relative !important;
     /* Force positioning context */
+}
+
+/* Shared opt-in sizing for dense scroll viewports. */
+.von-resizable-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 6px;
+}
+
+.von-resizable-panel-label {
+    color: #475569;
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.von-resize-controls,
+.concept-page-resize-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.von-resize-button {
+    min-width: 28px;
+    min-height: 28px;
+    padding: 3px 8px;
+    border: 1px solid #94a3b8;
+    border-radius: 6px;
+    background: #f8fafc;
+    color: #334155;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.von-resize-button:hover:not(:disabled),
+.von-resize-button:focus-visible {
+    border-color: #2563eb;
+    background: #eff6ff;
+    color: #1d4ed8;
+}
+
+.von-resize-button:focus-visible,
+.concept-page-resize-handle:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.von-resize-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.42;
+}
+
+.von-resize-button.von-resize-reset {
+    padding-left: 9px;
+    padding-right: 9px;
+    font-weight: 600;
+}
+
+.von-resizable-viewport {
+    box-sizing: border-box;
+    max-width: 100%;
+    overflow: auto;
+    resize: none;
+}
+
+.von-resizable-viewport.von-resizable-viewport-active {
+    min-height: 180px;
+    max-height: min(900px, calc(100vh - 160px));
+    overscroll-behavior: contain;
+}
+
+@media (pointer: fine) {
+    .von-resizable-viewport.von-resizable-viewport-active[data-resize-axis="vertical"] {
+        resize: vertical;
+    }
+
+    .von-resizable-viewport.von-resizable-viewport-active[data-resize-axis="both"] {
+        resize: both;
+    }
+}
+
+@media (pointer: coarse), (max-width: 760px) {
+    .von-resizable-viewport.von-resizable-viewport-active {
+        max-width: 100% !important;
+        resize: none !important;
+    }
 }
 
 /* Vontology top-of-page search UI */
@@ -7061,10 +7200,28 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     min-height: 0;
 }
 
-/* Chat needs a bit more horizontal room than other tabs. */
+/* Chat's outer work surface is full width, with a deliberate ultrawide inner measure. */
 #chatTab>.content-wrapper {
     max-width: 1600px;
     width: min(100%, calc(100vw - 32px));
+}
+
+/* Annotation is a dense two-column work surface, not a reading column. */
+#annotationTab > .content-wrapper.annotation-layout {
+    max-width: none;
+    width: 100%;
+}
+
+/* Keep explanatory copy readable without constraining Import/Export controls or previews. */
+#importExportTab .import-export-description,
+#importExportTab .import-export-direct-management > p,
+#importExportTab .import-export-card > p {
+    max-width: 78ch;
+}
+
+#importExportTab .import-export-small-text {
+    display: block;
+    max-width: 78ch;
 }
 
 .main-title {
@@ -11986,6 +12143,41 @@ button.prompt-vontology-cartouche {
     /* use gap instead of relying on ad-hoc margins */
 }
 
+.concept-page-resize-controls {
+    margin-left: auto;
+    order: 100;
+}
+
+.concept-page-resize-handle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 1px dashed #64748b;
+    border-radius: 6px;
+    background: #f8fafc;
+    color: #334155;
+    cursor: ew-resize;
+    font-size: 0.95rem;
+    line-height: 1;
+    touch-action: none;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+@media (pointer: coarse) {
+    .concept-page-resize-handle {
+        display: none;
+    }
+}
+
+@media (max-width: 760px) {
+    .concept-page-resize-controls {
+        display: none;
+    }
+}
+
 .concept-header .kind-badge:first-child {
     margin-left: 0 !important;
 }
@@ -14681,6 +14873,24 @@ body.settings-body {
     margin-bottom: 16px;
 }
 
+.relationship-extent-header {
+    margin-top: 2px;
+}
+
+.relationship-extent-viewport.von-resizable-viewport-active {
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    background: #ffffff;
+}
+
+.relationship-extent-viewport > .predicate-extent-table-container {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    margin-bottom: 0;
+}
+
 .relationships-toolbar {
     display: flex;
     flex-wrap: wrap;
@@ -14728,6 +14938,13 @@ body.settings-body {
     font-weight: 600;
     color: #495057;
     white-space: nowrap;
+}
+
+.relationship-extent-viewport .predicate-extent-table th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: #e9ecef;
 }
 
 .predicate-extent-table th.sortable {

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -3,6 +3,16 @@
   <span id="conceptTypeDisplayNamePluralElement" class="concept-type-header"></span>
   <button id="refreshConceptButton" class="round-icon-button" title="Refresh concept data"
     aria-label="Refresh concept data" data-icon="refresh"></button>
+  <div class="concept-page-resize-controls" role="group" aria-label="Concept page width">
+    <button type="button" class="von-resize-button" data-concept-width-action="decrease"
+      aria-label="Narrow concept page" title="Narrow concept page">−</button>
+    <button type="button" class="von-resize-button" data-concept-width-action="increase"
+      aria-label="Widen concept page" title="Widen concept page">+</button>
+    <button type="button" class="von-resize-button von-resize-reset" data-concept-width-action="fit"
+      aria-label="Fit concept page to available width" title="Fit concept page to available width">Fit</button>
+    <span class="concept-page-resize-handle" role="separator" tabindex="0" aria-orientation="vertical"
+      aria-label="Resize concept page width" title="Drag or use Left and Right arrow keys to resize">↔</span>
+  </div>
 </div>
 
 <!-- Step 1: Initial Input -->
@@ -187,8 +197,20 @@
 
 <!-- Relationships section (shown for both Type and Individual tabs) -->
 <div id="relationshipsSection" class="concept-list-subsection">
-  <h3 class="concept-list-title">Relation Extent</h3>
-  <div id="relationshipsContent">
+  <div class="von-resizable-panel-header relationship-extent-header">
+    <h3 class="concept-list-title">Relation Extent</h3>
+    <div id="relationshipExtentResizeControls" class="von-resize-controls" role="group"
+      aria-label="Relation Extent height">
+      <button type="button" class="von-resize-button" data-resize-action="decrease"
+        aria-label="Show fewer Relation Extent rows" title="Show fewer rows">−</button>
+      <button type="button" class="von-resize-button" data-resize-action="increase"
+        aria-label="Show more Relation Extent rows" title="Show more rows">+</button>
+      <button type="button" class="von-resize-button von-resize-reset" data-resize-action="reset"
+        aria-label="Reset Relation Extent height" title="Reset Relation Extent height">Reset</button>
+    </div>
+  </div>
+  <div id="relationshipsContent" class="relationship-extent-viewport von-resizable-viewport"
+    data-resize-axis="vertical">
     <!-- Populated dynamically -->
   </div>
   <div id="relationshipsAddForm" class="mt-2 flex gap-2 ai-center flex-wrap">

--- a/src/frontend/web/von_interface/templates/vontology_tab.html
+++ b/src/frontend/web/von_interface/templates/vontology_tab.html
@@ -2,7 +2,25 @@
 <!-- JVNAUTOSCI-322: Dynamic Concept Tabs on Vontology Selection -->
 <div class="vontology-container">
   <!-- Title & search moved to global header (JVNAUTOSCI-550) -->
-  <div id="vontologyTreeContainer">
+  <div class="von-resizable-panel-header vontology-tree-header">
+    <span class="von-resizable-panel-label">Tree viewport</span>
+    <div id="vontologyTreeResizeControls" class="von-resize-controls" role="group"
+      aria-label="Vontology tree viewport size" aria-controls="vontologyTreeContainer">
+      <button type="button" class="von-resize-button" data-resize-action="decrease"
+        aria-label="Show fewer Vontology tree rows" title="Show fewer tree rows">−</button>
+      <button type="button" class="von-resize-button" data-resize-action="increase"
+        aria-label="Show more Vontology tree rows" title="Show more tree rows">+</button>
+      <button type="button" class="von-resize-button von-resize-reset" data-resize-action="reset"
+        aria-label="Reset Vontology tree height" title="Reset Vontology tree height">Reset</button>
+      <button type="button" class="von-resize-button" data-resize-action="decrease-width"
+        aria-label="Make Vontology tree narrower" title="Make tree narrower">←</button>
+      <button type="button" class="von-resize-button" data-resize-action="increase-width"
+        aria-label="Make Vontology tree wider" title="Make tree wider">→</button>
+      <button type="button" class="von-resize-button von-resize-reset" data-resize-action="reset-width"
+        aria-label="Fit Vontology tree to available width" title="Fit tree to available width">Fit</button>
+    </div>
+  </div>
+  <div id="vontologyTreeContainer" class="von-resizable-viewport" data-resize-axis="both">
     <!-- Tree will be rendered here by JavaScript -->
     <p>Loading Vontology tree...</p>
   </div>

--- a/tests/frontend/dynamicTabsIdCollision.test.js
+++ b/tests/frontend/dynamicTabsIdCollision.test.js
@@ -93,9 +93,132 @@ describe('dynamic concept tab IDs', () => {
 
         const contents = Array.from(document.querySelectorAll('.tab-content-area .tab-content'));
         expect(contents).toHaveLength(2);
+        expect(contents.every((el) => el.classList.contains('dynamic-concept-tab'))).toBe(true);
 
         const contentIds = contents.map((el) => el.id);
         expect(new Set(contentIds).size).toBe(2);
+    });
+
+    test('clamps and applies accessible concept page width controls', () => {
+        const originalInnerWidth = window.innerWidth;
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1400 });
+        const {
+            clampConceptPageWidthPx,
+            createOrActivateConceptTab,
+            initialiseConceptPageResizeUI
+        } = require(dynamicTabsModulePath);
+        const tabId = createOrActivateConceptTab('#V#resizable', 'Resizable', false, { kind: 'type' });
+        const tabContent = document.getElementById(tabId);
+        const contentArea = document.querySelector('.tab-content-area');
+        contentArea.getBoundingClientRect = () => ({ width: window.innerWidth });
+        tabContent.innerHTML = `
+            <div class="concept-page-resize-controls" role="group" aria-label="Concept page width">
+                <button type="button" data-concept-width-action="decrease">−</button>
+                <button type="button" data-concept-width-action="increase">+</button>
+                <button type="button" data-concept-width-action="fit">Fit</button>
+                <span class="concept-page-resize-handle" role="separator" tabindex="0"></span>
+            </div>
+        `;
+
+        expect(clampConceptPageWidthPx(500, 1400)).toBe(640);
+        expect(clampConceptPageWidthPx(1700, 1400)).toBe(1400);
+        expect(clampConceptPageWidthPx(960, 1400)).toBe(960);
+
+        const cleanup = initialiseConceptPageResizeUI(tabContent);
+        const decreaseButton = tabContent.querySelector('[data-concept-width-action="decrease"]');
+        const fitButton = tabContent.querySelector('[data-concept-width-action="fit"]');
+        const handle = tabContent.querySelector('.concept-page-resize-handle');
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1400px');
+        expect(handle.getAttribute('aria-controls')).toBe(tabId);
+
+        decreaseButton.click();
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1280px');
+        handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1160px');
+        handle.dispatchEvent(new MouseEvent('pointerdown', { button: 0, clientX: 100, bubbles: true }));
+        handle.dispatchEvent(new MouseEvent('pointermove', { clientX: 160, bubbles: true }));
+        handle.dispatchEvent(new MouseEvent('pointerup', { clientX: 160, bubbles: true }));
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1220px');
+        fitButton.click();
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1400px');
+        expect(tabContent.dataset.conceptPageWidthUserSet).toBe('false');
+
+        cleanup();
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+    });
+
+    test('keeps a desktop width preference while disabling width changes on narrow viewports', () => {
+        const originalInnerWidth = window.innerWidth;
+        let availableWidth = 1400;
+        Object.defineProperty(window, 'innerWidth', { configurable: true, get: () => availableWidth });
+        const { createOrActivateConceptTab, initialiseConceptPageResizeUI } = require(dynamicTabsModulePath);
+        const tabId = createOrActivateConceptTab('#V#responsive', 'Responsive', false, { kind: 'type' });
+        const tabContent = document.getElementById(tabId);
+        document.querySelector('.tab-content-area').getBoundingClientRect = () => ({ width: availableWidth });
+        tabContent.innerHTML = `
+            <div class="concept-page-resize-controls">
+                <button type="button" data-concept-width-action="decrease">−</button>
+                <button type="button" data-concept-width-action="increase">+</button>
+                <button type="button" data-concept-width-action="fit">Fit</button>
+                <span class="concept-page-resize-handle" role="separator" tabindex="0"></span>
+            </div>
+        `;
+        const cleanup = initialiseConceptPageResizeUI(tabContent);
+        tabContent.querySelector('[data-concept-width-action="decrease"]').click();
+        expect(tabContent.dataset.conceptPageWidthPx).toBe('1280');
+
+        availableWidth = 390;
+        window.dispatchEvent(new Event('resize'));
+        expect(tabContent.dataset.conceptPageWidthPx).toBe('1280');
+        expect(tabContent.querySelector('[data-concept-width-action="decrease"]').disabled).toBe(true);
+        expect(tabContent.querySelector('.concept-page-resize-handle').tabIndex).toBe(-1);
+
+        availableWidth = 1400;
+        window.dispatchEvent(new Event('resize'));
+        expect(tabContent.dataset.conceptPageWidthPx).toBe('1280');
+        expect(tabContent.querySelector('[data-concept-width-action="decrease"]').disabled).toBe(false);
+
+        cleanup();
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+    });
+
+    test('cleans removed panel listeners and rebinds replacement controls after a failed load', () => {
+        const originalInnerWidth = window.innerWidth;
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1400 });
+        const {
+            createOrActivateConceptTab,
+            destroyConceptTabResizeUI,
+            initialiseConceptPageResizeUI
+        } = require(dynamicTabsModulePath);
+        const tabId = createOrActivateConceptTab('#V#retry_resize', 'Retry resize', false, { kind: 'type' });
+        const tabContent = document.getElementById(tabId);
+        document.querySelector('.tab-content-area').getBoundingClientRect = () => ({ width: 1400 });
+        const controlsMarkup = `
+            <div class="concept-page-resize-controls">
+                <button type="button" data-concept-width-action="decrease">−</button>
+                <button type="button" data-concept-width-action="increase">+</button>
+                <button type="button" data-concept-width-action="fit">Fit</button>
+                <span class="concept-page-resize-handle" role="separator" tabindex="0"></span>
+            </div>
+        `;
+        tabContent.innerHTML = `${controlsMarkup}<div class="von-resizable-viewport"></div>`;
+        const childDestroy = jest.fn();
+        tabContent.querySelector('.von-resizable-viewport').__vonResizableViewportController = {
+            destroy: childDestroy
+        };
+        initialiseConceptPageResizeUI(tabContent);
+
+        destroyConceptTabResizeUI(tabContent);
+        expect(childDestroy).toHaveBeenCalledTimes(1);
+        expect(tabContent.__vonConceptPageResizeCleanup).toBeUndefined();
+
+        tabContent.innerHTML = controlsMarkup;
+        const retryCleanup = initialiseConceptPageResizeUI(tabContent);
+        tabContent.querySelector('[data-concept-width-action="decrease"]').click();
+        expect(tabContent.style.getPropertyValue('--von-concept-page-width')).toBe('1280px');
+
+        retryCleanup();
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
     });
 
     test('marks and clears concept tab loading state accessibly', () => {
@@ -195,6 +318,96 @@ describe('relationship dropdown enter selection precedence', () => {
 
         const selected = chooseDropdownEnterSelection(items, -1, 'unknown');
         expect(selected).toEqual(items[0]);
+    });
+});
+
+describe('Relation Extent resize persistence', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <section id="relationshipsSection_resize_test" class="concept-list-subsection">
+                <div class="von-resizable-panel-header">
+                    <h3>Relation Extent</h3>
+                    <div class="von-resize-controls" role="group">
+                        <button type="button" data-resize-action="decrease">−</button>
+                        <button type="button" data-resize-action="increase">+</button>
+                        <button type="button" data-resize-action="reset">Reset</button>
+                    </div>
+                </div>
+                <div id="relationshipsContent_resize_test" class="relationship-extent-viewport"></div>
+            </section>
+        `;
+        global.ResizeObserver = undefined;
+        global.fetch = jest.fn(async (url) => {
+            const requestUrl = String(url);
+            if (requestUrl.startsWith('/vontology/api/vontology/relationships/extent?')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        rows: [{
+                            relation_id: 'rel-1',
+                            role: 'arg1',
+                            predicate_id: 'related_to',
+                            arg1_value: 'left literal',
+                            arg2_value: 'right literal',
+                            relation_state: 'asserted',
+                            is_asserted: true,
+                            source: 'structured',
+                            updated_at: '2026-08-20T10:00:00Z'
+                        }]
+                    })
+                };
+            }
+            if (requestUrl.startsWith('/api/concepts/')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ kind: 'predicate', display_name: 'Related to' })
+                };
+            }
+            return { ok: false, status: 404, json: async () => ({}) };
+        });
+    });
+
+    afterEach(() => {
+        document.querySelector('#relationshipsContent_resize_test')
+            ?.__vonResizableViewportController?.destroy?.();
+        global.ResizeObserver = undefined;
+        delete global.fetch;
+        jest.resetModules();
+    });
+
+    test('keeps the stable viewport height through sort and state-filter rerenders', async () => {
+        const { initializeRelationshipsUI } = require(dynamicTabsModulePath);
+        await initializeRelationshipsUI('#V#resize_test', 'resize_test', 'type');
+
+        const content = document.getElementById('relationshipsContent_resize_test');
+        const increaseButton = document.querySelector('[data-resize-action="increase"]');
+        expect(content.classList.contains('von-resizable-viewport-active')).toBe(true);
+        expect(content.style.height).toBe('440px');
+        increaseButton.click();
+        expect(content.style.height).toBe('520px');
+
+        const firstTableWrapper = content.querySelector('.predicate-extent-table-container');
+        const sortSelect = document.getElementById('relationshipSortBy_resize_test');
+        sortSelect.value = 'recency_asc';
+        sortSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const secondTableWrapper = content.querySelector('.predicate-extent-table-container');
+        expect(content.style.height).toBe('520px');
+        expect(firstTableWrapper.isConnected).toBe(false);
+        expect(secondTableWrapper).not.toBe(firstTableWrapper);
+
+        const filterSelect = document.getElementById('relationshipUncertaintyFilter_resize_test');
+        filterSelect.value = 'asserted_only';
+        filterSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(content.style.height).toBe('520px');
+        expect(secondTableWrapper.isConnected).toBe(false);
+        expect(content.querySelector('.predicate-extent-table-container')).not.toBe(secondTableWrapper);
     });
 });
 

--- a/tests/frontend/resizableViewport.test.js
+++ b/tests/frontend/resizableViewport.test.js
@@ -1,0 +1,298 @@
+/** @jest-environment jsdom */
+
+import {
+    clampResizableViewportHeightPx,
+    getResizableViewportHeightBounds,
+    initialiseResizableViewport
+} from '../../src/frontend/web/von_interface/static/js/utils/resizableViewport.js';
+
+function buildResizablePanel(id = 'panel') {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+        <div class="controls" role="group">
+            <button type="button" data-resize-action="decrease" aria-label="Show fewer rows">−</button>
+            <button type="button" data-resize-action="increase" aria-label="Show more rows">+</button>
+            <button type="button" data-resize-action="reset" aria-label="Reset height">Reset</button>
+        </div>
+        <div id="${id}"></div>
+    `;
+    document.body.appendChild(wrapper);
+    return {
+        controls: wrapper.querySelector('.controls'),
+        viewport: wrapper.querySelector(`#${id}`)
+    };
+}
+
+describe('shared resizable viewport', () => {
+    const originalInnerHeight = window.innerHeight;
+    const originalResizeObserver = global.ResizeObserver;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
+        global.ResizeObserver = undefined;
+    });
+
+    afterAll(() => {
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+        global.ResizeObserver = originalResizeObserver;
+    });
+
+    test('clamps requested height to panel and viewport bounds', () => {
+        const options = {
+            minHeightPx: 180,
+            defaultHeightPx: 440,
+            maxHeightPx: 800,
+            viewportHeightPx: 620,
+            viewportOffsetPx: 180
+        };
+
+        expect(getResizableViewportHeightBounds(options)).toEqual({
+            minHeightPx: 180,
+            maxHeightPx: 440
+        });
+        expect(clampResizableViewportHeightPx(120, options)).toBe(180);
+        expect(clampResizableViewportHeightPx(360, options)).toBe(360);
+        expect(clampResizableViewportHeightPx(900, options)).toBe(440);
+        expect(clampResizableViewportHeightPx('invalid', options)).toBe(440);
+    });
+
+    test('provides independent keyboard and touch-operable controls with reset', () => {
+        const first = buildResizablePanel('firstPanel');
+        const second = buildResizablePanel('secondPanel');
+        const firstController = initialiseResizableViewport(first.viewport, first.controls, {
+            defaultHeightPx: 440,
+            minHeightPx: 180,
+            maxHeightPx: 800,
+            stepPx: 80
+        });
+        const secondController = initialiseResizableViewport(second.viewport, second.controls, {
+            defaultHeightPx: 360,
+            minHeightPx: 180,
+            maxHeightPx: 800,
+            stepPx: 60
+        });
+
+        expect(first.viewport.style.height).toBe('440px');
+        expect(second.viewport.style.height).toBe('360px');
+        expect(first.controls.getAttribute('aria-controls')).toBe('firstPanel');
+        first.controls.querySelector('[data-resize-action="increase"]').click();
+        expect(first.viewport.style.height).toBe('520px');
+        expect(second.viewport.style.height).toBe('360px');
+
+        first.controls.querySelector('[data-resize-action="decrease"]').click();
+        expect(first.viewport.style.height).toBe('440px');
+        firstController.setHeight(650);
+        first.controls.querySelector('[data-resize-action="reset"]').click();
+        expect(first.viewport.style.height).toBe('440px');
+
+        firstController.destroy();
+        secondController.destroy();
+    });
+
+    test('is idempotent and preserves size when stable viewport children rerender', () => {
+        const { controls, viewport } = buildResizablePanel('stablePanel');
+        const controller = initialiseResizableViewport(viewport, controls, { defaultHeightPx: 440 });
+        const repeatedController = initialiseResizableViewport(viewport, controls, { defaultHeightPx: 300 });
+
+        expect(repeatedController).toBe(controller);
+        controller.setHeight(600);
+        const oldChild = document.createElement('table');
+        viewport.replaceChildren(oldChild);
+        const newChild = document.createElement('table');
+        viewport.replaceChildren(newChild);
+
+        expect(viewport.style.height).toBe('600px');
+        expect(oldChild.isConnected).toBe(false);
+        expect(newChild.isConnected).toBe(true);
+        controller.destroy();
+    });
+
+    test('ignores zero hidden-tab measurements and can disable without losing preference', () => {
+        const { controls, viewport } = buildResizablePanel('hiddenPanel');
+        viewport.getBoundingClientRect = () => ({ height: 0 });
+        Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 0 });
+        const controller = initialiseResizableViewport(viewport, controls, { defaultHeightPx: 440 });
+
+        controller.setHeight(600);
+        viewport.dispatchEvent(new Event('pointerup'));
+        expect(controller.getHeight()).toBe(600);
+
+        controller.setEnabled(false);
+        expect(viewport.style.height).toBe('');
+        expect(controls.getAttribute('aria-disabled')).toBe('true');
+        controller.setEnabled(true);
+        expect(viewport.style.height).toBe('600px');
+        controller.destroy();
+    });
+
+    test('retains a native fine-pointer drag measurement', () => {
+        const { controls, viewport } = buildResizablePanel('nativeResizePanel');
+        let measuredHeight = 440;
+        viewport.getBoundingClientRect = () => ({ height: measuredHeight });
+        const controller = initialiseResizableViewport(viewport, controls, { defaultHeightPx: 440 });
+
+        measuredHeight = 610;
+        viewport.style.height = '610px';
+        viewport.dispatchEvent(new Event('pointerup'));
+
+        expect(controller.getHeight()).toBe(610);
+        expect(viewport.dataset.vonResizeHeightPx).toBe('610');
+        controller.destroy();
+    });
+
+    test('bounds both-axis width changes and offers an accessible fit-width path', () => {
+        const { controls, viewport } = buildResizablePanel('bothAxisPanel');
+        controls.insertAdjacentHTML('beforeend', `
+            <button type="button" data-resize-action="decrease-width">Narrower</button>
+            <button type="button" data-resize-action="increase-width">Wider</button>
+            <button type="button" data-resize-action="reset-width">Fit</button>
+        `);
+        Object.defineProperty(viewport.parentElement, 'clientWidth', { configurable: true, value: 1000 });
+        let measuredWidth = 1000;
+        viewport.getBoundingClientRect = () => ({ height: 440, width: measuredWidth });
+        const controller = initialiseResizableViewport(viewport, controls, {
+            defaultHeightPx: 440,
+            minWidthPx: 320,
+            widthStepPx: 120,
+            resizeAxis: 'both'
+        });
+
+        expect(controller.getWidth()).toBeNull();
+        controls.querySelector('[data-resize-action="decrease-width"]').click();
+        expect(viewport.style.width).toBe('880px');
+        expect(viewport.dataset.vonResizeWidthPx).toBe('880');
+
+        measuredWidth = 880;
+        controls.querySelector('[data-resize-action="increase-width"]').click();
+        expect(viewport.style.width).toBe('1000px');
+        expect(controls.querySelector('[data-resize-action="increase-width"]').disabled).toBe(true);
+
+        controls.querySelector('[data-resize-action="reset-width"]').click();
+        expect(viewport.style.width).toBe('');
+        expect(viewport.dataset.vonResizeWidthPx).toBeUndefined();
+        expect(controls.querySelector('[data-resize-action="reset-width"]').disabled).toBe(true);
+
+        measuredWidth = 540;
+        viewport.style.width = '540px';
+        viewport.dispatchEvent(new Event('pointerup'));
+        expect(controller.getWidth()).toBe(540);
+        expect(viewport.dataset.vonResizeWidthPx).toBe('540');
+        controller.destroy();
+    });
+
+    test('retains a preferred width through a temporary responsive clamp', () => {
+        const { controls, viewport } = buildResizablePanel('responsiveWidthPanel');
+        controls.insertAdjacentHTML('beforeend', `
+            <button type="button" data-resize-action="decrease-width">Narrower</button>
+            <button type="button" data-resize-action="increase-width">Wider</button>
+            <button type="button" data-resize-action="reset-width">Fit</button>
+        `);
+        let availableWidth = 1000;
+        Object.defineProperty(viewport.parentElement, 'clientWidth', {
+            configurable: true,
+            get: () => availableWidth
+        });
+        viewport.getBoundingClientRect = () => ({
+            height: 440,
+            width: Math.min(
+                availableWidth,
+                Number.parseFloat(viewport.style.width || '') || availableWidth
+            )
+        });
+        const controller = initialiseResizableViewport(viewport, controls, {
+            minWidthPx: 320,
+            widthStepPx: 120,
+            resizeAxis: 'both'
+        });
+
+        controls.querySelector('[data-resize-action="decrease-width"]').click();
+        expect(viewport.style.width).toBe('880px');
+        expect(viewport.dataset.vonResizeWidthPx).toBe('880');
+
+        availableWidth = 500;
+        window.dispatchEvent(new Event('resize'));
+        expect(controller.getWidth()).toBe(500);
+        expect(viewport.style.width).toBe('880px');
+        expect(viewport.dataset.vonResizeWidthPx).toBe('880');
+
+        availableWidth = 1000;
+        window.dispatchEvent(new Event('resize'));
+        expect(controller.getWidth()).toBe(880);
+        expect(viewport.style.width).toBe('880px');
+        controller.destroy();
+    });
+
+    test('retains a preferred height through a temporary viewport clamp', () => {
+        const { controls, viewport } = buildResizablePanel('responsiveHeightPanel');
+        const controller = initialiseResizableViewport(viewport, controls, {
+            defaultHeightPx: 440,
+            minHeightPx: 180,
+            maxHeightPx: 800,
+            viewportOffsetPx: 180
+        });
+
+        controller.setHeight(680);
+        expect(viewport.style.height).toBe('680px');
+        expect(viewport.dataset.vonResizeHeightPx).toBe('680');
+
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 500 });
+        window.dispatchEvent(new Event('resize'));
+        expect(controller.getHeight()).toBe(320);
+        expect(viewport.style.height).toBe('320px');
+        expect(viewport.dataset.vonResizeHeightPx).toBe('680');
+        expect(controls.querySelector('[data-resize-action="reset"]').disabled).toBe(false);
+
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
+        window.dispatchEvent(new Event('resize'));
+        expect(controller.getHeight()).toBe(680);
+        expect(viewport.style.height).toBe('680px');
+
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 500 });
+        window.dispatchEvent(new Event('resize'));
+        controls.querySelector('[data-resize-action="reset"]').click();
+        expect(viewport.dataset.vonResizeHeightPx).toBe('440');
+        expect(controls.querySelector('[data-resize-action="reset"]').disabled).toBe(true);
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
+        window.dispatchEvent(new Event('resize'));
+        expect(controller.getHeight()).toBe(440);
+        expect(viewport.style.height).toBe('440px');
+        controller.destroy();
+    });
+
+    test('observes a native size drag even when pointerup is not delivered to the viewport', () => {
+        const { controls, viewport } = buildResizablePanel('observedWidthPanel');
+        controls.insertAdjacentHTML('beforeend', `
+            <button type="button" data-resize-action="decrease-width">Narrower</button>
+            <button type="button" data-resize-action="increase-width">Wider</button>
+            <button type="button" data-resize-action="reset-width">Fit</button>
+        `);
+        Object.defineProperty(viewport.parentElement, 'clientWidth', { configurable: true, value: 1000 });
+        let measuredHeight = 440;
+        let measuredWidth = 1000;
+        viewport.getBoundingClientRect = () => ({ height: measuredHeight, width: measuredWidth });
+        let observerCallback = null;
+        global.ResizeObserver = class {
+            constructor(callback) {
+                observerCallback = callback;
+            }
+            observe() {}
+            disconnect() {}
+        };
+        const controller = initialiseResizableViewport(viewport, controls, { resizeAxis: 'both' });
+
+        measuredHeight = 560;
+        measuredWidth = 620;
+        viewport.style.height = '560px';
+        viewport.style.width = '620px';
+        observerCallback();
+
+        expect(controller.getHeight()).toBe(560);
+        expect(viewport.dataset.vonResizeHeightPx).toBe('560');
+        expect(controller.getWidth()).toBe(620);
+        expect(viewport.dataset.vonResizeWidthPx).toBe('620');
+        expect(controls.querySelector('[data-resize-action="reset-width"]').disabled).toBe(false);
+        controller.destroy();
+        global.ResizeObserver = undefined;
+    });
+});

--- a/tests/frontend/tabContentSizing.test.js
+++ b/tests/frontend/tabContentSizing.test.js
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+
+const fs = require('fs');
+const path = require('path');
+
+const styles = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/styles.css'),
+    'utf8'
+);
+const conceptTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/concept_tab.html'),
+    'utf8'
+);
+const vontologyTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/vontology_tab.html'),
+    'utf8'
+);
+
+function cssRule(selector) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return styles.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`, 'm'))?.[1] || '';
+}
+
+function parseTemplate(markup) {
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    return template.content;
+}
+
+describe('full-width tab work surfaces', () => {
+    test('removes accidental outer caps while preserving opt-in concept sizing', () => {
+        const tabRule = cssRule('.tab-content');
+        const vontologyRule = cssRule('#vontologyTab');
+        const treeRule = cssRule('#vontologyTreeContainer');
+        const contentWrapperRule = cssRule('.content-wrapper');
+        const annotationRule = cssRule('#annotationTab > .content-wrapper.annotation-layout');
+        const conceptRule = cssRule('.tab-content.dynamic-concept-tab');
+
+        expect(tabRule).toContain('max-width: none');
+        expect(tabRule).not.toContain('max-width: 900px');
+        expect(tabRule).not.toContain('resize:');
+        expect(vontologyRule).toContain('max-width: none');
+        expect(vontologyRule).not.toContain('max-width: 800px');
+        expect(treeRule).toContain('max-width: 100%');
+        expect(contentWrapperRule).toContain('max-width: 800px');
+        expect(annotationRule).toContain('max-width: none');
+        expect(annotationRule).toContain('width: 100%');
+        expect(conceptRule).toContain('--von-concept-page-width');
+    });
+
+    test('retains specialised full-width and resize behaviour outside the shared panel contract', () => {
+        expect(styles).toContain('#chatTab.tab-content,\n#messagesTab.tab-content');
+        expect(cssRule('#chatTab>.content-wrapper')).toContain('max-width: 1600px');
+        expect(cssRule('#globalTasksTab.tab-content')).toContain('max-width: none');
+        expect(cssRule('.settings-iframe')).toContain('resize: vertical');
+        expect(styles).toContain('.thinking-card-wrapper.has-tools.is-expanded .thinking-card-body');
+        expect(styles).toContain('resize: vertical');
+    });
+
+    test('uses responsive padding and full width on narrow tabs', () => {
+        expect(styles).toMatch(/@media \(max-width: 760px\)[\s\S]*?\.tab-content-area\s*\{[\s\S]*?padding-left: 8px;/);
+        expect(styles).toContain('.tab-content.dynamic-concept-tab {\n        width: 100% !important;');
+        expect(styles).toMatch(/@media \(max-width: 1100px\)[\s\S]*?\.annotation-left,\s*\.annotation-right\s*\{[\s\S]*?min-width: 0;[\s\S]*?width: 100%;/);
+    });
+
+    test('contains legacy description actions inside the wider concept surface', () => {
+        const wrapperRule = cssRule('.dynamic-concept-tab .type-description-wrapper');
+        const actionsRule = cssRule('.dynamic-concept-tab .type-description-wrapper > .desc-actions');
+
+        expect(wrapperRule).toContain('padding-right: 172px');
+        expect(actionsRule).toContain('left: auto');
+        expect(actionsRule).toContain('right: 0');
+        expect(actionsRule).toContain('margin-left: 0');
+    });
+});
+
+describe('opt-in dense panel sizing contract', () => {
+    test('mounts accessible controls on stable Relation Extent and Vontology owners', () => {
+        const conceptFragment = parseTemplate(conceptTemplate);
+        const relationViewport = conceptFragment.querySelector('#relationshipsContent');
+        const relationComposer = conceptFragment.querySelector('#relationshipsAddForm');
+        const relationControls = conceptFragment.querySelector('#relationshipExtentResizeControls');
+        const pageControls = conceptFragment.querySelector('.concept-page-resize-controls');
+        const vontologyFragment = parseTemplate(vontologyTemplate);
+        const treeViewport = vontologyFragment.querySelector('#vontologyTreeContainer');
+        const treeControls = vontologyFragment.querySelector('#vontologyTreeResizeControls');
+
+        expect(relationViewport.classList.contains('von-resizable-viewport')).toBe(true);
+        expect(relationViewport.dataset.resizeAxis).toBe('vertical');
+        expect(relationViewport.contains(relationComposer)).toBe(false);
+        expect(relationViewport.nextElementSibling).toBe(relationComposer);
+        expect(relationControls.querySelectorAll('button')).toHaveLength(3);
+        expect(pageControls.querySelectorAll('button')).toHaveLength(3);
+        expect(pageControls.querySelector('[role="separator"]')).toBeTruthy();
+        expect(treeViewport.classList.contains('von-resizable-viewport')).toBe(true);
+        expect(treeViewport.dataset.resizeAxis).toBe('both');
+        expect(treeControls.querySelectorAll('button')).toHaveLength(6);
+        expect(treeControls.querySelector('[data-resize-action="decrease-width"]')).toBeTruthy();
+        expect(treeControls.querySelector('[data-resize-action="increase-width"]')).toBeTruthy();
+        expect(treeControls.querySelector('[data-resize-action="reset-width"]')).toBeTruthy();
+    });
+
+    test('keeps table scrolling on the stable viewport and its headings sticky', () => {
+        const innerTableWrapperRule = cssRule('.relationship-extent-viewport > .predicate-extent-table-container');
+        const stickyHeaderRule = cssRule('.relationship-extent-viewport .predicate-extent-table th');
+        const sharedViewportRule = cssRule('.von-resizable-viewport');
+
+        expect(sharedViewportRule).toContain('overflow: auto');
+        expect(innerTableWrapperRule).toContain('overflow: visible');
+        expect(stickyHeaderRule).toContain('position: sticky');
+        expect(stickyHeaderRule).toContain('top: 0');
+    });
+
+    test('restricts native resize handles to opted-in active panels', () => {
+        expect(styles).toContain('.von-resizable-viewport.von-resizable-viewport-active[data-resize-axis="vertical"]');
+        expect(styles).toContain('.von-resizable-viewport.von-resizable-viewport-active[data-resize-axis="both"]');
+        expect(styles).toContain('@media (pointer: coarse), (max-width: 760px)');
+        expect(cssRule('textarea')).toContain('resize: vertical');
+    });
+});


### PR DESCRIPTION
## Outcome

- Let desktop tab work surfaces use available application width while retaining deliberate readable inner measures.
- Add accessible width controls for dynamic concept pages.
- Add a reusable bounded resize controller for Relation Extent and the Vontology tree.
- Keep Relation Extent sizing across table rerenders, with sticky headers and contained scrolling.
- Preserve responsive containment for narrow concept and Annotation layouts.
- Restore the repository policy that finished Jira implementation proceeds through publication unless an explicit stopping boundary is set.

## Why

The generic tab shell imposed a 900 px cap even on dense work surfaces. Relation Extent then rendered a ten-column non-wrapping table inside a transient wrapper whose horizontal scrollbar could sit below a long result set. The stable relationships content owner is the correct resize and scroll boundary.

## Validation

- 6 focused Jest suites: 69 tests passed.
- JavaScript syntax checks passed for all changed modules.
- ESLint: 0 errors; 42 pre-existing warnings in legacy dynamicTabs and Vontology code.
- Diff checks passed.
- Live browser replay covered 2200 px desktop and 390 px mobile layouts, concept width controls, a real native Vontology drag, responsive clamp and restoration, Relation Extent height retention across tab switches and rerenders, sticky headers, reachable Actions, and zero body-level overflow.

## Known boundaries

- Coarse-pointer behaviour is covered by accessible buttons and scoped CSS but was not separately device-emulated.
- Cross-restart per-user persistence remains JVNAUTOSCI-1160.
- Repository publication does not imply runtime deployment or activation.

Jira: JVNAUTOSCI-2657