### PR TITLE
Store standalone text assertions before semantic analysis

### DIFF
--- a/docs/engineering/contextual_knowledge_evolution.md
+++ b/docs/engineering/contextual_knowledge_evolution.md
@@ -201,8 +201,10 @@ As observed on 20 August 2026, related capabilities are distributed across:
   metadata plus the route to that carrier-bearing read;
 - base concept and text relations in `concept_service.py`,
   `concept_relation_service.py`, and `text_value_service.py`;
-- actor- and organisation-visible assertion deltas in
-  `scoped_assertion_service.py`;
+- actor- and organisation-visible relation assertions and standalone exact-text
+  assertion occurrences in `scoped_assertion_service.py`, with optional
+  qualified concept links, a distinct assertion-context envelope, lifecycle,
+  and durable revision-aware RAG maintenance;
 - local assertions, lifecycle, diff, promotion, rollback, and stored inclusion
   identifiers in `testing_theory_service.py`;
 - evidence, hypotheses, branches, and theory references in
@@ -217,11 +219,20 @@ Material current limitations include:
 
 - base text relations require one subject concept and predicate, while their
   shared text values are deduplicated separately from assertion occurrence;
-- neither base nor scoped text assertions carry queryable links to an open set
-  of other concepts mentioned or involved in the assertion;
+- base text relations do not carry queryable links to an open set of other
+  concepts mentioned or involved in their text;
+- standalone text assertions can carry explicit qualified concept links, but
+  automatic analysis and complete linking are deliberately not admission or
+  retrieval requirements;
 - secondary-argument retrieval for base text currently recognises a concept
   only when its literal `#V#` identifier occurs in the text;
-- the scoped-assertion audience currently doubles as an implicit context;
+- the first standalone-assertion slice selects a distinct implicit intake
+  context from the audience when no context is supplied; this is not yet a
+  general microtheory selection or inheritance mechanism;
+- semantic RAG maintenance currently targets the writer's physical namespace:
+  canonical organisation-visible reads work across members, but organisation-
+  wide cross-member vector fan-out and user-scope portability between physical
+  organisation namespaces are not yet provided;
 - Testing Theory inclusion identifiers do not yet constitute a general
   inherited query model;
 - storage-specific metadata is exposed by compatibility adapters; and

--- a/docs/engineering/contextual_knowledge_evolution.md
+++ b/docs/engineering/contextual_knowledge_evolution.md
@@ -8,13 +8,13 @@
   hypotheses, knowledge publication or promotion, and actor-, organisation-,
   project-, source-, theory-, or time-relative knowledge
 - **Owner:** Von maintainers
-- **Last reviewed:** 29 July 2026
+- **Last reviewed:** 20 August 2026
 - **Review trigger:** Adoption of a first-class context/theory model, material
   multi-tenant scale evidence, material changes to the named implementation
   surfaces, or a change to assertion, namespace, inclusion, or publication
   semantics
 - **Live implementation evidence:** Revalidate the services named in section 4;
-  the map is a 29 July 2026 observation, not a permanent architecture contract
+  the map is a 20 August 2026 observation, not a permanent architecture contract
 
 ## 1. When to use this guide
 
@@ -124,6 +124,45 @@ may read the current situation and revise it in the same model call. Add
 sub-situation identity, promotion, inheritance, conflict resolution, or
 cross-session reuse only when actual work needs those semantics.
 
+### 2.2 Admit text assertions before semantic analysis
+
+Von may know an exact natural-language assertion before it knows which
+concepts, predicates, events, roles, or formal proposition express its meaning.
+That assertion must still be storable, retrievable through text and semantic
+search, and usable as provenance-bearing evidence. Concept resolution,
+aboutness analysis, complete entity linking, logical parsing, truth assessment,
+and alignment with an existing grounded relation are optional enrichment, not
+admission criteria.
+
+The minimum durable write is the exact language-tagged text plus an assertion
+identity, trusted provenance and visibility, lifecycle state, and either an
+explicit context or a documented implicit intake context. Choosing the default
+context is an authority and publication decision; it must not require analysis
+of what the sentence means. If indexing or enrichment is unavailable, preserve
+the assertion and expose retryable indexing or enrichment state rather than
+failing or discarding the write.
+
+Keep these identities distinct when they matter:
+
+- a text value or formulation, which may be shared or deduplicated;
+- an assertion occurrence, whose source, context, status, and lifecycle must
+  not be collapsed merely because another assertion has identical text; and
+- an optional claim-equivalence identity linking textual formulations and a
+  grounded binary or richer representation when that equivalence has actually
+  been established.
+
+Enrichment may add zero or more concept links such as `about`, `mentions`, or
+`involves`, with spans, method, provenance, and confidence where useful. It may
+also add a candidate grounded relation, event frame, translation, or
+paraphrase. Preserve the original text and qualify derived interpretations;
+neither a model extraction nor a concept match silently becomes the asserted
+meaning or a published ground predicate.
+
+RAG indexing must be able to start from the raw assertion body and authorised
+retrieval metadata alone. A semantic or exact-text query may therefore return
+an assertion with no concept links. Concept-relative queries use explicit links
+when they exist; an empty link set means only that no link is currently known.
+
 ## 3. Four questions for a coding agent
 
 For a triggered change, ask only:
@@ -150,7 +189,7 @@ claim.
 
 ## 4. Current starting points — verify live
 
-As observed on 29 July 2026, related capabilities are distributed across:
+As observed on 20 August 2026, related capabilities are distributed across:
 
 - inspectable conversation-situation text and bounded exact observations on
   chat-history sessions, used as provisional per-conversation context rather
@@ -176,6 +215,12 @@ one of them.
 
 Material current limitations include:
 
+- base text relations require one subject concept and predicate, while their
+  shared text values are deduplicated separately from assertion occurrence;
+- neither base nor scoped text assertions carry queryable links to an open set
+  of other concepts mentioned or involved in the assertion;
+- secondary-argument retrieval for base text currently recognises a concept
+  only when its literal `#V#` identifier occurs in the text;
 - the scoped-assertion audience currently doubles as an implicit context;
 - Testing Theory inclusion identifiers do not yet constitute a general
   inherited query model;

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -1905,6 +1905,32 @@ def _ensure_scoped_knowledge_assertions_indexes(coll: Collection) -> None:
         ],
         name="predicate_audience_status_id",
     )
+    # concept_links and scope.audience_keys are both arrays, so a compound
+    # index across them would be an invalid parallel-array index. New writes
+    # also materialise the one-valued scope.audience_key for this lookup.
+    coll.create_index(
+        [
+            ("concept_links.concept_id", ASCENDING),
+            ("scope.audience_key", ASCENDING),
+            ("status", ASCENDING),
+            ("updated_at", DESCENDING),
+            ("assertion_id", ASCENDING),
+        ],
+        name="concept_link_audience_status_updated_at_desc_assertion_id",
+    )
+    coll.create_index(
+        [
+            ("assertion_form", ASCENDING),
+            ("object_kind", ASCENDING),
+            ("status", ASCENDING),
+            ("rag_index.desired_operation", ASCENDING),
+            ("rag_index.status", ASCENDING),
+            ("rag_index.next_attempt_at", ASCENDING),
+            ("rag_index.lease_expires_at", ASCENDING),
+            ("updated_at", ASCENDING),
+        ],
+        name="standalone_rag_queue_status_due_lease_updated_at",
+    )
 
 
 def _ensure_meta_relations_indexes(coll: Collection) -> None:

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2872,6 +2872,195 @@ def _upsert_scoped_assertion(**kwargs):
         )
 
 
+def _store_text_assertion(**kwargs):
+    from ...services.scoped_assertion_service import (
+        add_text_assertion_concept_links,
+        store_text_assertion,
+    )
+
+    text = kwargs.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing non-empty 'text' parameter",
+            details={"missing": ["text"]},
+        )
+    actor_scope, denial = _resolve_internal_mcp_scoped_assertion_actor_scope(
+        kwargs,
+        surface="text assertion mutation",
+        require_actor=True,
+    )
+    if denial is not None:
+        return denial
+    if actor_scope.user_concept_id is None:
+        return make_error_response(
+            "authenticated_actor_context_required",
+            "Text assertion mutation requires an authenticated user actor.",
+        )
+
+    mutation_dispatched = False
+    try:
+        with _bind_internal_mcp_scoped_assertion_actor(actor_scope):
+            mutation_dispatched = True
+            result = store_text_assertion(
+                text=text,
+                language=kwargs.get("language") or "en-NZ",
+                scope_mode=kwargs.get("scope_mode") or "user",
+                context_id=kwargs.get("context_id"),
+                source_event_id=(
+                    kwargs.get("source_event_id")
+                    or kwargs.get("source_occurrence_key")
+                ),
+                evidence=kwargs.get("evidence"),
+                acting_user_concept_id=actor_scope.user_concept_id,
+                organisation_concept_id=actor_scope.organisation_concept_id,
+                namespace=actor_scope.namespace,
+                turn_id=kwargs.get("turn_id"),
+                canonical_publication=False,
+            )
+    except PermissionError as exc:
+        return make_error_response("access_denied", str(exc))
+    except ValueError as exc:
+        return make_error_response("invalid_text_assertion", str(exc))
+    except Exception as exc:
+        if not mutation_dispatched:
+            return make_error_response(
+                "exception",
+                f"Failed to prepare text assertion: {exc}",
+                details={"exception_type": type(exc).__name__},
+            )
+        return _indeterminate_effect_error(
+            "The text-assertion operation raised unexpectedly; canonical state "
+            "may already have changed.",
+            details={
+                "exception_type": type(exc).__name__,
+                "exception": str(exc),
+            },
+        )
+
+    concept_links = kwargs.get("concept_links")
+    if concept_links is None or concept_links == []:
+        return result
+    # Enrichment is deliberately after canonical admission. Bad, incomplete,
+    # or currently unresolvable links never discard the stored assertion.
+    try:
+        with _bind_internal_mcp_scoped_assertion_actor(actor_scope):
+            link_result = add_text_assertion_concept_links(
+                assertion_id=result["assertion_id"],
+                links=concept_links,
+                acting_user_concept_id=actor_scope.user_concept_id,
+                organisation_concept_id=actor_scope.organisation_concept_id,
+                namespace=actor_scope.namespace,
+                turn_id=kwargs.get("turn_id"),
+            )
+        result = {
+            **result,
+            "assertion": link_result.get("assertion") or result.get("assertion"),
+            "canonical_read_back": (
+                link_result.get("canonical_read_back")
+                or result.get("canonical_read_back")
+            ),
+            "derived_maintenance": (
+                link_result.get("derived_maintenance")
+                or result.get("derived_maintenance")
+            ),
+            "enrichment": {
+                "success": True,
+                "changed": bool(link_result.get("changed")),
+                "links_added": int(link_result.get("links_added") or 0),
+            },
+        }
+    except Exception as exc:
+        logger.warning(
+            "Text assertion persisted but optional concept linking failed: %s",
+            exc,
+        )
+        result = {
+            **result,
+            "enrichment": {
+                "success": False,
+                "changed": False,
+                "links_added": 0,
+                "retryable": True,
+                "error_code": (
+                    "access_denied"
+                    if isinstance(exc, PermissionError)
+                    else "invalid_concept_links"
+                    if isinstance(exc, ValueError)
+                    else "concept_linking_failed"
+                ),
+                "error": str(exc),
+            },
+        }
+    return result
+
+
+def _add_text_assertion_concept_links(**kwargs):
+    from ...services.scoped_assertion_service import (
+        add_text_assertion_concept_links,
+    )
+
+    assertion_id = kwargs.get("assertion_id")
+    links = kwargs.get("links")
+    if not isinstance(assertion_id, str) or not assertion_id.strip():
+        return make_error_response(
+            "missing_parameter",
+            "Missing non-empty 'assertion_id' parameter",
+            details={"missing": ["assertion_id"]},
+        )
+    if not isinstance(links, list) or not links:
+        return make_error_response(
+            "missing_parameter",
+            "Missing non-empty 'links' array",
+            details={"missing": ["links"]},
+        )
+    actor_scope, denial = _resolve_internal_mcp_scoped_assertion_actor_scope(
+        kwargs,
+        surface="text assertion concept-link enrichment",
+        require_actor=True,
+    )
+    if denial is not None:
+        return denial
+    if actor_scope.user_concept_id is None:
+        return make_error_response(
+            "authenticated_actor_context_required",
+            "Text assertion enrichment requires an authenticated user actor.",
+        )
+
+    mutation_dispatched = False
+    try:
+        with _bind_internal_mcp_scoped_assertion_actor(actor_scope):
+            mutation_dispatched = True
+            return add_text_assertion_concept_links(
+                assertion_id=assertion_id,
+                links=links,
+                acting_user_concept_id=actor_scope.user_concept_id,
+                organisation_concept_id=actor_scope.organisation_concept_id,
+                namespace=actor_scope.namespace,
+                turn_id=kwargs.get("turn_id"),
+            )
+    except PermissionError as exc:
+        return make_error_response("access_denied", str(exc))
+    except ValueError as exc:
+        return make_error_response("invalid_concept_links", str(exc))
+    except Exception as exc:
+        if not mutation_dispatched:
+            return make_error_response(
+                "exception",
+                f"Failed to prepare text assertion enrichment: {exc}",
+                details={"exception_type": type(exc).__name__},
+            )
+        return _indeterminate_effect_error(
+            "The text-assertion enrichment operation raised unexpectedly; "
+            "canonical link state may already have changed.",
+            details={
+                "exception_type": type(exc).__name__,
+                "exception": str(exc),
+                "assertion_id": assertion_id,
+            },
+        )
+
+
 def _retract_scoped_assertion(**kwargs):
     from ...services.rag_text_relation_change_hook_service import (
         maybe_sync_concept_text_relations_to_rag,
@@ -2990,6 +3179,8 @@ def _list_scoped_assertions(**kwargs):
             predicates=predicates,
             object_kind=kwargs.get("object_kind"),
             languages=kwargs.get("languages"),
+            assertion_form=kwargs.get("assertion_form"),
+            context_id=kwargs.get("context_id"),
             limit=kwargs.get("limit") or 200,
             offset=kwargs.get("offset") or 0,
             user_concept_id=actor_scope.user_concept_id,
@@ -9915,6 +10106,89 @@ def _upsert_scoped_assertion_input_schema() -> Schema:
     )
 
 
+def _store_text_assertion_input_schema() -> Schema:
+    return Schema(
+        required={"text": str},
+        optional={
+            "language": (str, type(None)),
+            "scope_mode": (str, type(None)),
+            "context_id": (str, type(None)),
+            "source_event_id": (str, type(None)),
+            "source_occurrence_key": (str, type(None)),
+            "evidence": (dict, type(None)),
+            "concept_links": (list, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "store_text_assertion input: exact text plus optional language, "
+            "user/organisation scope, opaque context_id, source occurrence key, "
+            "evidence, and optional qualified concept_links. No subject, predicate, "
+            "concept link, or semantic analysis is required. Actor, organisation, "
+            "namespace, turn, and non-publication are server-bound."
+        ),
+    )
+
+
+def _store_text_assertion_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "effect_status": (str, type(None)),
+            "changed": (bool, type(None)),
+            "assertion_id": (str, type(None)),
+            "assertion": (dict, type(None)),
+            "canonical_read_back": (dict, type(None)),
+            "canonical_publication": (bool, type(None)),
+            "storage_surface": (str, type(None)),
+            "derived_maintenance": (dict, type(None)),
+            "enrichment": (dict, type(None)),
+            "error": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "Standalone text-assertion write receipt. Canonical admission succeeds "
+            "before optional concept-link enrichment and RAG indexing; their status "
+            "is reported separately and never replaces the durable read-back."
+        ),
+    )
+
+
+def _add_text_assertion_concept_links_input_schema() -> Schema:
+    return Schema(
+        required={"assertion_id": str, "links": list},
+        optional={},
+        allow_unknown=True,
+        description=(
+            "Add optional qualified concept links to an existing standalone text "
+            "assertion. Actor, organisation, namespace, and turn are server-bound. "
+            "This enrichment never changes the exact assertion text."
+        ),
+    )
+
+
+def _add_text_assertion_concept_links_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "effect_status": (str, type(None)),
+            "changed": (bool, type(None)),
+            "assertion_id": (str, type(None)),
+            "links_added": (int, type(None)),
+            "assertion": (dict, type(None)),
+            "canonical_read_back": (dict, type(None)),
+            "canonical_publication": (bool, type(None)),
+            "storage_surface": (str, type(None)),
+            "derived_maintenance": (dict, type(None)),
+            "error": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "Canonical read-back for optional text-assertion concept-link "
+            "enrichment and its independently retryable RAG maintenance state."
+        ),
+    )
+
+
 def _upsert_scoped_assertion_output_schema() -> Schema:
     return Schema(
         required={
@@ -9984,6 +10258,8 @@ def _list_scoped_assertions_input_schema() -> Schema:
             "predicates": (list, type(None)),
             "object_kind": (str, type(None)),
             "languages": (list, type(None)),
+            "assertion_form": (str, type(None)),
+            "context_id": (str, type(None)),
             "limit": (int, type(None)),
             "offset": (int, type(None)),
         },
@@ -9991,7 +10267,7 @@ def _list_scoped_assertions_input_schema() -> Schema:
         description=(
             "List assertions visible in the trusted user/organisation scope, "
             "bounded by limit/offset and optionally filtered by subject, argument, "
-            "predicate, object kind, or text language."
+            "predicate, object kind, text language, assertion form, or context."
         ),
     )
 
@@ -25894,7 +26170,7 @@ def _rag_list_indexed(**kwargs):
                         "item_kind": "vontology_text_relation",
                         "source_system": (
                             "mongo.scoped_knowledge_assertions"
-                            if row_kind == "scoped_assertion"
+                            if row_kind in {"scoped_assertion", "text_assertion"}
                             else "mongo.text_relations"
                         ),
                         "namespace_source": ns_report.get("namespace_source"),
@@ -26527,17 +26803,21 @@ def _rag_get_item(**kwargs):
             "session_id": session_id,
             "index_item_id": doc.doc_id,
             "row_kind": (doc.metadata.get("row_kind") or "base_text_relation"),
+            "assertion_form": doc.metadata.get("assertion_form"),
             "relation_id": doc.metadata.get("relation_id"),
             "assertion_id": doc.metadata.get("assertion_id"),
+            "assertion_revision": doc.metadata.get("assertion_revision"),
             "subject_concept_id": doc.metadata.get("subject_concept_id"),
             "predicate": doc.metadata.get("predicate"),
             "lang": doc.metadata.get("lang"),
+            "context_id": doc.metadata.get("context_id"),
             "namespace": ns,
             "preview": (doc.text or "")[:4000],
             "item_kind": "vontology_text_relation",
             "source_system": (
                 "mongo.scoped_knowledge_assertions"
-                if doc.metadata.get("row_kind") == "scoped_assertion"
+                if doc.metadata.get("row_kind")
+                in {"scoped_assertion", "text_assertion"}
                 else "mongo.text_relations"
             ),
             "namespace_source": ns_report.get("namespace_source"),
@@ -37350,6 +37630,54 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "instance_of. Read-only and fail-closed: multiple matches or an "
                 "incomplete bounded scan return ambiguous rather than selecting a "
                 "candidate."
+            ),
+        ),
+        MethodDefinition(
+            name="add_text_assertion_concept_links",
+            handler=_add_text_assertion_concept_links,
+            input_schema=_add_text_assertion_concept_links_input_schema(),
+            output_schema=_add_text_assertion_concept_links_output_schema(),
+            category="write",
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "namespace": "turn_namespace",
+                "turn_id": "turn_id",
+            },
+            ordinary_turn_effect=True,
+            description=(
+                "Add optional, provenance-bearing links from an already stored "
+                "standalone text assertion to visible concepts. Use this after "
+                "later analysis discovers aboutness or involvement; unresolved "
+                "analysis never changes or removes the underlying assertion."
+            ),
+        ),
+        MethodDefinition(
+            name="store_text_assertion",
+            handler=_store_text_assertion,
+            input_schema=_store_text_assertion_input_schema(),
+            output_schema=_store_text_assertion_output_schema(),
+            category="write",
+            advisory_timeout_sec=20.0,
+            hard_timeout_enabled=False,
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "namespace": "turn_namespace",
+                "turn_id": "turn_id",
+            },
+            ordinary_turn_fixed_arguments={"canonical_publication": False},
+            ordinary_turn_effect=True,
+            description=(
+                "Store an exact provenance-bearing natural-language assertion in "
+                "the trusted user or organisation scope before semantic analysis. "
+                "No subject, predicate, or concept link is required. Equal text "
+                "from distinct occurrences remains distinct; retries within one "
+                "trusted occurrence are idempotent. Optional concept_links are "
+                "qualified enrichment and cannot block canonical admission. RAG "
+                "indexing is durable, asynchronous, observable, and retryable."
             ),
         ),
         MethodDefinition(

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -21210,13 +21210,77 @@ class InternalMCPChatOrchestrator:
             if isinstance(score, (int, float)):
                 compact_hit["score"] = round(float(score), 3)
 
+            relation_metadata = hit.get("relation_metadata")
+            if isinstance(relation_metadata, Mapping):
+                for field_name in (
+                    "assertion_id",
+                    "row_kind",
+                    "assertion_form",
+                    "link_id",
+                    "link_role",
+                    "linked_concept_id",
+                    "link_method",
+                    "lang",
+                    "match_type",
+                    "storage_surface",
+                ):
+                    field_value = relation_metadata.get(field_name)
+                    if isinstance(field_value, str) and field_value.strip():
+                        compact_hit[field_name] = field_value.strip()
+                assertion_revision = relation_metadata.get(
+                    "assertion_revision"
+                )
+                if isinstance(assertion_revision, (int, float)):
+                    compact_hit["assertion_revision"] = int(
+                        assertion_revision
+                    )
+                link_confidence = relation_metadata.get("link_confidence")
+                if isinstance(link_confidence, (int, float)):
+                    compact_hit["link_confidence"] = round(
+                        float(link_confidence), 3
+                    )
+                if isinstance(
+                    relation_metadata.get("canonical_publication"), bool
+                ):
+                    compact_hit["canonical_publication"] = relation_metadata[
+                        "canonical_publication"
+                    ]
+                assertion_context = relation_metadata.get("assertion_context")
+                if isinstance(assertion_context, Mapping):
+                    compact_context = {
+                        key: assertion_context.get(key)
+                        for key in ("context_id", "selection", "kind")
+                        if isinstance(assertion_context.get(key), str)
+                        and str(assertion_context.get(key)).strip()
+                    }
+                    if compact_context:
+                        compact_hit["assertion_context"] = compact_context
+                provenance = relation_metadata.get("provenance")
+                if isinstance(provenance, Mapping):
+                    compact_provenance = {
+                        key: provenance.get(key)
+                        for key in (
+                            "asserted_by_user_concept_id",
+                            "organisation_concept_id",
+                            "source_event_id",
+                            "turn_id",
+                            "capability_name",
+                        )
+                        if provenance.get(key) is not None
+                    }
+                    if compact_provenance:
+                        compact_hit["provenance"] = compact_provenance
+
             target_preview = hit.get("target_concept_preview")
             target_concept_id = _preview_concept_id(target_preview)
             target_name = _preview_name(target_preview)
             target_value = hit.get("target_value")
             if target_concept_id:
                 compact_hit["target_concept_id"] = target_concept_id
-            elif isinstance(target_value, str) and target_value.strip():
+            elif (
+                isinstance(target_value, str)
+                and target_value.strip().startswith("#V#")
+            ):
                 compact_hit["target_concept_id"] = target_value.strip()
             if target_name:
                 compact_hit["target_name"] = target_name
@@ -21715,14 +21779,53 @@ class InternalMCPChatOrchestrator:
                         "item_kind",
                         "source_system",
                         "type",
+                        "row_kind",
+                        "payload_kind",
+                        "assertion_form",
+                        "assertion_id",
                         "predicate",
                         "concept_id",
                         "subject_concept_id",
                         "target_concept_id",
+                        "language",
+                        "context_id",
+                        "context_selection",
                     ):
                         field_value = metadata_map.get(field_name)
                         if isinstance(field_value, str) and field_value.strip():
                             compact_row[field_name] = field_value.strip()
+                    assertion_revision = metadata_map.get(
+                        "assertion_revision"
+                    )
+                    if isinstance(assertion_revision, (int, float)):
+                        compact_row["assertion_revision"] = int(
+                            assertion_revision
+                        )
+                    if isinstance(
+                        metadata_map.get("canonical_publication"), bool
+                    ):
+                        compact_row["canonical_publication"] = metadata_map[
+                            "canonical_publication"
+                        ]
+                    assertion_provenance = metadata_map.get(
+                        "assertion_provenance"
+                    )
+                    if isinstance(assertion_provenance, Mapping):
+                        compact_provenance = {
+                            key: assertion_provenance.get(key)
+                            for key in (
+                                "asserted_by_user_concept_id",
+                                "organisation_concept_id",
+                                "source_event_id",
+                                "turn_id",
+                                "capability_name",
+                            )
+                            if assertion_provenance.get(key) is not None
+                        }
+                        if compact_provenance:
+                            compact_row["assertion_provenance"] = (
+                                compact_provenance
+                            )
                 _bump(source_system_counts, metadata_map.get("source_system"))
                 _bump(item_kind_counts, metadata_map.get("item_kind"))
                 _bump(type_counts, metadata_map.get("type"))

--- a/src/backend/services/concept_relation_service.py
+++ b/src/backend/services/concept_relation_service.py
@@ -387,6 +387,7 @@ def find_relations_with_argument(
     asserted_binary_hits: List[Dict[str, Any]] = []
     scoped_concept_query_truncated = False
     actor_effective_text_query_truncated = False
+    linked_text_assertion_query_truncated = False
 
     subject_doc = _load_accessible_relation_subject_document(
         resolved_concept_id,
@@ -773,6 +774,102 @@ def find_relations_with_argument(
                 hit["source_concept_preview"] = source_preview
             hits.append(hit)
 
+    if (
+        context_view == "actor_effective"
+        and include_asserted_rows
+        and include_text
+        and include_arg2_or_later
+    ):
+        from .scoped_assertion_service import (
+            STANDALONE_TEXT_ASSERTION_FORM,
+            list_visible_scoped_assertions_page,
+        )
+
+        linked_assertion_page = list_visible_scoped_assertions_page(
+            argument_concept_id=resolved_concept_id,
+            object_kind="text",
+            assertion_form=STANDALONE_TEXT_ASSERTION_FORM,
+            limit=_MAX_LIMIT + 1,
+        )
+        linked_assertions = list(linked_assertion_page.get("items") or ())
+        linked_text_assertion_query_truncated = bool(
+            linked_assertion_page.get("has_more")
+            or linked_assertion_page.get("counts_are_lower_bounds")
+            or len(linked_assertions) > _MAX_LIMIT
+        )
+        for assertion in linked_assertions[:_MAX_LIMIT]:
+            object_text = assertion.get("object_text")
+            if not isinstance(object_text, Mapping):
+                continue
+            text_value = object_text.get("text")
+            if not isinstance(text_value, str) or not text_value.strip():
+                continue
+            for link in assertion.get("concept_links") or ():
+                if not isinstance(link, Mapping):
+                    continue
+                if link.get("status") != "active":
+                    continue
+                if link.get("concept_id") != resolved_concept_id:
+                    continue
+                role = str(link.get("role") or "").strip()
+                if not _predicate_matches_terms(role, predicate_terms):
+                    continue
+                if not _argument_indexes_match(
+                    [_ARG_INDEX_FIRST_OBJECT], argument_filter
+                ):
+                    continue
+                assertion_context = assertion.get("assertion_context")
+                hit = {
+                    "source_concept_id": None,
+                    # A link role is qualified enrichment, not silently a
+                    # Vontology predicate concept or grounded binary relation.
+                    "predicate_concept_id": None,
+                    "relation_kind": "text",
+                    "argument_indexes": [_ARG_INDEX_FIRST_OBJECT],
+                    "target_value": text_value,
+                    "relation_metadata": {
+                        "relation_id": None,
+                        "assertion_id": assertion.get("assertion_id"),
+                        "assertion_revision": assertion.get(
+                            "assertion_revision"
+                        ),
+                        "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+                        "row_kind": "text_assertion",
+                        "link_id": link.get("link_id"),
+                        "link_role": role or None,
+                        "linked_concept_id": resolved_concept_id,
+                        "link_spans": link.get("spans") or [],
+                        "link_method": link.get("method"),
+                        "link_confidence": link.get("confidence"),
+                        "link_provenance": link.get("provenance") or {},
+                        "lang": object_text.get("language"),
+                        "updated_at": assertion.get("updated_at"),
+                        "match_type": "explicit_concept_link",
+                        "assertion_context": (
+                            assertion_context
+                            if isinstance(assertion_context, Mapping)
+                            else {}
+                        ),
+                        "assertion_scope": assertion.get("scope"),
+                        "canonical_publication": False,
+                        "storage_surface": "scoped_knowledge_assertions",
+                        "provenance": assertion.get("provenance"),
+                    },
+                    "access_granted": True,
+                    "follow_up_actions": [],
+                    "score": 1.0,
+                    "is_asserted": True,
+                    "relation_state": "asserted_text_with_link",
+                    "canonical_publication": False,
+                }
+                snippet = _make_snippet(
+                    text_value,
+                    "snippets" if include_text_snippets else "",
+                )
+                if snippet:
+                    hit["text_snippet"] = snippet
+                hits.append(hit)
+
     if include_asserted_rows and include_text and include_arg1:
         source_preview = _resolve_concept_preview(
             resolved_concept_id,
@@ -1007,6 +1104,7 @@ def find_relations_with_argument(
     counts_are_lower_bounds = bool(
         scoped_concept_query_truncated
         or actor_effective_text_query_truncated
+        or linked_text_assertion_query_truncated
         or (
             incoming_asserted_binary_diagnostics.get("requested")
             and not incoming_asserted_binary_diagnostics.get("complete", True)
@@ -1053,6 +1151,9 @@ def find_relations_with_argument(
                     ),
                     "actor_effective_text_query_truncated": (
                         actor_effective_text_query_truncated
+                    ),
+                    "linked_text_assertion_query_truncated": (
+                        linked_text_assertion_query_truncated
                     ),
                 }
                 if counts_are_lower_bounds
@@ -4087,6 +4188,7 @@ def _dedupe_argument_hits(hits: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]
             hit.get("target_value"),
             metadata.get("relation_id"),
             metadata.get("assertion_id"),
+            metadata.get("link_id"),
         )
         existing = deduped.get(key)
         if existing is None:

--- a/src/backend/services/knowledge_assertion_rag_service.py
+++ b/src/backend/services/knowledge_assertion_rag_service.py
@@ -1,0 +1,680 @@
+"""Durable, revision-aware RAG maintenance for standalone text assertions.
+
+The canonical assertion row is also the queue record. Assertion admission never
+depends on this worker, while leases and revision compare-and-set completion
+make lost workers and stale upserts recoverable without a second transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+from uuid import uuid4
+
+from pymongo import ReturnDocument
+
+from ..db.mongo_client import get_scoped_knowledge_assertions_collection
+from .rag_service import RAGBackendUnavailable, get_rag_service
+from .scoped_assertion_service import STANDALONE_TEXT_ASSERTION_FORM
+
+DEFAULT_LEASE_SECONDS = 120
+MAX_BATCH_LIMIT = 100
+MAX_ERROR_LENGTH = 500
+MAX_RETRY_SECONDS = 3600
+
+
+def _utc_now(value: datetime | None = None) -> datetime:
+    candidate = value or datetime.now(timezone.utc)
+    if candidate.tzinfo is None:
+        return candidate.replace(tzinfo=timezone.utc)
+    return candidate.astimezone(timezone.utc)
+
+
+def _collection_or_default(collection: Any = None) -> Any:
+    resolved = (
+        collection
+        if collection is not None
+        else get_scoped_knowledge_assertions_collection()
+    )
+    if resolved is None:
+        raise RuntimeError("text assertion storage is unavailable")
+    return resolved
+
+
+def _safe_limit(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+    if parsed < 1:
+        raise ValueError("limit must be at least 1")
+    return min(parsed, MAX_BATCH_LIMIT)
+
+
+def claim_next_assertion_rag_job(
+    *,
+    worker_id: str,
+    now: datetime | None = None,
+    lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    collection: Any = None,
+) -> dict[str, Any] | None:
+    """Atomically claim one due standalone-assertion index operation."""
+
+    clean_worker_id = str(worker_id or "").strip()
+    if not clean_worker_id:
+        raise ValueError("worker_id is required")
+    current_time = _utc_now(now)
+    lease_duration = max(1, int(lease_seconds))
+    lease_token = str(uuid4())
+    coll = _collection_or_default(collection)
+    due_filter = {
+        "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+        "object_kind": "text",
+        "status": {"$in": ["asserted", "retracted"]},
+        "$and": [
+            {
+                "$or": [
+                    {
+                        "status": "asserted",
+                        "rag_index.desired_operation": "upsert",
+                    },
+                    {
+                        "status": "retracted",
+                        "rag_index.desired_operation": "delete",
+                    },
+                ]
+            },
+            {
+                "$or": [
+                    {
+                        "rag_index.status": {"$in": ["pending", "failed"]},
+                        "$or": [
+                            {"rag_index.next_attempt_at": {"$lte": current_time}},
+                            {"rag_index.next_attempt_at": None},
+                            {"rag_index.next_attempt_at": {"$exists": False}},
+                        ],
+                    },
+                    {
+                        "rag_index.status": "processing",
+                        "rag_index.lease_expires_at": {"$lte": current_time},
+                    },
+                ]
+            },
+        ],
+    }
+    claimed = coll.find_one_and_update(
+        due_filter,
+        {
+            "$set": {
+                "rag_index.status": "processing",
+                "rag_index.worker_id": clean_worker_id,
+                "rag_index.lease_token": lease_token,
+                "rag_index.lease_expires_at": current_time
+                + timedelta(seconds=lease_duration),
+                "rag_index.last_attempt_at": current_time,
+            },
+            "$inc": {"rag_index.attempt_count": 1},
+        },
+        sort=[("rag_index.next_attempt_at", 1), ("updated_at", 1)],
+        return_document=ReturnDocument.AFTER,
+    )
+    return dict(claimed) if isinstance(claimed, Mapping) else None
+
+
+def _bounded_provenance_metadata(assertion: Mapping[str, Any]) -> dict[str, Any]:
+    provenance = assertion.get("provenance")
+    if not isinstance(provenance, Mapping):
+        return {}
+    return {
+        key: provenance.get(key)
+        for key in (
+            "asserted_by_user_concept_id",
+            "organisation_concept_id",
+            "capability_name",
+        )
+        if provenance.get(key) is not None
+    }
+
+
+def build_standalone_text_assertion_rag_document(
+    assertion: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build an exact-body RAG document without inventing relation semantics."""
+
+    if assertion.get("assertion_form") != STANDALONE_TEXT_ASSERTION_FORM:
+        raise ValueError("assertion is not a standalone text assertion")
+    if assertion.get("status") != "asserted":
+        raise ValueError("only asserted text assertions can be indexed")
+    assertion_id = str(assertion.get("assertion_id") or "").strip()
+    if not assertion_id.startswith("ska_"):
+        raise ValueError("assertion has no valid assertion_id")
+    revision = int(assertion.get("assertion_revision") or 0)
+    if revision < 1:
+        raise ValueError("assertion has no valid revision")
+    object_text = assertion.get("object_text")
+    if not isinstance(object_text, Mapping):
+        raise ValueError("assertion has no text body")
+    text = object_text.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("assertion has no text body")
+    language = str(object_text.get("language") or "en-NZ")
+    scope = assertion.get("scope")
+    scope = scope if isinstance(scope, Mapping) else {}
+    assertion_context = assertion.get("assertion_context")
+    assertion_context = (
+        assertion_context if isinstance(assertion_context, Mapping) else {}
+    )
+    metadata = {
+        "type": "scoped_knowledge_assertion",
+        "source": "scoped_knowledge_assertion",
+        "row_kind": "text_assertion",
+        "payload_kind": "text",
+        "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+        "assertion_id": assertion_id,
+        "assertion_revision": revision,
+        "relation_id": None,
+        "subject_concept_id": None,
+        "predicate": None,
+        "lang": language,
+        "language": language,
+        "content_length": len(text),
+        "context_id": assertion_context.get("context_id"),
+        "context_selection": assertion_context.get("selection"),
+        "canonical_publication": False,
+        "user_id": scope.get("user_concept_id"),
+        "organisation_concept_id": scope.get("organisation_concept_id"),
+        "org_id": scope.get("organisation_concept_id"),
+        "audience_user_concept_id": scope.get("user_concept_id"),
+        "audience_organisation_concept_id": scope.get("organisation_concept_id"),
+        "audience_keys": list(scope.get("audience_keys") or ()),
+        "assertion_provenance": _bounded_provenance_metadata(assertion),
+        "created_at": (
+            str(assertion.get("created_at")) if assertion.get("created_at") else None
+        ),
+        "updated_at": (
+            str(assertion.get("updated_at")) if assertion.get("updated_at") else None
+        ),
+    }
+    return {
+        "id": f"scoped_assertion:{assertion_id}",
+        "text": text,
+        "metadata": metadata,
+    }
+
+
+def _retry_delay_seconds(attempt_count: Any) -> int:
+    try:
+        attempts = max(1, int(attempt_count))
+    except (TypeError, ValueError):
+        attempts = 1
+    return min(2 ** min(attempts, 12), MAX_RETRY_SECONDS)
+
+
+def complete_assertion_rag_job(
+    *,
+    assertion_id: str,
+    claimed_revision: int,
+    lease_token: str,
+    operation: str,
+    success: bool,
+    error_code: str | None = None,
+    error: str | None = None,
+    now: datetime | None = None,
+    attempt_count: int = 1,
+    collection: Any = None,
+) -> dict[str, Any]:
+    """CAS-complete one job; a newer assertion revision always wins."""
+
+    current_time = _utc_now(now)
+    coll = _collection_or_default(collection)
+    completion_filter = {
+        "assertion_id": assertion_id,
+        "assertion_revision": claimed_revision,
+        "rag_index.desired_revision": claimed_revision,
+        "rag_index.status": "processing",
+        "rag_index.lease_token": lease_token,
+    }
+    if success:
+        terminal_status = "indexed" if operation == "upsert" else "absent"
+        update = {
+            "$set": {
+                "rag_index.status": terminal_status,
+                "rag_index.indexed_revision": claimed_revision,
+                "rag_index.last_success_at": current_time,
+                "rag_index.last_error_code": None,
+                "rag_index.last_error": None,
+                "rag_index.next_attempt_at": None,
+            },
+            "$unset": {
+                "rag_index.worker_id": "",
+                "rag_index.lease_token": "",
+                "rag_index.lease_expires_at": "",
+            },
+        }
+    else:
+        update = {
+            "$set": {
+                "rag_index.status": "failed",
+                "rag_index.last_error_code": str(error_code or "rag_operation_failed")[
+                    :100
+                ],
+                "rag_index.last_error": str(error or "RAG operation failed")[
+                    :MAX_ERROR_LENGTH
+                ],
+                "rag_index.next_attempt_at": current_time
+                + timedelta(seconds=_retry_delay_seconds(attempt_count)),
+            },
+            "$unset": {
+                "rag_index.worker_id": "",
+                "rag_index.lease_token": "",
+                "rag_index.lease_expires_at": "",
+            },
+        }
+    updated = coll.find_one_and_update(
+        completion_filter,
+        update,
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(updated, Mapping):
+        return {
+            "success": False,
+            "completed": False,
+            "superseded": True,
+            "assertion_id": assertion_id,
+            "claimed_revision": claimed_revision,
+        }
+    return {
+        "success": success,
+        "completed": True,
+        "superseded": False,
+        "assertion_id": assertion_id,
+        "claimed_revision": claimed_revision,
+        "rag_index": dict(updated.get("rag_index") or {}),
+    }
+
+
+def _requeue_current_revision_after_superseded_effect(
+    *,
+    assertion_id: str,
+    claimed_revision: int,
+    now: datetime,
+    collection: Any,
+) -> bool:
+    """Ensure a stale backend effect cannot become the final physical state.
+
+    A newer delete can finish before an older upsert (or conversely). When the
+    older backend call returns, its completion CAS correctly misses, but that
+    stale operation may nevertheless have changed the index after the newer
+    job finished. Requeueing the current revision makes its desired state run
+    once more after the stale effect.
+    """
+
+    current = collection.find_one(
+        {
+            "assertion_id": assertion_id,
+            "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+        },
+        {
+            "_id": 0,
+            "assertion_revision": 1,
+            "status": 1,
+        },
+    )
+    if not isinstance(current, Mapping):
+        return False
+    current_revision = int(current.get("assertion_revision") or 0)
+    if current_revision < 1 or current_revision == claimed_revision:
+        return False
+    current_status = str(current.get("status") or "")
+    if current_status not in {"asserted", "retracted"}:
+        return False
+    desired_operation = "delete" if current_status == "retracted" else "upsert"
+    result = collection.update_one(
+        {
+            "assertion_id": assertion_id,
+            "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+            "assertion_revision": current_revision,
+        },
+        {
+            "$set": {
+                "rag_index.status": "pending",
+                "rag_index.desired_operation": desired_operation,
+                "rag_index.desired_revision": current_revision,
+                "rag_index.indexed_revision": None,
+                "rag_index.next_attempt_at": now,
+                "rag_index.lease_token": None,
+                "rag_index.lease_expires_at": None,
+                "rag_index.last_error_code": None,
+                "rag_index.last_error": None,
+            },
+            "$unset": {"rag_index.worker_id": ""},
+        },
+    )
+    return bool(result.modified_count)
+
+
+def process_claimed_assertion_rag_job(
+    claimed: Mapping[str, Any],
+    *,
+    rag_service: Any = None,
+    now: datetime | None = None,
+    collection: Any = None,
+) -> dict[str, Any]:
+    """Execute and complete one already-claimed exact upsert or delete."""
+
+    assertion_id = str(claimed.get("assertion_id") or "").strip()
+    revision = int(claimed.get("assertion_revision") or 0)
+    rag_index = claimed.get("rag_index")
+    rag_index = rag_index if isinstance(rag_index, Mapping) else {}
+    lease_token = str(rag_index.get("lease_token") or "").strip()
+    operation = str(rag_index.get("desired_operation") or "").strip()
+    namespace = str(rag_index.get("namespace") or "").strip()
+    attempt_count = int(rag_index.get("attempt_count") or 1)
+    error_code: str | None = None
+    error: str | None = None
+    operation_success = False
+    backend_attempted = False
+    backend_receipt: dict[str, Any] = {}
+    try:
+        if not assertion_id or revision < 1 or not lease_token or not namespace:
+            raise ValueError("claimed assertion RAG job is incomplete")
+        if operation not in {"upsert", "delete"}:
+            raise ValueError("claimed assertion RAG operation is invalid")
+        service = rag_service or get_rag_service()
+        doc_id = f"scoped_assertion:{assertion_id}"
+        if operation == "upsert":
+            payload = build_standalone_text_assertion_rag_document(claimed)
+            backend_attempted = True
+            indexed, failed = service.upsert_documents(
+                [payload],
+                namespace=namespace,
+            )
+            operation_success = int(indexed) == 1 and int(failed) == 0
+            backend_receipt = {
+                "indexed": int(indexed),
+                "failed": int(failed),
+                "doc_id": doc_id,
+            }
+            if not operation_success:
+                error_code = "rag_upsert_incomplete"
+                error = f"RAG upsert returned indexed={indexed}, failed={failed}"
+        else:
+            if claimed.get("status") != "retracted":
+                raise ValueError("delete job does not match canonical assertion status")
+            backend_attempted = True
+            deleted = service.delete_documents([doc_id], namespace=namespace)
+            # Zero is a successful idempotent desired-absence result.
+            operation_success = True
+            backend_receipt = {"deleted": int(deleted), "doc_id": doc_id}
+    except RAGBackendUnavailable as exc:
+        error_code = "rag_backend_unavailable"
+        error = str(exc)
+    except Exception as exc:
+        error_code = type(exc).__name__
+        error = str(exc)
+
+    completion = complete_assertion_rag_job(
+        assertion_id=assertion_id,
+        claimed_revision=revision,
+        lease_token=lease_token,
+        operation=operation,
+        success=operation_success,
+        error_code=error_code,
+        error=error,
+        now=now,
+        attempt_count=attempt_count,
+        collection=collection,
+    )
+    requeued_current_revision = False
+    if completion.get("superseded") and backend_attempted:
+        requeued_current_revision = _requeue_current_revision_after_superseded_effect(
+            assertion_id=assertion_id,
+            claimed_revision=revision,
+            now=_utc_now(now),
+            collection=_collection_or_default(collection),
+        )
+    return {
+        **completion,
+        "operation": operation,
+        "namespace": namespace,
+        "backend_receipt": backend_receipt,
+        "current_revision_requeued": requeued_current_revision,
+        **({"error_code": error_code, "error": error} if error else {}),
+    }
+
+
+def process_pending_assertion_rag_jobs(
+    *,
+    limit: int = 10,
+    worker_id: str | None = None,
+    lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    rag_service: Any = None,
+    now: datetime | None = None,
+    collection: Any = None,
+) -> dict[str, Any]:
+    """Process a bounded synchronous batch for the existing RAG worker loop."""
+
+    batch_limit = _safe_limit(limit)
+    effective_worker_id = str(worker_id or f"assertion-rag-{uuid4()}")
+    counts = {
+        "claimed": 0,
+        "completed": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "superseded": 0,
+    }
+    receipts: list[dict[str, Any]] = []
+    for _ in range(batch_limit):
+        claimed = claim_next_assertion_rag_job(
+            worker_id=effective_worker_id,
+            now=now,
+            lease_seconds=lease_seconds,
+            collection=collection,
+        )
+        if claimed is None:
+            break
+        counts["claimed"] += 1
+        receipt = process_claimed_assertion_rag_job(
+            claimed,
+            rag_service=rag_service,
+            now=now,
+            collection=collection,
+        )
+        receipts.append(receipt)
+        if receipt.get("completed"):
+            counts["completed"] += 1
+        if receipt.get("superseded"):
+            counts["superseded"] += 1
+        elif receipt.get("success"):
+            counts["succeeded"] += 1
+        else:
+            counts["failed"] += 1
+    return {"success": counts["failed"] == 0, **counts, "receipts": receipts}
+
+
+def reconcile_assertion_rag_state(
+    *,
+    limit: int = 100,
+    include_failed: bool = False,
+    now: datetime | None = None,
+    collection: Any = None,
+) -> dict[str, Any]:
+    """Repair missing/mismatched operational state without touching RAG itself."""
+
+    batch_limit = _safe_limit(limit)
+    current_time = _utc_now(now)
+    coll = _collection_or_default(collection)
+    problem_filters: list[dict[str, Any]] = [
+        {"rag_index": {"$exists": False}},
+        {"rag_index.status": {"$exists": False}},
+        {"rag_index.status": {"$in": [None, ""]}},
+        {"rag_index.namespace": {"$exists": False}},
+        {"rag_index.namespace": {"$in": [None, ""]}},
+        {
+            "$expr": {
+                "$ne": [
+                    "$rag_index.desired_revision",
+                    "$assertion_revision",
+                ]
+            }
+        },
+        {
+            "status": "asserted",
+            "rag_index.desired_operation": {"$ne": "upsert"},
+        },
+        {
+            "status": "retracted",
+            "rag_index.desired_operation": {"$ne": "delete"},
+        },
+        {
+            "rag_index.status": "processing",
+            "rag_index.lease_expires_at": {"$lte": current_time},
+        },
+        {
+            "rag_index.status": "processing",
+            "rag_index.lease_expires_at": {"$exists": False},
+        },
+        {
+            "rag_index.status": "processing",
+            "rag_index.lease_expires_at": None,
+        },
+        {
+            "rag_index.status": "processing",
+            "rag_index.lease_expires_at": {"$not": {"$type": "date"}},
+        },
+        {
+            "rag_index.status": {"$in": ["indexed", "absent"]},
+            "$expr": {
+                "$ne": [
+                    "$rag_index.indexed_revision",
+                    "$assertion_revision",
+                ]
+            },
+        },
+        {
+            "rag_index.status": {
+                "$nin": [
+                    "pending",
+                    "processing",
+                    "indexed",
+                    "absent",
+                    "failed",
+                ]
+            }
+        },
+        {"status": "asserted", "rag_index.status": "absent"},
+        {"status": "retracted", "rag_index.status": "indexed"},
+    ]
+    if include_failed:
+        problem_filters.append({"rag_index.status": "failed"})
+    candidates = list(
+        coll.find(
+            {
+                "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+                "object_kind": "text",
+                "status": {"$in": ["asserted", "retracted"]},
+                "$or": problem_filters,
+            }
+        )
+        .sort([("updated_at", 1), ("assertion_id", 1)])
+        .limit(batch_limit)
+    )
+    repaired = 0
+    for assertion in candidates:
+        if not isinstance(assertion, Mapping):
+            continue
+        revision = int(assertion.get("assertion_revision") or 1)
+        desired_operation = (
+            "delete" if assertion.get("status") == "retracted" else "upsert"
+        )
+        rag_index = assertion.get("rag_index")
+        rag_index = rag_index if isinstance(rag_index, Mapping) else {}
+        status = str(rag_index.get("status") or "")
+        lease_expires_at = rag_index.get("lease_expires_at")
+        invalid_or_expired_lease = bool(
+            status == "processing"
+            and (
+                not isinstance(lease_expires_at, datetime)
+                or _utc_now(lease_expires_at) <= current_time
+            )
+        )
+        valid_statuses = {"pending", "processing", "indexed", "absent", "failed"}
+        invalid_status = status not in valid_statuses
+        terminal_revision_mismatch = bool(
+            status in {"indexed", "absent"}
+            and int(rag_index.get("indexed_revision") or 0) != revision
+        )
+        terminal_operation_mismatch = bool(
+            (assertion.get("status") == "asserted" and status == "absent")
+            or (assertion.get("status") == "retracted" and status == "indexed")
+        )
+        mismatch = bool(
+            int(rag_index.get("desired_revision") or 0) != revision
+            or rag_index.get("desired_operation") != desired_operation
+            or not str(rag_index.get("namespace") or "").strip()
+        )
+        should_repair = (
+            not status
+            or mismatch
+            or invalid_or_expired_lease
+            or invalid_status
+            or terminal_revision_mismatch
+            or terminal_operation_mismatch
+            or (include_failed and status == "failed")
+        )
+        if not should_repair:
+            continue
+        scope = assertion.get("scope")
+        scope = scope if isinstance(scope, Mapping) else {}
+        provenance = assertion.get("provenance")
+        provenance = provenance if isinstance(provenance, Mapping) else {}
+        namespace = str(
+            rag_index.get("namespace")
+            or provenance.get("namespace")
+            or scope.get("namespace")
+            or ""
+        ).strip()
+        if not namespace:
+            continue
+        result = coll.update_one(
+            {
+                "assertion_id": assertion.get("assertion_id"),
+                "assertion_revision": assertion.get("assertion_revision"),
+            },
+            {
+                "$set": {
+                    "rag_index": {
+                        "status": "pending",
+                        "desired_operation": desired_operation,
+                        "desired_revision": revision,
+                        "indexed_revision": None,
+                        "namespace": namespace,
+                        "attempt_count": int(rag_index.get("attempt_count") or 0),
+                        "next_attempt_at": current_time,
+                        "lease_token": None,
+                        "lease_expires_at": None,
+                        "last_attempt_at": rag_index.get("last_attempt_at"),
+                        "last_success_at": rag_index.get("last_success_at"),
+                        "last_error_code": None,
+                        "last_error": None,
+                    }
+                }
+            },
+        )
+        repaired += int(result.modified_count)
+    return {
+        "success": True,
+        "scanned": len(candidates),
+        "repaired": repaired,
+        "limit": batch_limit,
+    }
+
+
+__all__ = [
+    "build_standalone_text_assertion_rag_document",
+    "claim_next_assertion_rag_job",
+    "complete_assertion_rag_job",
+    "process_claimed_assertion_rag_job",
+    "process_pending_assertion_rag_jobs",
+    "reconcile_assertion_rag_state",
+]

--- a/src/backend/services/rag_backends/llamaindex_backend.py
+++ b/src/backend/services/rag_backends/llamaindex_backend.py
@@ -13,6 +13,7 @@ Namespace behaviour:
     allow defensive filtering.
 """
 
+import errno
 import hashlib
 import importlib
 import json
@@ -23,8 +24,20 @@ import shutil
 import tempfile
 import time
 import threading
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Iterable, Dict, Any, Optional, List, Tuple, Mapping
+from uuid import uuid4
+
+try:  # pragma: no cover - platform-specific import
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None
+
+try:  # pragma: no cover - platform-specific import
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    _msvcrt = None
 
 from ..rag_service import RAGQueryResults, RAGService, build_rag_retrieval_state
 from ...utils.concept_id_utils import normalise_concept_id_for_compare
@@ -136,7 +149,9 @@ try:  # pragma: no cover
     load_index_from_storage = getattr(core, "load_index_from_storage")
     Settings = getattr(core, "Settings", Settings)
     try:
-        embeddings_mod = importlib.import_module("llama_index.core.base.embeddings.base")
+        embeddings_mod = importlib.import_module(
+            "llama_index.core.base.embeddings.base"
+        )
         BaseEmbedding = getattr(embeddings_mod, "BaseEmbedding", BaseEmbedding)
     except Exception:
         pass
@@ -173,7 +188,9 @@ except Exception:  # pragma: no cover
         try:
             llms_mod = importlib.import_module("llama_index.llms")
             CustomLLM = getattr(llms_mod, "CustomLLM", CustomLLM)
-            CompletionResponse = getattr(llms_mod, "CompletionResponse", CompletionResponse)
+            CompletionResponse = getattr(
+                llms_mod, "CompletionResponse", CompletionResponse
+            )
             LLMMetadata = getattr(llms_mod, "LLMMetadata", LLMMetadata)
         except Exception:
             pass
@@ -260,6 +277,8 @@ class LlamaIndexRAGService(RAGService):
 
         # Cache of namespace -> index instance
         self._indices: Dict[str, Any] = {}
+        self._index_cache_generations: Dict[str, str] = {}
+        self._persisted_index_cache_namespaces: set[str] = set()
         self._namespace_runtime_state: Dict[str, Dict[str, Any]] = {}
         self._namespace_retrieval_states: Dict[str, Dict[str, Any]] = {}
         self._retrieval_state_lock = threading.Lock()
@@ -294,7 +313,9 @@ class LlamaIndexRAGService(RAGService):
             and "Settings" in message
         )
 
-    def _build_service_context(self, *, embed_model: Any = None, llm: Any = None) -> Any:
+    def _build_service_context(
+        self, *, embed_model: Any = None, llm: Any = None
+    ) -> Any:
         from_defaults = getattr(ServiceContext, "from_defaults", None)
         if not callable(from_defaults):
             return None
@@ -334,7 +355,9 @@ class LlamaIndexRAGService(RAGService):
             pass
 
     @staticmethod
-    def _normalise_runtime_entry(entry: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    def _normalise_runtime_entry(
+        entry: Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
         if not isinstance(entry, Mapping):
             return None
         provider = str(entry.get("provider") or "").strip().lower()
@@ -382,7 +405,9 @@ class LlamaIndexRAGService(RAGService):
         )
         if effective is None:
             return None
-        selection_source = str(resolution.get("selection_source") or "").strip() or "unknown"
+        selection_source = (
+            str(resolution.get("selection_source") or "").strip() or "unknown"
+        )
         if kind == "embedder":
             return _ConfiguredEmbeddingModel(
                 provider=effective["provider"],
@@ -404,7 +429,10 @@ class LlamaIndexRAGService(RAGService):
             self._runtime_configuration_refreshed_monotonic = 0.0
 
     def _refresh_runtime_configuration(self, *, force: bool = False) -> None:
-        from ..settings_service import resolve_rag_embedder_setting, resolve_rag_llm_setting
+        from ..settings_service import (
+            resolve_rag_embedder_setting,
+            resolve_rag_llm_setting,
+        )
 
         with self._runtime_configuration_lock:
             now = time.monotonic()
@@ -413,9 +441,8 @@ class LlamaIndexRAGService(RAGService):
                 and self._runtime_configuration is not None
                 and self._runtime_configuration_serialized is not None
                 and self._runtime_configuration_refreshed_monotonic > 0.0
-                and (
-                    now - self._runtime_configuration_refreshed_monotonic
-                ) < _RUNTIME_CONFIGURATION_CACHE_TTL_SECONDS
+                and (now - self._runtime_configuration_refreshed_monotonic)
+                < _RUNTIME_CONFIGURATION_CACHE_TTL_SECONDS
             ):
                 return
 
@@ -504,7 +531,10 @@ class LlamaIndexRAGService(RAGService):
         previous: Dict[str, Any] = {}
         settings_changed = False
         current_retries = getattr(embed_model, "max_retries", None)
-        if isinstance(current_retries, int) and current_retries > _QUERY_EMBED_MAX_RETRIES:
+        if (
+            isinstance(current_retries, int)
+            and current_retries > _QUERY_EMBED_MAX_RETRIES
+        ):
             previous["max_retries"] = current_retries
             setattr(embed_model, "max_retries", _QUERY_EMBED_MAX_RETRIES)
             settings_changed = True
@@ -553,7 +583,9 @@ class LlamaIndexRAGService(RAGService):
         if getattr(exc, "winerror", None) == 32:
             return True
         message = str(exc).strip().lower()
-        return "used by another process" in message or "cannot access the file" in message
+        return (
+            "used by another process" in message or "cannot access the file" in message
+        )
 
     def _get_namespace_lock(self, namespace: str) -> threading.RLock:
         with self._namespace_locks_guard:
@@ -562,6 +594,60 @@ class LlamaIndexRAGService(RAGService):
                 lock = threading.RLock()
                 self._namespace_locks[namespace] = lock
             return lock
+
+    @staticmethod
+    def _is_windows_lock_contention(exc: OSError) -> bool:
+        return getattr(exc, "winerror", None) in {32, 33} or exc.errno in {
+            errno.EACCES,
+            errno.EAGAIN,
+            errno.EDEADLK,
+        }
+
+    @contextmanager
+    def _namespace_process_lock(self, namespace: str):
+        """Serialise one namespace mutation across worker/app processes."""
+
+        lock_root = os.path.join(self.persistence_dir, ".namespace_locks")
+        os.makedirs(lock_root, exist_ok=True)
+        lock_path = os.path.join(
+            lock_root,
+            f"{self._namespace_dirname(namespace)}.lock",
+        )
+        with open(lock_path, "a+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if _fcntl is not None:
+                _fcntl.flock(handle.fileno(), _fcntl.LOCK_EX)
+            elif _msvcrt is not None:  # pragma: no cover - Windows
+                while True:
+                    try:
+                        _msvcrt.locking(handle.fileno(), _msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError as exc:
+                        if not self._is_windows_lock_contention(exc):
+                            raise
+                        time.sleep(_WINDOWS_NAMESPACE_IO_RETRY_DELAY_SECONDS)
+            else:  # pragma: no cover - unsupported platform
+                raise RuntimeError(
+                    "No inter-process file-lock implementation is available"
+                )
+            try:
+                yield
+            finally:
+                handle.seek(0)
+                if _fcntl is not None:
+                    _fcntl.flock(handle.fileno(), _fcntl.LOCK_UN)
+                elif _msvcrt is not None:  # pragma: no cover - Windows
+                    _msvcrt.locking(handle.fileno(), _msvcrt.LK_UNLCK, 1)
+
+    @contextmanager
+    def _namespace_mutation_lock(self, namespace: str):
+        with self._get_namespace_lock(namespace):
+            with self._namespace_process_lock(namespace):
+                yield
 
     def _run_namespace_io(
         self,
@@ -596,9 +682,11 @@ class LlamaIndexRAGService(RAGService):
         metadata_path = self._namespace_metadata_path(namespace)
         if not os.path.isfile(metadata_path):
             return None
+
         def _read_payload() -> Any:
             with open(metadata_path, "r", encoding="utf-8") as handle:
                 return json.load(handle)
+
         try:
             with self._get_namespace_lock(namespace):
                 payload = self._run_namespace_io(
@@ -645,7 +733,8 @@ class LlamaIndexRAGService(RAGService):
         namespace: str,
         *,
         runtime_summary: Mapping[str, Any] | None = None,
-    ) -> None:
+        persist_dir_override: str | None = None,
+    ) -> str:
         if runtime_summary is None:
             runtime_summary, _, _ = self._capture_embedding_runtime(namespace)
         embedding_signature = runtime_summary.get("embedding_signature")
@@ -653,15 +742,17 @@ class LlamaIndexRAGService(RAGService):
             raise RuntimeError(
                 "RAG index metadata requires a resolved embedding signature."
             )
+        index_generation = str(uuid4())
         payload = {
             "schema_version": "rag_index_metadata.v1",
             "namespace": namespace,
+            "index_generation": index_generation,
             "written_at_utc": datetime.now(timezone.utc).isoformat(),
             "embedding_signature": dict(embedding_signature),
             "llm_signature": runtime_summary.get("llm_signature"),
         }
-        persist_dir = self._namespace_persist_dir(namespace)
-        metadata_path = self._namespace_metadata_path(namespace)
+        persist_dir = persist_dir_override or self._namespace_persist_dir(namespace)
+        metadata_path = os.path.join(persist_dir, _INDEX_METADATA_FILENAME)
         with self._get_namespace_lock(namespace):
             os.makedirs(persist_dir, exist_ok=True)
             fd, temp_path = tempfile.mkstemp(
@@ -688,6 +779,27 @@ class LlamaIndexRAGService(RAGService):
                         os.remove(temp_path)
                     except OSError:
                         pass
+        return index_generation
+
+    def _advance_namespace_generation(self, namespace: str) -> str:
+        """Publish a new cache generation without changing index semantics."""
+
+        existing = self._read_namespace_metadata(namespace)
+        embedding_signature = (
+            existing.get("embedding_signature")
+            if isinstance(existing, Mapping)
+            else None
+        )
+        runtime_summary: Mapping[str, Any] | None = None
+        if isinstance(embedding_signature, Mapping):
+            runtime_summary = {
+                "embedding_signature": dict(embedding_signature),
+                "llm_signature": existing.get("llm_signature"),
+            }
+        return self._write_namespace_metadata(
+            namespace,
+            runtime_summary=runtime_summary,
+        )
 
     def _require_namespace_mutation_compatible(
         self,
@@ -941,10 +1053,41 @@ class LlamaIndexRAGService(RAGService):
                 if not bool(state.get("compatible", False)):
                     return None
 
-            if namespace in self._indices:
-                return self._indices[namespace]
-
             persist_dir = self._namespace_persist_dir(namespace)
+            try:
+                has_persisted_state = os.path.isdir(persist_dir) and bool(
+                    os.listdir(persist_dir)
+                )
+            except OSError:
+                has_persisted_state = os.path.isdir(persist_dir)
+            metadata = (
+                self._read_namespace_metadata(namespace)
+                if has_persisted_state
+                else None
+            )
+            disk_generation = (
+                str(metadata.get("index_generation") or "").strip()
+                if isinstance(metadata, Mapping)
+                else ""
+            )
+            if namespace in self._indices:
+                # Ephemeral/test indices have no persisted state. Persisted
+                # caches are reusable only while their generation still
+                # matches the version published by the last process holding
+                # the namespace mutation lock.
+                cache_was_persisted = (
+                    namespace in self._persisted_index_cache_namespaces
+                    or bool(self._index_cache_generations.get(namespace))
+                )
+                if (not has_persisted_state and not cache_was_persisted) or (
+                    disk_generation
+                    and self._index_cache_generations.get(namespace) == disk_generation
+                ):
+                    return self._indices[namespace]
+                self._indices.pop(namespace, None)
+                self._index_cache_generations.pop(namespace, None)
+                self._persisted_index_cache_namespaces.discard(namespace)
+
             if not os.path.isdir(persist_dir):
                 return None
 
@@ -968,6 +1111,9 @@ class LlamaIndexRAGService(RAGService):
                 return None
 
             self._indices[namespace] = index
+            self._persisted_index_cache_namespaces.add(namespace)
+            if disk_generation:
+                self._index_cache_generations[namespace] = disk_generation
             return index
 
     def _get_or_create_index(
@@ -997,17 +1143,34 @@ class LlamaIndexRAGService(RAGService):
                 return index
 
             persist_dir = self._namespace_persist_dir(namespace)
-            os.makedirs(persist_dir, exist_ok=True)
-            index = VectorStoreIndex.from_documents(
-                documents, **dict(runtime_index_kwargs)
+            namespaces_root = os.path.dirname(persist_dir)
+            os.makedirs(namespaces_root, exist_ok=True)
+            staging_dir = tempfile.mkdtemp(
+                prefix=f".{self._namespace_dirname(namespace)}.creating.",
+                dir=namespaces_root,
             )
-            index.storage_context.persist(persist_dir=persist_dir)
-            self._write_namespace_metadata(
-                namespace,
-                runtime_summary=runtime_summary,
-            )
-            self._indices[namespace] = index
-            return index
+            try:
+                index = VectorStoreIndex.from_documents(
+                    documents, **dict(runtime_index_kwargs)
+                )
+                index.storage_context.persist(persist_dir=staging_dir)
+                index_generation = self._write_namespace_metadata(
+                    namespace,
+                    runtime_summary=runtime_summary,
+                    persist_dir_override=staging_dir,
+                )
+                # The whole initial index, including its verified embedding
+                # signature, becomes visible as one same-volume directory
+                # rename. A failed build leaves no misleading final namespace.
+                os.rename(staging_dir, persist_dir)
+                staging_dir = ""
+                self._indices[namespace] = index
+                self._index_cache_generations[namespace] = index_generation
+                self._persisted_index_cache_namespaces.add(namespace)
+                return index
+            finally:
+                if staging_dir and os.path.isdir(staging_dir):
+                    shutil.rmtree(staging_dir)
 
     def upsert_documents(
         self,
@@ -1016,11 +1179,7 @@ class LlamaIndexRAGService(RAGService):
         namespace: Optional[str] = None,
         allow_partial_failures: bool = True,
     ) -> Tuple[int, int]:
-        """
-        Upsert documents into the index.
-        LlamaIndex 0.9.x simple index doesn't support granular updates easily without a vector store.
-        For this implementation, we will convert dicts to Documents and insert them.
-        """
+        """Idempotently insert or refresh documents and durably persist them."""
         effective_namespace = self._resolve_effective_namespace(namespace)
         runtime_summary, _, runtime_index_kwargs = self._capture_embedding_runtime(
             effective_namespace
@@ -1046,14 +1205,25 @@ class LlamaIndexRAGService(RAGService):
             # Stamp namespace into metadata to support filtering/debugging.
             if not isinstance(metadata, dict):
                 metadata = {}
+            else:
+                metadata = dict(metadata)
             metadata["namespace"] = effective_namespace
             l_doc.metadata = metadata
+            if metadata.get("assertion_form") == "standalone_text":
+                # The raw assertion body is the entire semantic embedding
+                # input. Keep authority, lifecycle, context, and provenance
+                # metadata in the docstore for live filtering and reasoning,
+                # but do not send operational tenant identifiers to an
+                # external embedder or let them distort similarity.
+                excluded_keys = sorted(metadata)
+                l_doc.excluded_embed_metadata_keys = excluded_keys
+                l_doc.excluded_llm_metadata_keys = excluded_keys
             llama_docs.append(l_doc)
 
         if not llama_docs:
             return (0, 0)
 
-        with self._get_namespace_lock(effective_namespace):
+        with self._namespace_mutation_lock(effective_namespace):
             self._require_namespace_mutation_compatible(
                 effective_namespace,
                 embedding_signature=embedding_signature,
@@ -1079,40 +1249,46 @@ class LlamaIndexRAGService(RAGService):
                 index.storage_context.persist(
                     persist_dir=self._namespace_persist_dir(effective_namespace)
                 )
-                self._write_namespace_metadata(
+                generation = self._write_namespace_metadata(
                     effective_namespace,
                     runtime_summary=runtime_summary,
                 )
+                self._index_cache_generations[effective_namespace] = generation
+                self._persisted_index_cache_namespaces.add(effective_namespace)
 
-            # Prefer bulk insertion when supported (significantly faster for
-            # embedding-backed indices).
-            try:
-                insert_documents = getattr(index, "insert_documents", None)
-                if callable(insert_documents):
-                    insert_documents(llama_docs)
-                    success = len(llama_docs)
-                    _persist()
-                    return (success, failed)
-            except Exception:
-                # Fall back to per-document insertion below.
-                pass
-
-            # Fallback: per-document insertion, optionally allowing partial failures.
-            for l_doc in llama_docs:
+            # ``refresh_ref_docs`` compares each stable document ID and updates
+            # changed text/metadata instead of accumulating duplicate nodes on
+            # retries or assertion revisions. It also inserts missing IDs.
+            refresh_ref_docs = getattr(index, "refresh_ref_docs", None)
+            if callable(refresh_ref_docs):
                 try:
-                    index.insert(l_doc)
-                    success += 1
+                    refresh_ref_docs(llama_docs)
+                    success = len(llama_docs)
                 except Exception:
-                    failed += 1
                     if not allow_partial_failures:
                         raise
+                    failed = len(llama_docs)
+            else:
+                # Compatibility path for an older index implementation: update
+                # each stable ref-doc ID (delete plus insert), never append it.
+                update_ref_doc = getattr(index, "update_ref_doc", None)
+                if not callable(update_ref_doc):
+                    raise RuntimeError(
+                        "RAG index does not support stable document refresh"
+                    )
+                for l_doc in llama_docs:
+                    try:
+                        update_ref_doc(l_doc)
+                        success += 1
+                    except Exception:
+                        failed += 1
+                        if not allow_partial_failures:
+                            raise
 
             if success > 0:
-                try:
-                    _persist()
-                except Exception:
-                    # Persist failures should not mask successful indexing.
-                    pass
+                # A persistence failure means the durable effect is unknown;
+                # propagate it so the assertion queue remains retryable.
+                _persist()
 
             return (success, failed)
 
@@ -1127,38 +1303,53 @@ class LlamaIndexRAGService(RAGService):
         Note: Simple VectorStoreIndex delete might be limited depending on the store.
         """
         effective_namespace = self._resolve_effective_namespace(namespace)
-        index = self._maybe_load_index(effective_namespace)
-        if not index:
-            return 0
+        with self._namespace_mutation_lock(effective_namespace):
+            index = self._maybe_load_index(effective_namespace)
+            if not index:
+                persist_dir = self._namespace_persist_dir(effective_namespace)
+                try:
+                    namespace_has_state = os.path.isdir(persist_dir) and bool(
+                        os.listdir(persist_dir)
+                    )
+                except OSError as exc:
+                    raise RuntimeError(
+                        "RAG namespace state could not be inspected for deletion"
+                    ) from exc
+                if namespace_has_state:
+                    raise RuntimeError(
+                        "Existing RAG namespace could not be loaded for deletion"
+                    )
+                return 0
 
-        count = 0
-        for doc_id in ids:
-            try:
+            count = 0
+            for doc_id in ids:
                 index.delete_ref_doc(doc_id, delete_from_docstore=True)
                 count += 1
-            except Exception:
-                pass
-
-        if count > 0:
-            with self._get_namespace_lock(effective_namespace):
+            if count > 0:
                 index.storage_context.persist(
                     persist_dir=self._namespace_persist_dir(effective_namespace)
                 )
-
-        return count
+                generation = self._advance_namespace_generation(effective_namespace)
+                self._index_cache_generations[effective_namespace] = generation
+                self._persisted_index_cache_namespaces.add(effective_namespace)
+            return count
 
     def reset_namespace(
         self,
         namespace: Optional[str] = None,
     ) -> None:
         effective_namespace = self._resolve_effective_namespace(namespace)
-        with self._get_namespace_lock(effective_namespace):
+        with self._namespace_mutation_lock(effective_namespace):
             self._indices.pop(effective_namespace, None)
+            self._index_cache_generations.pop(effective_namespace, None)
+            self._persisted_index_cache_namespaces.discard(effective_namespace)
             self._namespace_runtime_state.pop(effective_namespace, None)
             with self._retrieval_state_lock:
                 self._namespace_retrieval_states.pop(effective_namespace, None)
 
-            persist_dir = os.path.abspath(self._namespace_persist_dir(effective_namespace))
+            persist_dir = os.path.abspath(
+                self._namespace_persist_dir(effective_namespace)
+            )
             namespaces_root = os.path.abspath(
                 os.path.join(self.persistence_dir, "namespaces")
             )
@@ -1290,7 +1481,9 @@ class LlamaIndexRAGService(RAGService):
             else max(top_k * 10, top_k)
         )
         start = time.perf_counter()
-        embed_model, previous_embed_settings = self._temporarily_bound_query_embed_model()
+        embed_model, previous_embed_settings = (
+            self._temporarily_bound_query_embed_model()
+        )
         try:
             retriever = index.as_retriever(similarity_top_k=similarity_top_k)
             nodes = retriever.retrieve(query_text)
@@ -1339,8 +1532,7 @@ class LlamaIndexRAGService(RAGService):
                 dict,
             )
             and (
-                metadata.get("type")
-                in {"text_relation", "scoped_knowledge_assertion"}
+                metadata.get("type") in {"text_relation", "scoped_knowledge_assertion"}
                 or metadata.get("source")
                 in {
                     "vontology_text_relation",
@@ -1365,12 +1557,10 @@ class LlamaIndexRAGService(RAGService):
                 else None
             )
             try:
-                authorised_knowledge_keys = (
-                    current_authorised_rag_candidate_keys(
-                        knowledge_candidate_metadata,
-                        user_concept_id=actor_user_id,
-                        organisation_concept_id=actor_org_id,
-                    )
+                authorised_knowledge_keys = current_authorised_rag_candidate_keys(
+                    knowledge_candidate_metadata,
+                    user_concept_id=actor_user_id,
+                    organisation_concept_id=actor_org_id,
                 )
             except Exception as exc:
                 # Knowledge rows fail closed when their live authority surface
@@ -1420,6 +1610,11 @@ class LlamaIndexRAGService(RAGService):
             if not isinstance(metadata, dict):
                 return False
             actual_type = metadata.get("type")
+            metadata_source = metadata.get("source")
+            is_live_authorised_scoped_assertion = bool(
+                actual_type == "scoped_knowledge_assertion"
+                or metadata_source == "scoped_knowledge_assertion"
+            )
             if not permissions_context:
                 return True
 
@@ -1480,19 +1675,24 @@ class LlamaIndexRAGService(RAGService):
                     if metadata.get("predicate") not in allow:
                         return False
 
-            user_id = permissions_context.get("user_id")
-            if user_id:
-                if normalise_concept_id_for_compare(
-                    metadata.get("user_id")
-                ) != normalise_concept_id_for_compare(user_id):
-                    return False
+            # Knowledge rows have already passed the canonical live authority
+            # check above. Re-applying generic creator metadata equality would
+            # incorrectly reject user-scoped knowledge in an organisation turn
+            # and organisation-scoped knowledge written by another member.
+            if not is_live_authorised_scoped_assertion:
+                user_id = permissions_context.get("user_id")
+                if user_id:
+                    if normalise_concept_id_for_compare(
+                        metadata.get("user_id")
+                    ) != normalise_concept_id_for_compare(user_id):
+                        return False
 
-            org_id = permissions_context.get("organisation_concept_id")
-            if org_id:
-                if normalise_concept_id_for_compare(
-                    metadata.get("organisation_concept_id")
-                ) != normalise_concept_id_for_compare(org_id):
-                    return False
+                org_id = permissions_context.get("organisation_concept_id")
+                if org_id:
+                    if normalise_concept_id_for_compare(
+                        metadata.get("organisation_concept_id")
+                    ) != normalise_concept_id_for_compare(org_id):
+                        return False
 
             return True
 

--- a/src/backend/services/rag_text_relation_sync_service.py
+++ b/src/backend/services/rag_text_relation_sync_service.py
@@ -30,6 +30,10 @@ from src.backend.security.access_control import (
     override_current_user,
 )
 from src.backend.services.rag_service import RAGBackendUnavailable, get_rag_service
+from src.backend.services.namespace_service import (
+    derive_actor_context_from_namespace,
+    resolve_canonical_namespace,
+)
 from src.backend.services.text_relation_predicate_validation_service import (
     predicate_concept_id_for_storage,
 )
@@ -239,30 +243,19 @@ def get_text_relation_preview(
 
 
 def _parse_namespace(namespace: str) -> Tuple[str, str]:
-    """Parse a namespace of the form '#V#user@org' into (user_id, organisation_id)."""
+    """Parse a canonical user or user-at-organisation RAG namespace."""
     if not isinstance(namespace, str) or not namespace.strip():
         raise ValueError("namespace is required")
-
     cleaned = namespace.strip()
-    if "@" not in cleaned:
+    canonical = resolve_canonical_namespace(cleaned)
+    if canonical is None or canonical != cleaned:
         raise ValueError(
-            "namespace must be of the form '#V#user@org' (missing '@' separator)"
+            "namespace must use canonical #V#user or #V#user@organisation form"
         )
-
-    user_part, org_part = cleaned.split("@", 1)
-    user_id = user_part.strip()
-    org_id = org_part.strip()
-
-    if not user_id:
-        raise ValueError("namespace user part is empty")
-    if not org_id:
-        raise ValueError("namespace organisation part is empty")
-
-    # Ensure org is a concept id.
-    if not org_id.startswith("#V#"):
-        org_id = f"#V#{org_id}"
-
-    return user_id, org_id
+    user_id, org_id = derive_actor_context_from_namespace(canonical)
+    if user_id is None:
+        raise ValueError("namespace has no valid user concept ID")
+    return user_id, org_id or ""
 
 
 def _safe_object_id(value: Any) -> ObjectId | None:
@@ -482,6 +475,20 @@ def _scoped_assertion_to_rag_doc(
 ) -> TextRelationRagDoc | None:
     if not isinstance(assertion, dict):
         return None
+    if assertion.get("assertion_form") == "standalone_text":
+        try:
+            from .knowledge_assertion_rag_service import (
+                build_standalone_text_assertion_rag_document,
+            )
+
+            payload = build_standalone_text_assertion_rag_document(assertion)
+        except (TypeError, ValueError):
+            return None
+        return TextRelationRagDoc(
+            doc_id=str(payload["id"]),
+            text=str(payload["text"]),
+            metadata=dict(payload["metadata"]),
+        )
     object_text = assertion.get("object_text")
     if not isinstance(object_text, dict):
         return None

--- a/src/backend/services/scoped_assertion_service.py
+++ b/src/backend/services/scoped_assertion_service.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import hashlib
 import json
+import re
 from typing import Any, Mapping, Sequence
+from uuid import uuid4
 
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
@@ -32,13 +34,21 @@ from .text_relation_predicate_validation_service import (
 )
 
 SCHEMA_VERSION = "scoped_knowledge_assertion.v1"
+TEXT_ASSERTION_SCHEMA_VERSION = "scoped_knowledge_assertion.v2"
 STORAGE_SURFACE = "scoped_knowledge_assertions"
+STANDALONE_TEXT_ASSERTION_FORM = "standalone_text"
 SCOPE_MODES = frozenset({"user", "organisation"})
 OBJECT_KINDS = frozenset({"text", "concept"})
 MAX_PAGE_LIMIT = 1000
 MAX_PAGE_SUBJECTS = 100
 MAX_PAGE_CANDIDATES = 10_000
 MAX_RETRACTION_HISTORY = 20
+MAX_CONTEXT_ID_LENGTH = 512
+MAX_SOURCE_EVENT_ID_LENGTH = 512
+MAX_LINK_ROLE_LENGTH = 100
+MAX_LINK_METHOD_LENGTH = 200
+MAX_LINKS_PER_ASSERTION = 200
+_LINK_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]*$")
 
 
 def _clean_concept_id(value: Any, field_name: str) -> str:
@@ -161,6 +171,7 @@ def _scope_for_actor(
         # organisation supplied the turn context that first established it.
         "organisation_concept_id": assertion_org_id,
         "namespace": assertion_namespace,
+        "audience_key": audience_key,
         "audience_keys": [audience_key],
     }
     return scope, actor_context
@@ -169,6 +180,147 @@ def _scope_for_actor(
 def _assertion_identity(identity: Mapping[str, Any]) -> str:
     encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     return f"ska_{hashlib.sha256(encoded.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _bounded_token(value: Any, *, field_name: str, maximum: int) -> str:
+    token = str(value or "").strip()
+    if not token:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    if len(token) > maximum:
+        raise ValueError(f"{field_name} is limited to {maximum} characters")
+    return token
+
+
+def _text_assertion_context(
+    *,
+    context_id: Any,
+    scope: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Select an explicit context or the actor scope's implicit intake context.
+
+    The implicit identifier is operationally stable but is not a Vontology
+    concept or a claim that scope and context have the same semantics.
+    """
+
+    supplied = str(context_id or "").strip()
+    if supplied:
+        if len(supplied) > MAX_CONTEXT_ID_LENGTH:
+            raise ValueError(
+                f"context_id is limited to {MAX_CONTEXT_ID_LENGTH} characters"
+            )
+        return {
+            "context_id": supplied,
+            "selection": "explicit",
+        }
+    audience_keys = list(scope.get("audience_keys") or ())
+    if len(audience_keys) != 1:
+        raise ValueError("text assertion scope must resolve one intake audience")
+    return {
+        "context_id": f"intake:{audience_keys[0]}",
+        "selection": "implicit",
+        "kind": "intake",
+    }
+
+
+def _new_text_assertion_rag_index(
+    *,
+    now: datetime,
+    namespace: str,
+    revision: int,
+    desired_operation: str,
+) -> dict[str, Any]:
+    """Materialise a durable derived-index job in the canonical assertion row."""
+
+    return {
+        "status": "pending",
+        "desired_operation": desired_operation,
+        "desired_revision": revision,
+        "indexed_revision": None,
+        "namespace": namespace,
+        "attempt_count": 0,
+        "next_attempt_at": now,
+        "lease_token": None,
+        "lease_expires_at": None,
+        "last_attempt_at": None,
+        "last_success_at": None,
+        "last_error_code": None,
+        "last_error": None,
+    }
+
+
+def _text_assertion_occurrence_identity(
+    *,
+    scope: Mapping[str, Any],
+    context: Mapping[str, Any],
+    text: str,
+    language: str,
+    source_event_id: Any,
+    turn_id: Any,
+) -> tuple[str, dict[str, str]]:
+    """Return an occurrence ID without collapsing equal text across sources.
+
+    An explicit source event is the strongest replay key. A turn-bound call is
+    idempotent for the same exact text within that turn. Calls with neither get
+    a fresh occurrence identity, so equal wording remains distinct knowledge.
+    """
+
+    clean_source_event_id = str(source_event_id or "").strip()
+    clean_turn_id = str(turn_id or "").strip()
+    if clean_source_event_id:
+        if len(clean_source_event_id) > MAX_SOURCE_EVENT_ID_LENGTH:
+            raise ValueError(
+                "source_event_id is limited to "
+                f"{MAX_SOURCE_EVENT_ID_LENGTH} characters"
+            )
+        occurrence = {
+            "kind": "source_event",
+            "value": clean_source_event_id,
+        }
+        identity_occurrence: Mapping[str, Any] = occurrence
+    elif clean_turn_id:
+        occurrence = {
+            "kind": "turn_text",
+            "value": clean_turn_id,
+        }
+        identity_occurrence = {
+            **occurrence,
+            "text_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "language": language,
+            "context_id": context["context_id"],
+        }
+    else:
+        occurrence = {
+            "kind": "generated",
+            "value": str(uuid4()),
+        }
+        identity_occurrence = occurrence
+    assertion_id = _assertion_identity(
+        {
+            "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+            "scope_mode": scope.get("mode"),
+            "audience_keys": list(scope.get("audience_keys") or ()),
+            "asserted_by_user_concept_id": scope.get("user_concept_id"),
+            "occurrence": identity_occurrence,
+        }
+    )
+    return assertion_id, occurrence
+
+
+def _standalone_text_payload_matches(
+    assertion: Mapping[str, Any],
+    *,
+    text: str,
+    language: str,
+    context: Mapping[str, Any],
+) -> bool:
+    object_text = assertion.get("object_text")
+    return bool(
+        assertion.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM
+        and isinstance(object_text, Mapping)
+        and object_text.get("text") == text
+        and object_text.get("language") == language
+        and assertion.get("assertion_context") == context
+    )
 
 
 def _json_safe_value(value: Any, *, path: str) -> Any:
@@ -208,6 +360,463 @@ def _serialise(document: Mapping[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(serialised, dict):
         raise TypeError("assertion serialisation did not produce an object")
     return serialised
+
+
+def store_text_assertion(
+    *,
+    text: Any,
+    language: Any = "en-NZ",
+    scope_mode: str = "user",
+    context_id: Any = None,
+    source_event_id: Any = None,
+    evidence: Any = None,
+    acting_user_concept_id: Any,
+    organisation_concept_id: Any = None,
+    namespace: Any = None,
+    turn_id: Any = None,
+    canonical_publication: bool = False,
+) -> dict[str, Any]:
+    """Store one exact natural-language assertion before semantic analysis.
+
+    No subject, predicate, concept link, or successful RAG operation is needed
+    for admission. The returned canonical read-back is the write receipt; the
+    embedded ``rag_index`` state is a durable, independently retryable job.
+    """
+
+    if canonical_publication is not False:
+        raise ValueError("text assertions cannot request canonical publication")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("text must be a non-empty string")
+    exact_text = text
+    language_token = _bounded_token(
+        language or "en-NZ",
+        field_name="language",
+        maximum=64,
+    )
+    scope, actor_context = _scope_for_actor(
+        scope_mode=scope_mode,
+        acting_user_concept_id=acting_user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace,
+    )
+    assertion_context = _text_assertion_context(
+        context_id=context_id,
+        scope=scope,
+    )
+    assertion_id, occurrence_identity = _text_assertion_occurrence_identity(
+        scope=scope,
+        context=assertion_context,
+        text=exact_text,
+        language=language_token,
+        source_event_id=source_event_id,
+        turn_id=turn_id,
+    )
+    now = datetime.now(timezone.utc)
+    revision = 1
+    provenance = {
+        "asserted_by_user_concept_id": scope["user_concept_id"],
+        "organisation_concept_id": actor_context["organisation_concept_id"],
+        "namespace": actor_context["namespace"],
+        "turn_id": str(turn_id or "").strip() or None,
+        "source_event_id": str(source_event_id or "").strip() or None,
+        "capability_name": "store_text_assertion",
+        "evidence": _normalise_evidence(evidence),
+    }
+    insert_fields: dict[str, Any] = {
+        "_id": assertion_id,
+        "schema_version": TEXT_ASSERTION_SCHEMA_VERSION,
+        "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+        "assertion_id": assertion_id,
+        "assertion_revision": revision,
+        "occurrence_identity": occurrence_identity,
+        # These nulls keep old generic projections honest without treating a
+        # standalone assertion as a malformed subject-predicate relation.
+        "subject_concept_id": None,
+        "predicate": None,
+        "object_kind": "text",
+        "object_text": {
+            "text": exact_text,
+            "language": language_token,
+        },
+        "object_concept_id": None,
+        "concept_links": [],
+        "assertion_context": assertion_context,
+        "scope": scope,
+        "canonical_publication": False,
+        "status": "asserted",
+        "created_at": now,
+        "updated_at": now,
+        "provenance": provenance,
+        "rag_index": _new_text_assertion_rag_index(
+            now=now,
+            namespace=str(actor_context["namespace"]),
+            revision=revision,
+            desired_operation="upsert",
+        ),
+    }
+    collection = get_scoped_knowledge_assertions_collection()
+    if collection is None:
+        raise RuntimeError("text assertion storage is unavailable")
+    try:
+        previous = collection.find_one_and_update(
+            {"assertion_id": assertion_id},
+            {"$setOnInsert": insert_fields},
+            upsert=True,
+            return_document=ReturnDocument.BEFORE,
+        )
+    except DuplicateKeyError:
+        previous = collection.find_one({"assertion_id": assertion_id})
+        if previous is None:
+            raise
+    created = previous is None
+    persisted = collection.find_one({"assertion_id": assertion_id})
+    if not isinstance(persisted, Mapping):
+        raise RuntimeError("text assertion write did not produce read-back")
+    if not _standalone_text_payload_matches(
+        persisted,
+        text=exact_text,
+        language=language_token,
+        context=assertion_context,
+    ):
+        raise ValueError(
+            "the occurrence identity already identifies a different text assertion"
+        )
+    reactivated = None
+    if persisted.get("status") == "retracted":
+        current_revision = int(persisted.get("assertion_revision") or 1)
+        rag_index = persisted.get("rag_index")
+        rag_index = rag_index if isinstance(rag_index, Mapping) else {}
+        index_namespace = str(
+            rag_index.get("namespace") or actor_context["namespace"] or ""
+        ).strip()
+        retraction_history_item = {
+            "retracted_at": persisted.get("retracted_at"),
+            "retraction_provenance": persisted.get("retraction_provenance"),
+        }
+        reassertion_provenance = {
+            "reasserted_by_user_concept_id": actor_context["user_concept_id"],
+            "organisation_concept_id": actor_context[
+                "organisation_concept_id"
+            ],
+            "namespace": actor_context["namespace"],
+            "turn_id": str(turn_id or "").strip() or None,
+            "source_event_id": str(source_event_id or "").strip() or None,
+            "capability_name": "store_text_assertion",
+            "evidence": _normalise_evidence(evidence),
+        }
+        reactivated = collection.find_one_and_update(
+            {
+                "assertion_id": assertion_id,
+                "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+                "assertion_revision": current_revision,
+                "status": "retracted",
+            },
+            {
+                "$set": {
+                    "status": "asserted",
+                    "updated_at": now,
+                    "reasserted_at": now,
+                    "reassertion_provenance": reassertion_provenance,
+                    "rag_index": _new_text_assertion_rag_index(
+                        now=now,
+                        namespace=index_namespace,
+                        revision=current_revision + 1,
+                        desired_operation="upsert",
+                    ),
+                },
+                "$inc": {"assertion_revision": 1},
+                "$unset": {
+                    "retracted_at": "",
+                    "retraction_provenance": "",
+                },
+                "$push": {
+                    "retraction_history": {
+                        "$each": [retraction_history_item],
+                        "$slice": -MAX_RETRACTION_HISTORY,
+                    }
+                },
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        persisted = reactivated or collection.find_one(
+            {"assertion_id": assertion_id}
+        )
+    read_back = _serialise(persisted)
+    if read_back is None:
+        raise RuntimeError("text assertion write did not produce read-back")
+    return {
+        "success": True,
+        "effect_status": "succeeded",
+        "changed": bool(created or reactivated is not None),
+        "assertion_id": assertion_id,
+        "assertion": read_back,
+        "canonical_read_back": read_back,
+        "canonical_publication": False,
+        "storage_surface": STORAGE_SURFACE,
+        "derived_maintenance": {
+            "durable": True,
+            "rag_index": read_back.get("rag_index"),
+        },
+    }
+
+
+def _normalise_text_assertion_link(
+    raw_link: Any,
+    *,
+    assertion_id: str,
+    assertion_text: str,
+    actor_context: Mapping[str, Any],
+    turn_id: Any,
+    now: datetime,
+) -> dict[str, Any]:
+    if not isinstance(raw_link, Mapping):
+        raise ValueError("each concept link must be an object")
+    concept_id = _clean_concept_id(raw_link.get("concept_id"), "concept_id")
+    if not can_access_concept(concept_id):
+        raise PermissionError("linked concept is not visible to the current actor")
+    role = _bounded_token(
+        raw_link.get("role") or "mentions",
+        field_name="role",
+        maximum=MAX_LINK_ROLE_LENGTH,
+    )
+    if not _LINK_TOKEN_RE.fullmatch(role):
+        raise ValueError(
+            "role must start with a letter and contain only letters, digits, "
+            "underscore, dot, colon, or hyphen"
+        )
+    method = _bounded_token(
+        raw_link.get("method") or "unspecified",
+        field_name="method",
+        maximum=MAX_LINK_METHOD_LENGTH,
+    )
+    confidence_value = raw_link.get("confidence")
+    confidence: float | None = None
+    if confidence_value is not None:
+        if isinstance(confidence_value, bool):
+            raise ValueError("confidence must be a number from 0 to 1")
+        try:
+            confidence = float(confidence_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("confidence must be a number from 0 to 1") from exc
+        if confidence < 0 or confidence > 1:
+            raise ValueError("confidence must be a number from 0 to 1")
+
+    raw_spans = raw_link.get("spans")
+    if raw_spans is None:
+        raw_spans = []
+    if not isinstance(raw_spans, Sequence) or isinstance(raw_spans, (str, bytes)):
+        raise ValueError("spans must be an array of {start, end} objects")
+    spans: list[dict[str, int]] = []
+    for raw_span in raw_spans:
+        if not isinstance(raw_span, Mapping):
+            raise ValueError("each span must be an object")
+        start = raw_span.get("start")
+        end = raw_span.get("end")
+        if isinstance(start, bool) or isinstance(end, bool):
+            raise ValueError("span start and end must be integers")
+        try:
+            start_value = int(start)
+            end_value = int(end)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("span start and end must be integers") from exc
+        if start_value < 0 or end_value <= start_value or end_value > len(
+            assertion_text
+        ):
+            raise ValueError(
+                "span offsets must identify a non-empty range within the exact text"
+            )
+        spans.append({"start": start_value, "end": end_value})
+    spans.sort(key=lambda span: (span["start"], span["end"]))
+    link_identity = {
+        "assertion_id": assertion_id,
+        "concept_id": concept_id,
+        "role": role,
+        "spans": spans,
+        "method": method,
+    }
+    encoded = json.dumps(link_identity, sort_keys=True, separators=(",", ":"))
+    link_id = f"skl_{hashlib.sha256(encoded.encode('utf-8')).hexdigest()[:32]}"
+    return {
+        "link_id": link_id,
+        "concept_id": concept_id,
+        "role": role,
+        "spans": spans,
+        "method": method,
+        "confidence": confidence,
+        "status": "active",
+        "created_at": now,
+        "updated_at": now,
+        "provenance": {
+            "linked_by_user_concept_id": actor_context["user_concept_id"],
+            "organisation_concept_id": actor_context[
+                "organisation_concept_id"
+            ],
+            "namespace": actor_context["namespace"],
+            "turn_id": str(turn_id or "").strip() or None,
+            "capability_name": "add_text_assertion_concept_links",
+            "evidence": _normalise_evidence(raw_link.get("evidence")),
+        },
+    }
+
+
+def add_text_assertion_concept_links(
+    *,
+    assertion_id: Any,
+    links: Any,
+    acting_user_concept_id: Any,
+    organisation_concept_id: Any = None,
+    namespace: Any = None,
+    turn_id: Any = None,
+) -> dict[str, Any]:
+    """Add optional, qualified concept links without changing asserted text."""
+
+    assertion_token = str(assertion_id or "").strip()
+    if not assertion_token.startswith("ska_"):
+        raise ValueError("assertion_id must be an exact scoped assertion ID")
+    if not isinstance(links, Sequence) or isinstance(links, (str, bytes)):
+        raise ValueError("links must be an array")
+    if not links:
+        raise ValueError("links must contain at least one concept link")
+    if len(links) > MAX_LINKS_PER_ASSERTION:
+        raise ValueError(
+            f"links is limited to {MAX_LINKS_PER_ASSERTION} concept links"
+        )
+    actor_context = _resolve_actor_context(
+        acting_user_concept_id=acting_user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace,
+    )
+    user_id = actor_context["user_concept_id"]
+    org_id = actor_context["organisation_concept_id"]
+    scope_clauses: list[dict[str, Any]] = [{"scope.mode": "user"}]
+    if org_id:
+        scope_clauses.append(
+            {
+                "scope.mode": "organisation",
+                "scope.organisation_concept_id": org_id,
+            }
+        )
+    authority_filter: dict[str, Any] = {
+        "assertion_id": assertion_token,
+        "assertion_form": STANDALONE_TEXT_ASSERTION_FORM,
+        "status": "asserted",
+        "provenance.asserted_by_user_concept_id": user_id,
+        "$or": scope_clauses,
+    }
+    collection = get_scoped_knowledge_assertions_collection()
+    if collection is None:
+        raise RuntimeError("text assertion storage is unavailable")
+
+    for _attempt in range(5):
+        current = collection.find_one(authority_filter)
+        if not isinstance(current, Mapping):
+            raise PermissionError(
+                "text assertion is unavailable to the current actor"
+            )
+        object_text = current.get("object_text")
+        exact_text = (
+            object_text.get("text") if isinstance(object_text, Mapping) else None
+        )
+        if not isinstance(exact_text, str):
+            raise RuntimeError("text assertion has no canonical text body")
+        now = datetime.now(timezone.utc)
+        with override_current_actor(user_id, org_id):
+            requested_links = [
+                _normalise_text_assertion_link(
+                    raw_link,
+                    assertion_id=assertion_token,
+                    assertion_text=exact_text,
+                    actor_context=actor_context,
+                    turn_id=turn_id,
+                    now=now,
+                )
+                for raw_link in links
+            ]
+        existing_links = [
+            dict(link)
+            for link in current.get("concept_links") or ()
+            if isinstance(link, Mapping)
+        ]
+        existing_ids = {
+            str(link.get("link_id") or "").strip() for link in existing_links
+        }
+        additions = [
+            link for link in requested_links if link["link_id"] not in existing_ids
+        ]
+        if not additions:
+            read_back = _serialise(current)
+            if read_back is None:
+                raise RuntimeError("concept-link replay did not produce read-back")
+            return {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": False,
+                "assertion_id": assertion_token,
+                "links_added": 0,
+                "assertion": read_back,
+                "canonical_read_back": read_back,
+                "canonical_publication": False,
+                "storage_surface": STORAGE_SURFACE,
+            }
+        merged_links = [*existing_links, *additions]
+        if len(merged_links) > MAX_LINKS_PER_ASSERTION:
+            raise ValueError(
+                "the assertion would exceed the bounded concept-link limit of "
+                f"{MAX_LINKS_PER_ASSERTION}"
+            )
+        current_revision = int(current.get("assertion_revision") or 1)
+        next_revision = current_revision + 1
+        scope = current.get("scope")
+        scope = scope if isinstance(scope, Mapping) else {}
+        index_namespace = str(
+            (
+                current.get("rag_index", {}).get("namespace")
+                if isinstance(current.get("rag_index"), Mapping)
+                else None
+            )
+            or actor_context["namespace"]
+            or ""
+        ).strip()
+        updated = collection.find_one_and_update(
+            {
+                **authority_filter,
+                "assertion_revision": current_revision,
+            },
+            {
+                "$set": {
+                    "concept_links": merged_links,
+                    "assertion_revision": next_revision,
+                    "updated_at": now,
+                    "rag_index": _new_text_assertion_rag_index(
+                        now=now,
+                        namespace=index_namespace,
+                        revision=next_revision,
+                        desired_operation="upsert",
+                    ),
+                }
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if isinstance(updated, Mapping):
+            read_back = _serialise(updated)
+            if read_back is None:
+                raise RuntimeError("concept-link write did not produce read-back")
+            return {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": True,
+                "assertion_id": assertion_token,
+                "links_added": len(additions),
+                "assertion": read_back,
+                "canonical_read_back": read_back,
+                "canonical_publication": False,
+                "storage_surface": STORAGE_SURFACE,
+                "derived_maintenance": {
+                    "durable": True,
+                    "rag_index": read_back.get("rag_index"),
+                },
+            }
+    raise RuntimeError("text assertion changed concurrently; retry the link operation")
 
 
 def upsert_scoped_assertion(
@@ -338,6 +947,7 @@ def upsert_scoped_assertion(
         "_id": assertion_id,
         "schema_version": SCHEMA_VERSION,
         "assertion_id": assertion_id,
+        "assertion_revision": 1,
         "subject_concept_id": subject_id,
         "predicate": storage_predicate,
         "object_kind": object_kind,
@@ -398,18 +1008,20 @@ def upsert_scoped_assertion(
         # Compare-and-set makes exactly one concurrent replay reactivate the
         # tombstone. Original assertion provenance and logical scope remain
         # immutable; a bounded history preserves the retraction being undone.
+        reactivation_set: dict[str, Any] = {
+            "status": "asserted",
+            "updated_at": now,
+            "reasserted_at": now,
+            "reassertion_provenance": reassertion_provenance,
+        }
         reactivated = collection.find_one_and_update(
             {
                 "assertion_id": assertion_id,
                 "status": "retracted",
             },
             {
-                "$set": {
-                    "status": "asserted",
-                    "updated_at": now,
-                    "reasserted_at": now,
-                    "reassertion_provenance": reassertion_provenance,
-                },
+                "$set": reactivation_set,
+                "$inc": {"assertion_revision": 1},
                 "$unset": {
                     "retracted_at": "",
                     "retraction_provenance": "",
@@ -493,17 +1105,50 @@ def retract_scoped_assertion(
         **authority_filter,
         "status": "asserted",
     }
-    persisted = collection.find_one_and_update(
+    current = collection.find_one(
         retract_filter,
         {
-            "$set": {
-                "status": "retracted",
-                "retracted_at": now,
-                "updated_at": now,
-                "retraction_provenance": retraction_provenance,
-            }
+            "_id": 0,
+            "assertion_form": 1,
         },
-        return_document=ReturnDocument.AFTER,
+    )
+    update: dict[str, Any] = {
+        "$set": {
+            "status": "retracted",
+            "retracted_at": now,
+            "updated_at": now,
+            "retraction_provenance": retraction_provenance,
+        },
+        "$inc": {"assertion_revision": 1},
+    }
+    if (
+        isinstance(current, Mapping)
+        and current.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM
+    ):
+        update["$set"].update(
+            {
+                "rag_index.status": "pending",
+                "rag_index.desired_operation": "delete",
+                "rag_index.next_attempt_at": now,
+                "rag_index.lease_token": None,
+                "rag_index.lease_expires_at": None,
+                "rag_index.last_error_code": None,
+                "rag_index.last_error": None,
+            }
+        )
+        update["$inc"]["rag_index.desired_revision"] = 1
+        update["$unset"] = {
+            "rag_index.indexed_revision": "",
+            "rag_index.indexed_at": "",
+        }
+    persisted = (
+        collection.find_one_and_update(
+            retract_filter,
+            update,
+            return_document=ReturnDocument.AFTER,
+        )
+        if isinstance(current, Mapping)
+        else None
     )
     changed = persisted is not None
     if persisted is None:
@@ -518,7 +1163,7 @@ def retract_scoped_assertion(
     read_back = _serialise(persisted)
     if read_back is None:
         raise RuntimeError("scoped assertion retraction did not produce read-back")
-    return {
+    receipt = {
         "success": True,
         "effect_status": "succeeded",
         "changed": changed,
@@ -528,6 +1173,12 @@ def retract_scoped_assertion(
         "canonical_publication": False,
         "storage_surface": STORAGE_SURFACE,
     }
+    if read_back.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
+        receipt["derived_maintenance"] = {
+            "durable": True,
+            "rag_index": read_back.get("rag_index"),
+        }
+    return receipt
 
 
 def _resolve_read_actor(
@@ -613,6 +1264,16 @@ def _assertion_visibility_concept_ids(
 ) -> tuple[str, ...] | None:
     """Return every concept whose current visibility is required for one row."""
 
+    if assertion.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
+        object_text = assertion.get("object_text")
+        if (
+            assertion.get("object_kind") != "text"
+            or not isinstance(object_text, Mapping)
+            or not isinstance(object_text.get("text"), str)
+            or not object_text.get("text", "").strip()
+        ):
+            return None
+        return ()
     subject_id = _clean_optional_concept_id(assertion.get("subject_concept_id"))
     predicate_id = predicate_concept_id_for_storage(assertion.get("predicate"))
     if not subject_id or not predicate_id:
@@ -630,22 +1291,58 @@ def _assertion_visibility_concept_ids(
 def _visible_assertion_documents(
     documents: Sequence[Mapping[str, Any]],
 ) -> list[Mapping[str, Any]]:
-    """Batch current visibility once for a bounded candidate window."""
+    """Batch visibility and redact optional links without hiding their row."""
 
     candidates: list[tuple[Mapping[str, Any], tuple[str, ...]]] = []
-    concept_ids: set[str] = set()
+    required_concept_ids: set[str] = set()
+    optional_link_concept_ids: set[str] = set()
     for document in documents:
         required_ids = _assertion_visibility_concept_ids(document)
         if required_ids is None:
             continue
         candidates.append((document, required_ids))
-        concept_ids.update(required_ids)
-    visible_ids = filter_accessible_concept_ids(concept_ids)
-    return [
-        document
-        for document, required_ids in candidates
-        if all(concept_id in visible_ids for concept_id in required_ids)
-    ]
+        required_concept_ids.update(required_ids)
+        if document.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
+            for link in document.get("concept_links") or ():
+                if not isinstance(link, Mapping) or link.get("status") != "active":
+                    continue
+                concept_id = _clean_optional_concept_id(link.get("concept_id"))
+                if concept_id:
+                    optional_link_concept_ids.add(concept_id)
+    all_concept_ids = required_concept_ids | optional_link_concept_ids
+    try:
+        visible_ids = (
+            filter_accessible_concept_ids(all_concept_ids)
+            if all_concept_ids
+            else set()
+        )
+    except Exception:
+        # Optional enrichment must never become an admission or raw-retrieval
+        # dependency. If only link visibility failed, keep the assertion and
+        # redact every optional link. Required legacy relation concepts remain
+        # fail-closed through a separate visibility check.
+        visible_ids = (
+            filter_accessible_concept_ids(required_concept_ids)
+            if required_concept_ids
+            else set()
+        )
+    visible_documents: list[Mapping[str, Any]] = []
+    for document, required_ids in candidates:
+        if not all(concept_id in visible_ids for concept_id in required_ids):
+            continue
+        if document.get("assertion_form") != STANDALONE_TEXT_ASSERTION_FORM:
+            visible_documents.append(document)
+            continue
+        projected = dict(document)
+        projected["concept_links"] = [
+            dict(link)
+            for link in document.get("concept_links") or ()
+            if isinstance(link, Mapping)
+            and link.get("status") == "active"
+            and _clean_optional_concept_id(link.get("concept_id")) in visible_ids
+        ]
+        visible_documents.append(projected)
+    return visible_documents
 
 
 def _normalise_page_bound(
@@ -672,9 +1369,15 @@ def _build_assertion_query(
     predicates: Sequence[str] | None,
     object_kind: str | None,
     languages: Sequence[str] | None,
+    assertion_form: str | None,
+    context_id: str | None,
 ) -> dict[str, Any]:
     query: dict[str, Any] = {
-        "scope.audience_keys": {"$in": list(audience_keys)},
+        (
+            "scope.audience_key"
+            if assertion_form == STANDALONE_TEXT_ASSERTION_FORM
+            else "scope.audience_keys"
+        ): {"$in": list(audience_keys)},
         "status": "asserted",
     }
     if subject_concept_ids:
@@ -683,7 +1386,28 @@ def _build_assertion_query(
         query["$or"] = [
             {"subject_concept_id": argument_concept_id},
             {"object_concept_id": argument_concept_id},
+            {
+                "concept_links": {
+                    "$elemMatch": {
+                        "concept_id": argument_concept_id,
+                        "status": "active",
+                    }
+                }
+            },
         ]
+    if assertion_form is not None:
+        if assertion_form not in {"relation", STANDALONE_TEXT_ASSERTION_FORM}:
+            raise ValueError(
+                "assertion_form must be 'relation' or 'standalone_text'"
+            )
+        if assertion_form == "relation":
+            query["assertion_form"] = {
+                "$ne": STANDALONE_TEXT_ASSERTION_FORM
+            }
+        else:
+            query["assertion_form"] = STANDALONE_TEXT_ASSERTION_FORM
+    if context_id:
+        query["assertion_context.context_id"] = str(context_id).strip()
     if predicates:
         predicate_values: set[str] = set()
         for item in predicates:
@@ -765,6 +1489,8 @@ def list_visible_scoped_assertions_page(
     predicates: Sequence[str] | None = None,
     object_kind: str | None = None,
     languages: Sequence[str] | None = None,
+    assertion_form: str | None = None,
+    context_id: str | None = None,
     limit: int = 200,
     offset: int = 0,
     limit_per_subject: int | None = None,
@@ -849,8 +1575,10 @@ def list_visible_scoped_assertions_page(
             *requested_subjects,
             *([resolved_argument_id] if resolved_argument_id else []),
         }
-        visible_preflight_ids = filter_accessible_concept_ids(
-            preflight_concept_ids
+        visible_preflight_ids = (
+            filter_accessible_concept_ids(preflight_concept_ids)
+            if preflight_concept_ids
+            else set()
         )
         visible_subjects = [
             subject_id
@@ -882,6 +1610,8 @@ def list_visible_scoped_assertions_page(
             predicates=predicates,
             object_kind=object_kind,
             languages=languages,
+            assertion_form=assertion_form,
+            context_id=context_id,
         )
         collection = get_scoped_knowledge_assertions_collection()
         if collection is None:
@@ -1071,6 +1801,8 @@ def list_visible_scoped_assertions(
     predicates: Sequence[str] | None = None,
     object_kind: str | None = None,
     languages: Sequence[str] | None = None,
+    assertion_form: str | None = None,
+    context_id: str | None = None,
     limit: int = 200,
     user_concept_id: str | None = None,
     organisation_concept_id: str | None = None,
@@ -1083,6 +1815,8 @@ def list_visible_scoped_assertions(
         predicates=predicates,
         object_kind=object_kind,
         languages=languages,
+        assertion_form=assertion_form,
+        context_id=context_id,
         limit=limit,
         user_concept_id=user_concept_id,
         organisation_concept_id=organisation_concept_id,
@@ -1094,6 +1828,8 @@ def scoped_text_assertion_to_relation_row(
 ) -> dict[str, Any] | None:
     """Project a scoped text assertion into the generic text-read row shape."""
 
+    if assertion.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
+        return None
     object_text = assertion.get("object_text")
     if assertion.get("object_kind") != "text" or not isinstance(object_text, Mapping):
         return None
@@ -1124,9 +1860,12 @@ def scoped_text_assertion_to_relation_row(
 
 
 __all__ = [
+    "STANDALONE_TEXT_ASSERTION_FORM",
+    "add_text_assertion_concept_links",
     "list_visible_scoped_assertions",
     "list_visible_scoped_assertions_page",
     "retract_scoped_assertion",
     "scoped_text_assertion_to_relation_row",
+    "store_text_assertion",
     "upsert_scoped_assertion",
 ]

--- a/src/backend/services/scoped_rag_authority_service.py
+++ b/src/backend/services/scoped_rag_authority_service.py
@@ -17,6 +17,7 @@ from ..security.access_control import (
 from .text_relation_predicate_validation_service import (
     predicate_concept_id_for_storage,
 )
+from .scoped_assertion_service import STANDALONE_TEXT_ASSERTION_FORM
 
 
 def _clean_concept_id(value: Any) -> str | None:
@@ -101,6 +102,7 @@ def current_authorised_rag_candidate_keys(
         tuple[str, str],
         tuple[str, str, str],
     ] = {}
+    current_standalone_revisions: dict[str, int] = {}
     concept_ids: set[str] = set()
 
     if relation_metadata:
@@ -116,6 +118,8 @@ def current_authorised_rag_candidate_keys(
                 "_id": 1,
                 "subject_concept_id": 1,
                 "predicate": 1,
+                "assertion_form": 1,
+                "assertion_revision": 1,
             },
         )
         for relation in relations:
@@ -158,6 +162,8 @@ def current_authorised_rag_candidate_keys(
             {
                 "_id": 0,
                 "assertion_id": 1,
+                "assertion_form": 1,
+                "assertion_revision": 1,
                 "subject_concept_id": 1,
                 "predicate": 1,
             },
@@ -168,6 +174,14 @@ def current_authorised_rag_candidate_keys(
             assertion_id = _clean_assertion_id(
                 assertion.get("assertion_id")
             )
+            if assertion.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
+                try:
+                    revision = int(assertion.get("assertion_revision") or 0)
+                except (TypeError, ValueError):
+                    revision = 0
+                if assertion_id and revision > 0:
+                    current_standalone_revisions[assertion_id] = revision
+                continue
             subject_id = _clean_concept_id(
                 assertion.get("subject_concept_id")
             )
@@ -187,10 +201,24 @@ def current_authorised_rag_candidate_keys(
             )
             concept_ids.update((subject_id, predicate_id))
 
-    with override_current_actor(actor_user_id, actor_org_id):
-        visible_concept_ids = filter_accessible_concept_ids(concept_ids)
+    visible_concept_ids: set[str] = set()
+    if concept_ids:
+        with override_current_actor(actor_user_id, actor_org_id):
+            visible_concept_ids = filter_accessible_concept_ids(concept_ids)
 
     allowed: set[tuple[str, str]] = set()
+    for assertion_id, revision in current_standalone_revisions.items():
+        metadata = scoped_metadata.get(assertion_id)
+        if metadata is None:
+            continue
+        if metadata.get("assertion_form") != STANDALONE_TEXT_ASSERTION_FORM:
+            continue
+        try:
+            metadata_revision = int(metadata.get("assertion_revision") or 0)
+        except (TypeError, ValueError):
+            continue
+        if metadata_revision == revision:
+            allowed.add(("scoped_knowledge_assertion", assertion_id))
     for key, (subject_id, predicate, predicate_id) in current_rows.items():
         kind, candidate_id = key
         metadata = (

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -807,6 +807,10 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
             "before treating another filler as the requested entity; co-participation "
             "alone does not establish that role. A numeric object index selects one "
             "stored slot, not the whole object side."
+            " Actor-effective text hits may also be standalone assertions matched "
+            "through an explicit concept link; inspect row_kind, assertion_id, "
+            "link_role, context, provenance, and publication state rather than "
+            "treating them as ground binary predicates."
         ),
     },
     "find_concepts_by_name": {
@@ -954,7 +958,39 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "planner_hint": (
             "Use for represented-knowledge lookup over indexed content in the user's "
             "namespace, especially when answering questions about an entity and its "
-            "related facts, artefacts, or relationships."
+            "related facts, artefacts, or relationships. This includes raw text "
+            "assertions with no known concepts or predicates; use their assertion ID, "
+            "context, provenance, lifecycle, and publication metadata when weighing "
+            "them as evidence."
+        ),
+    },
+    "store_text_assertion": {
+        "salience": "medium",
+        "category": "vontology",
+        "display_template": "Stored text assertion",
+        "dispatch_surface_family": "knowledge_base",
+        "evidence_surface_family": "knowledge_base",
+        "external_surface": False,
+        "operation_category": "write",
+        "planner_hint": (
+            "Use when exact natural-language knowledge should survive even though its "
+            "subject, predicate, or related concepts are incomplete or unknown. Store "
+            "first; optional links and semantic analysis are enrichment, never an "
+            "admission prerequisite."
+        ),
+    },
+    "add_text_assertion_concept_links": {
+        "salience": "medium",
+        "category": "vontology",
+        "display_template": "Linked text assertion",
+        "dispatch_surface_family": "knowledge_base",
+        "evidence_surface_family": "knowledge_base",
+        "external_surface": False,
+        "operation_category": "write",
+        "planner_hint": (
+            "Use after a standalone assertion is already stored when later analysis "
+            "identifies visible related concepts. Links enrich retrieval but never "
+            "replace, reinterpret, or gate the exact text assertion."
         ),
     },
     "task_get": {

--- a/src/backend/utilities/rag_indexing_worker.py
+++ b/src/backend/utilities/rag_indexing_worker.py
@@ -256,6 +256,39 @@ def process_pending_interactions(loop_iteration: int) -> int:
     return success_count + skipped_count
 
 
+def process_pending_text_assertions() -> int:
+    """Run one bounded durable assertion-index batch in this worker process."""
+
+    try:
+        from src.backend.services.knowledge_assertion_rag_service import (
+            process_pending_assertion_rag_jobs,
+            reconcile_assertion_rag_state,
+        )
+
+        # Reconciliation is storage-only and bounded. It repairs records from
+        # interrupted/older writers before the claim loop attempts RAG work.
+        reconcile_assertion_rag_state(limit=BATCH_SIZE)
+        report = process_pending_assertion_rag_jobs(
+            limit=BATCH_SIZE,
+            worker_id=f"rag-index-worker:{os.getpid()}",
+        )
+        claimed = int(report.get("claimed") or 0)
+        if claimed:
+            logger.info(
+                "Assertion RAG batch claimed=%s succeeded=%s failed=%s superseded=%s",
+                claimed,
+                report.get("succeeded"),
+                report.get("failed"),
+                report.get("superseded"),
+            )
+        return int(report.get("succeeded") or 0)
+    except Exception as exc:
+        # The next worker iteration is the recovery boundary. Never stop chat
+        # indexing because derived assertion maintenance is unavailable.
+        logger.warning("Assertion RAG batch failed: %s", exc)
+        return 0
+
+
 def main():
     global _shutdown_requested
     print("[stdout] RAG Indexing Worker starting...")  # direct stdout banner
@@ -271,7 +304,11 @@ def main():
     while not _shutdown_requested:
         iteration += 1
         try:
-            processed_count = process_pending_interactions(iteration)
+            assertion_processed_count = process_pending_text_assertions()
+            processed_count = (
+                process_pending_interactions(iteration)
+                + assertion_processed_count
+            )
         except KeyboardInterrupt:
             logger.info("Worker stopped by user")
             _flush()

--- a/tests/backend/test_context_semantic_coherence.py
+++ b/tests/backend/test_context_semantic_coherence.py
@@ -508,6 +508,100 @@ def test_relation_lookup_uses_actor_effective_text_without_fabricated_id(
     assert metadata["row_kind"] == "scoped_assertion"
 
 
+def test_relation_lookup_returns_explicitly_linked_standalone_text_alongside_relations(
+    monkeypatch,
+):
+    from src.backend.services import concept_relation_service
+    from src.backend.services import scoped_assertion_service
+
+    monkeypatch.setattr(
+        concept_relation_service,
+        "_load_accessible_relation_subject_document",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        concept_relation_service,
+        "get_texts_for_concepts",
+        lambda concept_ids, **_kwargs: {concept_id: [] for concept_id in concept_ids},
+    )
+    monkeypatch.setattr(
+        concept_relation_service.TextValuesRepository,
+        "find",
+        lambda *_args, **_kwargs: [],
+    )
+    observed = []
+
+    def _list_linked(**kwargs):
+        observed.append(kwargs)
+        return {
+            "items": [
+                {
+                    "assertion_id": "ska_raw",
+                    "assertion_revision": 2,
+                    "assertion_form": "standalone_text",
+                    "object_kind": "text",
+                    "object_text": {
+                        "text": "Susan hosted gatherings in Svalbard.",
+                        "language": "en-NZ",
+                    },
+                    "concept_links": [
+                        {
+                            "link_id": "skl_susan",
+                            "concept_id": "#V#susan",
+                            "role": "about",
+                            "status": "active",
+                            "method": "explicit_user_link",
+                            "spans": [{"start": 0, "end": 5}],
+                        }
+                    ],
+                    "assertion_context": {
+                        "context_id": "intake:user:#V#member"
+                    },
+                    "scope": {"mode": "user"},
+                    "provenance": {"turn_id": "turn-1"},
+                }
+            ],
+            "has_more": False,
+            "counts_are_lower_bounds": False,
+        }
+
+    monkeypatch.setattr(
+        scoped_assertion_service,
+        "list_visible_scoped_assertions_page",
+        _list_linked,
+    )
+    payload = concept_relation_service.find_relations_with_argument(
+        "#V#susan",
+        argument_index="any",
+        relation_kind="text",
+        include_text_snippets=True,
+        include_concept_preview=False,
+        context_view="actor_effective",
+    )
+
+    assert observed == [
+        {
+            "argument_concept_id": "#V#susan",
+            "object_kind": "text",
+            "assertion_form": "standalone_text",
+            "limit": 501,
+        }
+    ]
+    assert payload["total_hits"] == 1
+    hit = payload["hits"][0]
+    assert hit["relation_kind"] == "text"
+    assert hit["target_value"] == "Susan hosted gatherings in Svalbard."
+    assert hit["predicate_concept_id"] is None
+    metadata = hit["relation_metadata"]
+    assert metadata["relation_id"] is None
+    assert metadata["assertion_id"] == "ska_raw"
+    assert metadata["row_kind"] == "text_assertion"
+    assert metadata["link_id"] == "skl_susan"
+    assert metadata["link_role"] == "about"
+    assert metadata["match_type"] == "explicit_concept_link"
+    assert metadata["canonical_publication"] is False
+
+
 def test_relation_lookup_propagates_scoped_page_completeness(monkeypatch):
     from src.backend.services import concept_relation_service
     from src.backend.services import scoped_assertion_service

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -46,6 +46,8 @@ def test_internal_mcp_catalogue_builds_and_includes_relationship_tools():
     methods = set(catalogue.list_methods())
 
     assert "add_relationship" in methods
+    assert "add_text_assertion_concept_links" in methods
+    assert "store_text_assertion" in methods
     assert "upsert_scoped_assertion" in methods
     assert "retract_scoped_assertion" in methods
     assert "list_scoped_assertions" in methods
@@ -233,6 +235,8 @@ def test_frequent_gmail_and_scoped_assertion_paths_use_advisory_only_timing():
         "gmail_import_attachment": 20.0,
         "gmail_list_labels": 15.0,
         "upsert_scoped_assertion": 20.0,
+        "add_text_assertion_concept_links": 20.0,
+        "store_text_assertion": 20.0,
         "list_scoped_assertions": 20.0,
     }
 
@@ -343,11 +347,13 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     }.isdisjoint(actor_mail_reads)
     assert delegated_effects == {
         "create_concepts",
+        "add_text_assertion_concept_links",
         "change_concept_publication_scope",
         "record_source_processing_marker",
         "preview_concept_publication_scope_change",
-        "retract_scoped_assertion",
-        "upsert_scoped_assertion",
+            "retract_scoped_assertion",
+            "store_text_assertion",
+            "upsert_scoped_assertion",
         "upsert_text_relation",
         "upsert_uncertain_relationship_assertion",
         "add_relationship",
@@ -447,6 +453,27 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "canonical_publication": False,
     }
     assert scoped_definition.ordinary_turn_mutation_subject_argument is None
+    text_assertion_definition = catalogue.get("store_text_assertion")
+    assert text_assertion_definition.ordinary_turn_trusted_argument_bindings == {
+        "acting_user_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+        "namespace": "turn_namespace",
+        "turn_id": "turn_id",
+    }
+    assert text_assertion_definition.ordinary_turn_fixed_arguments == {
+        "canonical_publication": False,
+    }
+    assert text_assertion_definition.ordinary_turn_effect is True
+    assert text_assertion_definition.ordinary_turn_mutation_subject_argument is None
+    link_definition = catalogue.get("add_text_assertion_concept_links")
+    assert link_definition.ordinary_turn_trusted_argument_bindings == {
+        "acting_user_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+        "namespace": "turn_namespace",
+        "turn_id": "turn_id",
+    }
+    assert link_definition.ordinary_turn_effect is True
+    assert link_definition.ordinary_turn_mutation_subject_argument is None
     uncertain_definition = catalogue.get("upsert_uncertain_relationship_assertion")
     assert uncertain_definition.ordinary_turn_effect is True
     assert uncertain_definition.ordinary_turn_mutation_subject_argument == "source_id"

--- a/tests/backend/test_internal_mcp_orchestrator_context_limits.py
+++ b/tests/backend/test_internal_mcp_orchestrator_context_limits.py
@@ -357,6 +357,59 @@ def test_format_tool_result_shapes_search_knowledge_base_payload_for_live_follow
     assert "source systems" in payload["retrieval_diagnostics"]["note"].lower()
 
 
+def test_format_tool_result_preserves_raw_text_assertion_identity_and_context():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, _StubGateway()),
+        max_tool_invocations=1,
+        max_tool_result_chars=5_000,
+        max_tool_result_field_chars=1_500,
+    )
+    encoded = orchestrator._format_tool_result(
+        "search_knowledge_base",
+        {
+            "query": "salon gatherings in Svalbard",
+            "count": 1,
+            "results": [
+                {
+                    "id": "scoped_assertion:ska_raw",
+                    "text": "Susan hosted salon-style gatherings in Svalbard.",
+                    "score": 0.91,
+                    "metadata": {
+                        "type": "scoped_knowledge_assertion",
+                        "row_kind": "text_assertion",
+                        "payload_kind": "text",
+                        "assertion_form": "standalone_text",
+                        "assertion_id": "ska_raw",
+                        "assertion_revision": 2,
+                        "language": "en-NZ",
+                        "context_id": "intake:user:#V#member",
+                        "context_selection": "implicit",
+                        "canonical_publication": False,
+                        "assertion_provenance": {
+                            "asserted_by_user_concept_id": "#V#member",
+                            "source_event_id": "source:7",
+                            "evidence": {"unbounded": "must not be copied"},
+                        },
+                    },
+                }
+            ],
+        },
+        1.0,
+        "ok",
+    )
+    row = json.loads(encoded)["payload"]["results"][0]
+    assert row["assertion_id"] == "ska_raw"
+    assert row["assertion_revision"] == 2
+    assert row["row_kind"] == "text_assertion"
+    assert row["assertion_form"] == "standalone_text"
+    assert row["context_id"] == "intake:user:#V#member"
+    assert row["canonical_publication"] is False
+    assert row["assertion_provenance"] == {
+        "asserted_by_user_concept_id": "#V#member",
+        "source_event_id": "source:7",
+    }
+
+
 def test_format_tool_result_preserves_bounded_rag_concept_frontier():
     orchestrator = InternalMCPChatOrchestrator(
         gateway=cast(Any, _StubGateway()),
@@ -700,6 +753,73 @@ def test_format_tool_result_shapes_find_relations_payload_with_target_type_ids()
     assert payload["hits"][1]["target_type_ids"] == [
         "#V#diary_entry_about_michael_witbrocks_work"
     ]
+
+
+def test_format_tool_result_preserves_linked_text_assertion_envelope():
+    orchestrator = InternalMCPChatOrchestrator(
+        gateway=cast(Any, _StubGateway()),
+        max_tool_invocations=1,
+        max_tool_result_chars=5_000,
+        max_tool_result_field_chars=1_500,
+    )
+    encoded = orchestrator._format_tool_result(
+        "find_relations_with_argument",
+        {
+            "concept_id": "#V#susan",
+            "context_view": "actor_effective",
+            "total_hits": 1,
+            "hits": [
+                {
+                    "source_concept_id": None,
+                    "predicate_concept_id": None,
+                    "relation_kind": "text",
+                    "argument_indexes": [2],
+                    "target_value": "Susan hosted gatherings in Svalbard.",
+                    "relation_state": "asserted_text_with_link",
+                    "canonical_publication": False,
+                    "relation_metadata": {
+                        "assertion_id": "ska_raw",
+                        "assertion_revision": 2,
+                        "row_kind": "text_assertion",
+                        "assertion_form": "standalone_text",
+                        "link_id": "skl_susan",
+                        "link_role": "about",
+                        "linked_concept_id": "#V#susan",
+                        "link_method": "explicit_user_link",
+                        "link_confidence": 0.9,
+                        "match_type": "explicit_concept_link",
+                        "canonical_publication": False,
+                        "assertion_context": {
+                            "context_id": "intake:user:#V#member",
+                            "selection": "implicit",
+                        },
+                        "provenance": {
+                            "asserted_by_user_concept_id": "#V#member",
+                            "turn_id": "turn-1",
+                            "evidence": {"large": "not copied"},
+                        },
+                    },
+                }
+            ],
+        },
+        1.0,
+        "ok",
+    )
+    hit = json.loads(encoded)["payload"]["hits"][0]
+    assert hit["assertion_id"] == "ska_raw"
+    assert hit["assertion_revision"] == 2
+    assert hit["row_kind"] == "text_assertion"
+    assert hit["link_id"] == "skl_susan"
+    assert hit["link_role"] == "about"
+    assert hit["canonical_publication"] is False
+    assert hit["assertion_context"] == {
+        "context_id": "intake:user:#V#member",
+        "selection": "implicit",
+    }
+    assert hit["provenance"] == {
+        "asserted_by_user_concept_id": "#V#member",
+        "turn_id": "turn-1",
+    }
 
 
 def test_format_tool_result_projects_unique_related_entities_in_both_directions():

--- a/tests/backend/test_internal_mcp_scoped_assertion_authority.py
+++ b/tests/backend/test_internal_mcp_scoped_assertion_authority.py
@@ -411,6 +411,8 @@ def test_scoped_list_forwards_offset_and_reports_bounded_page(
                 "predicates": ["hasDescription"],
                 "object_kind": "text",
                 "languages": ["en-NZ"],
+                "assertion_form": "standalone_text",
+                "context_id": "project:salons",
                 "limit": 2,
                 "offset": 40,
             },
@@ -435,6 +437,8 @@ def test_scoped_list_forwards_offset_and_reports_bounded_page(
     forwarded = calls["list"][-1]
     assert forwarded["offset"] == 40
     assert forwarded["languages"] == ["en-NZ"]
+    assert forwarded["assertion_form"] == "standalone_text"
+    assert forwarded["context_id"] == "project:salons"
     assert forwarded["_actor"] == (TRUSTED_USER, TRUSTED_ORG)
 
 
@@ -690,6 +694,184 @@ def test_text_assertion_receipt_includes_derived_maintenance_schedule(
         "durable": False,
         "success": True,
         "scheduled": True,
+    }
+
+
+def test_standalone_text_tool_binds_actor_and_admits_before_link_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from src.backend.security.access_control import override_current_actor
+
+    captured: dict[str, Any] = {}
+    assertion = {
+        "assertion_id": "ska_raw",
+        "assertion_form": "standalone_text",
+        "assertion_revision": 1,
+        "object_kind": "text",
+        "object_text": {
+            "text": "  Susan hosted gatherings in Svalbard.\n",
+            "language": "en-NZ",
+        },
+        "concept_links": [],
+        "canonical_publication": False,
+        "rag_index": {"status": "pending"},
+    }
+
+    def store(**kwargs):
+        captured["store"] = kwargs
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": "ska_raw",
+            "assertion": assertion,
+            "canonical_read_back": assertion,
+            "canonical_publication": False,
+            "derived_maintenance": {
+                "durable": True,
+                "rag_index": {"status": "pending"},
+            },
+        }
+
+    def reject_links(**kwargs):
+        captured["links"] = kwargs
+        raise ValueError("one proposed concept is unresolved")
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.store_text_assertion",
+        store,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service."
+        "add_text_assertion_concept_links",
+        reject_links,
+    )
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        result = _gateway().invoke(
+            "store_text_assertion",
+            {
+                "text": "  Susan hosted gatherings in Svalbard.\n",
+                "source_occurrence_key": "source:7",
+                "concept_links": [
+                    {"concept_id": "#V#unresolved", "role": "involves"}
+                ],
+            },
+        ).payload
+
+    assert result["success"] is True
+    assert result["effect_status"] == "succeeded"
+    assert result["canonical_read_back"] == assertion
+    assert result["enrichment"] == {
+        "success": False,
+        "changed": False,
+        "links_added": 0,
+        "retryable": True,
+        "error_code": "invalid_concept_links",
+        "error": "one proposed concept is unresolved",
+    }
+    assert captured["store"] == {
+        "text": "  Susan hosted gatherings in Svalbard.\n",
+        "language": "en-NZ",
+        "scope_mode": "user",
+        "context_id": None,
+        "source_event_id": "source:7",
+        "evidence": None,
+        "acting_user_concept_id": TRUSTED_USER,
+        "organisation_concept_id": TRUSTED_ORG,
+        "namespace": TRUSTED_NAMESPACE,
+        "turn_id": None,
+        "canonical_publication": False,
+    }
+    assert captured["links"]["acting_user_concept_id"] == TRUSTED_USER
+    assert captured["links"]["organisation_concept_id"] == TRUSTED_ORG
+    assert captured["links"]["namespace"] == TRUSTED_NAMESPACE
+
+
+def test_standalone_text_tool_rejects_payload_identity_without_actor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    called = False
+
+    def store(**_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("actorless payload must not reach storage")
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.store_text_assertion",
+        store,
+    )
+    result = _gateway().invoke(
+        "store_text_assertion",
+        {
+            "text": "Payload-claimed private assertion.",
+            "acting_user_concept_id": CLAIMED_USER,
+            "organisation_concept_id": CLAIMED_ORG,
+            "namespace": CLAIMED_NAMESPACE,
+        },
+    ).payload
+
+    assert result["success"] is False
+    assert result["error_code"] == "authenticated_actor_context_required"
+    assert called is False
+
+
+def test_later_text_assertion_link_enrichment_uses_trusted_actor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from src.backend.security.access_control import override_current_actor
+
+    captured: dict[str, Any] = {}
+
+    def add_links(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": "ska_raw",
+            "links_added": 1,
+            "assertion": {
+                "assertion_id": "ska_raw",
+                "assertion_form": "standalone_text",
+                "concept_links": [{"concept_id": "#V#svalbard"}],
+            },
+            "canonical_publication": False,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service."
+        "add_text_assertion_concept_links",
+        add_links,
+    )
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        result = _gateway().invoke(
+            "add_text_assertion_concept_links",
+            {
+                "assertion_id": "ska_raw",
+                "links": [
+                    {
+                        "concept_id": "#V#svalbard",
+                        "role": "involves",
+                    }
+                ],
+            },
+        ).payload
+
+    assert result["success"] is True
+    assert result["links_added"] == 1
+    assert captured == {
+        "assertion_id": "ska_raw",
+        "links": [
+            {
+                "concept_id": "#V#svalbard",
+                "role": "involves",
+            }
+        ],
+        "acting_user_concept_id": TRUSTED_USER,
+        "organisation_concept_id": TRUSTED_ORG,
+        "namespace": TRUSTED_NAMESPACE,
+        "turn_id": None,
     }
 
 

--- a/tests/backend/test_knowledge_assertion_rag_service.py
+++ b/tests/backend/test_knowledge_assertion_rag_service.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import mongomock
+
+
+class _StubRag:
+    def __init__(self, *, fail_upserts: int = 0, deleted: int = 1) -> None:
+        self.fail_upserts = fail_upserts
+        self.deleted = deleted
+        self.upserts: list[tuple[list[dict], str | None]] = []
+        self.deletes: list[tuple[list[str], str | None]] = []
+
+    def upsert_documents(self, docs, *, namespace=None, **_kwargs):
+        payload = list(docs)
+        self.upserts.append((payload, namespace))
+        if self.fail_upserts:
+            self.fail_upserts -= 1
+            raise RuntimeError("temporary vector failure")
+        return len(payload), 0
+
+    def delete_documents(self, ids, *, namespace=None):
+        payload = list(ids)
+        self.deletes.append((payload, namespace))
+        return self.deleted
+
+
+def _collection():
+    return mongomock.MongoClient()["von_test"]["scoped_knowledge_assertions"]
+
+
+def _store(monkeypatch, collection, *, text="  Exact raw assertion.\n"):
+    from src.backend.services import scoped_assertion_service
+
+    monkeypatch.setattr(
+        scoped_assertion_service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    return scoped_assertion_service.store_text_assertion(
+        text=text,
+        acting_user_concept_id="#V#member",
+        organisation_concept_id="#V#trusted_org",
+        turn_id="turn-rag",
+    )
+
+
+def test_pending_raw_assertion_indexes_exact_body_and_completes(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    rag = _StubRag()
+    now = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+
+    result = service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="worker-one",
+        rag_service=rag,
+        now=now,
+        collection=collection,
+    )
+
+    assert result["succeeded"] == 1
+    assert result["failed"] == 0
+    assert len(rag.upserts) == 1
+    payload, namespace = rag.upserts[0]
+    assert namespace == "#V#member@trusted_org"
+    assert payload[0]["id"] == f"scoped_assertion:{stored['assertion_id']}"
+    assert payload[0]["text"] == "  Exact raw assertion.\n"
+    assert payload[0]["metadata"]["row_kind"] == "text_assertion"
+    assert payload[0]["metadata"]["subject_concept_id"] is None
+    assert payload[0]["metadata"]["assertion_revision"] == 1
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["rag_index"]["status"] == "indexed"
+    assert persisted["rag_index"]["indexed_revision"] == 1
+
+
+def test_rag_failure_does_not_undo_assertion_and_is_retryable(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    rag = _StubRag(fail_upserts=1)
+    first_time = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+
+    failed = service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="worker-one",
+        rag_service=rag,
+        now=first_time,
+        collection=collection,
+    )
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert failed["failed"] == 1
+    assert persisted["status"] == "asserted"
+    assert persisted["object_text"]["text"] == "  Exact raw assertion.\n"
+    assert persisted["rag_index"]["status"] == "failed"
+    assert persisted["rag_index"]["last_error_code"] == "RuntimeError"
+
+    retried = service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="worker-two",
+        rag_service=rag,
+        now=first_time + timedelta(seconds=10),
+        collection=collection,
+    )
+    assert retried["succeeded"] == 1
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["rag_index"]["status"] == "indexed"
+    assert persisted["rag_index"]["attempt_count"] == 2
+
+
+def test_expired_claim_is_reclaimed_with_a_new_lease(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    _store(monkeypatch, collection)
+    now = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+    first = service.claim_next_assertion_rag_job(
+        worker_id="worker-one",
+        now=now,
+        lease_seconds=5,
+        collection=collection,
+    )
+    assert first is not None
+    assert (
+        service.claim_next_assertion_rag_job(
+            worker_id="worker-two",
+            now=now + timedelta(seconds=4),
+            lease_seconds=5,
+            collection=collection,
+        )
+        is None
+    )
+    reclaimed = service.claim_next_assertion_rag_job(
+        worker_id="worker-two",
+        now=now + timedelta(seconds=6),
+        lease_seconds=5,
+        collection=collection,
+    )
+    assert reclaimed is not None
+    assert reclaimed["rag_index"]["lease_token"] != first["rag_index"]["lease_token"]
+    assert reclaimed["rag_index"]["attempt_count"] == 2
+
+
+def test_old_upsert_completion_cannot_overwrite_retraction(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as rag_service
+    from src.backend.services import scoped_assertion_service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    now = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+    claimed = rag_service.claim_next_assertion_rag_job(
+        worker_id="old-worker",
+        now=now,
+        collection=collection,
+    )
+    assert claimed is not None
+
+    scoped_assertion_service.retract_scoped_assertion(
+        assertion_id=stored["assertion_id"],
+        acting_user_concept_id="#V#member",
+        organisation_concept_id="#V#trusted_org",
+    )
+    rag = _StubRag()
+    old_result = rag_service.process_claimed_assertion_rag_job(
+        claimed,
+        rag_service=rag,
+        now=now + timedelta(seconds=1),
+        collection=collection,
+    )
+    assert old_result["superseded"] is True
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["status"] == "retracted"
+    assert persisted["assertion_revision"] == 2
+    assert persisted["rag_index"]["status"] == "pending"
+    assert persisted["rag_index"]["desired_operation"] == "delete"
+
+    deleted = rag_service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="delete-worker",
+        rag_service=rag,
+        now=now + timedelta(seconds=2),
+        collection=collection,
+    )
+    assert deleted["succeeded"] == 1
+    assert rag.deletes == [
+        ([f"scoped_assertion:{stored['assertion_id']}"], "#V#member@trusted_org")
+    ]
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["rag_index"]["status"] == "absent"
+    assert persisted["rag_index"]["indexed_revision"] == 2
+
+
+def test_stale_upsert_after_completed_delete_requeues_current_delete(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as rag_service
+    from src.backend.services import scoped_assertion_service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    now = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+    stale_upsert = rag_service.claim_next_assertion_rag_job(
+        worker_id="stale-upsert",
+        now=now,
+        collection=collection,
+    )
+    scoped_assertion_service.retract_scoped_assertion(
+        assertion_id=stored["assertion_id"],
+        acting_user_concept_id="#V#member",
+        organisation_concept_id="#V#trusted_org",
+    )
+    rag = _StubRag()
+    first_delete = rag_service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="delete-first",
+        rag_service=rag,
+        now=now + timedelta(seconds=1),
+        collection=collection,
+    )
+    assert first_delete["succeeded"] == 1
+    assert (
+        collection.find_one({"assertion_id": stored["assertion_id"]})["rag_index"][
+            "status"
+        ]
+        == "absent"
+    )
+
+    stale_result = rag_service.process_claimed_assertion_rag_job(
+        stale_upsert,
+        rag_service=rag,
+        now=now + timedelta(seconds=2),
+        collection=collection,
+    )
+    assert stale_result["superseded"] is True
+    assert stale_result["current_revision_requeued"] is True
+    pending = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert pending["rag_index"]["status"] == "pending"
+    assert pending["rag_index"]["desired_operation"] == "delete"
+    assert pending["rag_index"]["desired_revision"] == 2
+
+    second_delete = rag_service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="delete-again",
+        rag_service=rag,
+        now=now + timedelta(seconds=3),
+        collection=collection,
+    )
+    assert second_delete["succeeded"] == 1
+    assert len(rag.deletes) == 2
+    assert (
+        collection.find_one({"assertion_id": stored["assertion_id"]})["rag_index"][
+            "status"
+        ]
+        == "absent"
+    )
+
+
+def test_delete_zero_is_idempotent_desired_absence(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as rag_service
+    from src.backend.services import scoped_assertion_service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    scoped_assertion_service.retract_scoped_assertion(
+        assertion_id=stored["assertion_id"],
+        acting_user_concept_id="#V#member",
+        organisation_concept_id="#V#trusted_org",
+    )
+    result = rag_service.process_pending_assertion_rag_jobs(
+        limit=1,
+        worker_id="delete-worker",
+        rag_service=_StubRag(deleted=0),
+        collection=collection,
+    )
+    assert result["succeeded"] == 1
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["rag_index"]["status"] == "absent"
+
+
+def test_reconciler_repairs_missing_materialised_job(monkeypatch):
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    stored = _store(monkeypatch, collection)
+    collection.update_one(
+        {"assertion_id": stored["assertion_id"]},
+        {"$unset": {"rag_index": ""}},
+    )
+    result = service.reconcile_assertion_rag_state(
+        collection=collection,
+        now=datetime(2030, 8, 20, 12, tzinfo=timezone.utc),
+    )
+    assert result["repaired"] == 1
+    persisted = collection.find_one({"assertion_id": stored["assertion_id"]})
+    assert persisted["rag_index"]["status"] == "pending"
+    assert persisted["rag_index"]["desired_revision"] == 1
+
+
+def test_reconciler_queries_anomalies_instead_of_starving_behind_healthy_rows():
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    old = datetime(2030, 8, 19, 12, tzinfo=timezone.utc)
+    healthy = [
+        {
+            "assertion_id": f"ska_healthy_{index}",
+            "assertion_form": "standalone_text",
+            "assertion_revision": 1,
+            "object_kind": "text",
+            "status": "asserted",
+            "updated_at": old,
+            "rag_index": {
+                "status": "indexed",
+                "desired_operation": "upsert",
+                "desired_revision": 1,
+                "indexed_revision": 1,
+                "namespace": "#V#member",
+            },
+        }
+        for index in range(100)
+    ]
+    collection.insert_many(healthy)
+    collection.insert_one(
+        {
+            "assertion_id": "ska_later_missing",
+            "assertion_form": "standalone_text",
+            "assertion_revision": 4,
+            "object_kind": "text",
+            "status": "asserted",
+            "updated_at": old + timedelta(days=1),
+            "scope": {"namespace": "#V#member"},
+        }
+    )
+
+    result = service.reconcile_assertion_rag_state(
+        collection=collection,
+        now=old + timedelta(days=2),
+        limit=10,
+    )
+
+    assert result["scanned"] == 1
+    assert result["repaired"] == 1
+    repaired = collection.find_one({"assertion_id": "ska_later_missing"})
+    assert repaired["rag_index"]["status"] == "pending"
+    assert repaired["rag_index"]["desired_revision"] == 4
+
+
+def test_reconciler_repairs_unclaimable_and_stale_terminal_states():
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    collection = _collection()
+    now = datetime(2030, 8, 20, 12, tzinfo=timezone.utc)
+    base = {
+        "assertion_form": "standalone_text",
+        "assertion_revision": 3,
+        "object_kind": "text",
+        "status": "asserted",
+        "updated_at": now,
+    }
+    collection.insert_many(
+        [
+            {
+                **base,
+                "assertion_id": "ska_bad_lease",
+                "rag_index": {
+                    "status": "processing",
+                    "desired_operation": "upsert",
+                    "desired_revision": 3,
+                    "namespace": "#V#member",
+                    "lease_expires_at": "not-a-date",
+                },
+            },
+            {
+                **base,
+                "assertion_id": "ska_stale_terminal",
+                "rag_index": {
+                    "status": "indexed",
+                    "desired_operation": "upsert",
+                    "desired_revision": 3,
+                    "indexed_revision": 2,
+                    "namespace": "#V#member",
+                },
+            },
+            {
+                **base,
+                "assertion_id": "ska_unknown_status",
+                "rag_index": {
+                    "status": "bogus",
+                    "desired_operation": "upsert",
+                    "desired_revision": 3,
+                    "namespace": "#V#member",
+                },
+            },
+        ]
+    )
+
+    result = service.reconcile_assertion_rag_state(
+        collection=collection,
+        now=now,
+    )
+
+    assert result["scanned"] == 3
+    assert result["repaired"] == 3
+    assert {
+        row["rag_index"]["status"]
+        for row in collection.find(
+            {
+                "assertion_id": {
+                    "$in": [
+                        "ska_bad_lease",
+                        "ska_stale_terminal",
+                        "ska_unknown_status",
+                    ]
+                }
+            }
+        )
+    } == {"pending"}

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -87,7 +87,7 @@ def test_scoped_assertion_indexes_are_ensured_once_per_database(monkeypatch):
 
     assert coll_first is coll_second
     assert coll_first is not None
-    assert len(coll_first.create_index_calls) == 8
+    assert len(coll_first.create_index_calls) == 10
     calls_by_name = {
         str(call["kwargs"].get("name")): call
         for call in coll_first.create_index_calls
@@ -101,6 +101,8 @@ def test_scoped_assertion_indexes_are_ensured_once_per_database(monkeypatch):
         "audience_status_id",
         "subject_audience_status_id",
         "predicate_audience_status_id",
+        "concept_link_audience_status_updated_at_desc_assertion_id",
+        "standalone_rag_queue_status_due_lease_updated_at",
     }
     assert calls_by_name["audience_status_updated_at_desc_assertion_id"]["keys"] == [
         ("scope.audience_keys", mc.ASCENDING),
@@ -151,6 +153,27 @@ def test_scoped_assertion_indexes_are_ensured_once_per_database(monkeypatch):
         ("scope.audience_keys", mc.ASCENDING),
         ("status", mc.ASCENDING),
         ("_id", mc.ASCENDING),
+    ]
+    assert calls_by_name[
+        "concept_link_audience_status_updated_at_desc_assertion_id"
+    ]["keys"] == [
+        ("concept_links.concept_id", mc.ASCENDING),
+        ("scope.audience_key", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("updated_at", mc.DESCENDING),
+        ("assertion_id", mc.ASCENDING),
+    ]
+    assert calls_by_name[
+        "standalone_rag_queue_status_due_lease_updated_at"
+    ]["keys"] == [
+        ("assertion_form", mc.ASCENDING),
+        ("object_kind", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("rag_index.desired_operation", mc.ASCENDING),
+        ("rag_index.status", mc.ASCENDING),
+        ("rag_index.next_attempt_at", mc.ASCENDING),
+        ("rag_index.lease_expires_at", mc.ASCENDING),
+        ("updated_at", mc.ASCENDING),
     ]
 
 

--- a/tests/backend/test_rag_indexing_worker.py
+++ b/tests/backend/test_rag_indexing_worker.py
@@ -53,3 +53,32 @@ def test_startup_diagnostics_logs_only_sanitized_mongo_location(
         raw_uri,
     ):
         assert fragment not in log_text
+
+
+def test_worker_iteration_runs_bounded_text_assertion_queue(monkeypatch) -> None:
+    from src.backend.services import knowledge_assertion_rag_service as service
+
+    calls = []
+    monkeypatch.setattr(
+        service,
+        "reconcile_assertion_rag_state",
+        lambda *, limit: calls.append(("reconcile", limit)) or {"repaired": 0},
+    )
+    monkeypatch.setattr(
+        service,
+        "process_pending_assertion_rag_jobs",
+        lambda *, limit, worker_id: calls.append(
+            ("process", limit, worker_id)
+        )
+        or {
+            "claimed": 2,
+            "succeeded": 1,
+            "failed": 1,
+            "superseded": 0,
+        },
+    )
+
+    assert worker.process_pending_text_assertions() == 1
+    assert calls[0] == ("reconcile", worker.BATCH_SIZE)
+    assert calls[1][0:2] == ("process", worker.BATCH_SIZE)
+    assert calls[1][2].startswith("rag-index-worker:")

--- a/tests/backend/test_rag_service.py
+++ b/tests/backend/test_rag_service.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import shutil
@@ -57,6 +58,82 @@ def test_base_rag_candidate_rechecks_subject_and_predicate_visibility(
     )
 
 
+def test_standalone_rag_candidate_uses_live_audience_status_and_revision(
+    monkeypatch,
+):
+    import mongomock
+
+    from src.backend.services import scoped_rag_authority_service as authority
+
+    collection = mongomock.MongoClient()["von_test"]["scoped_knowledge_assertions"]
+    collection.insert_one(
+        {
+            "assertion_id": "ska_raw",
+            "assertion_form": "standalone_text",
+            "assertion_revision": 3,
+            "status": "asserted",
+            "object_kind": "text",
+            "scope": {"audience_keys": ["user:#V#user"]},
+        }
+    )
+    monkeypatch.setattr(
+        authority,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+
+    def _concept_visibility_must_not_gate_raw_text(_concept_ids):
+        raise AssertionError("raw assertion authority must not require a concept")
+
+    monkeypatch.setattr(
+        authority,
+        "filter_accessible_concept_ids",
+        _concept_visibility_must_not_gate_raw_text,
+    )
+    metadata = {
+        "type": "scoped_knowledge_assertion",
+        "assertion_id": "ska_raw",
+        "assertion_form": "standalone_text",
+        "assertion_revision": 3,
+        "subject_concept_id": None,
+        "predicate": None,
+    }
+    key = ("scoped_knowledge_assertion", "ska_raw")
+    assert authority.current_authorised_rag_candidate_keys(
+        [metadata],
+        user_concept_id="#V#user",
+        organisation_concept_id=None,
+    ) == {key}
+    assert (
+        authority.current_authorised_rag_candidate_keys(
+            [{**metadata, "assertion_revision": 2}],
+            user_concept_id="#V#user",
+            organisation_concept_id=None,
+        )
+        == set()
+    )
+    assert (
+        authority.current_authorised_rag_candidate_keys(
+            [metadata],
+            user_concept_id="#V#other",
+            organisation_concept_id=None,
+        )
+        == set()
+    )
+    collection.update_one(
+        {"assertion_id": "ska_raw"},
+        {"$set": {"status": "retracted", "assertion_revision": 4}},
+    )
+    assert (
+        authority.current_authorised_rag_candidate_keys(
+            [metadata],
+            user_concept_id="#V#user",
+            organisation_concept_id=None,
+        )
+        == set()
+    )
+
+
 # Mock LlamaIndex components to avoid real API calls and dependencies during unit tests
 @pytest.fixture
 def mock_llamaindex():
@@ -64,12 +141,8 @@ def mock_llamaindex():
         patch(
             "src.backend.services.rag_backends.llamaindex_backend.VectorStoreIndex"
         ) as mock_index_cls,
-        patch(
-            "src.backend.services.rag_backends.llamaindex_backend.ServiceContext"
-        ),
-        patch(
-            "src.backend.services.rag_backends.llamaindex_backend.StorageContext"
-        ),
+        patch("src.backend.services.rag_backends.llamaindex_backend.ServiceContext"),
+        patch("src.backend.services.rag_backends.llamaindex_backend.StorageContext"),
         patch(
             "src.backend.services.rag_backends.llamaindex_backend.load_index_from_storage"
         ) as mock_load,
@@ -167,6 +240,192 @@ def test_upsert_documents(mock_llamaindex, monkeypatch, workspace_tmp_path):
     assert failed == 0
 
 
+def test_standalone_assertion_embedding_uses_exact_body_without_metadata(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from llama_index.core.schema import MetadataMode
+
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    exact_text = "  Exact assertion body.\n"
+    service.upsert_documents(
+        [
+            {
+                "id": "scoped_assertion:ska_raw",
+                "text": exact_text,
+                "metadata": {
+                    "type": "scoped_knowledge_assertion",
+                    "assertion_form": "standalone_text",
+                    "assertion_id": "ska_raw",
+                    "assertion_revision": 1,
+                    "audience_keys": ["user:#V#member"],
+                    "user_id": "#V#member",
+                },
+            }
+        ],
+        namespace="#V#member",
+    )
+
+    document = mock_llamaindex["index_cls"].from_documents.call_args.args[0][0]
+    assert document.get_content(metadata_mode=MetadataMode.EMBED) == exact_text
+    assert document.metadata["assertion_id"] == "ska_raw"
+    assert set(document.excluded_embed_metadata_keys) == set(document.metadata)
+    assert set(document.excluded_llm_metadata_keys) == set(document.metadata)
+
+
+def test_upsert_refreshes_stable_document_id_and_propagates_persist_failure(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    service.upsert_documents([{"id": "stable", "text": "revision one", "metadata": {}}])
+    success, failed = service.upsert_documents(
+        [{"id": "stable", "text": "revision two", "metadata": {}}]
+    )
+
+    assert (success, failed) == (1, 0)
+    refreshed = mock_llamaindex["index"].refresh_ref_docs.call_args.args[0]
+    assert [doc.doc_id for doc in refreshed] == ["stable"]
+    assert [doc.text for doc in refreshed] == ["revision two"]
+    mock_llamaindex["index"].insert_documents.assert_not_called()
+
+    mock_llamaindex["index"].storage_context.persist.side_effect = RuntimeError(
+        "disk unavailable"
+    )
+    with pytest.raises(RuntimeError, match="disk unavailable"):
+        service.upsert_documents(
+            [{"id": "stable", "text": "revision three", "metadata": {}}]
+        )
+
+
+def test_namespace_generation_reloads_stale_cache_before_next_mutation(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    persistence_dir = str(workspace_tmp_path / "rag_storage")
+    writer = LlamaIndexRAGService(persistence_dir=persistence_dir)
+    sibling = LlamaIndexRAGService(persistence_dir=persistence_dir)
+    namespace = "#V#member@org"
+    writer.upsert_documents(
+        [{"id": "writer", "text": "writer revision one"}],
+        namespace=namespace,
+    )
+
+    sibling_v1 = MagicMock()
+    sibling_v2 = MagicMock()
+    mock_llamaindex["load"].side_effect = [sibling_v1, sibling_v2]
+    assert sibling._maybe_load_index(namespace) is sibling_v1
+    first_generation = sibling._index_cache_generations[namespace]
+
+    writer.upsert_documents(
+        [{"id": "writer", "text": "writer revision two"}],
+        namespace=namespace,
+    )
+    assert writer._index_cache_generations[namespace] != first_generation
+
+    assert sibling.upsert_documents(
+        [{"id": "sibling", "text": "sibling assertion"}],
+        namespace=namespace,
+    ) == (1, 0)
+    sibling_v1.refresh_ref_docs.assert_not_called()
+    refreshed = sibling_v2.refresh_ref_docs.call_args.args[0]
+    assert [doc.doc_id for doc in refreshed] == ["sibling"]
+    with open(
+        sibling._namespace_metadata_path(namespace),
+        encoding="utf-8",
+    ) as handle:
+        current_generation = json.load(handle)["index_generation"]
+    assert sibling._index_cache_generations[namespace] == current_generation
+
+
+def test_reset_evicts_sibling_persisted_cache_before_recreate(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    persistence_dir = str(workspace_tmp_path / "rag_storage")
+    resetter = LlamaIndexRAGService(persistence_dir=persistence_dir)
+    sibling = LlamaIndexRAGService(persistence_dir=persistence_dir)
+    namespace = "#V#member@org"
+    resetter.upsert_documents(
+        [{"id": "old", "text": "old assertion"}],
+        namespace=namespace,
+    )
+    assert sibling._maybe_load_index(namespace) is mock_llamaindex["index"]
+    assert namespace in sibling._persisted_index_cache_namespaces
+
+    resetter.reset_namespace(namespace)
+
+    assert sibling.query("old", namespace=namespace) == []
+    assert namespace not in sibling._indices
+    assert sibling.upsert_documents(
+        [{"id": "new", "text": "new assertion"}],
+        namespace=namespace,
+    ) == (1, 0)
+    rebuilt_documents = mock_llamaindex["index_cls"].from_documents.call_args.args[0]
+    assert [doc.doc_id for doc in rebuilt_documents] == ["new"]
+    assert [doc.text for doc in rebuilt_documents] == ["new assertion"]
+
+
+def test_initial_index_failure_does_not_publish_incomplete_namespace(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    final_dir = service._namespace_persist_dir("chat_history")
+
+    def _partial_persist(*, persist_dir):
+        os.makedirs(persist_dir, exist_ok=True)
+        partial_path = os.path.join(persist_dir, "partial")
+        with open(partial_path, "w", encoding="utf-8") as handle:
+            handle.write("incomplete")
+        raise RuntimeError("initial persist failed")
+
+    mock_llamaindex["index"].storage_context.persist.side_effect = _partial_persist
+    with pytest.raises(RuntimeError, match="initial persist failed"):
+        service.upsert_documents([{"id": "stable", "text": "content"}])
+    assert not os.path.exists(final_dir)
+
+    mock_llamaindex["index"].storage_context.persist.side_effect = None
+    assert service.upsert_documents([{"id": "stable", "text": "content"}]) == (1, 0)
+    assert os.path.isfile(os.path.join(final_dir, "index_metadata.json"))
+
+
 def test_query(mock_llamaindex):
     service = get_rag_service("llamaindex")
     results = service.query("test query")
@@ -190,9 +449,7 @@ def test_query_honours_workflow_capability_retrieval_candidate_limit(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     rag.upsert_documents(
         [
             {
@@ -231,9 +488,7 @@ def test_concepts_mode_includes_current_scoped_assertion_candidates(
     )
     from src.backend.services import scoped_rag_authority_service
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     rag.upsert_documents(
         [
             {
@@ -252,14 +507,18 @@ def test_concepts_mode_includes_current_scoped_assertion_candidates(
         "subject_concept_id": "#V#subject",
         "predicate": "hasDescription",
         "user_id": "#V#user",
-        "organisation_concept_id": "#V#org",
+        # User-scoped canonical knowledge remains valid in an organisation
+        # turn even though its assertion audience is not organisation-scoped.
+        "organisation_concept_id": None,
     }
     authority_calls = []
     monkeypatch.setattr(
         scoped_rag_authority_service,
         "current_authorised_rag_candidate_keys",
-        lambda rows, **kwargs: authority_calls.append((rows, kwargs))
-        or {("scoped_knowledge_assertion", "ska_1")},
+        lambda rows, **kwargs: (
+            authority_calls.append((rows, kwargs))
+            or {("scoped_knowledge_assertion", "ska_1")}
+        ),
     )
 
     results = rag.query(
@@ -284,6 +543,79 @@ def test_concepts_mode_includes_current_scoped_assertion_candidates(
     ]
 
 
+def test_concepts_mode_returns_live_standalone_user_assertion_in_org_turn(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    import mongomock
+
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services import scoped_rag_authority_service
+    from src.backend.services.knowledge_assertion_rag_service import (
+        build_standalone_text_assertion_rag_document,
+    )
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    assertion = {
+        "assertion_id": "ska_raw_live",
+        "assertion_form": "standalone_text",
+        "assertion_revision": 2,
+        "status": "asserted",
+        "object_kind": "text",
+        "object_text": {"text": "Exact raw evidence.", "language": "en-NZ"},
+        "scope": {
+            "mode": "user",
+            "user_concept_id": "#V#user",
+            "organisation_concept_id": None,
+            "audience_keys": ["user:#V#user"],
+        },
+        "assertion_context": {
+            "context_id": "intake:user:#V#user",
+            "selection": "implicit",
+        },
+    }
+    collection = mongomock.MongoClient()["von_test"]["scoped_knowledge_assertions"]
+    collection.insert_one(assertion)
+    monkeypatch.setattr(
+        scoped_rag_authority_service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+
+    def _concept_visibility_must_not_run(_concept_ids):
+        raise AssertionError("linkless text authority has no concept dependency")
+
+    monkeypatch.setattr(
+        scoped_rag_authority_service,
+        "filter_accessible_concept_ids",
+        _concept_visibility_must_not_run,
+    )
+    rag_doc = build_standalone_text_assertion_rag_document(assertion)
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
+    rag.upsert_documents([rag_doc], namespace="#V#user@org")
+    node = mock_llamaindex["index"].as_retriever.return_value.retrieve.return_value[0]
+    node.node.ref_doc_id = rag_doc["id"]
+    node.node.metadata = rag_doc["metadata"]
+    node.node.get_content.return_value = rag_doc["text"]
+
+    results = rag.query(
+        "raw evidence",
+        namespace="#V#user@org",
+        permissions_context={
+            "mode": "concepts",
+            "user_id": "#V#user",
+            "organisation_concept_id": "#V#org",
+        },
+    )
+
+    assert [(row["id"], row["text"]) for row in results] == [
+        ("scoped_assertion:ska_raw_live", "Exact raw evidence.")
+    ]
+
+
 def test_scoped_rag_hit_is_live_filtered_after_assertion_revocation(
     mock_llamaindex,
     monkeypatch,
@@ -297,9 +629,7 @@ def test_scoped_rag_hit_is_live_filtered_after_assertion_revocation(
     )
     from src.backend.services import scoped_rag_authority_service
 
-    collection = mongomock.MongoClient()["von_test"][
-        "scoped_knowledge_assertions"
-    ]
+    collection = mongomock.MongoClient()["von_test"]["scoped_knowledge_assertions"]
     collection.insert_one(
         {
             "assertion_id": "ska_live",
@@ -322,9 +652,7 @@ def test_scoped_rag_hit_is_live_filtered_after_assertion_revocation(
         lambda concept_ids: set(concept_ids) & visible_concepts,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     rag.upsert_documents(
         [
             {
@@ -351,13 +679,16 @@ def test_scoped_rag_hit_is_live_filtered_after_assertion_revocation(
         "organisation_concept_id": "#V#org",
     }
 
-    assert len(
-        rag.query(
-            "programme context",
-            namespace="#V#user@org",
-            permissions_context=permissions,
+    assert (
+        len(
+            rag.query(
+                "programme context",
+                namespace="#V#user@org",
+                permissions_context=permissions,
+            )
         )
-    ) == 1
+        == 1
+    )
 
     collection.update_one(
         {"assertion_id": "ska_live"},
@@ -423,6 +754,80 @@ def test_delete_documents(mock_llamaindex):
     assert count >= 0
 
 
+def test_delete_documents_propagates_backend_failure(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    service.upsert_documents([{"id": "doc1", "text": "content"}])
+    mock_llamaindex["index"].delete_ref_doc.side_effect = RuntimeError("delete failed")
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        service.delete_documents(["doc1"])
+
+
+def test_delete_publishes_new_namespace_generation(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    service.upsert_documents([{"id": "doc1", "text": "content"}])
+    initial_generation = service._index_cache_generations["chat_history"]
+
+    assert service.delete_documents(["doc1"]) == 1
+    with open(
+        service._namespace_metadata_path("chat_history"),
+        encoding="utf-8",
+    ) as handle:
+        deleted_generation = json.load(handle)["index_generation"]
+    assert deleted_generation != initial_generation
+    assert service._index_cache_generations["chat_history"] == deleted_generation
+
+
+def test_delete_does_not_report_absence_when_existing_index_cannot_load(
+    mock_llamaindex,
+    monkeypatch,
+    workspace_tmp_path,
+):
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends.llamaindex_backend import (
+        LlamaIndexRAGService,
+    )
+
+    service = LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    persist_dir = (
+        workspace_tmp_path
+        / "rag_storage"
+        / "namespaces"
+        / service._namespace_dirname("chat_history")
+    )
+    persist_dir.mkdir(parents=True, exist_ok=True)
+    (persist_dir / "unreadable_state").write_text("present", encoding="utf-8")
+    service._write_namespace_metadata("chat_history")
+    mock_llamaindex["load"].side_effect = RuntimeError("load failed")
+
+    with pytest.raises(RuntimeError, match="could not be loaded"):
+        service.delete_documents(["doc1"])
+
+
 def test_llamaindex_servicecontext_deprecation_falls_back_to_settings(
     workspace_tmp_path,
     monkeypatch,
@@ -472,9 +877,9 @@ def test_llamaindex_servicecontext_deprecation_falls_back_to_settings(
         assert rag.service_context is None
         assert rag.llamaindex_settings is fake_settings
         assert rag.get_runtime_embed_model() is fake_settings.embed_model
-        assert rag.get_runtime_configuration_summary()["embedding_signature"]["model"] == (
-            "text-embedding-3-small"
-        )
+        assert rag.get_runtime_configuration_summary()["embedding_signature"][
+            "model"
+        ] == ("text-embedding-3-small")
 
 
 def test_llamaindex_runtime_configuration_tracks_embedding_signature_and_mismatch(
@@ -488,9 +893,7 @@ def test_llamaindex_runtime_configuration_tracks_embedding_signature_and_mismatc
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     summary = rag.get_runtime_configuration_summary()
 
     assert summary["embedding_signature"] == {
@@ -566,9 +969,7 @@ def test_llamaindex_upsert_rejects_unresolved_embedder_before_index_mutation(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     # LlamaIndex may expose a truthy MockEmbedding when no real embedder was
     # resolved. Mutation authority comes from the resolved configuration, not
     # from that compatibility fallback object.
@@ -599,9 +1000,7 @@ def test_llamaindex_upsert_requires_explicit_rebuild_for_incompatible_signature(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     rag.upsert_documents(
         [{"id": "doc1", "text": "first", "metadata": {}}],
         namespace="#V#user@org",
@@ -673,9 +1072,9 @@ def test_llamaindex_metadata_uses_embedder_captured_before_index_creation(
         rag.invalidate_runtime_configuration_cache()
         return mock_llamaindex["index"]
 
-    mock_llamaindex["index_cls"].from_documents.side_effect = (
-        _create_index_after_configuration_change
-    )
+    mock_llamaindex[
+        "index_cls"
+    ].from_documents.side_effect = _create_index_after_configuration_change
 
     rag.upsert_documents(
         [{"id": "doc1", "text": "content", "metadata": {}}],
@@ -705,9 +1104,7 @@ def test_llamaindex_metadata_write_retries_transient_sharing_violation(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     namespace = "workflow_capabilities"
     metadata_path = workspace_tmp_path / "rag_storage" / "namespaces"
 
@@ -735,6 +1132,57 @@ def test_llamaindex_metadata_write_retries_transient_sharing_violation(
     assert payload["embedding_signature"]["model"] == "text-embedding-3-small"
 
 
+def test_namespace_process_lock_windows_retries_only_contention(
+    monkeypatch,
+    workspace_tmp_path,
+) -> None:
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends import llamaindex_backend as backend
+
+    rag = backend.LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    fake_msvcrt = MagicMock()
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+    fake_msvcrt.locking.side_effect = [
+        OSError(errno.EACCES, "lock busy"),
+        None,
+        None,
+    ]
+    monkeypatch.setattr(backend, "_fcntl", None)
+    monkeypatch.setattr(backend, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(backend.time, "sleep", lambda _seconds: None)
+
+    with rag._namespace_process_lock("#V#member@org"):
+        pass
+
+    assert [call.args[1] for call in fake_msvcrt.locking.call_args_list] == [1, 1, 2]
+
+
+def test_namespace_process_lock_windows_propagates_non_contention_error(
+    monkeypatch,
+    workspace_tmp_path,
+) -> None:
+    _configure_rag_runtime_settings(monkeypatch)
+    from src.backend.services.rag_backends import llamaindex_backend as backend
+
+    rag = backend.LlamaIndexRAGService(
+        persistence_dir=str(workspace_tmp_path / "rag_storage")
+    )
+    fake_msvcrt = MagicMock()
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+    fake_msvcrt.locking.side_effect = OSError(errno.EINVAL, "unsupported lock")
+    monkeypatch.setattr(backend, "_fcntl", None)
+    monkeypatch.setattr(backend, "_msvcrt", fake_msvcrt)
+
+    with pytest.raises(OSError, match="unsupported lock"):
+        with rag._namespace_process_lock("#V#member@org"):
+            pass
+    assert fake_msvcrt.locking.call_count == 1
+
+
 def test_llamaindex_reset_namespace_retries_transient_sharing_violation(
     monkeypatch,
     workspace_tmp_path,
@@ -745,11 +1193,14 @@ def test_llamaindex_reset_namespace_retries_transient_sharing_violation(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     namespace = "workflow_capabilities"
-    persist_dir = workspace_tmp_path / "rag_storage" / "namespaces" / rag._namespace_dirname(namespace)
+    persist_dir = (
+        workspace_tmp_path
+        / "rag_storage"
+        / "namespaces"
+        / rag._namespace_dirname(namespace)
+    )
     persist_dir.mkdir(parents=True, exist_ok=True)
     (persist_dir / "index_metadata.json").write_text("{}", encoding="utf-8")
 
@@ -793,9 +1244,7 @@ def test_namespace_runtime_state_is_non_blocking_under_lock_contention(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     namespace = "workflow_capabilities"
 
     holder_acquired = threading.Event()
@@ -843,9 +1292,7 @@ def test_namespace_runtime_state_strict_blocks_until_lock_released(
         LlamaIndexRAGService,
     )
 
-    rag = LlamaIndexRAGService(
-        persistence_dir=str(workspace_tmp_path / "rag_storage")
-    )
+    rag = LlamaIndexRAGService(persistence_dir=str(workspace_tmp_path / "rag_storage"))
     namespace = "workflow_capabilities"
 
     holder_acquired = threading.Event()

--- a/tests/backend/test_rag_text_relation_sync_service.py
+++ b/tests/backend/test_rag_text_relation_sync_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import mongomock
+import pytest
 from bson import ObjectId
 
 
@@ -53,6 +54,15 @@ class _StubRAG:
         self.delete_batches.append(batch)
         self.deletes.extend(batch)
         return len(batch)
+
+
+def test_text_relation_sync_requires_a_canonical_actor_namespace():
+    from src.backend.services import rag_text_relation_sync_service as svc
+
+    assert svc._parse_namespace("#V#user") == ("#V#user", "")
+    assert svc._parse_namespace("#V#user@org") == ("#V#user", "#V#org")
+    with pytest.raises(ValueError, match="canonical"):
+        svc._parse_namespace("user@org")
 
 
 def test_one_pass_iterator_opens_each_store_once_and_batches_visibility(
@@ -754,6 +764,70 @@ def test_scoped_projection_requires_current_subject_and_predicate_visibility(
 
     assert docs == []
     assert checked == [{"#V#subject", "#V#private_predicate"}]
+
+
+def test_collect_indexes_linkless_standalone_assertion_as_exact_body(monkeypatch):
+    from src.backend.services import rag_text_relation_sync_service as svc
+
+    monkeypatch.setattr(
+        svc.TextRelationsRepository,
+        "find",
+        lambda *_args, **_kwargs: [],
+    )
+    scoped_collection = mongomock.MongoClient()["von_test"][
+        "scoped_knowledge_assertions"
+    ]
+    exact_text = "  Susan hosted gatherings in Svalbard.\n"
+    scoped_collection.insert_one(
+        {
+            "assertion_id": "ska_raw",
+            "assertion_form": "standalone_text",
+            "assertion_revision": 1,
+            "subject_concept_id": None,
+            "predicate": None,
+            "object_kind": "text",
+            "object_text": {"text": exact_text, "language": "en-NZ"},
+            "concept_links": [],
+            "assertion_context": {
+                "context_id": "intake:user:#V#user",
+                "selection": "implicit",
+            },
+            "scope": {
+                "user_concept_id": "#V#user",
+                "organisation_concept_id": None,
+                "audience_keys": ["user:#V#user"],
+            },
+            "provenance": {"asserted_by_user_concept_id": "#V#user"},
+            "status": "asserted",
+            "updated_at": datetime(2026, 8, 20, tzinfo=timezone.utc),
+        }
+    )
+    monkeypatch.setattr(
+        svc,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: scoped_collection,
+    )
+
+    def _concept_visibility_must_not_run(*_args, **_kwargs):
+        raise AssertionError("raw assertion indexing must not require concepts")
+
+    monkeypatch.setattr(
+        svc,
+        "_visible_concept_ids_in_namespace",
+        _concept_visibility_must_not_run,
+    )
+    docs = svc.collect_text_relation_docs_for_namespace(
+        namespace="#V#user",
+        limit=10,
+    )
+
+    assert len(docs) == 1
+    assert docs[0].doc_id == "scoped_assertion:ska_raw"
+    assert docs[0].text == exact_text
+    assert docs[0].metadata["row_kind"] == "text_assertion"
+    assert docs[0].metadata["assertion_revision"] == 1
+    assert docs[0].metadata["subject_concept_id"] is None
+    assert "concept_links" not in docs[0].metadata
 
 
 def test_collect_limit_zero_does_not_query_either_store(monkeypatch):

--- a/tests/backend/test_scoped_assertion_service.py
+++ b/tests/backend/test_scoped_assertion_service.py
@@ -45,6 +45,257 @@ def _stored_text_assertion(
     }
 
 
+def test_standalone_text_admission_preserves_exact_body_without_analysis(
+    monkeypatch,
+):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+
+    def _analysis_must_not_run(*_args, **_kwargs):
+        raise AssertionError("standalone text admission must not analyse concepts")
+
+    monkeypatch.setattr(service, "can_access_concept", _analysis_must_not_run)
+    monkeypatch.setattr(
+        service,
+        "resolve_text_relation_predicate_for_write",
+        _analysis_must_not_run,
+    )
+    exact_text = "  Susan hosted salon-style gatherings in Svalbard.\n"
+    receipt = service.store_text_assertion(
+        text=exact_text,
+        language="en-NZ",
+        acting_user_concept_id="#V#member",
+        turn_id="turn-raw-1",
+    )
+
+    assertion = receipt["canonical_read_back"]
+    assert receipt["changed"] is True
+    assert assertion["schema_version"] == "scoped_knowledge_assertion.v2"
+    assert assertion["assertion_form"] == "standalone_text"
+    assert assertion["subject_concept_id"] is None
+    assert assertion["predicate"] is None
+    assert assertion["concept_links"] == []
+    assert assertion["object_text"]["text"] == exact_text
+    assert assertion["assertion_context"] == {
+        "context_id": "intake:user:#V#member",
+        "selection": "implicit",
+        "kind": "intake",
+    }
+    assert assertion["rag_index"]["status"] == "pending"
+    assert assertion["rag_index"]["desired_operation"] == "upsert"
+    assert receipt["derived_maintenance"]["durable"] is True
+
+
+def test_standalone_occurrence_replay_and_distinct_turns(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    kwargs = {
+        "text": "The same formulation.",
+        "acting_user_concept_id": "#V#member",
+    }
+    first = service.store_text_assertion(**kwargs, turn_id="turn-1")
+    replay = service.store_text_assertion(**kwargs, turn_id="turn-1")
+    other_turn = service.store_text_assertion(**kwargs, turn_id="turn-2")
+    source_first = service.store_text_assertion(
+        **kwargs,
+        turn_id="turn-3",
+        source_event_id="source:item:7",
+    )
+    source_replay = service.store_text_assertion(
+        **kwargs,
+        turn_id="turn-4",
+        source_event_id="source:item:7",
+    )
+
+    assert replay["changed"] is False
+    assert replay["assertion_id"] == first["assertion_id"]
+    assert other_turn["assertion_id"] != first["assertion_id"]
+    assert source_replay["changed"] is False
+    assert source_replay["assertion_id"] == source_first["assertion_id"]
+    assert collection.count_documents({}) == 3
+
+
+def test_standalone_source_replay_rejects_different_payload(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    service.store_text_assertion(
+        text="Original body.",
+        source_event_id="source:item:8",
+        acting_user_concept_id="#V#member",
+    )
+    with pytest.raises(ValueError, match="different text assertion"):
+        service.store_text_assertion(
+            text="Changed body.",
+            source_event_id="source:item:8",
+            acting_user_concept_id="#V#member",
+        )
+    assert collection.count_documents({}) == 1
+
+
+def test_standalone_text_is_visible_without_links_and_links_are_optional(
+    monkeypatch,
+):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    visible = {"#V#susan", "#V#svalbard"}
+    monkeypatch.setattr(
+        service,
+        "can_access_concept",
+        lambda concept_id: concept_id in visible,
+    )
+    def _filter_link_concepts(concept_ids):
+        requested = set(concept_ids)
+        if not requested:
+            raise AssertionError(
+                "linkless standalone retrieval must not require concept access"
+            )
+        return requested & visible
+
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        _filter_link_concepts,
+    )
+    text = "Susan hosted salon-style gatherings in Svalbard."
+    receipt = service.store_text_assertion(
+        text=text,
+        acting_user_concept_id="#V#member",
+        turn_id="turn-links",
+    )
+    broad = service.list_visible_scoped_assertions(
+        assertion_form="standalone_text",
+        user_concept_id="#V#member",
+    )
+    assert [row["assertion_id"] for row in broad] == [receipt["assertion_id"]]
+
+    linked = service.add_text_assertion_concept_links(
+        assertion_id=receipt["assertion_id"],
+        links=[
+            {
+                "concept_id": "#V#susan",
+                "role": "about",
+                "method": "explicit_user_link",
+                "spans": [{"start": 0, "end": 5}],
+            },
+            {
+                "concept_id": "#V#svalbard",
+                "role": "involves",
+                "confidence": 0.9,
+                "spans": [{"start": 39, "end": 47}],
+            },
+        ],
+        acting_user_concept_id="#V#member",
+        turn_id="turn-links",
+    )
+    assert linked["changed"] is True
+    assert linked["links_added"] == 2
+    assert linked["assertion"]["object_text"]["text"] == text
+    for concept_id in ("#V#susan", "#V#svalbard"):
+        by_concept = service.list_visible_scoped_assertions(
+            argument_concept_id=concept_id,
+            assertion_form="standalone_text",
+            user_concept_id="#V#member",
+        )
+        assert [row["assertion_id"] for row in by_concept] == [
+            receipt["assertion_id"]
+        ]
+
+    visible.remove("#V#svalbard")
+    redacted = service.list_visible_scoped_assertions(
+        assertion_form="standalone_text",
+        user_concept_id="#V#member",
+    )
+    assert [link["concept_id"] for link in redacted[0]["concept_links"]] == [
+        "#V#susan"
+    ]
+
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda _concept_ids: (_ for _ in ()).throw(
+            RuntimeError("concept visibility temporarily unavailable")
+        ),
+    )
+    degraded = service.list_visible_scoped_assertions(
+        assertion_form="standalone_text",
+        user_concept_id="#V#member",
+    )
+    assert [row["assertion_id"] for row in degraded] == [receipt["assertion_id"]]
+    assert degraded[0]["concept_links"] == []
+
+
+def test_standalone_retraction_is_canonical_and_marks_rag_delete(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    stored = service.store_text_assertion(
+        text="A raw assertion.",
+        acting_user_concept_id="#V#member",
+        turn_id="turn-retract",
+    )
+    retracted = service.retract_scoped_assertion(
+        assertion_id=stored["assertion_id"],
+        acting_user_concept_id="#V#member",
+    )
+    repeated = service.retract_scoped_assertion(
+        assertion_id=stored["assertion_id"],
+        acting_user_concept_id="#V#member",
+    )
+
+    assert retracted["changed"] is True
+    assert retracted["assertion"]["status"] == "retracted"
+    assert retracted["assertion"]["assertion_revision"] == 2
+    assert retracted["assertion"]["rag_index"]["status"] == "pending"
+    assert retracted["assertion"]["rag_index"]["desired_operation"] == "delete"
+    assert retracted["assertion"]["rag_index"]["desired_revision"] == 2
+    assert retracted["derived_maintenance"]["durable"] is True
+    assert repeated["changed"] is False
+    assert service.list_visible_scoped_assertions(
+        user_concept_id="#V#member"
+    ) == []
+
+    reasserted = service.store_text_assertion(
+        text="A raw assertion.",
+        acting_user_concept_id="#V#member",
+        turn_id="turn-retract",
+    )
+    assert reasserted["changed"] is True
+    assert reasserted["assertion_id"] == stored["assertion_id"]
+    assert reasserted["assertion"]["status"] == "asserted"
+    assert reasserted["assertion"]["assertion_revision"] == 3
+    assert reasserted["assertion"]["rag_index"]["status"] == "pending"
+    assert reasserted["assertion"]["rag_index"]["desired_operation"] == "upsert"
+
+
 def test_visible_global_subject_accepts_user_scoped_text_assertion(monkeypatch):
     from src.backend.services import scoped_assertion_service as service
 


### PR DESCRIPTION
## Summary

- add exact, subject-free standalone text assertions to the existing actor-scoped assertion store
- keep admission independent of concept analysis and optional link enrichment
- add revision-safe durable RAG maintenance, live authority filtering, and cross-process namespace mutation locking
- expose ordinary-turn storage, add-only concept links, mixed concept-relative retrieval, and reasoning envelopes
- document the context and physical-namespace boundaries

## Release boundary

This is the independently shippable JVNAUTOSCI-343 Slice 1 path. It does not close the Jira task or claim completion of individual link revision/removal, explicit text-to-GBP equivalence, full slices 2–3, general microtheory semantics, or organisation-wide vector fan-out.

## Validation

- 195 affected persistence/RAG/catalogue/orchestrator tests passed
- 94 neighbouring metadata/manifest/retrieval/workflow compatibility tests passed after the final authority fix
- targeted inter-process generation/reset/delete and Windows lock tests passed
- changed Python files passed Ruff E9/F checks and compileall
- git diff whitespace check passed

Three broader failures were separately reproduced on unchanged main: one stale Jira registry expectation and two old RAG filtering fixtures. No external model was invoked.

Jira: JVNAUTOSCI-343