### PR TITLE
Stop concept embedding queue full scans

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -1727,6 +1727,11 @@ def _ensure_concepts_collection_indexes(concepts_coll: Collection) -> None:
         concepts_coll.create_index([("timestamps.created_at", DESCENDING)])
     if "timestamps.updated_at_-1" not in existing_indexes:
         concepts_coll.create_index([("timestamps.updated_at", DESCENDING)])
+    if "embedding_status_updated_at_desc" not in existing_indexes:
+        concepts_coll.create_index(
+            [("embedding_status", ASCENDING), ("updated_at", DESCENDING)],
+            name="embedding_status_updated_at_desc",
+        )
     if "updated_at_-1" not in existing_indexes:
         concepts_coll.create_index([("updated_at", DESCENDING)], name="updated_at_-1")
 

--- a/src/backend/db/repositories/concepts_repository.py
+++ b/src/backend/db/repositories/concepts_repository.py
@@ -62,6 +62,80 @@ RELATIONSHIP_KINDS: tuple[str, ...] = (
     "#V#has_author",
 )
 
+_EMBEDDING_STATUS_PENDING = "pending"
+_EMBEDDING_STATUS_STALE = "stale"
+_EMBEDDING_INPUT_FIELD_PREFIXES: tuple[str, ...] = (
+    "concept_id",
+    "guid",
+    "name",
+    "names",
+    "description",
+    "notes",
+    "relationships",
+    "system_tags",
+    "attributes.description",
+    "attributes.notes",
+    # Preserve the former updated_at > embedding_updated_at fallback without
+    # making every queue poll perform a collection scan.
+    "updated_at",
+)
+
+
+def _field_affects_concept_embedding(field_name: Any) -> bool:
+    if not isinstance(field_name, str) or not field_name:
+        return False
+    return any(
+        field_name == prefix or field_name.startswith(f"{prefix}.")
+        for prefix in _EMBEDDING_INPUT_FIELD_PREFIXES
+    )
+
+
+def _prepare_concept_embedding_status(update: Dict[str, Any]) -> Dict[str, Any]:
+    """Materialise embedding queue state for supported concept mutations.
+
+    The concept embedding worker must be able to select work through an index.
+    Semantic updates and updates that advance ``updated_at`` therefore mark the
+    concept stale at write time. Explicit embedding-status mutations remain
+    authoritative so the worker can publish ``indexed`` without immediately
+    turning its own write back into work.
+    """
+
+    if not update:
+        return update
+
+    modifier_update = any(str(key).startswith("$") for key in update)
+    if modifier_update:
+        modified_fields: set[str] = set()
+        for payload in update.values():
+            if isinstance(payload, Mapping):
+                modified_fields.update(
+                    field for field in payload if isinstance(field, str)
+                )
+
+        if any(
+            field == "embedding_status" or field.startswith("embedding_status.")
+            for field in modified_fields
+        ):
+            return update
+        if not any(
+            _field_affects_concept_embedding(field) for field in modified_fields
+        ):
+            return update
+
+        prepared = dict(update)
+        set_payload = dict(prepared.get("$set") or {})
+        set_payload["embedding_status"] = _EMBEDDING_STATUS_STALE
+        prepared["$set"] = set_payload
+        return prepared
+
+    if "embedding_status" in update:
+        return update
+    if not any(_field_affects_concept_embedding(field) for field in update):
+        return update
+    prepared = dict(update)
+    prepared["embedding_status"] = _EMBEDDING_STATUS_STALE
+    return prepared
+
 
 class _AccessControlledCursor:
     """Wrap a PyMongo cursor to sanitise concept documents on iteration."""
@@ -165,7 +239,9 @@ class ConceptsRepository:
         coll = ConceptsRepository.collection()
         if coll is None:
             raise RuntimeError("Concepts collection not available")
-        return coll.insert_one(document)
+        prepared = dict(document)
+        prepared.setdefault("embedding_status", _EMBEDDING_STATUS_PENDING)
+        return coll.insert_one(prepared)
 
     @staticmethod
     def update_one(
@@ -175,6 +251,7 @@ class ConceptsRepository:
         if coll is None:
             raise RuntimeError("Concepts collection not available")
         update = _sanitize_update_payload(update)
+        update = _prepare_concept_embedding_status(update)
         query = apply_concept_query_filter(filter or {})
         return coll.update_one(query, update, upsert=upsert)
 
@@ -184,6 +261,7 @@ class ConceptsRepository:
         if coll is None:
             raise RuntimeError("Concepts collection not available")
         update = _sanitize_update_payload(update)
+        update = _prepare_concept_embedding_status(update)
         query = apply_concept_query_filter(filter or {})
         return coll.update_many(query, update)
 
@@ -195,6 +273,7 @@ class ConceptsRepository:
         if coll is None:
             return None
         update = _sanitize_update_payload(update)
+        update = _prepare_concept_embedding_status(update)
         query = apply_concept_query_filter(filter or {})
         result = coll.find_one_and_update(
             query, update, return_document=return_document

--- a/src/backend/services/concept_embedding_service.py
+++ b/src/backend/services/concept_embedding_service.py
@@ -38,6 +38,12 @@ EMBEDDING_STATUS_INDEXED = "indexed"
 EMBEDDING_STATUS_STALE = "stale"
 EMBEDDING_STATUS_FAILED = "failed"
 
+EMBEDDING_QUEUE_STATUSES = (
+    EMBEDDING_STATUS_PENDING,
+    EMBEDDING_STATUS_STALE,
+    EMBEDDING_STATUS_FAILED,
+)
+
 # Namespace for concept embeddings
 CONCEPT_EMBEDDING_NAMESPACE = "concepts"
 
@@ -547,14 +553,28 @@ def mark_concept_embedding_stale(concept_id: str) -> bool:
         return False
 
 
+def _embedding_queue_query() -> Dict[str, Any]:
+    """Return the index-targetable materialised embedding queue predicate.
+
+    A non-sparse ``embedding_status`` index represents missing fields as null,
+    so including ``None`` keeps legacy never-indexed concepts eligible without
+    an unindexed ``$exists`` or field-to-field ``$expr`` branch.
+    """
+
+    return {
+        "embedding_status": {
+            "$in": [None, *EMBEDDING_QUEUE_STATUSES],
+        }
+    }
+
+
 def get_concepts_needing_indexing(
     batch_size: int = 50,
 ) -> List[Dict[str, Any]]:
     """Get concepts that need (re)indexing.
 
-    Returns concepts where:
-    - embedding_status is not "indexed", OR
-    - updated_at > embedding_updated_at
+    Returns concepts whose materialised embedding status is missing, pending,
+    stale, or failed.
 
     Args:
         batch_size: Maximum number of concepts to return
@@ -563,30 +583,8 @@ def get_concepts_needing_indexing(
         List of concept documents needing indexing
     """
     try:
-        # Query for concepts needing indexing
-        # This includes:
-        # 1. No embedding_status field (never indexed)
-        # 2. embedding_status = "pending" or "stale" or "failed"
-        # 3. updated_at > embedding_updated_at (changed since last index)
-
-        query = {
-            "$or": [
-                {"embedding_status": {"$exists": False}},
-                {
-                    "embedding_status": {
-                        "$in": [
-                            EMBEDDING_STATUS_PENDING,
-                            EMBEDDING_STATUS_STALE,
-                            EMBEDDING_STATUS_FAILED,
-                        ]
-                    }
-                },
-                {"$expr": {"$gt": ["$updated_at", "$embedding_updated_at"]}},
-            ]
-        }
-
         cursor = ConceptsRepository.find(
-            query,
+            _embedding_queue_query(),
             sort=[("updated_at", -1)],  # Most recently updated first
             limit=batch_size,
         )
@@ -605,23 +603,7 @@ def count_concepts_needing_indexing() -> int:
         Count of concepts needing indexing
     """
     try:
-        query = {
-            "$or": [
-                {"embedding_status": {"$exists": False}},
-                {
-                    "embedding_status": {
-                        "$in": [
-                            EMBEDDING_STATUS_PENDING,
-                            EMBEDDING_STATUS_STALE,
-                            EMBEDDING_STATUS_FAILED,
-                        ]
-                    }
-                },
-                {"$expr": {"$gt": ["$updated_at", "$embedding_updated_at"]}},
-            ]
-        }
-
-        return ConceptsRepository.count_documents(query)
+        return ConceptsRepository.count_documents(_embedding_queue_query())
 
     except Exception as e:
         logger.error(f"Error counting concepts needing indexing: {e}")

--- a/src/backend/utilities/concept_index_worker.py
+++ b/src/backend/utilities/concept_index_worker.py
@@ -4,7 +4,7 @@ Background worker that polls for concepts needing (re)indexing and updates
 the concept vector store in LlamaIndex.
 
 This worker:
-1. Polls for concepts where embedding_status != "indexed" or updated_at > embedding_updated_at
+1. Polls the indexed materialised embedding-status queue
 2. Builds aggregated searchable text for each concept (kind-specific)
 3. Generates embeddings via LlamaIndex RAG service
 4. Updates embedding_status and embedding_updated_at on success
@@ -128,18 +128,15 @@ def process_concept_batch(rag_service, iteration: int) -> int:
     concepts = get_concepts_needing_indexing(batch_size=BATCH_SIZE)
 
     if not concepts:
-        # Heartbeat log when idle
-        pending = count_concepts_needing_indexing()
-        logger.info(
-            f"[Iteration {iteration}] No pending concepts. " f"Queue depth: {pending}"
-        )
+        # The bounded queue read already proves the queue is empty. Repeating
+        # the same predicate as an exact count doubled idle Atlas work.
+        logger.info(f"[Iteration {iteration}] No pending concepts. Queue depth: 0")
         _flush()
         return 0
 
-    pending_total = count_concepts_needing_indexing()
     logger.info(
         f"[Iteration {iteration}] Processing {len(concepts)} concepts. "
-        f"Total queue depth: {pending_total}"
+        f"Queue depth: at least {len(concepts)}"
     )
 
     success_count = 0

--- a/tests/backend/test_concept_index_worker.py
+++ b/tests/backend/test_concept_index_worker.py
@@ -6,6 +6,8 @@ Tests the background worker that indexes concepts for semantic search.
 import logging
 from unittest.mock import patch, MagicMock
 
+import mongomock
+
 from src.backend.services.concept_embedding_service import (
     EMBEDDING_STATUS_INDEXED,
     EMBEDDING_STATUS_FAILED,
@@ -22,12 +24,10 @@ class TestConceptIndexWorkerProcessBatch:
         "src.backend.utilities.concept_index_worker.build_concept_embedding_metadata"
     )
     @patch("src.backend.utilities.concept_index_worker.build_concept_searchable_text")
-    @patch("src.backend.utilities.concept_index_worker.count_concepts_needing_indexing")
     @patch("src.backend.utilities.concept_index_worker.get_concepts_needing_indexing")
     def test_process_batch_indexes_pending_concepts(
         self,
         mock_get_concepts,
-        mock_count,
         mock_build_text,
         mock_build_metadata,
         mock_update_status,
@@ -38,7 +38,6 @@ class TestConceptIndexWorkerProcessBatch:
             {"concept_id": "#V#concept1", "relationships": {}},
             {"concept_id": "#V#concept2", "relationships": {}},
         ]
-        mock_count.return_value = 2
         mock_build_text.return_value = "searchable text content"
         mock_build_metadata.return_value = {
             "concept_id": "#V#concept1",
@@ -64,12 +63,10 @@ class TestConceptIndexWorkerProcessBatch:
         "src.backend.utilities.concept_index_worker.build_concept_embedding_metadata"
     )
     @patch("src.backend.utilities.concept_index_worker.build_concept_searchable_text")
-    @patch("src.backend.utilities.concept_index_worker.count_concepts_needing_indexing")
     @patch("src.backend.utilities.concept_index_worker.get_concepts_needing_indexing")
     def test_process_batch_handles_rag_failure(
         self,
         mock_get_concepts,
-        mock_count,
         mock_build_text,
         mock_build_metadata,
         mock_update_status,
@@ -78,7 +75,6 @@ class TestConceptIndexWorkerProcessBatch:
         mock_get_concepts.return_value = [
             {"concept_id": "#V#concept1", "relationships": {}},
         ]
-        mock_count.return_value = 1
         mock_build_text.return_value = "text"
         mock_build_metadata.return_value = {"concept_id": "#V#concept1"}
 
@@ -98,12 +94,10 @@ class TestConceptIndexWorkerProcessBatch:
 
     @patch("src.backend.utilities.concept_index_worker.update_concept_embedding_status")
     @patch("src.backend.utilities.concept_index_worker.build_concept_searchable_text")
-    @patch("src.backend.utilities.concept_index_worker.count_concepts_needing_indexing")
     @patch("src.backend.utilities.concept_index_worker.get_concepts_needing_indexing")
     def test_process_batch_handles_empty_searchable_text(
         self,
         mock_get_concepts,
-        mock_count,
         mock_build_text,
         mock_update_status,
     ):
@@ -111,7 +105,6 @@ class TestConceptIndexWorkerProcessBatch:
         mock_get_concepts.return_value = [
             {"concept_id": "#V#empty_concept", "relationships": {}},
         ]
-        mock_count.return_value = 1
         mock_build_text.return_value = ""  # Empty text
 
         mock_rag = MagicMock()
@@ -126,24 +119,27 @@ class TestConceptIndexWorkerProcessBatch:
             "#V#empty_concept", EMBEDDING_STATUS_INDEXED
         )
 
-    @patch("src.backend.utilities.concept_index_worker.count_concepts_needing_indexing")
     @patch("src.backend.utilities.concept_index_worker.get_concepts_needing_indexing")
     def test_process_batch_returns_zero_when_queue_empty(
         self,
         mock_get_concepts,
-        mock_count,
     ):
         """Worker should return 0 when no concepts need indexing."""
         mock_get_concepts.return_value = []
-        mock_count.return_value = 0
 
         mock_rag = MagicMock()
 
-        from src.backend.utilities.concept_index_worker import process_concept_batch
+        from src.backend.utilities import concept_index_worker
 
-        success_count = process_concept_batch(mock_rag, iteration=1)
+        with patch.object(
+            concept_index_worker, "count_concepts_needing_indexing"
+        ) as mock_count:
+            success_count = concept_index_worker.process_concept_batch(
+                mock_rag, iteration=1
+            )
 
         assert success_count == 0
+        mock_count.assert_not_called()
         mock_rag.upsert_documents.assert_not_called()
 
 
@@ -271,7 +267,17 @@ class TestConceptsNeedingIndexing:
         # Verify find was called with correct filter
         call_args = mock_repo.find.call_args
         query = call_args[0][0]
-        assert "$or" in query
+        assert query == {
+            "embedding_status": {
+                "$in": [
+                    None,
+                    EMBEDDING_STATUS_PENDING,
+                    EMBEDDING_STATUS_STALE,
+                    EMBEDDING_STATUS_FAILED,
+                ]
+            }
+        }
+        assert "$expr" not in str(query)
 
     @patch("src.backend.services.concept_embedding_service.ConceptsRepository")
     def test_get_concepts_respects_batch_size(self, mock_repo):
@@ -288,6 +294,58 @@ class TestConceptsNeedingIndexing:
 
         call_args = mock_repo.find.call_args
         assert call_args[1].get("limit") == 25
+
+    @patch("src.backend.services.concept_embedding_service.ConceptsRepository")
+    def test_count_uses_same_materialised_queue_predicate(self, mock_repo):
+        mock_repo.count_documents.return_value = 3
+
+        from src.backend.services.concept_embedding_service import (
+            count_concepts_needing_indexing,
+        )
+
+        assert count_concepts_needing_indexing() == 3
+        mock_repo.count_documents.assert_called_once_with(
+            {
+                "embedding_status": {
+                    "$in": [
+                        None,
+                        EMBEDDING_STATUS_PENDING,
+                        EMBEDDING_STATUS_STALE,
+                        EMBEDDING_STATUS_FAILED,
+                    ]
+                }
+            }
+        )
+
+    def test_materialised_queue_includes_legacy_missing_and_null_statuses(self):
+        from src.backend.services.concept_embedding_service import (
+            _embedding_queue_query,
+        )
+
+        collection = mongomock.MongoClient().db.concepts
+        collection.insert_many(
+            [
+                {"concept_id": "#V#missing"},
+                {"concept_id": "#V#null", "embedding_status": None},
+                {"concept_id": "#V#pending", "embedding_status": "pending"},
+                {"concept_id": "#V#stale", "embedding_status": "stale"},
+                {"concept_id": "#V#failed", "embedding_status": "failed"},
+                {"concept_id": "#V#indexed", "embedding_status": "indexed"},
+            ]
+        )
+
+        matched = {
+            document["concept_id"]
+            for document in collection.find(_embedding_queue_query())
+        }
+
+        assert matched == {
+            "#V#missing",
+            "#V#null",
+            "#V#pending",
+            "#V#stale",
+            "#V#failed",
+        }
 
 
 class TestBuildConceptDocumentId:

--- a/tests/backend/test_concepts_repository_embedding_queue.py
+++ b/tests/backend/test_concepts_repository_embedding_queue.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from src.backend.db.repositories import concepts_repository as repository_module
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+
+
+class _WriteResult:
+    modified_count = 1
+    matched_count = 1
+
+
+class _FakeConceptsCollection:
+    def __init__(self) -> None:
+        self.inserted: list[dict[str, Any]] = []
+        self.updated: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def insert_one(self, document: dict[str, Any]) -> _WriteResult:
+        self.inserted.append(document)
+        return _WriteResult()
+
+    def update_one(
+        self,
+        query: dict[str, Any],
+        update: dict[str, Any],
+        *,
+        upsert: bool = False,
+    ) -> _WriteResult:
+        self.updated.append(("one", query, update))
+        return _WriteResult()
+
+    def update_many(
+        self, query: dict[str, Any], update: dict[str, Any]
+    ) -> _WriteResult:
+        self.updated.append(("many", query, update))
+        return _WriteResult()
+
+    def find_one_and_update(
+        self,
+        query: dict[str, Any],
+        update: dict[str, Any],
+        *,
+        return_document: bool = False,
+    ) -> dict[str, Any]:
+        self.updated.append(("find_one", query, update))
+        return {"concept_id": "#V#example"}
+
+
+@pytest.fixture
+def fake_collection(monkeypatch: pytest.MonkeyPatch) -> _FakeConceptsCollection:
+    collection = _FakeConceptsCollection()
+    monkeypatch.setattr(ConceptsRepository, "collection", lambda: collection)
+    monkeypatch.setattr(
+        repository_module,
+        "apply_concept_query_filter",
+        lambda query: query,
+    )
+    monkeypatch.setattr(
+        repository_module,
+        "sanitize_concept_document",
+        lambda document: document,
+    )
+    return collection
+
+
+def test_insert_materialises_pending_embedding_status(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    source = {"concept_id": "#V#new_concept", "relationships": {}}
+
+    ConceptsRepository.insert_one(source)
+
+    assert source == {"concept_id": "#V#new_concept", "relationships": {}}
+    assert fake_collection.inserted == [
+        {
+            "concept_id": "#V#new_concept",
+            "relationships": {},
+            "embedding_status": "pending",
+        }
+    ]
+
+
+def test_insert_preserves_explicit_embedding_status(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    ConceptsRepository.insert_one(
+        {"concept_id": "#V#imported", "embedding_status": "indexed"}
+    )
+
+    assert fake_collection.inserted[0]["embedding_status"] == "indexed"
+
+
+@pytest.mark.parametrize("method_name", ["update_one", "update_many"])
+def test_timestamped_updates_materialise_stale_status(
+    fake_collection: _FakeConceptsCollection,
+    method_name: str,
+) -> None:
+    update = {"$set": {"updated_at": datetime(2026, 8, 20, tzinfo=UTC)}}
+
+    getattr(ConceptsRepository, method_name)({"concept_id": "#V#example"}, update)
+
+    assert fake_collection.updated[-1][2]["$set"]["embedding_status"] == "stale"
+
+
+def test_relationship_mutation_materialises_stale_status(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    ConceptsRepository.update_one(
+        {"concept_id": "#V#example"},
+        {"$addToSet": {"relationships.is_a_type_of": "#V#thing"}},
+    )
+
+    assert fake_collection.updated[-1][2] == {
+        "$addToSet": {"relationships.is_a_type_of": "#V#thing"},
+        "$set": {"embedding_status": "stale"},
+    }
+
+
+def test_operational_update_without_embedding_input_stays_out_of_queue(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    ConceptsRepository.update_one(
+        {"concept_id": "#V#message"},
+        {"$addToSet": {"concept_data.read_by": "#V#reader"}},
+    )
+
+    assert fake_collection.updated[-1][2] == {
+        "$addToSet": {"concept_data.read_by": "#V#reader"}
+    }
+
+
+def test_worker_embedding_status_write_is_not_overridden(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    indexed_at = datetime(2026, 8, 20, tzinfo=UTC)
+
+    ConceptsRepository.update_one(
+        {"concept_id": "#V#example"},
+        {
+            "$set": {
+                "embedding_status": "indexed",
+                "embedding_updated_at": indexed_at,
+            },
+            "$unset": {"embedding_error": ""},
+        },
+    )
+
+    assert fake_collection.updated[-1][2]["$set"] == {
+        "embedding_status": "indexed",
+        "embedding_updated_at": indexed_at,
+    }
+
+
+def test_find_one_and_update_materialises_stale_status(
+    fake_collection: _FakeConceptsCollection,
+) -> None:
+    ConceptsRepository.find_one_and_update(
+        {"concept_id": "#V#example"},
+        {"$unset": {"names": ""}},
+        return_document=True,
+    )
+
+    assert fake_collection.updated[-1][2] == {
+        "$unset": {"names": ""},
+        "$set": {"embedding_status": "stale"},
+    }

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -271,6 +271,7 @@ def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
         "relationships_has_initial_step_1",
         "relationships_v_evidence_view_applies_to_tool_1",
         "episode_critique_remediation_external_instance_lookup",
+        "embedding_status_updated_at_desc",
         "legacy_name_exact_1",
         "updated_at_-1",
     }.issubset(concept_index_names)
@@ -284,6 +285,13 @@ def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
     assert concept_indexes_by_name["legacy_name_exact_1"]["kwargs"] == {
         "name": "legacy_name_exact_1",
         "sparse": True,
+    }
+    assert concept_indexes_by_name["embedding_status_updated_at_desc"]["keys"] == [
+        ("embedding_status", mc.ASCENDING),
+        ("updated_at", mc.DESCENDING),
+    ]
+    assert concept_indexes_by_name["embedding_status_updated_at_desc"]["kwargs"] == {
+        "name": "embedding_status_updated_at_desc"
     }
 
 


### PR DESCRIPTION
Merge decision: ready — the embedding worker now uses an indexed explicit-status queue, preserves mutation-driven reindexing, and avoids the repeated full-collection count that caused wasted Atlas work.

## User outcome

Stop the idle concept-index worker from repeatedly scanning the full `concepts` collection and generating severe Atlas query-targeting alerts while still reindexing new or semantically changed concepts.

## Material changes

- Replace the queue's unindexable field-to-field `$expr` fallback with explicit embedding-status targeting.
- Add a compound `embedding_status, updated_at` index that supports queue filtering and newest-first batch selection.
- Maintain queue state at the repository boundary: new concepts default to `pending`, and supported semantic/timestamped updates become `stale` unless embedding state is being written explicitly.
- Remove the redundant full queue count from every worker poll.
- Add focused queue, mutation-invalidation, worker, and index-guard regressions.

## Evidence

- 228 targeted and neighbouring tests passed.
- Python compilation, Ruff fatal/error checks, and `git diff --check` passed.
- Incident evidence identified the old queue aggregate and find as the dominant sustained shapes: each examined about 69,794 concept documents while usually returning zero, and the worker ran both every ~31 seconds.
- Current data had an empty queue with all concepts explicitly marked indexed, supporting the explicit-status hot path.

## Ship boundary

- **Minimum ship criteria:** repository writes preserve explicit queue state; the worker performs one indexed queue read per idle poll; targeted tests and CI pass; post-deployment explain selects the new compound index without a collection scan.
- **Stop-ship conditions:** a supported semantic write can bypass stale marking; the new query cannot use the compound index; CI exposes an affected-path regression; or deployment leaves duplicate workers producing the old shape.
- **Non-blocking observations:** direct database writes outside repository contracts remain unsupported; a separately scheduled low-frequency integrity audit may be considered if evidence later shows missed invalidations.
- **Non-goals:** redesigning embedding generation, reindexing all existing concepts, changing Atlas alert thresholds, or optimising unrelated durable-workflow claim queries.
