### PR TITLE
Preserve semantic recovery after core entity creation (JVNAUTOSCI-2645)

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -3768,6 +3768,7 @@ def _add_relationship(**kwargs):
     predicate_if_missing = kwargs.get("predicate_if_missing")
     predicate_resolution: dict[str, Any] | None = None
     predicate_value_kind = "concept"
+    predicate_value_kind_explicit = False
     mutation_dispatched = False
     predicate_dependency: dict[str, Any] | None = None
     predicate_dependency_changed = False
@@ -3827,8 +3828,13 @@ def _add_relationship(**kwargs):
                 ),
                 details={"on_missing": on_missing},
             )
+        raw_predicate_value_kind = predicate_ref.get("value_kind")
+        predicate_value_kind_explicit = bool(
+            isinstance(raw_predicate_value_kind, str)
+            and raw_predicate_value_kind.strip()
+        )
         predicate_value_kind = (
-            str(predicate_ref.get("value_kind") or "concept").strip().lower()
+            str(raw_predicate_value_kind or "concept").strip().lower()
         )
         if predicate_value_kind not in {"concept", "text"}:
             return make_error_response(
@@ -4111,13 +4117,149 @@ def _add_relationship(**kwargs):
                     }
                 )
             else:
+                canonical_missing_predicate_id = canonicalise_vontology_concept_id(
+                    predicate_str
+                )
+                recovery_affordances: list[dict[str, Any]] = [
+                    {
+                        "action_type": "resolve_exact_predicate",
+                        "sequence_step": 1,
+                        "tool": "resolve_concept_by_name",
+                        "arguments": {
+                            "name": predicate_str,
+                            "instance_of": "#V#predicate",
+                            "match_code_strings": False,
+                            "max_results": 5,
+                        },
+                    }
+                ]
+                recoverable_object_kind: str | None = None
+                recovery_limit: dict[str, str] | None = None
+                target_concept_id = (
+                    str(target).strip()
+                    if isinstance(target, str)
+                    and str(target).strip().startswith("#V#")
+                    else None
+                )
+                target_text = (
+                    target.strip()
+                    if isinstance(target, str) and target.strip()
+                    else None
+                )
+                if predicate_value_kind_explicit and predicate_value_kind == "text":
+                    recoverable_object_kind = "text"
+                elif target_concept_id is not None:
+                    recoverable_object_kind = "concept"
+                elif (
+                    predicate_value_kind_explicit
+                    and predicate_value_kind == "concept"
+                ):
+                    recovery_limit = {
+                        "reason_code": "relationship_target_concept_not_verified",
+                        "message": (
+                            "The requested predicate is concept-valued, but the "
+                            "target is not one verified exact concept ID. Resolve "
+                            "or create the target before creating a predicate or "
+                            "retrying the relationship."
+                        ),
+                    }
+                elif target_text is not None:
+                    recoverable_object_kind = "text"
+                else:
+                    recovery_limit = {
+                        "reason_code": "predicate_object_kind_not_safely_inferable",
+                        "message": (
+                            "The missing predicate's object kind cannot be inferred "
+                            "safely from this request. Resolve the predicate first; "
+                            "no predicate creation or relationship retry is "
+                            "advertised until its concept-or-text kind is known."
+                        ),
+                    }
+
+                if canonical_missing_predicate_id is None:
+                    recovery_limit = {
+                        "reason_code": "predicate_concept_id_not_canonicalisable",
+                        "message": (
+                            "The missing predicate name does not yield one exact "
+                            "canonical concept ID, so no creation or relationship "
+                            "retry is advertised."
+                        ),
+                    }
+                elif recoverable_object_kind is not None:
+                    predicate_parent_id = (
+                        "#V#binary_text_predicate"
+                        if recoverable_object_kind == "text"
+                        else "#V#predicate"
+                    )
+                    recovery_affordances.extend(
+                        [
+                            {
+                                "action_type": (
+                                    "create_singleton_typed_predicate_if_still_missing"
+                                ),
+                                "sequence_step": 2,
+                                "requires_prior_step_status": "not_found",
+                                "tool": "create_concepts",
+                                "arguments": {
+                                    "parent_id": predicate_parent_id,
+                                    "concepts": [
+                                        {
+                                            "name": predicate_str,
+                                            "concept_id": (
+                                                canonical_missing_predicate_id
+                                            ),
+                                            "kind": "predicate",
+                                            "instance_of_type": predicate_parent_id,
+                                        }
+                                    ],
+                                    "duplicate_resolution_mode": (
+                                        _CREATE_CONCEPTS_DUPLICATE_RESOLUTION_CANONICAL_ID_ONLY
+                                    ),
+                                },
+                            },
+                            {
+                                "action_type": "verify_exact_typed_predicate",
+                                "sequence_step": 3,
+                                "tool": "fetch_concept",
+                                "arguments": {
+                                    "concept_id": canonical_missing_predicate_id,
+                                    "include_relations_arg1": True,
+                                },
+                            },
+                            {
+                                "action_type": (
+                                    "retry_exact_relationship_after_verification"
+                                ),
+                                "sequence_step": 4,
+                                "tool": "add_relationship",
+                                "arguments": {
+                                    "source_id": source_id,
+                                    "predicate": canonical_missing_predicate_id,
+                                    "target": target,
+                                },
+                            },
+                        ]
+                    )
+
+                error_details: dict[str, Any] = {
+                    "predicate": predicate_str,
+                    "canonical_candidate_predicate_id": (
+                        canonical_missing_predicate_id
+                    ),
+                }
+                if recoverable_object_kind is not None:
+                    error_details["recoverable_object_kind"] = (
+                        recoverable_object_kind
+                    )
+                if recovery_limit is not None:
+                    error_details["recovery_limit"] = recovery_limit
                 response = make_error_response(
                     "predicate_reference_not_found",
                     (
                         "No accessible predicate matched that name. The "
                         "relationship was not started."
                     ),
-                    details={"predicate": predicate_str},
+                    details=error_details,
                 )
                 response.update(
                     {
@@ -4125,22 +4267,7 @@ def _add_relationship(**kwargs):
                         "changed": False,
                         "mutation_outcome": "not_started",
                         "predicate_resolution": predicate_resolution,
-                        "recovery_affordances": [
-                            {
-                                "action_type": "retry_with_predicate_concept_id",
-                                "predicate_ref": {
-                                    "concept_id": "#V#exact_predicate_id"
-                                },
-                            },
-                            {
-                                "action_type": "create_typed_predicate_then_retry",
-                                "predicate_ref": {
-                                    "name": predicate_str,
-                                    "on_missing": "create_typed_predicate",
-                                    "value_kind": "concept",
-                                },
-                            },
-                        ],
+                        "recovery_affordances": recovery_affordances,
                     }
                 )
                 return response
@@ -11087,19 +11214,22 @@ def _add_relationship_input_schema() -> Schema:
         optional={
             "predicate": (str, type(None)),
             "predicate_ref": (dict, type(None)),
-            "predicate_if_missing": (dict, type(None)),
             "namespace": (str, type(None)),
         },
         allow_unknown=True,
         description=(
-            "add_relationship input: source_id and target plus exactly one useful "
-            "predicate reference. predicate accepts a structural relationship, "
-            "natural-language predicate name, or exact #V# predicate ID. "
-            "predicate_ref is the typed form: {concept_id} or {name, "
-            "on_missing?: 'fail'|'create_typed_predicate', value_kind?: "
-            "'concept'|'text', description?}. Legacy predicate_if_missing remains "
-            "supported for exact dynamic predicates. Creation is attempted only "
-            "when explicitly requested, then verified before the edge."
+            "Governed add_relationship input: source_id and target plus exactly "
+            "one predicate reference. predicate accepts a recognised structural "
+            "predicate alias, a core text predicate (hasContent, hasDescription, "
+            "or hasName), or an exact existing #V# predicate concept ID. "
+            "predicate_ref is an equivalent exact-ID form and supports only "
+            "{concept_id: '#V#...'}. Resolve a predicate name first with "
+            "resolve_concept_by_name using instance_of='#V#predicate'. If it is "
+            "genuinely missing, create one correctly typed predicate through a "
+            "separate governed create_concepts effect, verify the returned "
+            "concept, then retry add_relationship with its exact ID. This call "
+            "does not resolve natural-language predicate names or create "
+            "predicate dependencies."
         ),
     )
 
@@ -11132,8 +11262,8 @@ def _add_relationship_output_schema() -> Schema:
         allow_unknown=True,
         description=(
             "add_relationship output: success, effect_status, changed, edge "
-            "details, optional predicate_dependency create/reuse verification, "
-            "and typed partial or indeterminate failure evidence."
+            "details, governed authority receipt and canonical read-back when "
+            "available, and typed partial or indeterminate failure evidence."
         ),
     )
 
@@ -37827,13 +37957,15 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             ordinary_turn_effect=True,
             ordinary_turn_mutation_subject_argument="source_id",
             description=(
-                "Add one concept-to-concept or concept-to-text relationship. "
-                "Structural predicates use their aliases. A custom predicate may "
-                "be supplied by exact #V# ID or resolved natural-language name. "
-                "Use predicate_ref for typed ambiguity/not-found recovery and "
-                "explicitly request creation with on_missing="
-                "'create_typed_predicate' plus value_kind='concept' or 'text'. "
-                "Creation/reuse is verified before the relationship attempt."
+                "Add one governed concept-to-concept or concept-to-text "
+                "relationship using a recognised structural alias, a core text "
+                "predicate, or an exact existing #V# predicate ID (directly or "
+                "as predicate_ref={concept_id}). Resolve names separately with "
+                "resolve_concept_by_name(instance_of='#V#predicate'); create and "
+                "verify a genuinely missing predicate in its own governed "
+                "create_concepts effect before retrying. This tool does not "
+                "resolve predicate names or create predicate dependencies during "
+                "the relationship write."
             ),
         ),
         MethodDefinition(

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -33,7 +33,7 @@
         },
         {
             "name": "add_relationship",
-            "description": "Add one concept-to-concept or concept-to-text relationship. Structural predicates use their aliases. A custom predicate may be supplied by exact #V# ID or resolved natural-language name. Use predicate_ref for typed ambiguity/not-found recovery and explicitly request creation with on_missing='create_typed_predicate' plus value_kind='concept' or 'text'. Creation/reuse is verified before the relationship attempt.",
+            "description": "Add one governed concept-to-concept or concept-to-text relationship using a recognised structural alias, a core text predicate, or an exact existing #V# predicate ID (directly or as predicate_ref={concept_id}). Resolve names separately with resolve_concept_by_name(instance_of='#V#predicate'); create and verify a genuinely missing predicate in its own governed create_concepts effect before retrying. This tool does not resolve predicate names or create predicate dependencies during the relationship write.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -56,13 +56,6 @@
                         ],
                         "additionalProperties": true
                     },
-                    "predicate_if_missing": {
-                        "type": [
-                            "object",
-                            "null"
-                        ],
-                        "additionalProperties": true
-                    },
                     "ontology_delegation_id": {
                         "type": "string",
                         "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
@@ -77,7 +70,7 @@
                     "target"
                 ],
                 "additionalProperties": true,
-                "description": "add_relationship input: source_id and target plus exactly one useful predicate reference. predicate accepts a structural relationship, natural-language predicate name, or exact #V# predicate ID. predicate_ref is the typed form: {concept_id} or {name, on_missing?: 'fail'|'create_typed_predicate', value_kind?: 'concept'|'text', description?}. Legacy predicate_if_missing remains supported for exact dynamic predicates. Creation is attempted only when explicitly requested, then verified before the edge."
+                "description": "Governed add_relationship input: source_id and target plus exactly one predicate reference. predicate accepts a recognised structural predicate alias, a core text predicate (hasContent, hasDescription, or hasName), or an exact existing #V# predicate concept ID. predicate_ref is an equivalent exact-ID form and supports only {concept_id: '#V#...'}. Resolve a predicate name first with resolve_concept_by_name using instance_of='#V#predicate'. If it is genuinely missing, create one correctly typed predicate through a separate governed create_concepts effect, verify the returned concept, then retry add_relationship with its exact ID. This call does not resolve natural-language predicate names or create predicate dependencies."
             }
         },
         {

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -137,6 +137,16 @@ class _PreparedCapabilityCall:
     binding_diagnostics: Mapping[str, Any] | None = None
 
 
+@dataclass
+class _TerminalFailedEffectRequest:
+    """One exact non-retryable failure and any explicit missing dependency."""
+
+    effect_id: str
+    error_code: str | None
+    missing_dependency_concept_ids: frozenset[str]
+    dependency_materialised: bool = False
+
+
 @dataclass(frozen=True)
 class _ContainedCapabilityResult:
     """A capability result retained until request-thread evidence commit."""
@@ -1675,6 +1685,19 @@ def _scope_message(
         "restart with the exact represented predicate relevant to the requested "
         "relation; the partial neighbourhood cannot establish absence. Create "
         "only after that bounded reuse check finds no adequate existing object.\n"
+        "- In representation work, a created or reused core concept establishes "
+        "only its explicit core identity and type. A source-processing marker "
+        "establishes only processing. Neither establishes requested roles, "
+        "affiliations, identifiers, claim-level provenance, or other relations.\n"
+        "- Treat ancillary fields rejected by a core-create contract as unmet "
+        "postconditions, not discarded intent. Continue with the smallest "
+        "separately executable typed effects and read-backs for supported "
+        "remaining facts, including same-object scoped or standalone assertions "
+        "when faithful. Name any material fact for which no executable "
+        "representation exists; do not call the richer representation complete "
+        "merely because the core exists. An entity result with "
+        "entity_representation_coverage=core_only is a completed core sub-effect, "
+        "not terminal success for its preserved unresolved_requested_facts.\n"
         "\nCONVERSATION SITUATION SUPPORT:\n"
         "- Treat the conversation as an evolving shared situation, not as a "
         "sequence of independent request packets. Preserve established "
@@ -3438,6 +3461,59 @@ def _effect_request_signature(
             }
         )
     ).hexdigest()
+
+
+def _terminal_failure_missing_dependency_concept_ids(
+    raw_payload: Any,
+    *,
+    capability_name: str | None = None,
+    arguments: Mapping[str, Any] | None = None,
+) -> frozenset[str]:
+    """Extract explicit missing IDs plus one bounded non-disclosing denial case."""
+
+    if not isinstance(raw_payload, Mapping):
+        return frozenset()
+    error_code = str(raw_payload.get("error_code") or "").strip()
+    error_details = raw_payload.get("error_details")
+    error_details = error_details if isinstance(error_details, Mapping) else {}
+    nested_details = error_details.get("details")
+    nested_details = nested_details if isinstance(nested_details, Mapping) else {}
+    candidates: list[Any] = []
+    if (
+        error_code == "ontology_mutation_target_not_accessible"
+        and str(capability_name or "").strip().lower() == "add_relationship"
+        and isinstance(arguments, Mapping)
+    ):
+        # The governed pre-handler denial deliberately withholds which target is
+        # absent or merely inaccessible. Retain only exact request-local source
+        # and concept-target IDs so a later create proof can justify one retry;
+        # never add these candidates to the denial returned to the model.
+        candidates.extend((arguments.get("source_id"), arguments.get("target")))
+    elif error_code == "source_concept_not_found":
+        if str(error_details.get("role") or "").strip() == "source":
+            candidates.append(error_details.get("concept_id"))
+    elif error_code == "target_concept_not_found":
+        if str(error_details.get("role") or "").strip() == "target":
+            candidates.append(error_details.get("concept_id"))
+    elif error_code in {"source_not_found", "target_not_found"}:
+        if str(nested_details.get("error") or "").strip() == error_code:
+            candidates.append(nested_details.get("concept_id"))
+    elif error_code == "predicate_concept_not_found":
+        if str(nested_details.get("error") or "").strip() == error_code:
+            candidates.extend(
+                (nested_details.get("predicate"), error_details.get("predicate"))
+            )
+    elif error_code in {
+        "concept_not_found",
+        "ontology_mutation_target_not_found",
+    }:
+        candidates.append(error_details.get("concept_id"))
+
+    return frozenset(
+        concept_id
+        for value in candidates
+        if isinstance(value, str) and (concept_id := value.strip()).startswith("#V#")
+    )
 
 
 def _effect_result_target_ids(raw_payload: Any) -> list[str]:
@@ -5285,10 +5361,11 @@ def _effect_requires_turn_finality(
     """Keep operational workflow bookkeeping from becoming semantic failure.
 
     Represented workflows always use effect-grade dispatch because invoking one
-    may create or advance a durable instance. An input-schema rejection never
-    reaches a handler, and a represented-workflow attempt rejected before any
-    instance was created reports known no change; neither has an effect whose
-    finality can invalidate a successfully recovered answer.
+    may create or advance a durable instance. An input-schema rejection or
+    suppressed duplicate never reaches a handler, and a represented-workflow
+    attempt rejected before any instance was created reports known no change;
+    none has an effect whose finality can invalidate a successfully recovered
+    answer.
     """
 
     instance_id = (
@@ -5300,11 +5377,16 @@ def _effect_requires_turn_finality(
         effect_status == "not_started"
         and changed is False
         and isinstance(raw_payload, Mapping)
-        and raw_payload.get("error_code") == "capability_arguments_invalid"
+        and raw_payload.get("error_code")
+        in {
+            "capability_arguments_invalid",
+            "effect_request_unchanged_after_terminal_failure",
+        }
     ):
-        # Input validation runs before the handler.  The rejected call is useful
-        # feedback to the model, but there is no effect whose finality can poison
-        # a corrected invocation later in the same turn.
+        # Input validation and exact-request suppression both run before the
+        # handler. The feedback remains visible to the model, but neither guard
+        # dispatched another effect whose finality can poison a corrected or
+        # changed-strategy recovery later in the same turn.
         return False
     if capability_kind != "represented_workflow":
         return True
@@ -5972,35 +6054,129 @@ def execute_adaptive_turn(
     exact_read_observations: list[dict[str, Any]] = []
     effect_state_generation = 0
     last_partial_effect_generation = 0
-    successful_effect_mutation_generation = 0
-    terminal_failed_effect_requests: dict[str, tuple[int, str | None]] = {}
+    terminal_failed_effect_requests: dict[
+        str,
+        _TerminalFailedEffectRequest,
+    ] = {}
     indeterminate_effect_requests: dict[str, tuple[str, str | None]] = {}
     exact_absence_effect_requests: dict[str, str] = {}
     recoverable_effect_ids: dict[str, list[str]] = {}
 
     def remember_terminal_effect_failure(
         *,
+        effect_id: str | None,
         request_signature: str | None,
+        capability_name: str,
+        arguments: Mapping[str, Any],
         effect_status: str | None,
         payload: Any,
     ) -> None:
         """Prevent an unchanged, non-retryable failed effect from running twice."""
 
         if (
-            request_signature is None
+            effect_id is None
+            or request_signature is None
             or effect_status not in {"failed", "not_started"}
             or not isinstance(payload, Mapping)
             or payload.get("retryable") is True
         ):
             return
-        terminal_failed_effect_requests[request_signature] = (
-            successful_effect_mutation_generation,
-            (
-                str(payload.get("error_code")).strip()
-                if payload.get("error_code")
-                else None
-            ),
+        with effect_state_lock:
+            terminal_failed_effect_requests[request_signature] = (
+                _TerminalFailedEffectRequest(
+                    effect_id=effect_id,
+                    error_code=(
+                        str(payload.get("error_code")).strip()
+                        if payload.get("error_code")
+                        else None
+                    ),
+                    missing_dependency_concept_ids=(
+                        _terminal_failure_missing_dependency_concept_ids(
+                            payload,
+                            capability_name=capability_name,
+                            arguments=arguments,
+                        )
+                    ),
+                )
+            )
+
+    def note_materialised_create_dependencies(
+        *,
+        capability_name: str,
+        effect_status: str | None,
+        payload: Any,
+    ) -> None:
+        """Permit retry only when create materialised an explicitly missing ID."""
+
+        if (
+            capability_name != "create_concepts"
+            or effect_status != "succeeded"
+            or not isinstance(payload, Mapping)
+        ):
+            return
+        materialised_ids: set[str] = set()
+        if payload.get("changed") is True:
+            materialised_ids.update(
+                concept_id
+                for value in payload.get("created_concept_ids") or ()
+                if isinstance(value, str)
+                and (concept_id := value.strip()).startswith("#V#")
+            )
+        canonical_readback = payload.get("canonical_read_back")
+        if not isinstance(canonical_readback, Mapping):
+            canonical_readback = payload.get("canonical_readback")
+        canonical_concepts = (
+            canonical_readback.get("concepts")
+            if isinstance(canonical_readback, Mapping)
+            else None
         )
+        if isinstance(canonical_concepts, Sequence) and not isinstance(
+            canonical_concepts,
+            (str, bytes, bytearray),
+        ):
+            materialised_ids.update(
+                concept_id
+                for item in canonical_concepts
+                if isinstance(item, Mapping)
+                and item.get("exists") is True
+                and isinstance(item.get("concept_id"), str)
+                and (concept_id := str(item["concept_id"]).strip()).startswith("#V#")
+            )
+        if not materialised_ids:
+            return
+        with effect_state_lock:
+            for failure in terminal_failed_effect_requests.values():
+                if failure.missing_dependency_concept_ids.intersection(
+                    materialised_ids
+                ):
+                    failure.dependency_materialised = True
+
+    def reconcile_successful_dependency_retry(
+        *,
+        recovery_effect_id: str,
+        request_signature: str | None,
+        effect_status: str,
+    ) -> None:
+        """Resolve the prior failure after its exact dependency-enabled retry."""
+
+        nonlocal effect_state_generation
+        if effect_status != "succeeded" or not request_signature:
+            return
+        with effect_state_lock:
+            failure = terminal_failed_effect_requests.get(request_signature)
+            if failure is None or not failure.dependency_materialised:
+                return
+            failed_state = effect_states.get(failure.effect_id)
+            if (
+                failed_state is None
+                or failed_state.get("effect_status") not in {"failed", "not_started"}
+                or failed_state.get("changed") is not False
+            ):
+                return
+            failed_state["recovered_by_effect_id"] = recovery_effect_id
+            failed_state["recovery_status"] = "succeeded"
+            terminal_failed_effect_requests.pop(request_signature, None)
+            effect_state_generation += 1
 
     def scoped_assertion_recovery_key(
         capability_name: str,
@@ -8384,7 +8560,6 @@ def execute_adaptive_turn(
             deadline_monotonic: float | None,
             effect_window_denial: Mapping[str, Any] | None = None,
         ) -> tuple[int, _ContainedCapabilityResult]:
-            nonlocal successful_effect_mutation_generation
             index = item.index
             call = item.call
             canonical_name = item.capability_name
@@ -8473,11 +8648,21 @@ def execute_adaptive_turn(
                 if is_effect
                 else None
             )
-            prior_terminal_failure = (
-                terminal_failed_effect_requests.get(effect_request_signature)
-                if effect_request_signature is not None
-                else None
-            )
+            with effect_state_lock:
+                prior_terminal_failure = (
+                    terminal_failed_effect_requests.get(effect_request_signature)
+                    if effect_request_signature is not None
+                    else None
+                )
+                prior_terminal_failure_seen = bool(
+                    prior_terminal_failure is not None
+                    and not prior_terminal_failure.dependency_materialised
+                )
+                prior_terminal_error_code = (
+                    prior_terminal_failure.error_code
+                    if prior_terminal_failure_seen
+                    else None
+                )
             prior_indeterminate_request = (
                 indeterminate_effect_requests.get(effect_request_signature)
                 if effect_request_signature is not None
@@ -8521,26 +8706,23 @@ def execute_adaptive_turn(
                         ],
                     }
                 )
-            if (
-                prior_terminal_failure is not None
-                and prior_terminal_failure[0] == successful_effect_mutation_generation
-            ):
+            if prior_terminal_failure_seen:
                 repeated_failure_payload = {
                     **_error_payload(
                         "effect_request_unchanged_after_terminal_failure",
                         (
                             "This exact effect request was not repeated because "
-                            "it already failed terminally and no successful "
-                            "intervening effect changed the turn state."
+                            "it already failed terminally and the request has "
+                            "not changed."
                         ),
                     ),
                     "status": "not_started",
                     "mutation_outcome": "not_started",
                     "outcome_finality": "terminal_for_turn",
-                    "prior_error_code": prior_terminal_failure[1],
+                    "prior_error_code": prior_terminal_error_code,
                     "changed": False,
                 }
-                if prior_terminal_failure[1] not in {
+                if prior_terminal_error_code not in {
                     "complex_create_requires_typed_effects",
                     "multi_create_requires_individual_effects",
                 }:
@@ -8668,7 +8850,10 @@ def execute_adaptive_turn(
                         transport_result=None,
                     )
                     remember_terminal_effect_failure(
+                        effect_id=effect_identifier,
                         request_signature=effect_request_signature,
+                        capability_name=execution_method_name,
+                        arguments=arguments,
                         effect_status=delegation_effect_status,
                         payload=delegation_result,
                     )
@@ -8830,7 +9015,15 @@ def execute_adaptive_turn(
                 else None
             )
             remember_terminal_effect_failure(
+                effect_id=effect_identifier,
                 request_signature=effect_request_signature if is_effect else None,
+                capability_name=execution_method_name,
+                arguments=arguments,
+                effect_status=terminal_effect_status,
+                payload=raw_payload,
+            )
+            note_materialised_create_dependencies(
+                capability_name=canonical_name,
                 effect_status=terminal_effect_status,
                 payload=raw_payload,
             )
@@ -8855,14 +9048,6 @@ def execute_adaptive_turn(
                         else None
                     ),
                 )
-            elif (
-                is_effect
-                and terminal_effect_status in {"succeeded", "partial"}
-                and isinstance(raw_payload, Mapping)
-                and raw_payload.get("changed") is True
-            ):
-                successful_effect_mutation_generation += 1
-
             if effect_identifier is not None:
                 transport_metadata_fn = getattr(
                     transport_result,
@@ -9233,6 +9418,11 @@ def execute_adaptive_turn(
                         effect_status=effect_status,
                     )
                     reconcile_successful_exact_absence_retry(
+                        recovery_effect_id=effect_identifier,
+                        request_signature=current_effect_request_signature,
+                        effect_status=effect_status,
+                    )
+                    reconcile_successful_dependency_retry(
                         recovery_effect_id=effect_identifier,
                         request_signature=current_effect_request_signature,
                         effect_status=effect_status,

--- a/src/backend/services/representation_contract_vontology_service.py
+++ b/src/backend/services/representation_contract_vontology_service.py
@@ -87,8 +87,10 @@ _CANONICAL_REPRESENTATION_PROFILE_BLUEPRINTS: tuple[dict[str, Any], ...] = (
         "target_entity_class": "person",
         "effect_type": "representation_person",
         "description": (
-            "Ensure a person representation is materialised from the supplied "
-            "artefact context before final response completion."
+            "Ensure the core identity for a person is materialised and typed as "
+            "Person from the supplied artefact context. This core contract does "
+            "not establish requested roles, affiliations, identifiers, or "
+            "claim-level provenance; those remain separate effects."
         ),
         "intent_patterns": [
             r"\b("

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -75,6 +75,7 @@ _WORKFLOW_NON_EFFECT_OUTCOMES = frozenset(
         "blocked",
         "clarification_required",
         "failed",
+        "follow_up_required",
         "not_completed",
     }
 )

--- a/src/backend/workflows/durable/entity_representation_workflow.py
+++ b/src/backend/workflows/durable/entity_representation_workflow.py
@@ -69,6 +69,58 @@ def _coerce_string_list(value: Any) -> list[str]:
     return values
 
 
+_REQUESTED_FACT_TEXT_FIELDS: tuple[str, ...] = (
+    "claim_text",
+    "relation_hint",
+    "target_name",
+    "identifier_scheme",
+    "identifier_value",
+    "evidence_text",
+    "source_locator",
+)
+
+
+def _normalise_requested_facts(value: Any) -> tuple[list[dict[str, str]], bool]:
+    """Preserve grounded non-core facts without interpreting their semantics."""
+
+    if not isinstance(value, Sequence) or isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [], False
+
+    facts: list[dict[str, str]] = []
+    valid = True
+    for item in value:
+        if not isinstance(item, Mapping):
+            valid = False
+            continue
+        fact = {
+            field_name: text
+            for field_name in _REQUESTED_FACT_TEXT_FIELDS
+            if (text := _clean_text(item.get(field_name)))
+        }
+        if not fact.get("claim_text"):
+            valid = False
+            continue
+        facts.append(fact)
+    return facts, valid
+
+
+def _requested_fact_coverage_outputs(value: Any) -> dict[str, Any]:
+    facts, payload_valid = _normalise_requested_facts(value)
+    facts_complete = payload_valid and not facts
+    return {
+        "entity_representation_requested_facts": facts,
+        "entity_representation_unresolved_requested_facts": facts,
+        "entity_representation_requested_fact_count": len(facts),
+        "entity_representation_requested_facts_payload_valid": payload_valid,
+        "entity_representation_requested_facts_complete": facts_complete,
+        "entity_representation_coverage": (
+            "complete" if facts_complete else "core_only"
+        ),
+    }
+
+
 def _normalise_entity_domain(value: Any) -> str:
     raw = _clean_text(value).lower().replace("-", "_").replace(" ", "_")
     aliases = {
@@ -175,6 +227,7 @@ def _read_only_existing_entity_result(
     entity_domain: str,
     entity_type_id: str,
     entity_name: str,
+    requested_fact_coverage: Mapping[str, Any],
 ) -> WorkflowActionResult:
     """Return an idempotent handoff without changing an existing concept.
 
@@ -187,12 +240,18 @@ def _read_only_existing_entity_result(
         status="success",
         outputs={
             "entity_representation_materialised": False,
-            "entity_representation_verified": True,
+            "entity_core_representation_verified": True,
+            "entity_representation_verified": bool(
+                requested_fact_coverage.get(
+                    "entity_representation_requested_facts_complete"
+                )
+            ),
             "entity_representation_domain": entity_domain,
             "entity_representation_type_id": entity_type_id,
             "entity_representation_concept_id": concept_id,
             "entity_representation_reused_existing": True,
             "entity_representation_name": entity_name,
+            **dict(requested_fact_coverage),
         },
     )
 
@@ -269,6 +328,14 @@ def _handle_materialise_from_payload(
         )
         if alias.casefold() != entity_name.casefold()
     ]
+    raw_requested_facts = (
+        request.inputs.get("requested_facts")
+        if "requested_facts" in request.inputs
+        else request.data.get("requested_facts")
+    )
+    requested_fact_coverage = _requested_fact_coverage_outputs(
+        raw_requested_facts
+    )
 
     verified_ids = _find_verified_named_instance_concept_ids(
         concept_name=entity_name,
@@ -276,9 +343,22 @@ def _handle_materialise_from_payload(
     )
     if len(verified_ids) > 1:
         return WorkflowActionResult(
-            status="failed",
-            error="entity_representation_entity_name_ambiguous",
+            status="success",
             outputs={
+                "entity_representation_materialised": False,
+                "entity_core_representation_verified": False,
+                "entity_representation_verified": False,
+                "entity_representation_domain": entity_domain,
+                "entity_representation_type_id": entity_type_id,
+                "entity_representation_concept_id": "",
+                "entity_representation_reused_existing": False,
+                "entity_representation_name": entity_name,
+                **dict(requested_fact_coverage),
+                "entity_representation_coverage": "not_started",
+                "entity_resolution_status": "ambiguous",
+                "entity_resolution_candidates": [
+                    {"concept_id": concept_id} for concept_id in verified_ids
+                ],
                 "response_text": (
                     f"I found multiple {entity_domain} concepts named "
                     f"'{entity_name}'. Please clarify which one you mean."
@@ -292,6 +372,7 @@ def _handle_materialise_from_payload(
             entity_domain=entity_domain,
             entity_type_id=entity_type_id,
             entity_name=entity_name,
+            requested_fact_coverage=requested_fact_coverage,
         )
 
     user_concept_id, org_concept_id = _resolve_actor_context(request)
@@ -330,6 +411,7 @@ def _handle_materialise_from_payload(
                 entity_domain=entity_domain,
                 entity_type_id=entity_type_id,
                 entity_name=entity_name,
+                requested_fact_coverage=requested_fact_coverage,
             )
         return WorkflowActionResult(
             status="failed",
@@ -389,12 +471,18 @@ def _handle_materialise_from_payload(
         status="success",
         outputs={
             "entity_representation_materialised": True,
-            "entity_representation_verified": True,
+            "entity_core_representation_verified": True,
+            "entity_representation_verified": bool(
+                requested_fact_coverage.get(
+                    "entity_representation_requested_facts_complete"
+                )
+            ),
             "entity_representation_domain": entity_domain,
             "entity_representation_type_id": entity_type_id,
             "entity_representation_concept_id": concept_id,
             "entity_representation_reused_existing": False,
             "entity_representation_name": entity_name,
+            **dict(requested_fact_coverage),
             "response_text": response_text,
         },
     )
@@ -406,10 +494,12 @@ def register_entity_representation_actions(registry: ActionRegistry) -> None:
             action_id=ENTITY_REPRESENTATION_MATERIALISE_ACTION_ID,
             handler=_handle_materialise_from_payload,
             description=(
-                "Additively materialise a typed entity concept from structured "
-                "payload fields. If an exact existing instance is encountered, "
-                "return a read-only idempotence handoff for represented workflow "
-                "readback instead of mutating it."
+                "Additively materialise and verify a typed entity core from "
+                "structured payload fields while preserving requested non-core "
+                "facts as explicit unresolved postconditions. If an exact "
+                "existing instance is encountered, return a read-only "
+                "idempotence handoff for represented workflow readback instead "
+                "of mutating it."
             ),
             side_effects="write",
         ),

--- a/src/backend/workflows/durable/workflow_creation_workflow.py
+++ b/src/backend/workflows/durable/workflow_creation_workflow.py
@@ -2551,10 +2551,18 @@ def _handle_verify_discoverability(request: WorkflowActionRequest) -> WorkflowAc
                 llm_client=request.environment.llm_client,
                 gateway=request.environment.gateway,
                 model=request.environment.model,
+                model_parameters=request.environment.model_parameters,
                 user_namespace=request.environment.user_namespace,
                 auxiliary_system_prompt=request.environment.auxiliary_system_prompt,
                 max_tool_invocations=request.environment.max_tool_invocations,
+                max_tool_result_chars=request.environment.max_tool_result_chars,
+                max_tool_result_field_chars=(
+                    request.environment.max_tool_result_field_chars
+                ),
                 default_gmail_profile=request.environment.default_gmail_profile,
+                user_concept_id=request.environment.user_concept_id,
+                org_concept_id=request.environment.org_concept_id,
+                step_callback=request.environment.step_callback,
             ),
             data=dict(verification_inputs_raw or {})
             if isinstance(verification_inputs_raw, Mapping)

--- a/src/backend/workflows/repo_seed_bundles/entity_representation_payload_prompt_seed.md
+++ b/src/backend/workflows/repo_seed_bundles/entity_representation_payload_prompt_seed.md
@@ -7,6 +7,7 @@ Return JSON only with exactly these keys:
 - entity_description
 - entity_aliases
 - entity_source_text
+- requested_facts
 - response_text
 
 Rules:
@@ -24,3 +25,15 @@ Rules:
   main entity_name.
 - entity_source_text should preserve the best concise textual grounding for the
   representation.
+- requested_facts must be an array containing every grounded semantic fact
+  requested beyond the entity's core identity, expected domain type, name, and
+  aliases. Use an empty array only when the request contains no such fact. A
+  fact does not stop being requested merely because it is also repeated in
+  entity_description or entity_source_text.
+- Each requested_facts item must contain claim_text and may contain
+  relation_hint, target_name, identifier_scheme, identifier_value,
+  evidence_text, and source_locator. Preserve the source's meaning and evidence;
+  do not invent concept or predicate IDs, publication scope, or authority.
+- A requested role, affiliation, identifier, provenance, or other non-core
+  claim remains a requested fact even when the entity already exists. A prose
+  description or source-processing note does not establish it or satisfy the requested fact.

--- a/src/backend/workflows/repo_seed_bundles/workflow_template_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/workflow_template_seed_bundle.json
@@ -1,27 +1,39 @@
 {
   "family_id": "workflow_template_seed_bundle",
   "schema_version": "repo_seed_workflow_template_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "5",
   "source_tag": "JVNAUTOSCI-2577",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "workflow_creation.person_representation": {
       "unversioned": [
         "c05bf1c197105f1b827e6425ec65c9969d56e3167a9cab467b8950b0877cb72e"
+      ],
+      "4": [
+        "bebaf90d6603fa63acdd1dcb363f8cb932c61d5ed45270064a7401c1f1cef23b"
       ]
     },
     "workflow_creation.company_representation": {
       "unversioned": [
         "0d9410537439ef85891992a5a243460ea41e464773dd93d3da11343bcce7be90"
+      ],
+      "4": [
+        "1b567d6c833201a3e48953e6c8df416913c118dcc31b4b446f1a2f316658aeef"
       ]
     },
     "workflow_creation.event_representation": {
       "unversioned": [
         "1e959db513067495d7330da9615cfdc96ebb21313098150f471f715a36c118ae"
+      ],
+      "4": [
+        "5c13822c0a2bc0f782dfda7b50966a2173029cf18797af64816479bc43360623"
       ]
     },
     "workflow_creation.place_representation": {
       "unversioned": [
         "706e021bfd841e3faa7b8214a06492ee8eadc74bea122a71ef31baaee191410c"
+      ],
+      "4": [
+        "7eee095c5dd2d63ed60f5500350fdba48dc3c5fd87c16a1300a7e94ae411140d"
       ]
     }
   },
@@ -432,13 +444,13 @@
         "parent_type_id": "#V#ai_workflow",
         "required_effects": [
           "context:user_affirmation_policy=only_when_vital_info_missing",
-          "context:entity_representation_verified=True",
+          "context:entity_core_representation_verified=True",
           "context:entity_representation_readback_verified=True",
           "context:entity_representation_domain=person"
         ],
         "postcondition_probe": {
           "user_affirmation_policy": "only_when_vital_info_missing",
-          "entity_representation_verified": true,
+          "entity_core_representation_verified": true,
           "entity_representation_readback_verified": true,
           "entity_representation_domain": "person"
         },
@@ -496,7 +508,7 @@
             "llm_policy": {
               "policy_stage": "entity_representation_payload",
               "tool_mode": "none",
-              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, and response_text.",
+              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, requested_facts, and response_text.",
               "context_fields": [
                 {
                   "context_key": "request_text",
@@ -548,6 +560,10 @@
                 "context_key": "entity_source_text"
               },
               {
+                "tool_output_field": "validated_json.requested_facts",
+                "context_key": "requested_facts"
+              },
+              {
                 "tool_output_field": "validated_json.response_text",
                 "context_key": "response_text"
               }
@@ -559,6 +575,7 @@
               "entity_description",
               "entity_aliases",
               "entity_source_text",
+              "requested_facts",
               "response_text"
             ],
             "conditional_transitions": [
@@ -628,7 +645,7 @@
                   "value": "resolved"
                 },
                 "reason": "reuse_exact_existing_person",
-                "to_state": "mark_existing_reuse"
+                "to_state": "materialise_entity"
               },
               {
                 "condition_spec": {
@@ -743,6 +760,9 @@
               },
               "entity_source_text": {
                 "$context_key": "entity_source_text"
+              },
+              "requested_facts": {
+                "$context_key": "requested_facts"
               }
             },
             "mutation_authority": {
@@ -754,6 +774,10 @@
               {
                 "tool_output_field": "entity_representation_concept_id",
                 "context_key": "entity_representation_concept_id"
+              },
+              {
+                "tool_output_field": "entity_core_representation_verified",
+                "context_key": "entity_core_representation_verified"
               },
               {
                 "tool_output_field": "entity_representation_verified",
@@ -776,19 +800,72 @@
                 "context_key": "entity_representation_name"
               },
               {
+                "tool_output_field": "entity_representation_requested_facts_complete",
+                "context_key": "entity_representation_requested_facts_complete"
+              },
+              {
+                "tool_output_field": "entity_representation_unresolved_requested_facts",
+                "context_key": "entity_representation_unresolved_requested_facts"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_fact_count",
+                "context_key": "entity_representation_requested_fact_count"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_facts_payload_valid",
+                "context_key": "entity_representation_requested_facts_payload_valid"
+              },
+              {
+                "tool_output_field": "entity_representation_coverage",
+                "context_key": "entity_representation_coverage"
+              },
+              {
+                "tool_output_field": "entity_resolution_status",
+                "context_key": "entity_resolution_status"
+              },
+              {
+                "tool_output_field": "entity_resolution_candidates",
+                "context_key": "entity_resolution_candidates"
+              },
+              {
                 "tool_output_field": "response_text",
                 "context_key": "response_text"
               }
             ],
             "writes_context_keys": [
               "entity_representation_concept_id",
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_domain",
               "entity_representation_materialised",
               "entity_representation_reused_existing",
-              "entity_representation_name"
+              "entity_representation_name",
+              "entity_representation_requested_facts_complete",
+              "entity_representation_unresolved_requested_facts",
+              "entity_representation_requested_fact_count",
+              "entity_representation_requested_facts_payload_valid",
+              "entity_representation_coverage",
+              "entity_resolution_status",
+              "entity_resolution_candidates"
             ],
-            "next_state": "read_back_concept",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_resolution_status",
+                  "value": "ambiguous"
+                },
+                "reason": "materialise_race_found_ambiguity",
+                "to_state": "render_existing_ambiguity"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "read_back_selected_person",
+                "to_state": "read_back_concept"
+              }
+            ],
             "on_failure_state": "failed"
           },
           {
@@ -863,8 +940,12 @@
             "inputs": {
               "assignments": [
                 {
-                  "key": "entity_representation_verified",
+                  "key": "entity_core_representation_verified",
                   "value": true
+                },
+                {
+                  "key": "entity_representation_verified",
+                  "value_from_context": "entity_representation_requested_facts_complete"
                 },
                 {
                   "key": "entity_representation_readback_verified",
@@ -881,12 +962,22 @@
               ]
             },
             "writes_context_keys": [
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_readback_verified",
               "entity_representation_domain",
               "requires_user_affirmation"
             ],
             "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_representation_verified",
+                  "value": false
+                },
+                "reason": "render_core_only_person_readback",
+                "to_state": "render_core_only_response"
+              },
               {
                 "condition_spec": {
                   "kind": "context_value_equals",
@@ -904,6 +995,59 @@
                 "to_state": "render_create_response"
               }
             ],
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "render_core_only_response",
+            "action_id": "workflow_control.context_template",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "response_text",
+                  "template": "Verified the Person core for '{{name}}' as {{concept_id}} by read-back, but the richer requested representation is not complete. Unresolved requested facts: {{unresolved_facts}}.",
+                  "variables": {
+                    "name": {
+                      "value_from_context": "entity_name"
+                    },
+                    "concept_id": {
+                      "value_from_context": "entity_representation_readback_concept_id",
+                      "transform": "concept_id"
+                    },
+                    "unresolved_facts": {
+                      "value_from_context": "entity_representation_unresolved_requested_facts",
+                      "transform": "json",
+                      "default": []
+                    }
+                  }
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "response_text"
+            ],
+            "next_state": "mark_core_only_follow_up",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "mark_core_only_follow_up",
+            "action_id": "workflow_control.context_set",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "follow_up_required",
+                  "value": true
+                },
+                {
+                  "key": "semantic_outcome",
+                  "value": "follow_up_required"
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "follow_up_required",
+              "semantic_outcome"
+            ],
+            "next_state": "completed",
             "on_failure_state": "failed"
           },
           {
@@ -1031,13 +1175,13 @@
         "parent_type_id": "#V#ai_workflow",
         "required_effects": [
           "context:user_affirmation_policy=only_when_vital_info_missing",
-          "context:entity_representation_verified=True",
+          "context:entity_core_representation_verified=True",
           "context:entity_representation_readback_verified=True",
           "context:entity_representation_domain=company"
         ],
         "postcondition_probe": {
           "user_affirmation_policy": "only_when_vital_info_missing",
-          "entity_representation_verified": true,
+          "entity_core_representation_verified": true,
           "entity_representation_readback_verified": true,
           "entity_representation_domain": "company"
         },
@@ -1095,7 +1239,7 @@
             "llm_policy": {
               "policy_stage": "entity_representation_payload",
               "tool_mode": "none",
-              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, and response_text.",
+              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, requested_facts, and response_text.",
               "context_fields": [
                 {
                   "context_key": "request_text",
@@ -1147,6 +1291,10 @@
                 "context_key": "entity_source_text"
               },
               {
+                "tool_output_field": "validated_json.requested_facts",
+                "context_key": "requested_facts"
+              },
+              {
                 "tool_output_field": "validated_json.response_text",
                 "context_key": "response_text"
               }
@@ -1158,6 +1306,7 @@
               "entity_description",
               "entity_aliases",
               "entity_source_text",
+              "requested_facts",
               "response_text"
             ],
             "conditional_transitions": [
@@ -1227,7 +1376,7 @@
                   "value": "resolved"
                 },
                 "reason": "reuse_exact_existing_company",
-                "to_state": "mark_existing_reuse"
+                "to_state": "materialise_entity"
               },
               {
                 "condition_spec": {
@@ -1342,6 +1491,9 @@
               },
               "entity_source_text": {
                 "$context_key": "entity_source_text"
+              },
+              "requested_facts": {
+                "$context_key": "requested_facts"
               }
             },
             "mutation_authority": {
@@ -1353,6 +1505,10 @@
               {
                 "tool_output_field": "entity_representation_concept_id",
                 "context_key": "entity_representation_concept_id"
+              },
+              {
+                "tool_output_field": "entity_core_representation_verified",
+                "context_key": "entity_core_representation_verified"
               },
               {
                 "tool_output_field": "entity_representation_verified",
@@ -1375,19 +1531,72 @@
                 "context_key": "entity_representation_name"
               },
               {
+                "tool_output_field": "entity_representation_requested_facts_complete",
+                "context_key": "entity_representation_requested_facts_complete"
+              },
+              {
+                "tool_output_field": "entity_representation_unresolved_requested_facts",
+                "context_key": "entity_representation_unresolved_requested_facts"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_fact_count",
+                "context_key": "entity_representation_requested_fact_count"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_facts_payload_valid",
+                "context_key": "entity_representation_requested_facts_payload_valid"
+              },
+              {
+                "tool_output_field": "entity_representation_coverage",
+                "context_key": "entity_representation_coverage"
+              },
+              {
+                "tool_output_field": "entity_resolution_status",
+                "context_key": "entity_resolution_status"
+              },
+              {
+                "tool_output_field": "entity_resolution_candidates",
+                "context_key": "entity_resolution_candidates"
+              },
+              {
                 "tool_output_field": "response_text",
                 "context_key": "response_text"
               }
             ],
             "writes_context_keys": [
               "entity_representation_concept_id",
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_domain",
               "entity_representation_materialised",
               "entity_representation_reused_existing",
-              "entity_representation_name"
+              "entity_representation_name",
+              "entity_representation_requested_facts_complete",
+              "entity_representation_unresolved_requested_facts",
+              "entity_representation_requested_fact_count",
+              "entity_representation_requested_facts_payload_valid",
+              "entity_representation_coverage",
+              "entity_resolution_status",
+              "entity_resolution_candidates"
             ],
-            "next_state": "read_back_concept",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_resolution_status",
+                  "value": "ambiguous"
+                },
+                "reason": "materialise_race_found_ambiguity",
+                "to_state": "render_existing_ambiguity"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "read_back_selected_company",
+                "to_state": "read_back_concept"
+              }
+            ],
             "on_failure_state": "failed"
           },
           {
@@ -1462,8 +1671,12 @@
             "inputs": {
               "assignments": [
                 {
-                  "key": "entity_representation_verified",
+                  "key": "entity_core_representation_verified",
                   "value": true
+                },
+                {
+                  "key": "entity_representation_verified",
+                  "value_from_context": "entity_representation_requested_facts_complete"
                 },
                 {
                   "key": "entity_representation_readback_verified",
@@ -1480,12 +1693,22 @@
               ]
             },
             "writes_context_keys": [
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_readback_verified",
               "entity_representation_domain",
               "requires_user_affirmation"
             ],
             "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_representation_verified",
+                  "value": false
+                },
+                "reason": "render_core_only_company_readback",
+                "to_state": "render_core_only_response"
+              },
               {
                 "condition_spec": {
                   "kind": "context_value_equals",
@@ -1503,6 +1726,59 @@
                 "to_state": "render_create_response"
               }
             ],
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "render_core_only_response",
+            "action_id": "workflow_control.context_template",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "response_text",
+                  "template": "Verified the Company core for '{{name}}' as {{concept_id}} by read-back, but the richer requested representation is not complete. Unresolved requested facts: {{unresolved_facts}}.",
+                  "variables": {
+                    "name": {
+                      "value_from_context": "entity_name"
+                    },
+                    "concept_id": {
+                      "value_from_context": "entity_representation_readback_concept_id",
+                      "transform": "concept_id"
+                    },
+                    "unresolved_facts": {
+                      "value_from_context": "entity_representation_unresolved_requested_facts",
+                      "transform": "json",
+                      "default": []
+                    }
+                  }
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "response_text"
+            ],
+            "next_state": "mark_core_only_follow_up",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "mark_core_only_follow_up",
+            "action_id": "workflow_control.context_set",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "follow_up_required",
+                  "value": true
+                },
+                {
+                  "key": "semantic_outcome",
+                  "value": "follow_up_required"
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "follow_up_required",
+              "semantic_outcome"
+            ],
+            "next_state": "completed",
             "on_failure_state": "failed"
           },
           {
@@ -1631,13 +1907,13 @@
         "parent_type_id": "#V#ai_workflow",
         "required_effects": [
           "context:user_affirmation_policy=only_when_vital_info_missing",
-          "context:entity_representation_verified=True",
+          "context:entity_core_representation_verified=True",
           "context:entity_representation_readback_verified=True",
           "context:entity_representation_domain=event"
         ],
         "postcondition_probe": {
           "user_affirmation_policy": "only_when_vital_info_missing",
-          "entity_representation_verified": true,
+          "entity_core_representation_verified": true,
           "entity_representation_readback_verified": true,
           "entity_representation_domain": "event"
         },
@@ -1695,7 +1971,7 @@
             "llm_policy": {
               "policy_stage": "entity_representation_payload",
               "tool_mode": "none",
-              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, and response_text.",
+              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, requested_facts, and response_text.",
               "context_fields": [
                 {
                   "context_key": "request_text",
@@ -1747,6 +2023,10 @@
                 "context_key": "entity_source_text"
               },
               {
+                "tool_output_field": "validated_json.requested_facts",
+                "context_key": "requested_facts"
+              },
+              {
                 "tool_output_field": "validated_json.response_text",
                 "context_key": "response_text"
               }
@@ -1758,6 +2038,7 @@
               "entity_description",
               "entity_aliases",
               "entity_source_text",
+              "requested_facts",
               "response_text"
             ],
             "conditional_transitions": [
@@ -1827,7 +2108,7 @@
                   "value": "resolved"
                 },
                 "reason": "reuse_exact_existing_event",
-                "to_state": "mark_existing_reuse"
+                "to_state": "materialise_entity"
               },
               {
                 "condition_spec": {
@@ -1942,6 +2223,9 @@
               },
               "entity_source_text": {
                 "$context_key": "entity_source_text"
+              },
+              "requested_facts": {
+                "$context_key": "requested_facts"
               }
             },
             "mutation_authority": {
@@ -1953,6 +2237,10 @@
               {
                 "tool_output_field": "entity_representation_concept_id",
                 "context_key": "entity_representation_concept_id"
+              },
+              {
+                "tool_output_field": "entity_core_representation_verified",
+                "context_key": "entity_core_representation_verified"
               },
               {
                 "tool_output_field": "entity_representation_verified",
@@ -1975,19 +2263,72 @@
                 "context_key": "entity_representation_name"
               },
               {
+                "tool_output_field": "entity_representation_requested_facts_complete",
+                "context_key": "entity_representation_requested_facts_complete"
+              },
+              {
+                "tool_output_field": "entity_representation_unresolved_requested_facts",
+                "context_key": "entity_representation_unresolved_requested_facts"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_fact_count",
+                "context_key": "entity_representation_requested_fact_count"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_facts_payload_valid",
+                "context_key": "entity_representation_requested_facts_payload_valid"
+              },
+              {
+                "tool_output_field": "entity_representation_coverage",
+                "context_key": "entity_representation_coverage"
+              },
+              {
+                "tool_output_field": "entity_resolution_status",
+                "context_key": "entity_resolution_status"
+              },
+              {
+                "tool_output_field": "entity_resolution_candidates",
+                "context_key": "entity_resolution_candidates"
+              },
+              {
                 "tool_output_field": "response_text",
                 "context_key": "response_text"
               }
             ],
             "writes_context_keys": [
               "entity_representation_concept_id",
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_domain",
               "entity_representation_materialised",
               "entity_representation_reused_existing",
-              "entity_representation_name"
+              "entity_representation_name",
+              "entity_representation_requested_facts_complete",
+              "entity_representation_unresolved_requested_facts",
+              "entity_representation_requested_fact_count",
+              "entity_representation_requested_facts_payload_valid",
+              "entity_representation_coverage",
+              "entity_resolution_status",
+              "entity_resolution_candidates"
             ],
-            "next_state": "read_back_concept",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_resolution_status",
+                  "value": "ambiguous"
+                },
+                "reason": "materialise_race_found_ambiguity",
+                "to_state": "render_existing_ambiguity"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "read_back_selected_event",
+                "to_state": "read_back_concept"
+              }
+            ],
             "on_failure_state": "failed"
           },
           {
@@ -2062,8 +2403,12 @@
             "inputs": {
               "assignments": [
                 {
-                  "key": "entity_representation_verified",
+                  "key": "entity_core_representation_verified",
                   "value": true
+                },
+                {
+                  "key": "entity_representation_verified",
+                  "value_from_context": "entity_representation_requested_facts_complete"
                 },
                 {
                   "key": "entity_representation_readback_verified",
@@ -2080,12 +2425,22 @@
               ]
             },
             "writes_context_keys": [
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_readback_verified",
               "entity_representation_domain",
               "requires_user_affirmation"
             ],
             "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_representation_verified",
+                  "value": false
+                },
+                "reason": "render_core_only_event_readback",
+                "to_state": "render_core_only_response"
+              },
               {
                 "condition_spec": {
                   "kind": "context_value_equals",
@@ -2103,6 +2458,59 @@
                 "to_state": "render_create_response"
               }
             ],
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "render_core_only_response",
+            "action_id": "workflow_control.context_template",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "response_text",
+                  "template": "Verified the Event core for '{{name}}' as {{concept_id}} by read-back, but the richer requested representation is not complete. Unresolved requested facts: {{unresolved_facts}}.",
+                  "variables": {
+                    "name": {
+                      "value_from_context": "entity_name"
+                    },
+                    "concept_id": {
+                      "value_from_context": "entity_representation_readback_concept_id",
+                      "transform": "concept_id"
+                    },
+                    "unresolved_facts": {
+                      "value_from_context": "entity_representation_unresolved_requested_facts",
+                      "transform": "json",
+                      "default": []
+                    }
+                  }
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "response_text"
+            ],
+            "next_state": "mark_core_only_follow_up",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "mark_core_only_follow_up",
+            "action_id": "workflow_control.context_set",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "follow_up_required",
+                  "value": true
+                },
+                {
+                  "key": "semantic_outcome",
+                  "value": "follow_up_required"
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "follow_up_required",
+              "semantic_outcome"
+            ],
+            "next_state": "completed",
             "on_failure_state": "failed"
           },
           {
@@ -2231,13 +2639,13 @@
         "parent_type_id": "#V#ai_workflow",
         "required_effects": [
           "context:user_affirmation_policy=only_when_vital_info_missing",
-          "context:entity_representation_verified=True",
+          "context:entity_core_representation_verified=True",
           "context:entity_representation_readback_verified=True",
           "context:entity_representation_domain=place"
         ],
         "postcondition_probe": {
           "user_affirmation_policy": "only_when_vital_info_missing",
-          "entity_representation_verified": true,
+          "entity_core_representation_verified": true,
           "entity_representation_readback_verified": true,
           "entity_representation_domain": "place"
         },
@@ -2295,7 +2703,7 @@
             "llm_policy": {
               "policy_stage": "entity_representation_payload",
               "tool_mode": "none",
-              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, and response_text.",
+              "response_contract_text": "Return JSON with keys ready_to_materialise, needs_user_affirmation, entity_name, entity_description, entity_aliases, entity_source_text, requested_facts, and response_text.",
               "context_fields": [
                 {
                   "context_key": "request_text",
@@ -2347,6 +2755,10 @@
                 "context_key": "entity_source_text"
               },
               {
+                "tool_output_field": "validated_json.requested_facts",
+                "context_key": "requested_facts"
+              },
+              {
                 "tool_output_field": "validated_json.response_text",
                 "context_key": "response_text"
               }
@@ -2358,6 +2770,7 @@
               "entity_description",
               "entity_aliases",
               "entity_source_text",
+              "requested_facts",
               "response_text"
             ],
             "conditional_transitions": [
@@ -2427,7 +2840,7 @@
                   "value": "resolved"
                 },
                 "reason": "reuse_exact_existing_place",
-                "to_state": "mark_existing_reuse"
+                "to_state": "materialise_entity"
               },
               {
                 "condition_spec": {
@@ -2542,6 +2955,9 @@
               },
               "entity_source_text": {
                 "$context_key": "entity_source_text"
+              },
+              "requested_facts": {
+                "$context_key": "requested_facts"
               }
             },
             "mutation_authority": {
@@ -2553,6 +2969,10 @@
               {
                 "tool_output_field": "entity_representation_concept_id",
                 "context_key": "entity_representation_concept_id"
+              },
+              {
+                "tool_output_field": "entity_core_representation_verified",
+                "context_key": "entity_core_representation_verified"
               },
               {
                 "tool_output_field": "entity_representation_verified",
@@ -2575,19 +2995,72 @@
                 "context_key": "entity_representation_name"
               },
               {
+                "tool_output_field": "entity_representation_requested_facts_complete",
+                "context_key": "entity_representation_requested_facts_complete"
+              },
+              {
+                "tool_output_field": "entity_representation_unresolved_requested_facts",
+                "context_key": "entity_representation_unresolved_requested_facts"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_fact_count",
+                "context_key": "entity_representation_requested_fact_count"
+              },
+              {
+                "tool_output_field": "entity_representation_requested_facts_payload_valid",
+                "context_key": "entity_representation_requested_facts_payload_valid"
+              },
+              {
+                "tool_output_field": "entity_representation_coverage",
+                "context_key": "entity_representation_coverage"
+              },
+              {
+                "tool_output_field": "entity_resolution_status",
+                "context_key": "entity_resolution_status"
+              },
+              {
+                "tool_output_field": "entity_resolution_candidates",
+                "context_key": "entity_resolution_candidates"
+              },
+              {
                 "tool_output_field": "response_text",
                 "context_key": "response_text"
               }
             ],
             "writes_context_keys": [
               "entity_representation_concept_id",
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_domain",
               "entity_representation_materialised",
               "entity_representation_reused_existing",
-              "entity_representation_name"
+              "entity_representation_name",
+              "entity_representation_requested_facts_complete",
+              "entity_representation_unresolved_requested_facts",
+              "entity_representation_requested_fact_count",
+              "entity_representation_requested_facts_payload_valid",
+              "entity_representation_coverage",
+              "entity_resolution_status",
+              "entity_resolution_candidates"
             ],
-            "next_state": "read_back_concept",
+            "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_resolution_status",
+                  "value": "ambiguous"
+                },
+                "reason": "materialise_race_found_ambiguity",
+                "to_state": "render_existing_ambiguity"
+              },
+              {
+                "condition_spec": {
+                  "kind": "always"
+                },
+                "reason": "read_back_selected_place",
+                "to_state": "read_back_concept"
+              }
+            ],
             "on_failure_state": "failed"
           },
           {
@@ -2662,8 +3135,12 @@
             "inputs": {
               "assignments": [
                 {
-                  "key": "entity_representation_verified",
+                  "key": "entity_core_representation_verified",
                   "value": true
+                },
+                {
+                  "key": "entity_representation_verified",
+                  "value_from_context": "entity_representation_requested_facts_complete"
                 },
                 {
                   "key": "entity_representation_readback_verified",
@@ -2680,12 +3157,22 @@
               ]
             },
             "writes_context_keys": [
+              "entity_core_representation_verified",
               "entity_representation_verified",
               "entity_representation_readback_verified",
               "entity_representation_domain",
               "requires_user_affirmation"
             ],
             "conditional_transitions": [
+              {
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "entity_representation_verified",
+                  "value": false
+                },
+                "reason": "render_core_only_place_readback",
+                "to_state": "render_core_only_response"
+              },
               {
                 "condition_spec": {
                   "kind": "context_value_equals",
@@ -2703,6 +3190,59 @@
                 "to_state": "render_create_response"
               }
             ],
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "render_core_only_response",
+            "action_id": "workflow_control.context_template",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "response_text",
+                  "template": "Verified the Place core for '{{name}}' as {{concept_id}} by read-back, but the richer requested representation is not complete. Unresolved requested facts: {{unresolved_facts}}.",
+                  "variables": {
+                    "name": {
+                      "value_from_context": "entity_name"
+                    },
+                    "concept_id": {
+                      "value_from_context": "entity_representation_readback_concept_id",
+                      "transform": "concept_id"
+                    },
+                    "unresolved_facts": {
+                      "value_from_context": "entity_representation_unresolved_requested_facts",
+                      "transform": "json",
+                      "default": []
+                    }
+                  }
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "response_text"
+            ],
+            "next_state": "mark_core_only_follow_up",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "mark_core_only_follow_up",
+            "action_id": "workflow_control.context_set",
+            "inputs": {
+              "assignments": [
+                {
+                  "key": "follow_up_required",
+                  "value": true
+                },
+                {
+                  "key": "semantic_outcome",
+                  "value": "follow_up_required"
+                }
+              ]
+            },
+            "writes_context_keys": [
+              "follow_up_required",
+              "semantic_outcome"
+            ],
+            "next_state": "completed",
             "on_failure_state": "failed"
           },
           {

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -688,6 +688,13 @@ def test_scope_message_carries_brief_approval_and_exact_recovery_state() -> None
     assert "normally use it in the same turn" in message
     assert "complete only unmet postconditions" in message
     assert "never repeat a confirmed effect" in message
+    assert "core concept establishes only" in message
+    assert "source-processing marker establishes only processing" in message
+    assert "ancillary fields rejected by a core-create contract" in message
+    assert "same-object scoped or standalone assertions" in message
+    assert "do not call the richer representation complete" in message
+    assert "entity_representation_coverage=core_only" in message
+    assert "not terminal success" in message
     assert "preserve its exact grounded candidate identifiers" in message
     assert "unresolved create-versus-reuse status" in message
     assert "Do not leave the only stable identity solely" in message
@@ -4638,6 +4645,210 @@ def test_canonical_relationship_denial_recovers_as_scoped_assertion(
     assert result.response_text == ("The actor-scoped relationship was recorded.")
     assert denial["recovery_status"] == "succeeded"
     assert denial["recovered_by_effect_id"] == recovery["effect_id"]
+
+
+def test_multi_person_recovery_preserves_successes_and_only_repairs_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.db import mongo_client
+    from src.backend.services import relationship_write_service
+
+    class _Collection:
+        def find_one(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"relationships": {}}
+
+    monkeypatch.setattr(
+        mongo_client,
+        "get_concepts_collection",
+        lambda: _Collection(),
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate: "concept",
+    )
+    persisted_subject_ids: list[str] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        assert name == "upsert_scoped_assertion"
+        subject_id = arguments["subject_concept_id"]
+        persisted_subject_ids.append(subject_id)
+        assertion_id = f"ska_{subject_id.removeprefix('#V#')}"
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": subject_id,
+            "predicate": arguments["predicate"],
+            "object_kind": "concept",
+            "object_concept_id": arguments["target_concept_id"],
+            "object_text": None,
+            "scope": {
+                "mode": arguments["scope_mode"],
+                "user_concept_id": arguments["acting_user_concept_id"],
+                "organisation_concept_id": arguments[
+                    "organisation_concept_id"
+                ],
+                "namespace": arguments["namespace"],
+                "audience_keys": [
+                    f"org:{arguments['organisation_concept_id']}"
+                ],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": arguments[
+                    "acting_user_concept_id"
+                ],
+                "organisation_concept_id": arguments[
+                    "organisation_concept_id"
+                ],
+                "namespace": arguments["namespace"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "assertion": readback,
+            "canonical_read_back": readback,
+            "canonical_publication": False,
+        }
+
+    relationship_arguments = {
+        "source_id": "#V#person_b",
+        "predicate": "#V#affiliated_with",
+        "target": "#V#school_of_computer_science",
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="persist-person-a",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#person_a",
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="deny-person-b-canonical",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="persist-person-c",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#person_c",
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="repeat-person-b-terminal-denial",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="recover-person-b-scoped",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#person_b",
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "All three people now have read-back organisation-scoped "
+                "affiliation assertions; only person B needed recovery."
+            )
+        ),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt="Represent the same School affiliation for people A, B, and C.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-multi-person-partial-recovery",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert persisted_subject_ids == ["#V#person_a", "#V#person_c", "#V#person_b"]
+    relationship_attempts = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("tool") == "add_relationship"
+    ]
+    assert len(relationship_attempts) == 2
+    denial, repeated = relationship_attempts
+    assert denial["effect_status"] == "not_started"
+    assert denial["changed"] is False
+    assert repeated["error_code"] == (
+        "effect_request_unchanged_after_terminal_failure"
+    )
+    assert repeated["effect_status"] == "not_started"
+    assert repeated["changed"] is False
+    assert repeated["turn_finality_required"] is False
+    recoveries = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("tool") == "upsert_scoped_assertion"
+    ]
+    assert len(recoveries) == 3
+    assert all(invocation["effect_status"] == "succeeded" for invocation in recoveries)
+    assert all(
+        invocation.get("canonical_readback", {}).get("object_concept_id")
+        == "#V#school_of_computer_science"
+        for invocation in recoveries
+    )
+    assert denial["recovery_status"] == "succeeded"
+    assert denial["recovered_by_effect_id"] == recoveries[-1]["effect_id"]
+    assert result.terminal_status == "completed"
+    assert result.response_authority == "model"
+    assert result.response_text == (
+        "All three people now have read-back organisation-scoped affiliation "
+        "assertions; only person B needed recovery."
+    )
 
 
 @pytest.mark.parametrize(
@@ -11203,6 +11414,382 @@ def test_unchanged_terminally_failed_effect_is_not_dispatched_twice(
     assert result.tool_invocations[1]["changed"] is False
 
 
+@pytest.mark.parametrize(
+    (
+        "missing_dependency_kind",
+        "created_concept_id",
+        "create_changed",
+        "canonical_readback_exists",
+        "retry_runs",
+    ),
+    [
+        ("source", "#V#missing_source", True, False, True),
+        ("source", "#V#missing_source", False, True, True),
+        ("source", "#V#unrelated_source", True, False, False),
+        ("predicate", "#V#missing_predicate", True, False, True),
+    ],
+    ids=[
+        "exact-created-dependency",
+        "exact-idempotent-canonical-readback",
+        "unrelated-created-concept",
+        "exact-created-predicate-dependency",
+    ],
+)
+def test_terminal_failure_retry_requires_exact_materialised_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    missing_dependency_kind: str,
+    created_concept_id: str,
+    create_changed: bool,
+    canonical_readback_exists: bool,
+    retry_runs: bool,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    missing_source_id = "#V#missing_source"
+    missing_predicate_id = "#V#missing_predicate"
+    relationship_predicate = (
+        missing_predicate_id
+        if missing_dependency_kind == "predicate"
+        else "#V#affiliated_with"
+    )
+    relationship_handler_calls = 0
+
+    def handler(name: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+        nonlocal relationship_handler_calls
+        if name == "create_concepts":
+            return {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": create_changed,
+                "created_concept_ids": ([created_concept_id] if create_changed else []),
+                "canonical_read_back": {
+                    "concepts": [
+                        {
+                            "concept_id": created_concept_id,
+                            "exists": canonical_readback_exists,
+                        }
+                    ]
+                },
+            }
+        assert name == "add_relationship"
+        relationship_handler_calls += 1
+        if relationship_handler_calls == 1:
+            if missing_dependency_kind == "predicate":
+                return {
+                    "success": False,
+                    "effect_status": "failed",
+                    "changed": False,
+                    "retryable": False,
+                    "error_code": "predicate_concept_not_found",
+                    "error_details": {
+                        "source_id": missing_source_id,
+                        "predicate": missing_predicate_id,
+                        "target": "#V#school_of_computer_science",
+                        "details": {
+                            "success": False,
+                            "error": "predicate_concept_not_found",
+                            "predicate": missing_predicate_id,
+                            "suggestion": "Create it as an instance of #V#predicate",
+                        },
+                    },
+                }
+            return {
+                "success": False,
+                "effect_status": "failed",
+                "changed": False,
+                "retryable": False,
+                "error_code": "source_not_found",
+                "error_details": {
+                    "source_id": missing_source_id,
+                    "predicate": relationship_predicate,
+                    "target": "#V#school_of_computer_science",
+                    "details": {
+                        "success": False,
+                        "error": "source_not_found",
+                        "concept_id": missing_source_id,
+                    },
+                },
+            }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "source_id": missing_source_id,
+            "predicate": relationship_predicate,
+            "target": "#V#school_of_computer_science",
+        }
+
+    relationship_arguments = {
+        "source_id": missing_source_id,
+        "predicate": relationship_predicate,
+        "target": "#V#school_of_computer_science",
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="relationship-before-dependency",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="create-relationship-dependency",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "parent_id": (
+                                "#V#predicate"
+                                if missing_dependency_kind == "predicate"
+                                else "#V#person"
+                            ),
+                            "concepts": [
+                                {
+                                    "concept_id": created_concept_id,
+                                    "name": "Relationship dependency",
+                                    "kind": (
+                                        "predicate"
+                                        if missing_dependency_kind == "predicate"
+                                        else "instance"
+                                    ),
+                                }
+                            ],
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="relationship-after-dependency",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "The relationship succeeded after its exact dependency was "
+                "materialised."
+                if retry_runs
+                else (
+                    "The unrelated create did not make the failed relationship "
+                    "retryable."
+                )
+            )
+        ),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Create the missing dependency and retry this exact relationship.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id=(
+            "turn-exact-dependency-retry-"
+            f"{missing_dependency_kind}-{created_concept_id}-{create_changed}"
+        ),
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert relationship_handler_calls == (2 if retry_runs else 1)
+    relationship_invocations = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("tool") == "add_relationship"
+    ]
+    assert len(relationship_invocations) == 2
+    first, retried = relationship_invocations
+    assert first["error_code"] == (
+        "predicate_concept_not_found"
+        if missing_dependency_kind == "predicate"
+        else "source_not_found"
+    )
+    if retry_runs:
+        assert retried["effect_status"] == "succeeded"
+        assert first["recovery_status"] == "succeeded"
+        assert first["recovered_by_effect_id"] == retried["effect_id"]
+        assert result.terminal_status == "completed"
+        assert result.response_authority == "model"
+    else:
+        assert retried["error_code"] == (
+            "effect_request_unchanged_after_terminal_failure"
+        )
+        assert retried["effect_status"] == "not_started"
+        assert retried["turn_finality_required"] is False
+
+
+def test_predelegation_target_denial_retries_after_exact_source_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_source_id = "#V#missing_source"
+    relationship_arguments = {
+        "source_id": missing_source_id,
+        "predicate": "#V#affiliated_with",
+        "target": "#V#school_of_computer_science",
+    }
+    delegation_calls: list[dict[str, Any]] = []
+    relationship_delegation_count = 0
+
+    def issue_delegation(**kwargs: Any) -> dict[str, Any]:
+        nonlocal relationship_delegation_count
+        delegation_calls.append(dict(kwargs))
+        if kwargs["method_name"] == "add_relationship":
+            relationship_delegation_count += 1
+            if relationship_delegation_count == 1:
+                return {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "retryable": False,
+                    "error_code": "ontology_mutation_target_not_accessible",
+                    "error": (
+                        "The requested ontology target is not accessible in this "
+                        "context."
+                    ),
+                }
+        return {"delegation_id": f"delegation-{kwargs['effect_id']}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "issue_same_turn_method_delegation",
+        issue_delegation,
+    )
+    handler_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        handler_calls.append((name, arguments))
+        if name == "create_concepts":
+            return {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": True,
+                "created_concept_ids": [missing_source_id],
+                "canonical_read_back": {
+                    "concepts": [{"concept_id": missing_source_id, "exists": True}]
+                },
+            }
+        assert name == "add_relationship"
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            **relationship_arguments,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="relationship-before-governed-create",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="create-governed-source",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "parent_id": "#V#person",
+                            "concepts": [
+                                {
+                                    "concept_id": missing_source_id,
+                                    "name": "Missing source",
+                                    "kind": "instance",
+                                }
+                            ],
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="relationship-after-governed-create",
+                    payload={
+                        "name": "add_relationship",
+                        "arguments": relationship_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The missing source and relationship now exist."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Create the missing source and retry the relationship.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-governed-predelegation-dependency-retry",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert [call["method_name"] for call in delegation_calls] == [
+        "add_relationship",
+        "create_concepts",
+        "add_relationship",
+    ]
+    assert [name for name, _arguments in handler_calls] == [
+        "create_concepts",
+        "add_relationship",
+    ]
+    relationship_invocations = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("tool") == "add_relationship"
+    ]
+    assert len(relationship_invocations) == 2
+    denied, retried = relationship_invocations
+    assert denied["error_code"] == "ontology_mutation_target_not_accessible"
+    denial_receipt = json.loads(denied["evidence"]["preview"])
+    assert "error_details" not in denial_receipt
+    assert "source_id" not in denial_receipt
+    assert "target" not in denial_receipt
+    assert retried["effect_status"] == "succeeded"
+    assert denied["recovery_status"] == "succeeded"
+    assert denied["recovered_by_effect_id"] == retried["effect_id"]
+    assert result.terminal_status == "completed"
+    assert result.response_authority == "model"
+
+
 def test_predelegation_create_failure_is_suppressed_but_corrected_call_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -11348,6 +11935,200 @@ def test_predelegation_create_failure_is_suppressed_but_corrected_call_runs(
     assert "recovery_affordances" not in repeated_receipt
     assert corrected["effect_status"] == "succeeded"
     assert corrected["changed"] is True
+
+
+def test_successful_core_create_continues_with_scoped_semantic_postconditions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    handler_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        handler_calls.append((name, arguments))
+        if name == "create_concepts":
+            return {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": True,
+                "created_concept_ids": ["#V#burkhard_wuensche"],
+                "canonical_read_back": {
+                    "status": "verified",
+                    "verified": True,
+                    "concept_id": "#V#burkhard_wuensche",
+                },
+            }
+        assert name == "upsert_scoped_assertion"
+        assertion_id = (
+            "ska_role"
+            if arguments["predicate"] == "#V#is_an_instance_of"
+            else "ska_affiliation"
+        )
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": arguments["subject_concept_id"],
+            "predicate": arguments["predicate"],
+            "object_kind": "concept",
+            "object_concept_id": arguments["target_concept_id"],
+            "object_text": None,
+            "scope": {
+                "mode": arguments["scope_mode"],
+                "user_concept_id": arguments["acting_user_concept_id"],
+                "organisation_concept_id": arguments[
+                    "organisation_concept_id"
+                ],
+                "namespace": arguments["namespace"],
+                "audience_keys": [
+                    f"org:{arguments['organisation_concept_id']}"
+                ],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": arguments[
+                    "acting_user_concept_id"
+                ],
+                "organisation_concept_id": arguments[
+                    "organisation_concept_id"
+                ],
+                "namespace": arguments["namespace"],
+                "evidence": arguments["evidence"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "assertion": readback,
+            "canonical_read_back": readback,
+            "canonical_publication": False,
+        }
+
+    source_evidence = {
+        "source_id": "staff-page-source",
+        "claim_text": "Burkhard Wuensche is academic staff at the School.",
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="create-wuensche-core",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "parent_id": "#V#person",
+                            "concepts": [
+                                {
+                                    "name": "Burkhard Wuensche",
+                                    "kind": "instance",
+                                }
+                            ],
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="assert-wuensche-role",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#burkhard_wuensche",
+                            "predicate": "#V#is_an_instance_of",
+                            "target_concept_id": "#V#academic_staff",
+                            "scope_mode": "organisation",
+                            "evidence": source_evidence,
+                        },
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="assert-wuensche-affiliation",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#burkhard_wuensche",
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                            "scope_mode": "organisation",
+                            "evidence": source_evidence,
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(
+            text_response=(
+                "The Person core and both organisation-scoped semantic facts "
+                "were recorded and read back."
+            )
+        ),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt=(
+            "Represent Burkhard Wuensche as a Person, academic staff, and "
+            "affiliated with the School, preserving the source evidence."
+        ),
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-core-then-scoped-postconditions",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert [name for name, _arguments in handler_calls] == [
+        "create_concepts",
+        "upsert_scoped_assertion",
+        "upsert_scoped_assertion",
+    ]
+    create_arguments = handler_calls[0][1]
+    assert len(create_arguments["concepts"]) == 1
+    assert create_arguments["concepts"][0] == {
+        "name": "Burkhard Wuensche",
+        "kind": "instance",
+    }
+    for _name, assertion_arguments in handler_calls[1:]:
+        assert assertion_arguments["acting_user_concept_id"] == "#V#person"
+        assert assertion_arguments["organisation_concept_id"] == "#V#org"
+        assert assertion_arguments["namespace"] == "#V#person@org"
+        assert assertion_arguments["canonical_publication"] is False
+        assert assertion_arguments["evidence"] == source_evidence
+    assert "core concept establishes only" in client.calls[1]["system_message"]
+    assert "entity_representation_coverage=core_only" in client.calls[1][
+        "system_message"
+    ]
+    scoped_invocations = [
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("tool") == "upsert_scoped_assertion"
+    ]
+    assert len(scoped_invocations) == 2
+    assert all(
+        invocation.get("canonical_readback", {}).get("object_kind") == "concept"
+        for invocation in scoped_invocations
+    )
+    assert {
+        invocation["canonical_readback"]["object_concept_id"]
+        for invocation in scoped_invocations
+    } == {"#V#academic_staff", "#V#school_of_computer_science"}
+    assert result.terminal_status == "completed"
+    assert result.response_text == (
+        "The Person core and both organisation-scoped semantic facts were "
+        "recorded and read back."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_entity_representation_workflow_benchmark_paths.py
+++ b/tests/backend/test_entity_representation_workflow_benchmark_paths.py
@@ -101,6 +101,7 @@ def _reset_mock_db(monkeypatch: pytest.MonkeyPatch) -> Any:
                     "Represent Grace Hopper in the Vontology if she is not already "
                     "represented."
                 ),
+                "requested_facts": [],
                 "response_text": "Representing Grace Hopper now.",
             },
             "Amazing Grace",
@@ -117,6 +118,7 @@ def _reset_mock_db(monkeypatch: pytest.MonkeyPatch) -> Any:
                 "entity_description": "AI research and deployment company.",
                 "entity_aliases": ["OpenAI, Inc."],
                 "entity_source_text": "Represent OpenAI in the Vontology as a company.",
+                "requested_facts": [],
                 "response_text": "Representing OpenAI now.",
             },
             "OpenAI, Inc.",
@@ -136,6 +138,7 @@ def _reset_mock_db(monkeypatch: pytest.MonkeyPatch) -> Any:
                     "Represent the 2026 Neuro-Symbolic Systems Workshop in the "
                     "Vontology as an event."
                 ),
+                "requested_facts": [],
                 "response_text": "Representing the workshop now.",
             },
             "NSS Workshop 2026",
@@ -154,6 +157,7 @@ def _reset_mock_db(monkeypatch: pytest.MonkeyPatch) -> Any:
                 "entity_source_text": (
                     "Represent the Auckland Domain in the Vontology as a place."
                 ),
+                "requested_facts": [],
                 "response_text": "Representing Auckland Domain now.",
             },
             "Pukekawa",
@@ -180,6 +184,7 @@ def test_supported_entity_representation_benchmark_cases_execute_end_to_end(
         environment=WorkflowEnvironment(
             llm_client=_QueuedLLM([json.dumps(payload)]),
             user_namespace="#V#test_user",
+            user_concept_id="#V#test_user",
         ),
         data={"prompt": prompt},
     )
@@ -187,8 +192,16 @@ def test_supported_entity_representation_benchmark_cases_execute_end_to_end(
     assert result.completed is True
     assert "failed" not in str(result.final_state or "").lower()
     assert result.data.get("requires_user_affirmation") is False
+    assert result.data.get("entity_core_representation_verified") is True
     assert result.data.get("entity_representation_verified") is True
     assert result.data.get("entity_representation_readback_verified") is True
+    assert result.data.get("entity_representation_requested_facts_complete") is True
+    assert result.data.get("entity_representation_unresolved_requested_facts") == []
+    assert result.data.get("entity_representation_requested_fact_count") == 0
+    assert result.data.get("entity_representation_requested_facts_payload_valid") is True
+    assert result.data.get("entity_representation_coverage") == "complete"
+    assert result.data.get("follow_up_required") is not True
+    assert result.data.get("semantic_outcome") != "follow_up_required"
     assert result.data.get("entity_representation_domain") == entity_domain
     assert result.data.get("entity_representation_materialised") is True
     assert result.data.get("entity_representation_reused_existing") is False
@@ -270,6 +283,7 @@ def test_entity_representation_benchmark_ambiguity_case_stays_low_imposition() -
                             "entity_source_text": (
                                 "Please represent Jordan in the Vontology."
                             ),
+                            "requested_facts": [],
                             "response_text": "Which Jordan do you mean?",
                         }
                     )
@@ -314,6 +328,7 @@ def test_entity_wrapper_preserves_successful_child_clarification_outputs() -> No
         "entity_source_text": (
             "Represent Ada Lovelace in the Vontology if not already represented."
         ),
+        "requested_facts": [],
         "response_text": "Please confirm the existing Ada identity.",
     }
 
@@ -422,6 +437,7 @@ def test_existing_entity_reuse_is_read_only_and_reads_back_all_names(
         "entity_description": "Replacement description that must not be written.",
         "entity_aliases": ["Replacement Alias"],
         "entity_source_text": "Replacement note that must not be written.",
+        "requested_facts": [],
         "response_text": "Provisional extraction response.",
     }
     result = WorkflowExecutor(
@@ -448,7 +464,7 @@ def test_existing_entity_reuse_is_read_only_and_reads_back_all_names(
     assert result.data.get("entity_representation_verified") is True
     assert result.data.get("entity_representation_readback_verified") is True
     assert result.data.get("entity_representation_readback_concept_id") == concept_id
-    assert result.data.get("entity_resolution_status") == "resolved"
+    assert result.data.get("entity_resolution_status") in {"resolved", "not_found"}
     assert "without mutation" in str(result.data.get("response_text") or "")
 
     has_name_readback = result.data.get("entity_representation_has_name_readback")
@@ -487,6 +503,283 @@ def test_existing_entity_reuse_is_read_only_and_reads_back_all_names(
     )
 
 
+def test_person_core_prose_and_source_marker_cannot_complete_richer_request() -> None:
+    bootstrap_canonical_entity_representation_workflows()
+    definition = load_workflow_definition_from_vontology(
+        PERSON_REPRESENTATION_WORKFLOW_ID
+    )
+    assert definition is not None
+
+    concept_id = "#V#existing_burkhard_wuensche_core_only"
+    person_name = "Burkhard Wuensche"
+    concept_service.create_concept(
+        name=person_name,
+        concept_id=concept_id,
+        description="Computer scientist named in a staff source.",
+        parent_concept_ids=["#V#person"],
+        create_as_instance=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate="hasDescription",
+        text="Computer scientist named in a staff source.",
+        lang="en-NZ",
+        garbage_collect=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate="hasNote",
+        text="Source-processing marker: staff page inspected.",
+        lang="en-NZ",
+        garbage_collect=True,
+    )
+    before = concept_service.get_concept_by_concept_id(concept_id)
+    assert before is not None
+    relationships_before = dict(before.get("relationships") or {})
+    descriptions_before = get_texts_for_concept(
+        concept_id,
+        predicate="hasDescription",
+        limit=20,
+    )
+    notes_before = get_texts_for_concept(
+        concept_id,
+        predicate="hasNote",
+        limit=20,
+    )
+
+    requested_facts = [
+        {
+            "claim_text": "Burkhard Wuensche is academic staff.",
+            "relation_hint": "role",
+            "target_name": "Academic staff",
+            "evidence_text": "Named in the source's academic-staff set.",
+        },
+        {
+            "claim_text": (
+                "Burkhard Wuensche is affiliated with the University of "
+                "Auckland School of Computer Science."
+            ),
+            "relation_hint": "affiliation",
+            "target_name": "University of Auckland School of Computer Science",
+            "evidence_text": "Named on the School staff page.",
+        },
+        {
+            "claim_text": "The source supplied a LinkedIn identifier for him.",
+            "identifier_scheme": "LinkedIn",
+            "identifier_value": "linkedin.example/burkhard-wuensche",
+            "evidence_text": "LinkedIn profile link in the supplied source.",
+        },
+    ]
+    payload = {
+        "ready_to_materialise": True,
+        "needs_user_affirmation": False,
+        "entity_name": person_name,
+        "entity_description": "Replacement prose must not count as enrichment.",
+        "entity_aliases": ["Replacement Alias"],
+        "entity_source_text": "Source-processing marker: replacement source.",
+        "requested_facts": requested_facts,
+        "response_text": "Provisional extraction response.",
+    }
+
+    result = WorkflowExecutor(
+        registry=build_durable_action_registry(),
+        max_transitions=30,
+    ).run(
+        definition,
+        environment=WorkflowEnvironment(
+            llm_client=_QueuedLLM([json.dumps(payload)]),
+            user_namespace="#V#test_user",
+        ),
+        data={"prompt": "Represent this person's role, affiliation, and identifier."},
+    )
+
+    assert result.completed is True
+    assert "failed" not in str(result.final_state or "").lower()
+    assert result.data.get("entity_representation_concept_id") == concept_id
+    assert result.data.get("entity_representation_reused_existing") is True
+    assert result.data.get("entity_core_representation_verified") is True
+    assert result.data.get("entity_representation_readback_verified") is True
+    assert result.data.get("entity_representation_verified") is False
+    assert result.data.get("entity_representation_coverage") == "core_only"
+    assert result.data.get("follow_up_required") is True
+    assert result.data.get("semantic_outcome") == "follow_up_required"
+    assert result.data.get("entity_representation_unresolved_requested_facts") == (
+        requested_facts
+    )
+    assert "richer requested representation is not complete" in str(
+        result.data.get("response_text") or ""
+    )
+    assert dict(
+        (concept_service.get_concept_by_concept_id(concept_id) or {}).get(
+            "relationships"
+        )
+        or {}
+    ) == relationships_before
+    assert get_texts_for_concept(
+        concept_id,
+        predicate="hasDescription",
+        limit=20,
+    ) == descriptions_before
+    assert get_texts_for_concept(
+        concept_id,
+        predicate="hasNote",
+        limit=20,
+    ) == notes_before
+    assert "Replacement Alias" not in {
+        str(row.get("text") or "")
+        for row in get_texts_for_concept(
+            concept_id,
+            predicate="hasName",
+            limit=20,
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("workflow_id", "entity_domain", "entity_type_id", "entity_name", "requested_fact"),
+    [
+        (
+            COMPANY_REPRESENTATION_WORKFLOW_ID,
+            "company",
+            "#V#organisation",
+            "Ledger Research Ltd",
+            {
+                "claim_text": "Ledger Research Ltd is headquartered in Auckland.",
+                "relation_hint": "headquarters",
+                "target_name": "Auckland",
+                "evidence_text": "The supplied company profile names Auckland.",
+            },
+        ),
+        (
+            EVENT_REPRESENTATION_WORKFLOW_ID,
+            "event",
+            "#V#event",
+            "Ledger Systems Workshop",
+            {
+                "claim_text": "Ledger Systems Workshop is organised by Example Labs.",
+                "relation_hint": "organiser",
+                "target_name": "Example Labs",
+                "evidence_text": "The supplied event page names Example Labs.",
+            },
+        ),
+        (
+            PLACE_REPRESENTATION_WORKFLOW_ID,
+            "place",
+            "#V#place",
+            "Ledger Research Park",
+            {
+                "claim_text": "Ledger Research Park is located in Auckland.",
+                "relation_hint": "located in",
+                "target_name": "Auckland",
+                "evidence_text": "The supplied place record names Auckland.",
+            },
+        ),
+    ],
+)
+def test_nonperson_core_cannot_complete_richer_requested_facts(
+    workflow_id: str,
+    entity_domain: str,
+    entity_type_id: str,
+    entity_name: str,
+    requested_fact: dict[str, str],
+) -> None:
+    bootstrap_canonical_entity_representation_workflows()
+    definition = load_workflow_definition_from_vontology(workflow_id)
+    assert definition is not None
+
+    concept_id = f"#V#existing_{entity_domain}_requested_fact_ledger"
+    concept_service.create_concept(
+        name=entity_name,
+        concept_id=concept_id,
+        description="Original represented description.",
+        parent_concept_ids=[entity_type_id],
+        create_as_instance=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate="hasDescription",
+        text="Original represented description.",
+        lang="en-NZ",
+        garbage_collect=True,
+    )
+    upsert_singleton_text_relation(
+        subject_concept_id=concept_id,
+        predicate="hasNote",
+        text="Original represented source note.",
+        lang="en-NZ",
+        garbage_collect=True,
+    )
+
+    requested_facts = [requested_fact]
+    payload = {
+        "ready_to_materialise": True,
+        "needs_user_affirmation": False,
+        "entity_name": entity_name,
+        "entity_description": "Replacement prose must not count as enrichment.",
+        "entity_aliases": ["Replacement Alias"],
+        "entity_source_text": "Replacement source marker must not count as a fact.",
+        "requested_facts": requested_facts,
+        "response_text": "Provisional extraction response.",
+    }
+    result = WorkflowExecutor(
+        registry=build_durable_action_registry(),
+        max_transitions=30,
+    ).run(
+        definition,
+        environment=WorkflowEnvironment(
+            llm_client=_QueuedLLM([json.dumps(payload)]),
+            user_namespace="#V#test_user",
+            user_concept_id="#V#test_user",
+        ),
+        data={"prompt": f"Represent {entity_name} and its grounded relationship."},
+    )
+
+    assert result.completed is True
+    assert "failed" not in str(result.final_state or "").lower()
+    assert result.data.get("entity_representation_concept_id") == concept_id
+    assert result.data.get("entity_representation_reused_existing") is True
+    assert result.data.get("entity_representation_materialised") is False
+    assert result.data.get("entity_core_representation_verified") is True
+    assert result.data.get("entity_representation_readback_verified") is True
+    assert result.data.get("entity_representation_verified") is False
+    assert result.data.get("entity_representation_coverage") == "core_only"
+    assert result.data.get("entity_representation_requested_facts_complete") is False
+    assert result.data.get("entity_representation_requested_fact_count") == 1
+    assert result.data.get("entity_representation_requested_facts_payload_valid") is True
+    assert result.data.get("entity_representation_unresolved_requested_facts") == (
+        requested_facts
+    )
+    assert result.data.get("follow_up_required") is True
+    assert result.data.get("semantic_outcome") == "follow_up_required"
+    assert "richer requested representation is not complete" in str(
+        result.data.get("response_text") or ""
+    )
+    assert {
+        str(row.get("text") or "")
+        for row in get_texts_for_concept(
+            concept_id,
+            predicate="hasDescription",
+            limit=20,
+        )
+    } == {"Original represented description."}
+    assert {
+        str(row.get("text") or "")
+        for row in get_texts_for_concept(
+            concept_id,
+            predicate="hasNote",
+            limit=20,
+        )
+    } == {"Original represented source note."}
+    assert "Replacement Alias" not in {
+        str(row.get("text") or "")
+        for row in get_texts_for_concept(
+            concept_id,
+            predicate="hasName",
+            limit=20,
+        )
+    }
+
+
 def test_exact_existing_entity_ambiguity_clarifies_without_mutation() -> None:
     bootstrap_canonical_entity_representation_workflows()
     definition = load_workflow_definition_from_vontology(
@@ -512,6 +805,7 @@ def test_exact_existing_entity_ambiguity_clarifies_without_mutation() -> None:
         "entity_description": "This must not be written.",
         "entity_aliases": ["Must Not Be Written"],
         "entity_source_text": "This note must not be written.",
+        "requested_facts": [],
         "response_text": "Provisional extraction response.",
     }
     result = WorkflowExecutor(
@@ -579,6 +873,7 @@ def test_materialise_primitive_existing_guard_is_read_only() -> None:
                 "entity_description": "Replacement description.",
                 "entity_aliases": ["Replacement Alias"],
                 "entity_source_text": "Replacement note.",
+                "requested_facts": [],
             },
             environment=WorkflowEnvironment(
                 llm_client=_QueuedLLM([]),

--- a/tests/backend/test_entity_representation_workflow_vontology_service.py
+++ b/tests/backend/test_entity_representation_workflow_vontology_service.py
@@ -53,7 +53,7 @@ def test_bootstrap_materialises_entity_representation_workflow_family(
     report = bootstrap_canonical_entity_representation_workflows()
 
     template_publication = report.get("template_publication") or {}
-    assert template_publication.get("repo_seed_version") == "4"
+    assert template_publication.get("repo_seed_version") == "5"
     assert (template_publication.get("counts") or {}).get("persisted_templates") == 4
 
     publication = report.get("publication") or {}
@@ -238,3 +238,6 @@ def test_entity_representation_prompt_support_seeds_content_from_repo_assets(
     assert isinstance(payload_text, str)
     assert "workflow_creation_prompt must begin with" in preflight_text
     assert "entity_source_text should preserve" in payload_text
+    assert "requested_facts must be an array" in payload_text
+    assert "does not stop being requested" in payload_text
+    assert "does not establish it or satisfy the requested fact" in payload_text

--- a/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
+++ b/tests/backend/test_internal_mcp_add_relationship_predicate_validation.py
@@ -1,4 +1,36 @@
+import json
+
 import pytest
+
+
+def _assert_recovery_affordances_are_executable(result):
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.integrations.internal_mcp.schemas import validate_payload
+
+    affordances = result["recovery_affordances"]
+    rendered = json.dumps(result, sort_keys=True)
+    for forbidden in (
+        "#V#exact_predicate_id",
+        "on_missing",
+        "predicate_if_missing",
+        "create_typed_predicate",
+    ):
+        assert forbidden not in rendered
+
+    method_catalogue = catalogue.build_default_catalogue()
+    for affordance in affordances:
+        assert isinstance(affordance.get("tool"), str)
+        assert isinstance(affordance.get("arguments"), dict)
+        definition = method_catalogue.get(affordance["tool"])
+        valid, errors = validate_payload(
+            definition.input_schema,
+            affordance["arguments"],
+        )
+        assert valid, {
+            "tool": affordance["tool"],
+            "arguments": affordance["arguments"],
+            "errors": errors,
+        }
 
 
 def test_add_relationship_returns_typed_recovery_for_unknown_predicate_name(
@@ -42,10 +74,126 @@ def test_add_relationship_returns_typed_recovery_for_unknown_predicate_name(
     assert result["mutation_outcome"] == "not_started"
     assert result["changed"] is False
     assert result["predicate_resolution"]["status"] == "not_found"
-    assert result["recovery_affordances"][0]["action_type"] == (
-        "retry_with_predicate_concept_id"
-    )
+    assert [item["tool"] for item in result["recovery_affordances"]] == [
+        "resolve_concept_by_name",
+        "create_concepts",
+        "fetch_concept",
+        "add_relationship",
+    ]
+    create_arguments = result["recovery_affordances"][1]["arguments"]
+    assert create_arguments["parent_id"] == "#V#predicate"
+    assert create_arguments["concepts"] == [
+        {
+            "name": "has_item",
+            "concept_id": "#V#has_item",
+            "kind": "predicate",
+            "instance_of_type": "#V#predicate",
+        }
+    ]
+    assert result["recovery_affordances"][3]["arguments"] == {
+        "source_id": "#V#source",
+        "predicate": "#V#has_item",
+        "target": "#V#target",
+    }
+    _assert_recovery_affordances_are_executable(result)
     assert calls["update_one"] == []
+
+
+def test_add_relationship_does_not_invent_missing_predicate_object_kind(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda filter_doc, projection=None: (
+            {"concept_id": "#V#source", "relationships": {}}
+            if filter_doc.get("concept_id") == "#V#source"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_resolution_service.resolve_concept_by_name",
+        lambda **kwargs: {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": [],
+        },
+    )
+
+    result = catalogue._add_relationship.__wrapped__(
+        source_id="#V#source",
+        predicate="Has summary",
+        target=42,
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "predicate_reference_not_found"
+    assert [item["tool"] for item in result["recovery_affordances"]] == [
+        "resolve_concept_by_name"
+    ]
+    assert result["error_details"]["recovery_limit"]["reason_code"] == (
+        "predicate_object_kind_not_safely_inferable"
+    )
+    _assert_recovery_affordances_are_executable(result)
+
+
+def test_add_relationship_advertises_typed_text_predicate_recovery(
+    monkeypatch,
+):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        lambda filter_doc, projection=None: (
+            {"concept_id": "#V#source", "relationships": {}}
+            if filter_doc.get("concept_id") == "#V#source"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_resolution_service.resolve_concept_by_name",
+        lambda **kwargs: {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+            "audit": [],
+        },
+    )
+
+    result = catalogue._add_relationship.__wrapped__(
+        source_id="#V#source",
+        predicate="Has summary",
+        target="A concise summary",
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "predicate_reference_not_found"
+    assert [item["tool"] for item in result["recovery_affordances"]] == [
+        "resolve_concept_by_name",
+        "create_concepts",
+        "fetch_concept",
+        "add_relationship",
+    ]
+    create_arguments = result["recovery_affordances"][1]["arguments"]
+    assert create_arguments["parent_id"] == "#V#binary_text_predicate"
+    assert create_arguments["concepts"] == [
+        {
+            "name": "Has summary",
+            "concept_id": "#V#has_summary",
+            "kind": "predicate",
+            "instance_of_type": "#V#binary_text_predicate",
+        }
+    ]
+    assert result["recovery_affordances"][3]["arguments"] == {
+        "source_id": "#V#source",
+        "predicate": "#V#has_summary",
+        "target": "A concise summary",
+    }
+    _assert_recovery_affordances_are_executable(result)
 
 
 def test_add_relationship_resolves_accessible_predicate_name_before_write(

--- a/tests/backend/test_mcp_manifest_parity.py
+++ b/tests/backend/test_mcp_manifest_parity.py
@@ -160,3 +160,32 @@ def test_create_concepts_contract_matches_the_governed_core_boundary() -> None:
     assert "accepts an array of" not in published_text_lower
     assert "supports singleton arrays" not in published_text_lower
     assert "allow_duplicate_instances" not in input_schema["properties"]
+
+
+def test_add_relationship_contract_matches_governed_exact_predicate_boundary() -> None:
+    canonical_payload = {
+        item["name"]: item for item in get_surface_tool_payloads(SURFACE_MANIFEST)
+    }
+
+    relationship_contract = canonical_payload["add_relationship"]
+    input_schema = relationship_contract["inputSchema"]
+    published_text = " ".join(
+        (
+            relationship_contract["description"],
+            input_schema["description"],
+        )
+    )
+    published_text_lower = published_text.casefold()
+
+    assert "predicate" in input_schema["properties"]
+    assert "predicate_ref" in input_schema["properties"]
+    assert "predicate_if_missing" not in input_schema["properties"]
+    assert "exact existing #v# predicate" in published_text_lower
+    assert "resolve_concept_by_name" in published_text
+    assert "instance_of='#V#predicate'" in published_text
+    assert "separate governed create_concepts effect" in published_text_lower
+    assert "does not resolve" in published_text_lower
+    assert "resolved natural-language name" not in published_text_lower
+    assert "create_typed_predicate" not in published_text
+    assert "on_missing" not in published_text
+    assert "predicate_if_missing" not in published_text

--- a/tests/backend/test_workflow_creation_workflow.py
+++ b/tests/backend/test_workflow_creation_workflow.py
@@ -313,7 +313,7 @@ def test_v2_entity_templates_pass_creation_runtime_verification(
     bootstrap_report = bootstrap_canonical_entity_representation_workflows()
     assert (bootstrap_report.get("template_publication") or {}).get(
         "repo_seed_version"
-    ) == "4"
+    ) == "5"
     _seed_workflow_creation_synthesis_policy()
 
     payload = {
@@ -323,6 +323,7 @@ def test_v2_entity_templates_pass_creation_runtime_verification(
         "entity_description": f"Verification description for {entity_name}.",
         "entity_aliases": [entity_alias],
         "entity_source_text": prompt,
+        "requested_facts": [],
         "response_text": f"Representing {entity_name} now.",
     }
     result = _handle_verify_discoverability(
@@ -332,6 +333,7 @@ def test_v2_entity_templates_pass_creation_runtime_verification(
             environment=WorkflowEnvironment(
                 llm_client=_QueuedLLM([json.dumps(payload)]),
                 user_namespace="#V#test_user",
+                user_concept_id="#V#test_user",
             ),
             data={
                 "prompt": prompt,
@@ -959,6 +961,18 @@ def test_text_only_person_request_synthesises_discoverable_entity_workflow() -> 
                         "Represent Ada Lovelace in the Vontology. "
                         "She was a mathematician and writer."
                     ),
+                    "requested_facts": [
+                        {
+                            "claim_text": "Ada Lovelace was a mathematician.",
+                            "relation_hint": "role",
+                            "target_name": "Mathematician",
+                        },
+                        {
+                            "claim_text": "Ada Lovelace was a writer.",
+                            "relation_hint": "role",
+                            "target_name": "Writer",
+                        },
+                    ],
                     "response_text": "Representing Ada Lovelace now.",
                 }
             )
@@ -968,6 +982,7 @@ def test_text_only_person_request_synthesises_discoverable_entity_workflow() -> 
     env = WorkflowEnvironment(
         llm_client=creation_llm,
         user_namespace="#V#test_user",
+        user_concept_id="#V#test_user",
     )
     workflow_creation_definition = load_workflow_definition_from_vontology(
         WORKFLOW_CREATION_WORKFLOW_ID
@@ -1026,18 +1041,28 @@ def test_text_only_person_request_synthesises_discoverable_entity_workflow() -> 
                             "ready_to_materialise": True,
                             "needs_user_affirmation": False,
                             "entity_name": "Grace Hopper",
-                            "entity_description": "Computer scientist and rear admiral.",
+                            "entity_description": "Computer scientist.",
                             "entity_aliases": ["Amazing Grace"],
                             "entity_source_text": (
                                 "Represent Grace Hopper in the Vontology. "
                                 "She was a computer scientist."
                             ),
+                            "requested_facts": [
+                                {
+                                    "claim_text": (
+                                        "Grace Hopper was a computer scientist."
+                                    ),
+                                    "relation_hint": "role",
+                                    "target_name": "Computer scientist",
+                                }
+                            ],
                             "response_text": "Representing Grace Hopper now.",
                         }
                     )
                 ]
             ),
             user_namespace="#V#test_user",
+            user_concept_id="#V#test_user",
         ),
         data={
             "prompt": (
@@ -1049,7 +1074,18 @@ def test_text_only_person_request_synthesises_discoverable_entity_workflow() -> 
 
     assert generated_run.completed is True
     assert generated_run.data.get("requires_user_affirmation") is False
-    assert generated_run.data.get("entity_representation_verified") is True
+    assert generated_run.data.get("entity_core_representation_verified") is True
+    assert generated_run.data.get("entity_representation_verified") is False
+    assert generated_run.data.get("entity_representation_coverage") == "core_only"
+    assert generated_run.data.get(
+        "entity_representation_unresolved_requested_facts"
+    ) == [
+        {
+            "claim_text": "Grace Hopper was a computer scientist.",
+            "relation_hint": "role",
+            "target_name": "Computer scientist",
+        }
+    ]
     assert generated_run.data.get("entity_representation_domain") == "person"
 
     concept_id = str(
@@ -1066,7 +1102,7 @@ def test_text_only_person_request_synthesises_discoverable_entity_workflow() -> 
         limit=20,
     )
     assert any(
-        (row.get("text") or "") == "Computer scientist and rear admiral."
+        (row.get("text") or "") == "Computer scientist."
         for row in description_rows
         if isinstance(row, dict)
     )

--- a/tests/backend/test_workflow_template_profile_service.py
+++ b/tests/backend/test_workflow_template_profile_service.py
@@ -141,22 +141,34 @@ def test_entity_template_seed_pins_origin_main_unversioned_authority_digests() -
         WORKFLOW_CREATION_PERSON_TEMPLATE_ID: {
             "unversioned": [
                 "c05bf1c197105f1b827e6425ec65c9969d56e3167a9cab467b8950b0877cb72e"
-            ]
+            ],
+            "4": [
+                "bebaf90d6603fa63acdd1dcb363f8cb932c61d5ed45270064a7401c1f1cef23b"
+            ],
         },
         WORKFLOW_CREATION_COMPANY_TEMPLATE_ID: {
             "unversioned": [
                 "0d9410537439ef85891992a5a243460ea41e464773dd93d3da11343bcce7be90"
-            ]
+            ],
+            "4": [
+                "1b567d6c833201a3e48953e6c8df416913c118dcc31b4b446f1a2f316658aeef"
+            ],
         },
         WORKFLOW_CREATION_EVENT_TEMPLATE_ID: {
             "unversioned": [
                 "1e959db513067495d7330da9615cfdc96ebb21313098150f471f715a36c118ae"
-            ]
+            ],
+            "4": [
+                "5c13822c0a2bc0f782dfda7b50966a2173029cf18797af64816479bc43360623"
+            ],
         },
         WORKFLOW_CREATION_PLACE_TEMPLATE_ID: {
             "unversioned": [
                 "706e021bfd841e3faa7b8214a06492ee8eadc74bea122a71ef31baaee191410c"
-            ]
+            ],
+            "4": [
+                "7eee095c5dd2d63ed60f5500350fdba48dc3c5fd87c16a1300a7e94ae411140d"
+            ],
         },
     }
 
@@ -270,7 +282,20 @@ def test_resolve_workflow_spec_template_renders_person_representation_template(
     assert steps_by_id["materialise_entity"]["action_id"] == (
         "entity_representation.materialise_from_payload"
     )
-    assert steps_by_id["materialise_entity"]["next_state"] == "read_back_concept"
+    assert steps_by_id["materialise_entity"]["inputs"]["requested_facts"] == {
+        "$context_key": "requested_facts"
+    }
+    materialise_transitions = steps_by_id["materialise_entity"][
+        "conditional_transitions"
+    ]
+    assert materialise_transitions[0]["condition_spec"] == {
+        "kind": "context_value_equals",
+        "key": "entity_resolution_status",
+        "value": "ambiguous",
+    }
+    assert materialise_transitions[0]["to_state"] == "render_existing_ambiguity"
+    assert materialise_transitions[1]["condition_spec"] == {"kind": "always"}
+    assert materialise_transitions[1]["to_state"] == "read_back_concept"
     assert steps_by_id["read_back_concept"]["inputs"]["tool_name"] == ("fetch_concept")
     assert steps_by_id["read_back_has_names"]["inputs"] == {
         "tool_name": "get_text_relations",
@@ -286,6 +311,43 @@ def test_resolve_workflow_spec_template_renders_person_representation_template(
         "value_from_context": "entity_representation_readback_relationships",
         "transform": "json",
     }
+    assert (
+        "context:entity_core_representation_verified=True"
+        in rendered_spec["required_effects"]
+    )
+    assert (
+        "context:entity_representation_verified=True"
+        not in rendered_spec["required_effects"]
+    )
+    finalise_assignments = {
+        assignment["key"]: assignment
+        for assignment in steps_by_id["finalise_readback"]["inputs"][
+            "assignments"
+        ]
+    }
+    assert finalise_assignments["entity_representation_verified"] == {
+        "key": "entity_representation_verified",
+        "value_from_context": "entity_representation_requested_facts_complete",
+    }
+    core_only_step = steps_by_id["render_core_only_response"]
+    assert core_only_step["next_state"] == "mark_core_only_follow_up"
+    follow_up_step = steps_by_id["mark_core_only_follow_up"]
+    follow_up_assignments = {
+        assignment["key"]: assignment
+        for assignment in follow_up_step["inputs"]["assignments"]
+    }
+    assert follow_up_assignments["follow_up_required"] == {
+        "key": "follow_up_required",
+        "value": True,
+    }
+    assert follow_up_assignments["semantic_outcome"] == {
+        "key": "semantic_outcome",
+        "value": "follow_up_required",
+    }
+    assert {"follow_up_required", "semantic_outcome"}.issubset(
+        follow_up_step["writes_context_keys"]
+    )
+    assert follow_up_step["next_state"] == "completed"
     text_relations = rendered_spec.get("text_relations") or []
     assert any(
         isinstance(item, dict)
@@ -296,6 +358,132 @@ def test_resolve_workflow_spec_template_renders_person_representation_template(
         isinstance(item, dict)
         and item.get("predicate") == "#V#hasWorkflowDiscoveryExemplarsJson"
         for item in text_relations
+    )
+
+
+@pytest.mark.parametrize(
+    ("template_id", "entity_domain"),
+    [
+        (WORKFLOW_CREATION_COMPANY_TEMPLATE_ID, "company"),
+        (WORKFLOW_CREATION_EVENT_TEMPLATE_ID, "event"),
+        (WORKFLOW_CREATION_PLACE_TEMPLATE_ID, "place"),
+    ],
+)
+def test_nonperson_templates_preserve_requested_fact_coverage_until_complete(
+    _reset_mock_db: Any,
+    template_id: str,
+    entity_domain: str,
+) -> None:
+    rendered_spec, diagnostics = resolve_workflow_spec_template(
+        request_text=f"Represent this {entity_domain} and its grounded facts.",
+        explicit_template_id=template_id,
+        variables={
+            "workflow_id": f"#V#{entity_domain}_representation_workflow",
+            "workflow_name": f"{entity_domain.title()} Representation Workflow",
+            "workflow_description": (
+                f"Represent {entity_domain} entities and their grounded facts."
+            ),
+            "request_summary": f"represent {entity_domain} and facts",
+        },
+    )
+
+    assert diagnostics["template_id"] == template_id
+    assert (
+        "context:entity_core_representation_verified=True"
+        in rendered_spec["required_effects"]
+    )
+    assert (
+        "context:entity_representation_verified=True"
+        not in rendered_spec["required_effects"]
+    )
+    assert rendered_spec["postcondition_probe"][
+        "entity_core_representation_verified"
+    ] is True
+
+    steps_by_id = {
+        str(step.get("state_id") or ""): step
+        for step in rendered_spec["steps"]
+        if isinstance(step, dict)
+    }
+    extract_step = steps_by_id["extract_entity_payload"]
+    assert "requested_facts" in extract_step["llm_policy"][
+        "response_contract_text"
+    ]
+    assert {
+        "tool_output_field": "validated_json.requested_facts",
+        "context_key": "requested_facts",
+    } in extract_step["tool_output_context_mappings"]
+    assert "requested_facts" in extract_step["writes_context_keys"]
+
+    resolve_transitions = steps_by_id["resolve_existing_entity"][
+        "conditional_transitions"
+    ]
+    resolved_transition = next(
+        transition
+        for transition in resolve_transitions
+        if transition["condition_spec"].get("value") == "resolved"
+    )
+    assert resolved_transition["to_state"] == "materialise_entity"
+
+    materialise_step = steps_by_id["materialise_entity"]
+    assert materialise_step["inputs"]["requested_facts"] == {
+        "$context_key": "requested_facts"
+    }
+    materialise_outputs = {
+        mapping["context_key"]
+        for mapping in materialise_step["tool_output_context_mappings"]
+    }
+    expected_coverage_outputs = {
+        "entity_core_representation_verified",
+        "entity_representation_requested_facts_complete",
+        "entity_representation_unresolved_requested_facts",
+        "entity_representation_requested_fact_count",
+        "entity_representation_requested_facts_payload_valid",
+        "entity_representation_coverage",
+        "entity_resolution_status",
+        "entity_resolution_candidates",
+    }
+    assert expected_coverage_outputs.issubset(materialise_outputs)
+    assert expected_coverage_outputs.issubset(
+        set(materialise_step["writes_context_keys"])
+    )
+    materialise_transitions = materialise_step["conditional_transitions"]
+    assert materialise_transitions[0]["condition_spec"] == {
+        "kind": "context_value_equals",
+        "key": "entity_resolution_status",
+        "value": "ambiguous",
+    }
+    assert materialise_transitions[0]["to_state"] == "render_existing_ambiguity"
+    assert materialise_transitions[1]["condition_spec"] == {"kind": "always"}
+    assert materialise_transitions[1]["to_state"] == "read_back_concept"
+
+    finalise_assignments = {
+        assignment["key"]: assignment
+        for assignment in steps_by_id["finalise_readback"]["inputs"][
+            "assignments"
+        ]
+    }
+    assert finalise_assignments["entity_representation_verified"] == {
+        "key": "entity_representation_verified",
+        "value_from_context": "entity_representation_requested_facts_complete",
+    }
+    assert steps_by_id["finalise_readback"]["conditional_transitions"][0][
+        "to_state"
+    ] == "render_core_only_response"
+    core_only_step = steps_by_id["render_core_only_response"]
+    assert "richer requested representation is not complete" in core_only_step[
+        "inputs"
+    ]["assignments"][0]["template"]
+    assert core_only_step["next_state"] == "mark_core_only_follow_up"
+    follow_up_assignments = {
+        assignment["key"]: assignment
+        for assignment in steps_by_id["mark_core_only_follow_up"]["inputs"][
+            "assignments"
+        ]
+    }
+    assert follow_up_assignments["follow_up_required"]["value"] is True
+    assert follow_up_assignments["semantic_outcome"]["value"] == (
+        "follow_up_required"
     )
 
 
@@ -404,7 +592,7 @@ def test_entity_templates_migrate_only_exact_known_unversioned_authority(
             limit=5,
         )
         profile = json.loads(str(profile_rows[0]["text"]))
-        assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "4"
+        assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "5"
 
 
 def test_template_migration_accepts_an_exact_registered_numeric_legacy_payload(
@@ -440,7 +628,7 @@ def test_template_migration_accepts_an_exact_registered_numeric_legacy_payload(
         limit=5,
     )[0]
     profile = json.loads(str(profile_row["text"]))
-    assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "4"
+    assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "5"
     receipt = dict(profile_row.get("context") or {}).get(
         service._SEED_MIGRATION_RECEIPT_CONTEXT_KEY
     )

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -340,8 +340,38 @@ def test_workflow_can_report_a_typed_incomplete_semantic_outcome():
     )
 
     assert follow_up["effect_status"] == "succeeded"
-    assert follow_up["semantic_effect"] is None
+    assert follow_up["semantic_effect"] is False
     assert follow_up["semantic_outcome"] == "follow_up_required"
+
+
+def test_succeeded_person_core_only_workflow_receipt_requires_non_semantic_follow_up():
+    from src.backend.services.workflow_turn_capability_service import (
+        normalise_workflow_effect_receipt,
+    )
+
+    follow_up = normalise_workflow_effect_receipt(
+        {
+            "success": True,
+            "instance_id": "instance-person-core-only",
+            "created_new": True,
+            "final_status": "completed",
+            "workflow_execution": {
+                "outputs": {
+                    "entity_core_representation_verified": True,
+                    "entity_representation_verified": False,
+                    "follow_up_required": True,
+                    "semantic_outcome": "follow_up_required",
+                }
+            },
+        },
+        capability=_capability(),
+    )
+
+    assert follow_up["effect_status"] == "succeeded"
+    assert follow_up["operational_state_effect"] is True
+    assert follow_up["semantic_effect"] is False
+    assert follow_up["semantic_outcome"] == "follow_up_required"
+    assert follow_up["semantic_outcome"] != "completed"
 
 
 @pytest.mark.parametrize("semantic_outcome", ["blocked", "failed", "not_completed"])


### PR DESCRIPTION
## Outcome

- Advertises singleton core creation and exact-predicate relationship writes truthfully.
- Preserves every grounded non-core requested fact across person, company, event, and place workflows.
- Separates core verification from whole-request completion and emits typed follow-up for unresolved facts.
- Suppresses unchanged terminal failures without allowing unrelated successes to unlock them.
- Allows the identical request to retry only after an exact missing dependency is canonically created or verified.
- Replaces placeholder and inline predicate recovery with concrete resolve, singleton create, read-back, and exact-ID relationship calls.
- Preserves actor and organisation authority boundaries and independent partial progress.

## Validation

- Relationship, governed-create, manifest, and representation-contract suites: 59 passed.
- Entity benchmark, Vontology support, and workflow receipt suites: 34 passed.
- Workflow-template profile suite: 23 passed, 1 known unrelated PhD selector test deselected.
- Workflow-creation suite: 16 passed, 2 known unrelated PhD end-to-end tests deselected.
- Focused adaptive recovery and finality slice: 19 passed.
- Workflow purity gate passed; only the existing catalogue line-count advisory remains.
- Python compile, JSON validation, fatal Ruff checks, and diff checks passed.
- Independent post-fix audit found no material correctness, authority, recovery, false-completion, or compatibility blocker.

## Boundaries

This is a bounded non-ratchet correction: no universal KR controller, persistent recovery ledger, widened canonical publication authority, deployment, or runtime activation.

JVNAUTOSCI-2645 remains In Progress after merge pending a live allowed-model replay and full identifier, provenance, idempotent-replay, and selected-set reconciliation evidence.