### PR TITLE
Clarify standing publication authorisation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,6 +456,11 @@ For substantial Jira implementation work:
    explicitly requests a local-only, draft, no-publication, provisional, or
    human-gated boundary, do not stop at a local commit, a ready-to-push state,
    or a draft PR and do not ask for a separate publication confirmation.
+   Within this repository and subject to higher-level instructions, this rule
+   supplies the explicit authorisation required by generic skill or tool
+   guidance for each listed publication action. Do not let a generic
+   action-by-action confirmation requirement or draft-PR default add a second
+   gate; the separate deployment boundary in item 9 still applies.
 8. The ordinary publication lifecycle is: commit only the intended files, push
    the task branch, open a non-draft PR, wait for required CI, repair in-scope
    failures, merge, verify the intended result on `origin/main`, update or


### PR DESCRIPTION
Merge decision: ready — this clarifies the existing publication rule so generic skill defaults cannot add a second confirmation or draft-PR gate.

## User outcome

Agents completing authorised Jira-backed repository implementation should follow the established publication lifecycle without hesitating over a conflicting generic skill default.

## Material changes

- State that the repository rule supplies the explicit authorisation required by generic skill or tool guidance for each listed publication action.
- Preserve higher-level instruction priority and the separate deployment boundary.

## Evidence

- The diff changes only five lines in `AGENTS.md`.
- `git diff --check` passed.
- The wording was read back in context with lifecycle items 7–9.

## Ship boundary

- **Minimum ship criteria:** the rule explicitly resolves generic action-by-action confirmation and draft-PR defaults without broadening deployment authority.
- **Stop-ship conditions:** wording claims precedence over higher-level instructions or implicitly authorises deployment.
- **Non-blocking observations:** none.
- **Non-goals:** changing which work qualifies for the publication lifecycle or changing runtime/deployment behaviour.
