### PR TITLE
Let the nightly notification path be tested on demand

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -20,6 +20,11 @@ on:
     # introduced during the working day is reported before the next one.
     - cron: "0 15 * * *"
   workflow_dispatch:
+    inputs:
+      test_notification:
+        description: "Send a test email and skip the suite, to prove the path works"
+        type: boolean
+        default: false
 
 jobs:
   drift-report:
@@ -66,7 +71,19 @@ jobs:
           pip install --group dev || pip install \
             pytest pytest-mock pytest-cov pytest-asyncio mongomock blinker anyio
 
+      # Without this the notification path is only exercised the night something
+      # actually breaks, which is when you least want to discover a bad secret.
+      - name: Send a test notification
+        if: inputs.test_notification
+        env:
+          NIGHTLY_SMTP_USERNAME: ${{ secrets.NIGHTLY_SMTP_USERNAME }}
+          NIGHTLY_SMTP_APP_PASSWORD: ${{ secrets.NIGHTLY_SMTP_APP_PASSWORD }}
+        run: |
+          echo "Test notification requested; the suite is not run." > /tmp/drift.txt
+          python scripts/notify_backend_test_drift.py test /tmp/drift.txt
+
       - name: Report drift against the recorded backlog
+        if: ${{ !inputs.test_notification }}
         id: drift
         run: |
           set +e

--- a/scripts/notify_backend_test_drift.py
+++ b/scripts/notify_backend_test_drift.py
@@ -7,7 +7,8 @@ an accident of authorship rather than a decision. This sends the result to a
 named recipient instead.
 
 Sends only when there is something to act on: newly failing tests, or a run that
-broke before it could report. A nightly that mails on success trains its reader
+broke before it could report. The "test" status is the exception, triggered
+deliberately to prove the path works before it is needed. A nightly that mails on success trains its reader
 to ignore it.
 
 Credentials come from the environment and are never logged. If they are absent
@@ -51,6 +52,7 @@ def build_message(status: str, body: str) -> EmailMessage:
     subject = {
         "new_failures": f"[{repo}] Nightly backend tests: new failures",
         "broken": f"[{repo}] Nightly backend tests: the run itself failed",
+        "test": f"[{repo}] Nightly backend tests: notification path test",
     }.get(status, f"[{repo}] Nightly backend tests: {status}")
 
     message = EmailMessage()


### PR DESCRIPTION
The notifier deliberately sends nothing on success, so until now the only way to learn whether the SMTP credentials work was for the suite to actually break — the worst possible moment to discover a malformed secret.

A `workflow_dispatch` input sends a test message and skips the suite entirely, so the path can be proved in seconds whenever the secrets change. Same pattern as testing a smoke alarm rather than waiting for a fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)