### PR TITLE
Give the nightly a workable ceiling and a named reader

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,9 +26,11 @@ jobs:
     name: Backend test drift
     runs-on: ubuntu-latest
     # A 2-core runner is far slower than a laptop: the same suite that takes
-    # 13m48s locally exceeded 35 minutes here. A nightly can afford the time,
-    # which is why this is one job rather than a shard matrix.
-    timeout-minutes: 90
+    # 13m48s locally exceeded 35 minutes here, and an unsharded run was
+    # cancelled at 90 minutes. A nightly can absorb the time, which is why this
+    # is one job rather than a shard matrix, but the ceiling has to be honest
+    # about what the suite actually costs.
+    timeout-minutes: 350
     permissions:
       contents: read
 
@@ -65,4 +67,28 @@ jobs:
             pytest pytest-mock pytest-cov pytest-asyncio mongomock blinker anyio
 
       - name: Report drift against the recorded backlog
-        run: python scripts/report_backend_test_drift.py
+        id: drift
+        run: |
+          set +e
+          python scripts/report_backend_test_drift.py | tee /tmp/drift.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify on new failures
+        if: steps.drift.outputs.status == '1'
+        env:
+          NIGHTLY_SMTP_USERNAME: ${{ secrets.NIGHTLY_SMTP_USERNAME }}
+          NIGHTLY_SMTP_APP_PASSWORD: ${{ secrets.NIGHTLY_SMTP_APP_PASSWORD }}
+        run: python scripts/notify_backend_test_drift.py new_failures /tmp/drift.txt
+
+      - name: Notify when the run itself broke
+        if: steps.drift.outputs.status == '2'
+        env:
+          NIGHTLY_SMTP_USERNAME: ${{ secrets.NIGHTLY_SMTP_USERNAME }}
+          NIGHTLY_SMTP_APP_PASSWORD: ${{ secrets.NIGHTLY_SMTP_APP_PASSWORD }}
+        run: python scripts/notify_backend_test_drift.py broken /tmp/drift.txt
+
+      - name: Fail the run when there is drift
+        if: steps.drift.outputs.status != '0'
+        run: |
+          echo "drift report exited ${{ steps.drift.outputs.status }}"
+          exit 1

--- a/scripts/notify_backend_test_drift.py
+++ b/scripts/notify_backend_test_drift.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Email the nightly backend test drift result.
+
+JVNAUTOSCI-2656. A report nobody reads is decorative, and GitHub's default for a
+scheduled workflow is to mail whoever last edited the cron expression, which is
+an accident of authorship rather than a decision. This sends the result to a
+named recipient instead.
+
+Sends only when there is something to act on: newly failing tests, or a run that
+broke before it could report. A nightly that mails on success trains its reader
+to ignore it.
+
+Credentials come from the environment and are never logged. If they are absent
+this exits quietly rather than failing the run, so the suite result is not lost
+behind a notification problem:
+
+    NIGHTLY_SMTP_USERNAME       account to authenticate as
+    NIGHTLY_SMTP_APP_PASSWORD   app password, not the account password
+    NIGHTLY_SMTP_HOST           default smtp.gmail.com
+    NIGHTLY_SMTP_PORT           default 587, STARTTLS
+    NIGHTLY_NOTIFY_TO           default zhanvonwitbrock@gmail.com
+    NIGHTLY_NOTIFY_CC           default witbrock@gmail.com
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+import sys
+from email.message import EmailMessage
+
+DEFAULT_RECIPIENT = "zhanvonwitbrock@gmail.com"
+# Copied while the notification path is new and its reliability unproven.
+DEFAULT_CC = "witbrock@gmail.com"
+DEFAULT_HOST = "smtp.gmail.com"
+DEFAULT_PORT = 587
+
+
+def build_message(status: str, body: str) -> EmailMessage:
+    sender = os.environ["NIGHTLY_SMTP_USERNAME"]
+    recipient = os.environ.get("NIGHTLY_NOTIFY_TO", DEFAULT_RECIPIENT)
+    cc = os.environ.get("NIGHTLY_NOTIFY_CC", DEFAULT_CC)
+
+    repo = os.environ.get("GITHUB_REPOSITORY", "Von")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    run_url = (
+        f"https://github.com/{repo}/actions/runs/{run_id}" if run_id else "(local run)"
+    )
+
+    subject = {
+        "new_failures": f"[{repo}] Nightly backend tests: new failures",
+        "broken": f"[{repo}] Nightly backend tests: the run itself failed",
+    }.get(status, f"[{repo}] Nightly backend tests: {status}")
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = sender
+    message["To"] = recipient
+    if cc and cc != recipient:
+        message["Cc"] = cc
+    message.set_content(
+        f"{body.strip()}\n\n"
+        f"Run: {run_url}\n\n"
+        "Newly failing tests should be fixed or reverted. Adding them to\n"
+        "ci/known_test_failures.txt is not a remedy: that list may only shrink.\n"
+    )
+    return message
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: notify_backend_test_drift.py <status> [body-file]")
+        return 2
+    status = sys.argv[1]
+    body = ""
+    if len(sys.argv) > 2 and os.path.exists(sys.argv[2]):
+        body = open(sys.argv[2], encoding="utf-8").read()
+
+    username = os.environ.get("NIGHTLY_SMTP_USERNAME")
+    password = os.environ.get("NIGHTLY_SMTP_APP_PASSWORD")
+    if not (username and password):
+        # Deliberately not an error. The suite result matters more than the
+        # notification, and a missing secret should not turn a green run red.
+        print(
+            "NIGHTLY_SMTP_USERNAME or NIGHTLY_SMTP_APP_PASSWORD is unset; "
+            "skipping the notification. Add both as repository secrets to "
+            "enable it."
+        )
+        return 0
+
+    host = os.environ.get("NIGHTLY_SMTP_HOST", DEFAULT_HOST)
+    port = int(os.environ.get("NIGHTLY_SMTP_PORT", DEFAULT_PORT))
+    message = build_message(status, body)
+
+    try:
+        with smtplib.SMTP(host, port, timeout=30) as smtp:
+            smtp.starttls(context=ssl.create_default_context())
+            smtp.login(username, password)
+            smtp.send_message(message)
+    except Exception as exc:
+        # Report the class of failure, never the credentials.
+        print(f"notification failed ({type(exc).__name__}): {exc}")
+        return 1
+
+    recipients = message["To"] + (f", cc {message['Cc']}" if message["Cc"] else "")
+    print(f"notified {recipients}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report_backend_test_drift.py
+++ b/scripts/report_backend_test_drift.py
@@ -26,6 +26,7 @@ is a small change if branch protection is introduced.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -58,6 +59,54 @@ def observed_failures(output: str) -> set[str]:
         if match:
             found.add(match.group(1))
     return found
+
+
+def _write_summary(
+    observed: set[str],
+    new_failures: list[str],
+    now_passing: list[str],
+    *,
+    full_run: bool,
+) -> None:
+    """Render the result into the GitHub run page.
+
+    A report nobody reads is decorative. This makes the outcome visible on the
+    run itself rather than only in scrolled-past log output.
+    """
+    target = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not target:
+        return
+
+    lines = ["# Backend test drift", ""]
+    if new_failures:
+        lines.append(f"**{len(new_failures)} newly failing.** These are the signal.")
+        lines.append("")
+        lines += [f"- `{entry}`" for entry in new_failures[:50]]
+        if len(new_failures) > 50:
+            lines.append(f"- ... and {len(new_failures) - 50} more")
+        lines.append("")
+        lines.append(
+            "Fix or revert them. Adding them to `ci/known_test_failures.txt` is "
+            "not a remedy: that list may only shrink."
+        )
+    else:
+        lines.append("No newly failing tests.")
+    lines.append("")
+    lines.append(f"Observed failures: {len(observed)}")
+    if full_run and now_passing:
+        lines.append("")
+        lines.append(
+            f"**{len(now_passing)} recorded entries now pass** and should be "
+            "removed from `ci/known_test_failures.txt`, lowering `BASELINE_COUNT`."
+        )
+        lines += [f"- `{entry}`" for entry in now_passing[:50]]
+        if len(now_passing) > 50:
+            lines.append(f"- ... and {len(now_passing) - 50} more")
+
+    try:
+        Path(target).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except OSError:
+        pass
 
 
 def main() -> int:
@@ -136,7 +185,10 @@ def main() -> int:
             "\nFix or revert them. Adding them to the backlog is not a remedy: "
             "that list may only shrink."
         )
+        _write_summary(observed, new_failures, now_passing, full_run=paths == [TEST_PATH])
         return 1
+
+    _write_summary(observed, new_failures, now_passing, full_run=paths == [TEST_PATH])
 
     print("\nno new failures")
     return 0


### PR DESCRIPTION
Two defects in the job merged an hour ago, both confirmed against real runs rather than predicted.

## The suite doesn't fit 90 minutes

The manual run started 13:42:04 and was **cancelled at 15:12:36**. The first scheduled run was cancelled the same way. So the nightly as merged never completed once.

That's my error. I dropped sharding when moving to nightly on the reasoning that "a nightly can afford the time" — without checking what the time was. The evidence was already in hand: a four-way shard took 20m58s, implying well over an hour serial. Ceiling raised to 350 minutes, inside the 6-hour job limit.

## Nobody was the reader

GitHub mails a scheduled workflow's failures to whoever last edited the cron — an accident of authorship, not a decision. A report with no recipient goes unread, which would make this decorative in the same way the gate was.

Now: results render into the **run page summary**, and new failures or a broken run are **emailed to `zhanvonwitbrock@gmail.com`, cc `witbrock@gmail.com`** while the path is new.

Design points:

- **`smtplib`, not a third-party action** — no new supply chain in CI.
- **Nothing on success.** A nightly that mails when all is well trains its reader to ignore it.
- **Missing secrets skip the notification** with an explanatory line rather than failing. A notification problem must not turn a green suite red.
- **Credentials never logged** — only the exception class is reported on failure.
- The two exit codes are distinguished: `1` new failures, `2` the run itself broke. Different subject lines, because they need different responses.

## Action required

Mail won't send until these are added as repository secrets:

- `NIGHTLY_SMTP_USERNAME`
- `NIGHTLY_SMTP_APP_PASSWORD` — a Gmail **app password**, not the account password

Until then the run logs a line saying so and carries on. `NIGHTLY_NOTIFY_TO` and `NIGHTLY_NOTIFY_CC` can override the recipients without a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)