### PR TITLE
Reconcile exact recovery and late workflow outcomes

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2756,6 +2756,126 @@ def _upsert_text_relation(**kwargs):
         )
 
 
+_SCOPED_ASSERTION_EXACT_PREDICATE_ERROR = (
+    "predicate must be an exact #V# concept ID"
+)
+_SCOPED_ASSERTION_BARE_TEXT_PREDICATE_ERROR_CODE = (
+    "unsupported_text_relation_predicate"
+)
+_SCOPED_ASSERTION_CODE_PREDICATE_RE = re.compile(
+    r"^[A-Za-z0-9_][A-Za-z0-9._-]*$"
+)
+
+
+def _is_scoped_assertion_predicate_syntax_error(error: ValueError) -> bool:
+    from ...services.text_relation_predicate_validation_service import (
+        TextRelationPredicateResolutionError,
+    )
+
+    return (
+        str(error) == _SCOPED_ASSERTION_EXACT_PREDICATE_ERROR
+        or (
+            isinstance(error, TextRelationPredicateResolutionError)
+            and error.error_code
+            == _SCOPED_ASSERTION_BARE_TEXT_PREDICATE_ERROR_CODE
+        )
+    )
+
+
+def _exact_scoped_assertion_predicate_recovery(
+    *,
+    actor_scope: Any,
+    arguments: Mapping[str, Any],
+    error: ValueError,
+) -> dict[str, Any] | None:
+    """Return one executable syntax-only predicate repair, or no affordance."""
+
+    concept_predicate_syntax_error = (
+        str(error) == _SCOPED_ASSERTION_EXACT_PREDICATE_ERROR
+    )
+    text_predicate_syntax_error = (
+        _is_scoped_assertion_predicate_syntax_error(error)
+        and not concept_predicate_syntax_error
+    )
+    if not concept_predicate_syntax_error and not text_predicate_syntax_error:
+        return None
+    raw_predicate = str(arguments.get("predicate") or "").strip()
+    if (
+        not raw_predicate
+        or raw_predicate.startswith("#V#")
+        or _SCOPED_ASSERTION_CODE_PREDICATE_RE.fullmatch(raw_predicate) is None
+    ):
+        return None
+
+    target_text = arguments.get("target_text")
+    target_concept_id = str(arguments.get("target_concept_id") or "").strip()
+    has_text = isinstance(target_text, str) and bool(target_text.strip())
+    has_concept = bool(target_concept_id)
+    if has_text == has_concept:
+        return None
+    if concept_predicate_syntax_error != has_concept:
+        return None
+    if text_predicate_syntax_error != has_text:
+        return None
+    if has_concept and not target_concept_id.startswith("#V#"):
+        return None
+    evidence = arguments.get("evidence")
+    if evidence is not None and not isinstance(evidence, Mapping):
+        return None
+
+    from ...security.access_control import can_access_concept
+    from ...services.relationship_write_service import (
+        resolve_existing_predicate_value_kind,
+    )
+    from ...utils.concept_id_utils import canonicalise_vontology_concept_id
+
+    predicate_concept_id = canonicalise_vontology_concept_id(raw_predicate)
+    subject_concept_id = str(
+        arguments.get("subject_concept_id") or ""
+    ).strip()
+    if not predicate_concept_id or not subject_concept_id:
+        return None
+
+    expected_value_kind = "text" if has_text else "concept"
+    with _bind_internal_mcp_scoped_assertion_actor(actor_scope):
+        if not can_access_concept(subject_concept_id):
+            return None
+        if not can_access_concept(predicate_concept_id):
+            return None
+        if has_concept and not can_access_concept(target_concept_id):
+            return None
+        if (
+            resolve_existing_predicate_value_kind(predicate_concept_id)
+            != expected_value_kind
+        ):
+            return None
+
+    retry_arguments = {
+        field_name: arguments[field_name]
+        for field_name in (
+            "subject_concept_id",
+            "target_text",
+            "target_concept_id",
+            "language",
+            "scope_mode",
+            "evidence",
+        )
+        if field_name in arguments and arguments[field_name] is not None
+    }
+    retry_arguments["predicate"] = predicate_concept_id
+    return {
+        "action_type": "retry_exact_scoped_assertion_with_canonical_predicate_id",
+        "tool": "upsert_scoped_assertion",
+        "arguments": retry_arguments,
+        "resolution": {
+            "kind": "canonical_code_identifier",
+            "input_predicate": raw_predicate,
+            "predicate_concept_id": predicate_concept_id,
+            "value_kind": expected_value_kind,
+        },
+    }
+
+
 def _upsert_scoped_assertion(**kwargs):
     from ...services.rag_text_relation_change_hook_service import (
         maybe_sync_concept_text_relations_to_rag,
@@ -2852,11 +2972,44 @@ def _upsert_scoped_assertion(**kwargs):
             details={"subject_concept_id": subject_concept_id},
         )
     except ValueError as exc:
-        return make_error_response(
+        predicate_rejected = _is_scoped_assertion_predicate_syntax_error(exc)
+        try:
+            recovery = _exact_scoped_assertion_predicate_recovery(
+                actor_scope=actor_scope,
+                arguments=service_kwargs,
+                error=exc,
+            )
+        except Exception:
+            # Recovery discovery is a read-only convenience after a known
+            # pre-dispatch validation failure. A failed feasibility probe must
+            # not erase or weaken that authoritative no-change receipt.
+            logger.debug(
+                "Scoped assertion predicate recovery probe failed",
+                exc_info=True,
+            )
+            recovery = None
+        details = {
+            "subject_concept_id": subject_concept_id,
+        }
+        if predicate_rejected:
+            details["rejected_fields"] = ["predicate"]
+        if recovery is not None:
+            details["predicate_resolution"] = dict(recovery["resolution"])
+        payload = make_error_response(
             "invalid_scoped_assertion",
             str(exc),
-            details={"subject_concept_id": subject_concept_id},
+            details=details,
         )
+        payload.update(
+            {
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+            }
+        )
+        if recovery is not None:
+            payload["recovery_affordances"] = [recovery]
+        return payload
     except Exception as exc:
         return _indeterminate_effect_error(
             "The scoped-assertion operation raised unexpectedly.",
@@ -10208,8 +10361,13 @@ def _upsert_scoped_assertion_input_schema() -> Schema:
         description=(
             "upsert_scoped_assertion input: subject_concept_id and predicate, "
             "exactly one of target_text or target_concept_id, optional language, "
-            "scope_mode ('user' default or 'organisation'), and evidence. Actor, "
-            "organisation, namespace, turn, and non-publication are server-bound."
+            "scope_mode ('user' default or 'organisation'), and evidence. For a "
+            "concept target, and for any custom text predicate, predicate must be "
+            "one exact existing #V# predicate concept ID. A missing #V# prefix "
+            "fails without mutation and exposes one exact retry only when the "
+            "corresponding canonical code ID is visible, typed, and value-kind "
+            "compatible. Actor, organisation, "
+            "namespace, turn, and non-publication are server-bound."
         ),
     )
 
@@ -10304,6 +10462,7 @@ def _upsert_scoped_assertion_output_schema() -> Schema:
         },
         optional={
             "effect_status": (str, type(None)),
+            "mutation_outcome": (str, type(None)),
             "changed": (bool, type(None)),
             "assertion_id": (str, type(None)),
             "assertion": (dict, type(None)),
@@ -10311,13 +10470,18 @@ def _upsert_scoped_assertion_output_schema() -> Schema:
             "canonical_publication": (bool, type(None)),
             "storage_surface": (str, type(None)),
             "derived_maintenance": (dict, type(None)),
+            "recovery_affordances": (list, type(None)),
             "error": (str, type(None)),
+            "error_code": (str, type(None)),
+            "error_details": (dict, type(None)),
         },
         allow_unknown=True,
         description=(
             "Scoped assertion write receipt with durable read-back. "
             "canonical_publication is always false. derived_maintenance reports "
-            "best-effort index refresh scheduling without changing effect success."
+            "best-effort index refresh scheduling without changing effect success. "
+            "A syntax-only predicate repair is advertised only when one exact, "
+            "visible, correctly typed retry is executable."
         ),
     )
 
@@ -37802,7 +37966,11 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "canonical Vontology record. Use this instead of upsert_text_relation "
                 "or add_relationship when the actor can see but does not own the "
                 "canonical subject. Provide exactly one of target_text or "
-                "target_concept_id; choose scope_mode='organisation' only for "
+                "target_concept_id. A concept-valued assertion, or a custom text "
+                "predicate, requires one exact existing #V# predicate concept ID; "
+                "a syntax-only missing-prefix failure advertises an exact retry "
+                "only after visibility, typing, and value-kind checks. Choose "
+                "scope_mode='organisation' only for "
                 "knowledge intended to be shared with the authenticated organisation."
             ),
         ),

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -6182,11 +6182,13 @@ def execute_adaptive_turn(
         capability_name: str,
         arguments: Mapping[str, Any],
         *,
-        include_language: bool = True,
+        recovery_contract: str,
     ) -> str | None:
-        """Identify one exact scoped assertion independently of trusted bindings."""
+        """Identify one scoped recovery under its advertised contract."""
 
         if capability_name != "upsert_scoped_assertion":
+            return None
+        if recovery_contract not in {"actor_scope_alternative", "exact_retry"}:
             return None
         subject_id = str(arguments.get("subject_concept_id") or "").strip()
         predicate = str(arguments.get("predicate") or "").strip()
@@ -6207,15 +6209,33 @@ def execute_adaptive_turn(
         if has_text == has_concept:
             return None
         semantic_identity = {
+            "recovery_contract": recovery_contract,
             "subject_concept_id": subject_id,
             "predicate": predicate,
             "target_kind": "text" if has_text else "concept",
             "target": (str(target_text).strip() if has_text else target_concept_id),
         }
-        if has_text and include_language:
-            language = arguments.get("language")
-            if isinstance(language, str) and language.strip():
-                semantic_identity["language"] = language.strip()
+        if has_text:
+            semantic_identity["language"] = (
+                str(arguments.get("language") or "en-NZ").strip() or "en-NZ"
+            )
+        if recovery_contract == "exact_retry":
+            scope_mode = str(arguments.get("scope_mode") or "user").strip().lower()
+            if scope_mode not in {"user", "organisation"}:
+                return None
+            evidence = arguments.get("evidence")
+            if evidence is None:
+                evidence = {}
+            elif isinstance(evidence, Mapping):
+                evidence = dict(evidence)
+            else:
+                return None
+            semantic_identity.update(
+                {
+                    "scope_mode": scope_mode,
+                    "evidence": evidence,
+                }
+            )
         return hashlib.sha256(_json_bytes(semantic_identity)).hexdigest()
 
     def remember_recovery_affordance(
@@ -6234,6 +6254,15 @@ def execute_adaptive_turn(
         for affordance in affordances:
             if not isinstance(affordance, Mapping):
                 continue
+            action_type = str(affordance.get("action_type") or "").strip()
+            recovery_contract = {
+                "assert_in_actor_scope": "actor_scope_alternative",
+                "retry_exact_scoped_assertion_with_canonical_predicate_id": (
+                    "exact_retry"
+                ),
+            }.get(action_type)
+            if recovery_contract is None:
+                continue
             tool_name = str(affordance.get("tool") or "").strip()
             alternative_arguments = affordance.get("arguments")
             if not isinstance(alternative_arguments, Mapping):
@@ -6241,6 +6270,7 @@ def execute_adaptive_turn(
             recovery_key = scoped_assertion_recovery_key(
                 tool_name,
                 alternative_arguments,
+                recovery_contract=recovery_contract,
             )
             if recovery_key is None:
                 continue
@@ -6256,30 +6286,21 @@ def execute_adaptive_turn(
         nonlocal effect_state_generation
         if effect_status != "succeeded":
             return
-        recovery_keys = [
-            scoped_assertion_recovery_key(
+        failed_effect_id = None
+        for recovery_contract in ("exact_retry", "actor_scope_alternative"):
+            recovery_key = scoped_assertion_recovery_key(
                 capability_name,
                 arguments,
+                recovery_contract=recovery_contract,
             )
-        ]
-        language_agnostic_key = scoped_assertion_recovery_key(
-            capability_name,
-            arguments,
-            include_language=False,
-        )
-        if language_agnostic_key not in recovery_keys:
-            recovery_keys.append(language_agnostic_key)
-        failed_effect_id = None
-        for recovery_key in recovery_keys:
             if recovery_key is None:
                 continue
             pending_effect_ids = recoverable_effect_ids.get(recovery_key)
-            if not pending_effect_ids:
-                continue
-            failed_effect_id = pending_effect_ids.pop(0)
-            if not pending_effect_ids:
-                recoverable_effect_ids.pop(recovery_key, None)
-            break
+            if pending_effect_ids:
+                failed_effect_id = pending_effect_ids.pop(0)
+                if not pending_effect_ids:
+                    recoverable_effect_ids.pop(recovery_key, None)
+                break
         if failed_effect_id is None:
             if capability_name == "upsert_scoped_assertion":
                 attempted_effect_ids = {
@@ -7264,6 +7285,10 @@ def execute_adaptive_turn(
             state.get("reconciliation_status") == "current_state_observed"
             for state in incomplete_effects
         )
+        mismatched_recovery_present = any(
+            state.get("recovery_status") == "mismatched"
+            for state in incomplete_effects
+        )
         if status == "completed" and incomplete_effects:
             all_incomplete_statuses = {
                 str(state.get("effect_status") or "")
@@ -7278,6 +7303,8 @@ def execute_adaptive_turn(
             elif "partial" in incomplete_statuses:
                 status = "effect_partially_completed"
             elif current_state_observation_present:
+                status = "effect_partially_completed"
+            elif mismatched_recovery_present and succeeded_effects:
                 status = "effect_partially_completed"
             elif (
                 succeeded_effects
@@ -9447,6 +9474,8 @@ def execute_adaptive_turn(
                             "final_status",
                             "created_new",
                             "semantic_outcome",
+                            "change_kind",
+                            "operational_changed",
                         ):
                             receipt_value = raw_payload.get(receipt_key)
                             if isinstance(receipt_value, (str, int, float, bool)):

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -1838,6 +1838,7 @@ _CONVERSATION_OBSERVATION_STRING_FIELDS = frozenset(
         "instance_id",
         "terminal_status",
         "effect_status",
+        "domain_postcondition_status",
         "outcome_finality",
         "final_state",
         "completed_at",

--- a/src/backend/services/turn_execution_record_service.py
+++ b/src/backend/services/turn_execution_record_service.py
@@ -5328,6 +5328,8 @@ def _summarise_tool_invocations(
             "timeout_phase",
             "effect_id",
             "effect_status",
+            "recovery_status",
+            "recovered_by_effect_id",
             "capability_kind",
             "capability_display_name",
             "execution_method",
@@ -9532,6 +9534,10 @@ def _extract_mutation_metadata_from_invocation(
             include_arguments=False,
         )
 
+    changed_value = invocation.get("changed")
+    if not isinstance(changed_value, bool) and isinstance(payload, Mapping):
+        changed_value = payload.get("changed")
+
     return {
         "tool_name": tool_name,
         "status": status,
@@ -9544,6 +9550,9 @@ def _extract_mutation_metadata_from_invocation(
         "mutation_outcome": mutation_outcome,
         "outcome_finality": _receipt_text("outcome_finality"),
         "error_code": _receipt_text("error_code"),
+        "changed": changed_value if isinstance(changed_value, bool) else None,
+        "recovery_status": _receipt_text("recovery_status"),
+        "recovered_by_effect_id": _receipt_text("recovered_by_effect_id"),
     }
 
 
@@ -9556,22 +9565,44 @@ def _build_tool_authored_mutation_effects(
 
     Durable adaptive effects are projected independently by their stable
     ``effect_id`` so one successful invocation cannot mask another attempted
-    effect that was not started, partial, or indeterminate. Legacy invocations
-    without an effect identifier retain the existing per-tool grouping.
+    effect that was not started, partial, or indeterminate. An unchanged failed
+    or unstarted effect is superseded only when its existing recovery metadata
+    names an effect that is independently observed as successful in this same
+    execution evidence. Legacy invocations without an effect identifier retain
+    the existing per-tool grouping.
     """
     if not tool_invocations:
         return []
 
-    groups: dict[str, dict[str, Any]] = {}
-    group_order: list[str] = []
-
+    metadata_rows: list[dict[str, Any]] = []
     for invocation in tool_invocations:
         if not isinstance(invocation, Mapping):
             continue
         metadata = _extract_mutation_metadata_from_invocation(invocation)
         if metadata is None:
             continue
+        metadata_rows.append(metadata)
 
+    effect_evidence_rows: dict[str, list[dict[str, Any]]] = {}
+    for metadata in metadata_rows:
+        effect_id = _safe_str(metadata.get("effect_id"))
+        if effect_id:
+            effect_evidence_rows.setdefault(effect_id, []).append(metadata)
+    successful_effect_ids = {
+        effect_id
+        for effect_id, rows in effect_evidence_rows.items()
+        if rows
+        and all(
+            (_safe_str(row.get("status")) or "error") == "ok"
+            and (_safe_str(row.get("effect_status")) or "").lower()
+            == "succeeded"
+            for row in rows
+        )
+    }
+
+    groups: dict[str, dict[str, Any]] = {}
+    group_order: list[str] = []
+    for metadata in metadata_rows:
         canonical_tool_key = _tool_requirement_key(metadata["tool_name"])
         stable_effect_id = _safe_str(metadata.get("effect_id"))
         if not stable_effect_id and not include_legacy_without_effect_id:
@@ -9599,6 +9630,10 @@ def _build_tool_authored_mutation_effects(
                 "mutation_outcomes": [],
                 "outcome_finalities": [],
                 "error_codes": [],
+                "recovery_statuses": [],
+                "recovered_by_effect_ids": [],
+                "superseded_by_effect_id": None,
+                "unrecovered_failure": False,
             }
             group_order.append(group_key)
 
@@ -9628,10 +9663,28 @@ def _build_tool_authored_mutation_effects(
             ("mutation_outcome", "mutation_outcomes"),
             ("outcome_finality", "outcome_finalities"),
             ("error_code", "error_codes"),
+            ("recovery_status", "recovery_statuses"),
+            ("recovered_by_effect_id", "recovered_by_effect_ids"),
         ):
             field_value = _safe_str(metadata.get(field_name))
             if field_value and field_value not in group[group_field]:
                 group[group_field].append(field_value)
+
+        recovery_status = (_safe_str(metadata.get("recovery_status")) or "").lower()
+        recovered_by_effect_id = _safe_str(metadata.get("recovered_by_effect_id"))
+        if metadata["status"] != "ok":
+            recovery_supersedes_failure = bool(
+                stable_effect_id
+                and metadata.get("changed") is False
+                and metadata["status"] in {"error", "not_started"}
+                and recovery_status == "succeeded"
+                and recovered_by_effect_id in successful_effect_ids
+            )
+            if recovery_supersedes_failure:
+                if group["superseded_by_effect_id"] is None:
+                    group["superseded_by_effect_id"] = recovered_by_effect_id
+            else:
+                group["unrecovered_failure"] = True
 
         normalised_effect_status = (
             _safe_str(metadata.get("effect_status")) or ""
@@ -9671,8 +9724,19 @@ def _build_tool_authored_mutation_effects(
         predicates = group["predicates"][:5]
         relation_tuples = group["relation_tuples"][:5]
         independently_observed = bool(group["effect_id"])
+        recovery_superseded = bool(
+            group["superseded_by_effect_id"]
+            and not group["unrecovered_failure"]
+            and (group["any_failure"] or group["any_not_started"])
+        )
 
-        if independently_observed and group["any_not_started"]:
+        if recovery_superseded:
+            effect_status = "satisfied"
+            status_reason = (
+                f"Unchanged {tool_name} failure was superseded by successful "
+                f"recovery effect {group['superseded_by_effect_id']}."
+            )
+        elif independently_observed and group["any_not_started"]:
             effect_status = "not_executed"
             status_reason = f"{tool_name} invocation was not started."
         elif independently_observed and group["any_indeterminate"]:
@@ -9700,7 +9764,9 @@ def _build_tool_authored_mutation_effects(
             effect_status = "not_executed"
             status_reason = f"No {tool_name} invocation completed."
 
-        failure_codes: list[str] = _dedupe_string_sequence(group["error_codes"])
+        failure_codes: list[str] = (
+            [] if recovery_superseded else _dedupe_string_sequence(group["error_codes"])
+        )
         if effect_status in {"not_satisfied", "not_executed"} and not failure_codes:
             failure_codes = [
                 (
@@ -9729,6 +9795,8 @@ def _build_tool_authored_mutation_effects(
             "status_reason": status_reason,
             "failure_codes": failure_codes,
         }
+        if recovery_superseded:
+            effect["postcondition_strategy"] = "execution_observed"
         if relation_tuples:
             effect["required_relation_tuples"] = relation_tuples
         if independently_observed and (
@@ -9745,6 +9813,15 @@ def _build_tool_authored_mutation_effects(
                 effect[effect_field] = observed_values[0]
             elif observed_values:
                 effect[f"{effect_field}s"] = list(observed_values)
+        for source_field, effect_field in (
+            ("recovery_statuses", "recovery_status"),
+            ("recovered_by_effect_ids", "recovered_by_effect_id"),
+        ):
+            recovery_values = group[source_field]
+            if len(recovery_values) == 1:
+                effect[effect_field] = recovery_values[0]
+            elif recovery_values:
+                effect[f"{effect_field}s"] = list(recovery_values)
         if failure_codes:
             effect["failure_code"] = failure_codes[0]
 
@@ -12806,6 +12883,14 @@ def reconcile_durable_workflow_terminal_effect(
                 "instance_id": clean_instance_id,
                 "terminal_status": clean_terminal_status,
                 "effect_status": effect_status,
+                # A terminal workflow-instance state is operational evidence. It
+                # does not, by itself, prove the requested domain postconditions.
+                # Keep that distinction on the existing conversation observation
+                # so a late UI update cannot turn an operational completion into
+                # a semantic-success claim.
+                "domain_postcondition_status": (
+                    "not_established_by_workflow_terminal"
+                ),
                 "changed": changed,
                 "outcome_finality": "canonical_durable_terminal",
                 "final_state": canonical_receipt.get("final_state"),

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -931,6 +931,8 @@ def normalise_workflow_effect_receipt(
             "workflow_id": capability.workflow_id,
             "effect_status": effect_status,
             "changed": changed,
+            "change_kind": "workflow_instance_operational_state",
+            "operational_changed": changed,
             "semantic_effect": semantic_effect,
             "semantic_outcome": semantic_outcome,
             "operational_state_effect": True,

--- a/src/backend/workflows/durable/instance_manager.py
+++ b/src/backend/workflows/durable/instance_manager.py
@@ -2211,8 +2211,12 @@ class WorkflowInstanceManager:
                     else instance_before.llm_usage_cost_summary
                 ),
             )
-            self._broadcast_instance(completed_instance)
             self._reconcile_conversation_turn_terminal_effect(completed_instance)
+            # Reconcile the durable effect and append its conversation
+            # observation before the actor-scoped terminal SSE event. The
+            # browser can then perform one bounded read and see the persisted
+            # observation without another prompt or a page reload.
+            self._broadcast_instance(completed_instance)
             self._emit_episode_evaluation_terminal_event(
                 instance=completed_instance,
                 terminal_status=WorkflowInstanceStatus.COMPLETED.value,
@@ -2354,8 +2358,8 @@ class WorkflowInstanceManager:
                     else instance_before.llm_usage_cost_summary
                 ),
             )
-            self._broadcast_instance(failed_instance)
             self._reconcile_conversation_turn_terminal_effect(failed_instance)
+            self._broadcast_instance(failed_instance)
             self._emit_episode_evaluation_terminal_event(
                 instance=failed_instance,
                 terminal_status=WorkflowInstanceStatus.FAILED.value,
@@ -2420,8 +2424,8 @@ class WorkflowInstanceManager:
                 progress_message="cancelled",
                 progress_updated_at=now,
             )
-            self._broadcast_instance(cancelled_instance)
             self._reconcile_conversation_turn_terminal_effect(cancelled_instance)
+            self._broadcast_instance(cancelled_instance)
             self._emit_episode_evaluation_terminal_event(
                 instance=cancelled_instance,
                 terminal_status=WorkflowInstanceStatus.CANCELLED.value,

--- a/src/backend/workflows/repo_seed_bundles/concept_search_instance_retrieval_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/concept_search_instance_retrieval_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "concept_search_instance_retrieval_workflow_seed_bundle",
   "managed_by": "concept_search_instance_retrieval_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "5",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#concept_search_instance_retrieval_workflow": {
       "2": [
@@ -10,6 +10,9 @@
       ],
       "3": [
         "3d008215ae98e89b3743a84795cc144292919e90df3acca5471e1e195cbe595c"
+      ],
+      "4": [
+        "26b0bae36b7cb1ddf8b0b0a53e87c6b93bcb35e8d2ce6677a1b0784cdafbbffb"
       ]
     }
   },
@@ -104,12 +107,6 @@
               ],
               "max_tool_invocations": 6,
               "tool_argument_defaults": {
-                "fetch_concept": {
-                  "include_relations_arg1": true,
-                  "include_text_relations_arg1": true,
-                  "include_relations_any_arg": true,
-                  "limit": 80
-                },
                 "get_text_relations_summary": {
                   "max_relation_ids_per_group": 20
                 },
@@ -117,7 +114,7 @@
                   "argument_index": "any",
                   "relation_kind": "any",
                   "include_text_snippets": true,
-                  "include_concept_preview": true,
+                  "include_concept_preview": false,
                   "limit": 30
                 }
               },

--- a/src/backend/workflows/repo_seed_bundles/entity_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/entity_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "entity_representation_workflow_seed_bundle",
   "managed_by": "entity_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "5",
+  "seed_version": "6",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#entity_representation_workflow": {
       "2": [
@@ -10,6 +10,9 @@
       ],
       "4": [
         "4d6f1b2d87d0b861ac19241bd021ca78e3037cacdd161c6c956e764d9847e529"
+      ],
+      "5": [
+        "bca9845b99f4558392719cd06a63be2f03473dd739221d00a5ea8066ea5ef6be"
       ]
     }
   },
@@ -24,8 +27,8 @@
     {
       "workflow_id": "#V#entity_representation_workflow",
       "display_name": "Entity Representation Workflow",
-      "description": "Route conversational entity-representation requests across reusable person, company, event, and place workflows, creating missing specialised workflows when necessary.",
-      "content": "Conversational wrapper workflow for entity representation. It discovers reusable specialised workflows, decides whether to reuse or create one for people, companies, events, or places, and only asks the user for clarification when vital information is missing.",
+      "description": "Route conversational entity-representation requests that may require creating or additively representing missing people, companies, events, or places; exclude pure read-only verification when an exact entity is already resolved.",
+      "content": "Conversational wrapper workflow for mutation-capable entity representation. It discovers reusable specialised workflows, decides whether to reuse or create one for people, companies, events, or places, and only asks the user for clarification when vital information is missing. Pure read-only verification of an exact already-resolved entity should use the smallest adequate read-only capability plan.",
       "type_ids": [
         "#V#ai_workflow",
         "#V#durable_workflow"
@@ -67,7 +70,7 @@
         },
         {
           "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-          "text": "{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"represent person in vontology\",\"represent company in vontology\",\"represent event in vontology\",\"represent place in vontology\",\"entity representation workflow\"],\"examples\":[\"Represent these people in the Vontology if they are not already represented.\",\"Please represent this company in the Vontology.\",\"Represent this event in the Vontology.\",\"Represent this place in the Vontology.\"]}",
+          "text": "{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"represent person in vontology\",\"represent company in vontology\",\"represent event in vontology\",\"represent place in vontology\",\"entity representation workflow\"],\"examples\":[\"Represent these people in the Vontology if they are not already represented.\",\"Please represent this company in the Vontology.\",\"Represent this event in the Vontology.\",\"Represent this place in the Vontology.\"],\"routing_notes\":[\"Choose this workflow when the entity may be missing or the requested outcome may require additive representation. For pure read-only verification of an exact already-resolved entity, choose the smallest adequate read-only capability plan.\"]}",
           "lang": "en-NZ"
         },
         {

--- a/src/backend/workflows/repo_seed_bundles/selector_routing_benchmark_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/selector_routing_benchmark_seed_bundle.json
@@ -457,6 +457,45 @@
           "reasoning": "The request is ambiguous, but the Entity Representation Workflow is the right place to ask one minimal clarification question."
         },
         "notes": "Low-imposition ambiguity case: routing should still go to the entity wrapper, not to a plain assistant reply."
+      },
+      {
+        "case_id": "entity_known_person_idempotence_verification",
+        "replay_family_id": "known_entity_idempotence_verification",
+        "case_tags": [
+          "known_exact_entity",
+          "idempotence_verification",
+          "read_only",
+          "bounded_canonical_read"
+        ],
+        "turn_text": "Replay Marc Vinyals's representation idempotently. The conversation already resolves him as #V#marc_vinyals. Verify his exact Person typing and actor-effective assertions without mutation.",
+        "candidate_workflows": [
+          {
+            "concept_id": "#V#entity_representation_workflow",
+            "name": "Entity Representation Workflow",
+            "description": "Mutation-capable representation route for an entity that may be missing or require additive representation."
+          },
+          {
+            "concept_id": "#V#concept_search_instance_retrieval_workflow",
+            "name": "Concept Search and Instance Retrieval Workflow",
+            "description": "Read-only grounded profile retrieval for an exact or already-resolved Vontology concept."
+          },
+          {
+            "concept_id": "#V#tool_calling_workflow",
+            "name": "Tool Calling Workflow",
+            "description": "General-purpose tool-calling workflow supporting bounded exact canonical reads."
+          }
+        ],
+        "allowed_workflow_ids": [
+          "#V#concept_search_instance_retrieval_workflow",
+          "#V#tool_calling_workflow"
+        ],
+        "baseline_workflow_id": "#V#entity_representation_workflow",
+        "selector_response": {
+          "workflow_id": "#V#tool_calling_workflow",
+          "confidence": 0.98,
+          "reasoning": "The exact person concept is already resolved and the user requests bounded read-only verification, so direct canonical reads are sufficient and mutation-capable entity representation is unnecessary."
+        },
+        "notes": "Known-entity replay regression: exact actor-effective verification should use a bounded read-only route, while neighbouring missing/new entity requests remain eligible for representation. The selected direct-tool fixture is not the only valid read-only implementation path."
       }
     ],
     "corrective_evidence_failure_family": [

--- a/src/backend/workflows/repo_seed_bundles/workflow_template_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/workflow_template_seed_bundle.json
@@ -1,7 +1,7 @@
 {
   "family_id": "workflow_template_seed_bundle",
   "schema_version": "repo_seed_workflow_template_bundle.v1",
-  "seed_version": "5",
+  "seed_version": "6",
   "source_tag": "JVNAUTOSCI-2577",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "workflow_creation.person_representation": {
@@ -10,6 +10,9 @@
       ],
       "4": [
         "bebaf90d6603fa63acdd1dcb363f8cb932c61d5ed45270064a7401c1f1cef23b"
+      ],
+      "5": [
+        "33321addf574eeed20ea11bb0aa879d31cbfdf821ff1b12bbc2e46284b3d41a7"
       ]
     },
     "workflow_creation.company_representation": {
@@ -18,6 +21,9 @@
       ],
       "4": [
         "1b567d6c833201a3e48953e6c8df416913c118dcc31b4b446f1a2f316658aeef"
+      ],
+      "5": [
+        "39336dd71db1c92a53506d7a9ae8b863109cc39d2aaced06a9fdbaa80d50c7a9"
       ]
     },
     "workflow_creation.event_representation": {
@@ -26,6 +32,9 @@
       ],
       "4": [
         "5c13822c0a2bc0f782dfda7b50966a2173029cf18797af64816479bc43360623"
+      ],
+      "5": [
+        "ee854744c22e256a8757061f5d549c0bff1b6ce1fc96e18111d9cffcd4f91a73"
       ]
     },
     "workflow_creation.place_representation": {
@@ -34,6 +43,9 @@
       ],
       "4": [
         "7eee095c5dd2d63ed60f5500350fdba48dc3c5fd87c16a1300a7e94ae411140d"
+      ],
+      "5": [
+        "eb5380690cddfbfea3b405c673d36665bbe0017cdcea61542fcdd9dc6828c181"
       ]
     }
   },
@@ -465,7 +477,7 @@
           },
           {
             "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"person representation\",\"represent person\",\"represent researcher\",\"represent contact\",\"represent people in vontology\"],\"examples\":[\"Represent this person in the Vontology.\",\"Please represent these researchers if they are not already represented.\",\"Create or update a person representation from this conversational description.\"]}}",
+            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"person representation\",\"represent person\",\"represent researcher\",\"represent contact\",\"represent people in vontology\"],\"examples\":[\"Represent this person in the Vontology.\",\"Please represent these researchers if they are not already represented.\",\"Create or update a person representation from this conversational description.\"],\"routing_notes\":[\"Choose this workflow when a person may need to be created or additively represented. For pure read-only verification of an exact already-resolved person, choose the smallest adequate read-only capability plan.\"]}}",
             "lang": "en-NZ"
           }
         ],
@@ -876,9 +888,7 @@
               "tool_name": "fetch_concept",
               "concept_id": {
                 "$context_key": "entity_representation_concept_id"
-              },
-              "include_relations_any_arg": true,
-              "limit": 40
+              }
             },
             "tool_output_context_mappings": [
               {
@@ -1196,7 +1206,7 @@
           },
           {
             "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"company representation\",\"organisation representation\",\"organization representation\",\"represent company\",\"represent organisation\"],\"examples\":[\"Represent this company in the Vontology.\",\"Please represent these organisations if they are not already represented.\",\"Create or update a company representation from this conversational description.\"]}}",
+            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"company representation\",\"organisation representation\",\"organization representation\",\"represent company\",\"represent organisation\"],\"examples\":[\"Represent this company in the Vontology.\",\"Please represent these organisations if they are not already represented.\",\"Create or update a company representation from this conversational description.\"],\"routing_notes\":[\"Choose this workflow when an organisation may need to be created or additively represented. For pure read-only verification of an exact already-resolved organisation, choose the smallest adequate read-only capability plan.\"]}}",
             "lang": "en-NZ"
           }
         ],
@@ -1607,9 +1617,7 @@
               "tool_name": "fetch_concept",
               "concept_id": {
                 "$context_key": "entity_representation_concept_id"
-              },
-              "include_relations_any_arg": true,
-              "limit": 40
+              }
             },
             "tool_output_context_mappings": [
               {
@@ -1928,7 +1936,7 @@
           },
           {
             "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"event representation\",\"meeting representation\",\"represent event\",\"represent meeting\",\"calendar event representation\"],\"examples\":[\"Represent this event in the Vontology.\",\"Please represent these meetings if they are not already represented.\",\"Create or update an event representation from this conversational description.\"]}}",
+            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"event representation\",\"meeting representation\",\"represent event\",\"represent meeting\",\"calendar event representation\"],\"examples\":[\"Represent this event in the Vontology.\",\"Please represent these meetings if they are not already represented.\",\"Create or update an event representation from this conversational description.\"],\"routing_notes\":[\"Choose this workflow when an event may need to be created or additively represented. For pure read-only verification of an exact already-resolved event, choose the smallest adequate read-only capability plan.\"]}}",
             "lang": "en-NZ"
           }
         ],
@@ -2339,9 +2347,7 @@
               "tool_name": "fetch_concept",
               "concept_id": {
                 "$context_key": "entity_representation_concept_id"
-              },
-              "include_relations_any_arg": true,
-              "limit": 40
+              }
             },
             "tool_output_context_mappings": [
               {
@@ -2660,7 +2666,7 @@
           },
           {
             "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
-            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"place representation\",\"location representation\",\"represent place\",\"represent location\",\"venue representation\"],\"examples\":[\"Represent this place in the Vontology.\",\"Please represent these locations if they are not already represented.\",\"Create or update a place representation from this conversational description.\"]}}",
+            "text": "{{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"place representation\",\"location representation\",\"represent place\",\"represent location\",\"venue representation\"],\"examples\":[\"Represent this place in the Vontology.\",\"Please represent these locations if they are not already represented.\",\"Create or update a place representation from this conversational description.\"],\"routing_notes\":[\"Choose this workflow when a place may need to be created or additively represented. For pure read-only verification of an exact already-resolved place, choose the smallest adequate read-only capability plan.\"]}}",
             "lang": "en-NZ"
           }
         ],
@@ -3071,9 +3077,7 @@
               "tool_name": "fetch_concept",
               "concept_id": {
                 "$context_key": "entity_representation_concept_id"
-              },
-              "include_relations_any_arg": true,
-              "limit": 40
+              }
             },
             "tool_output_context_mappings": [
               {

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -251,6 +251,7 @@ const workflowStatusStreamState = {
     retryAttempt: 0,
     liveRefreshTimeoutId: null
 };
+const workflowTerminalObservationRefreshKeys = new Set();
 const workflowDefinitionsState = {
     visible: false,
     loading: false,
@@ -4921,6 +4922,7 @@ function _acceptConversationSituationPayload(payload, sessionId, options = {}) {
     conversationSituationStateBySession.set(sid, accepted);
     if (sid === activeChatSessionId) {
         _renderConversationSituationForActiveSession();
+        _renderLateWorkflowOutcomesForActiveSession();
     }
     return accepted;
 }
@@ -5057,6 +5059,7 @@ function _renderConversationObservation(observation) {
         'observed_at_utc',
         'terminal_status',
         'effect_status',
+        'domain_postcondition_status',
         'outcome_finality',
         'final_state',
         'capability_name',
@@ -5088,6 +5091,128 @@ function _renderConversationObservation(observation) {
     });
     card.appendChild(fields);
     return card;
+}
+
+function _lateWorkflowOutcomeLead(observation) {
+    const status = String(observation?.terminal_status || '').trim().toLowerCase();
+    const workflowLabel = String(
+        observation?.capability_name || observation?.workflow_id || 'Background workflow'
+    ).trim();
+    if (status === 'completed' || status === 'succeeded' || status === 'success') {
+        return `${workflowLabel} completed after the original response.`;
+    }
+    if (status === 'cancelled' || status === 'canceled') {
+        return `${workflowLabel} was cancelled after the original response.`;
+    }
+    if (status === 'failed') {
+        return `${workflowLabel} failed after the original response.`;
+    }
+    return `${workflowLabel} reached terminal status ${status || 'unknown'} after the original response.`;
+}
+
+function _renderLateWorkflowOutcome(observation, sessionId) {
+    const card = document.createElement('aside');
+    card.className = 'message-container assistant-turn chat-late-workflow-outcome';
+    card.setAttribute('role', 'status');
+    card.setAttribute('aria-live', 'polite');
+    card.dataset.conversationObservationId = observation.observation_id;
+    card.dataset.sessionId = sessionId;
+
+    const header = document.createElement('div');
+    header.className = 'message-header chat-late-workflow-outcome-header';
+    header.textContent = 'Workflow update';
+    const observedAt = String(
+        observation.completed_at || observation.observed_at_utc || ''
+    ).trim();
+    if (observedAt) {
+        header.textContent += ` • ${formatChatTimestamp(observedAt)}`;
+        setUnambiguousTimestampTooltip(header, observedAt, 'Observed: ');
+    }
+
+    const lead = document.createElement('p');
+    lead.className = 'chat-late-workflow-outcome-lead';
+    lead.textContent = _lateWorkflowOutcomeLead(observation);
+
+    const qualification = document.createElement('p');
+    qualification.className = 'chat-late-workflow-outcome-qualification';
+    qualification.textContent = (
+        observation.domain_postcondition_status === 'verified'
+            ? 'The linked requested postconditions were canonically verified.'
+            : 'This confirms the workflow execution status only; it does not by itself prove every requested knowledge change.'
+    );
+
+    const details = document.createElement('details');
+    details.className = 'chat-late-workflow-outcome-details';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Exact outcome details';
+    details.appendChild(summary);
+    const fields = document.createElement('dl');
+    fields.className = 'chat-situation-observation-fields';
+    [
+        'terminal_status',
+        'effect_status',
+        'domain_postcondition_status',
+        'workflow_id',
+        'instance_id',
+        'request_id',
+        'effect_id',
+        'completed_at',
+        'execution_trace_id'
+    ].forEach((key) => {
+        _appendConversationSituationDefinitionRow(
+            fields,
+            _humaniseConversationSituationField(key),
+            observation[key],
+            key
+        );
+    });
+    details.appendChild(fields);
+
+    const message = document.createElement('div');
+    message.className = 'chat-message-text';
+    message.appendChild(lead);
+    message.appendChild(qualification);
+    message.appendChild(details);
+
+    card.appendChild(header);
+    card.appendChild(message);
+    return card;
+}
+
+function _renderLateWorkflowOutcomesForActiveSession() {
+    const sid = normaliseHistorySessionId(activeChatSessionId);
+    const scrollableField = document.getElementById('scrollableField');
+    if (!sid || !scrollableField) {
+        return 0;
+    }
+    if (displayedHistorySessionId && displayedHistorySessionId !== sid) {
+        return 0;
+    }
+    const state = conversationSituationStateBySession.get(sid);
+    const observations = Array.isArray(state?.observations) ? state.observations : [];
+    const existingIds = new Set(
+        Array.from(
+            scrollableField.querySelectorAll('[data-conversation-observation-id]')
+        ).map(element => String(element.dataset.conversationObservationId || '').trim())
+            .filter(Boolean)
+    );
+    let appended = 0;
+    observations.forEach((observation) => {
+        if (
+            observation?.kind !== 'durable_workflow_terminal'
+            || !observation.observation_id
+            || existingIds.has(observation.observation_id)
+        ) {
+            return;
+        }
+        scrollableField.appendChild(_renderLateWorkflowOutcome(observation, sid));
+        existingIds.add(observation.observation_id);
+        appended += 1;
+    });
+    if (appended > 0) {
+        updateScrollToEndButtonVisibility(scrollableField);
+    }
+    return appended;
 }
 
 function _renderConversationSituationForActiveSession() {
@@ -27238,6 +27363,7 @@ async function loadChatHistory(options = {}) {
             });
 
             displayedHistorySessionId = targetSessionId;
+            _renderLateWorkflowOutcomesForActiveSession();
             clearHistoryLoadState({ sessionId: targetSessionId });
             updateHistoryBanner();
             const sessionMeta = sessionTabsCache.find(
@@ -27287,6 +27413,7 @@ async function loadChatHistory(options = {}) {
         historySegmentsShown = segmentsReturned;
         totalHistorySegments = totalSegments;
         displayedHistorySessionId = targetSessionId;
+        _renderLateWorkflowOutcomesForActiveSession();
         clearHistoryLoadState({ sessionId: targetSessionId });
         updateHistoryBanner();
         console.log('No Conversation history to load or empty history');
@@ -27449,6 +27576,11 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
             }
         }
     });
+
+    // Conversation observations are a separate append-only carrier. Rebuild
+    // their user-visible late-result cards after transcript rehydration, which
+    // clears the scrollable field after accepting the carrier snapshot.
+    _renderLateWorkflowOutcomesForActiveSession();
 
     // JVNAUTOSCI-2128: rehydrate the per-conversation ArrowUp recall buffer
     // from history so the most recent user prompt is recallable after a
@@ -30267,12 +30399,71 @@ function scheduleWorkflowStatusLiveRefresh() {
     }, WORKFLOW_STATUS_LIVE_REFRESH_DEBOUNCE_MS);
 }
 
+function _activeConversationContainsRequestId(requestId) {
+    const cleanRequestId = String(requestId || '').trim();
+    if (!cleanRequestId || !activeChatSessionId) {
+        return false;
+    }
+    const requestCandidates = [
+        activeChatRequest?.clientRequestId,
+        activeChatRequest?.latestProgress?.request_id,
+        lastFinishedThinkingCard?.clientRequestId,
+        lastFinishedThinkingCard?.latestProgress?.request_id
+    ];
+    if (requestCandidates.some(value => String(value || '').trim() === cleanRequestId)) {
+        return true;
+    }
+    for (const debugData of llmDebugData.values()) {
+        if (
+            debugData
+            && typeof debugData === 'object'
+            && String(debugData.request_id || '').trim() === cleanRequestId
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _refreshLateWorkflowObservationAfterTerminalEvent(payload) {
+    const status = String(payload?.status || '').trim().toLowerCase();
+    const requestId = String(payload?.source_event_id || '').trim();
+    const instanceId = String(payload?.instance_id || '').trim();
+    if (
+        payload?.source_event_type !== 'conversation_turn'
+        || !['completed', 'failed', 'cancelled', 'canceled'].includes(status)
+        || !requestId
+        || !instanceId
+        || !_activeConversationContainsRequestId(requestId)
+    ) {
+        return false;
+    }
+    const refreshKey = `${requestId}:${instanceId}:${status}`;
+    if (workflowTerminalObservationRefreshKeys.has(refreshKey)) {
+        return false;
+    }
+    workflowTerminalObservationRefreshKeys.add(refreshKey);
+    if (workflowTerminalObservationRefreshKeys.size > 200) {
+        const oldest = workflowTerminalObservationRefreshKeys.values().next().value;
+        workflowTerminalObservationRefreshKeys.delete(oldest);
+    }
+    void refreshConversationSituationForSession(activeChatSessionId).then((refreshed) => {
+        if (!refreshed) {
+            workflowTerminalObservationRefreshKeys.delete(refreshKey);
+        }
+    }).catch(() => {
+        workflowTerminalObservationRefreshKeys.delete(refreshKey);
+    });
+    return true;
+}
+
 function applyWorkflowStatusUpdate(payload) {
     if (!payload || !payload.instance_id) return;
     const existingItem = workflowStatusStreamState.items.get(payload.instance_id) || null;
     const mergedPayload = mergeWorkflowStatusPayload(existingItem, payload);
     const status = mergedPayload.status || '';
     if (!WORKFLOW_STATUS_ACTIVE.has(status)) {
+        _refreshLateWorkflowObservationAfterTerminalEvent(mergedPayload);
         workflowStatusStreamState.items.delete(payload.instance_id);
         syncWorkflowStatusSnapshotNotice();
         renderWorkflowStatusBody();
@@ -37340,6 +37531,7 @@ export function __testOnly_resetWorkflowStatusState() {
     workflowStatusStreamState.snapshotError = '';
     workflowStatusStreamState.snapshotNotice = '';
     workflowStatusStreamState.lastSnapshotPayload = null;
+    workflowTerminalObservationRefreshKeys.clear();
     workflowStatusGroupUiState.collapsedByWorkflowId.clear();
     workflowStatusGroupUiState.globallyFurled = false;
     workflowStatusPanelInitialised = false;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1887,6 +1887,7 @@ describe('conversation situation affordance', () => {
             <div id="chat-history-length"></div>
         `;
         __testOnly_resetHistoryUiState();
+        __testOnly_resetWorkflowStatusState();
         __testOnly_resetConversationSituationState();
         __testOnly_setActiveChatSession('session-1', 'Session 1');
         __testOnly_initializeConversationSituationPanel();
@@ -1895,6 +1896,7 @@ describe('conversation situation affordance', () => {
     afterEach(() => {
         delete global.fetch;
         __testOnly_resetHistoryUiState();
+        __testOnly_resetWorkflowStatusState();
         __testOnly_resetConversationSituationState();
         __testOnly_setActiveChatSession(null, null);
     });
@@ -2025,6 +2027,257 @@ describe('conversation situation affordance', () => {
         expect(exported.conversation_situation.revision).toBe(4);
         expect(exported.conversation_observation_state.total_count).toBe(5);
         expect(exported.conversation_observations).toHaveLength(1);
+    });
+
+    test('shows one append-only late workflow outcome and preserves it on history reload', async () => {
+        const lateObservation = {
+            schema_version: 'conversation_observation.v1',
+            observation_id: 'late-workflow-observation-1',
+            kind: 'durable_workflow_terminal',
+            observed_at_utc: '2026-07-29T09:11:00Z',
+            request_id: 'request-late-workflow-1',
+            effect_id: 'effect-late-workflow-1',
+            capability_name: 'Represent a person',
+            workflow_id: '#V#person_representation_workflow',
+            instance_id: 'instance-late-workflow-1',
+            terminal_status: 'completed',
+            effect_status: 'succeeded',
+            domain_postcondition_status: 'not_established_by_workflow_terminal'
+        };
+        const payload = situationPayload({
+            history: [
+                {
+                    role: 'assistant',
+                    content: 'The workflow is still running.',
+                    timestamp: '2026-07-29T09:10:00Z',
+                    llm_debug_data: { request_id: 'request-late-workflow-1' }
+                }
+            ],
+            conversation_observations: [lateObservation],
+            conversation_observation_state: {
+                retained_count: 1,
+                total_count: 1,
+                omitted_count: 0,
+                retention_limit: 12
+            }
+        });
+        __testOnly_setDisplayedHistorySession('session-1');
+        __testOnly_applyConversationSituationPayload(payload, 'session-1');
+        __testOnly_applyConversationSituationPayload(payload, 'session-1');
+
+        let cards = document.querySelectorAll('.chat-late-workflow-outcome');
+        expect(cards).toHaveLength(1);
+        expect(cards[0].textContent).toContain(
+            'Represent a person completed after the original response.'
+        );
+        expect(cards[0].textContent).toContain(
+            'does not by itself prove every requested knowledge change'
+        );
+        __testOnly_setTranscriptTurns([]);
+        const visibleTranscript = __testOnly_getConversationTranscriptTurnsSnapshot();
+        const lateTranscriptTurn = visibleTranscript.find(turn => turn.message.includes(
+            'Represent a person completed after the original response.'
+        ));
+        expect(lateTranscriptTurn).toBeDefined();
+
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/session/context')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        user_id: '#V#user',
+                        organisation_id: '#V#org',
+                        namespace: '#V#user@org'
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => payload
+            });
+        });
+        expect(await __testOnly_loadChatHistory({ segments: 1 })).toBe(true);
+
+        cards = document.querySelectorAll('.chat-late-workflow-outcome');
+        expect(cards).toHaveLength(1);
+        expect(cards[0].dataset.conversationObservationId).toBe(
+            'late-workflow-observation-1'
+        );
+    });
+
+    test('terminal workflow SSE refreshes the matching conversation once without a prompt', async () => {
+        const latePayload = situationPayload({
+            conversation_observations: [
+                {
+                    observation_id: 'late-workflow-observation-sse',
+                    kind: 'durable_workflow_terminal',
+                    observed_at_utc: '2026-07-29T09:12:00Z',
+                    request_id: 'request-late-workflow-sse',
+                    workflow_id: '#V#person_representation_workflow',
+                    instance_id: 'instance-late-workflow-sse',
+                    terminal_status: 'completed',
+                    effect_status: 'succeeded',
+                    domain_postcondition_status: 'not_established_by_workflow_terminal'
+                }
+            ],
+            conversation_observation_state: {
+                retained_count: 1,
+                total_count: 1,
+                omitted_count: 0,
+                retention_limit: 12
+            }
+        });
+        __testOnly_setDisplayedHistorySession('session-1');
+        setLlmDebugDataForTurn('history-assistant-late-sse', {
+            request_id: 'request-late-workflow-sse'
+        });
+        let historyReads = 0;
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/session/context')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        user_id: '#V#user',
+                        organisation_id: '#V#org',
+                        namespace: '#V#user@org'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                historyReads += 1;
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => latePayload
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+        const terminalEvent = {
+            instance_id: 'instance-late-workflow-sse',
+            workflow_id: '#V#person_representation_workflow',
+            status: 'completed',
+            source_event_type: 'conversation_turn',
+            source_event_id: 'request-late-workflow-sse'
+        };
+
+        __testOnly_applyWorkflowStatusUpdate(terminalEvent);
+        __testOnly_applyWorkflowStatusUpdate(terminalEvent);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(historyReads).toBe(1);
+        expect(document.querySelectorAll('.chat-late-workflow-outcome')).toHaveLength(1);
+        expect(document.querySelector('.chat-late-workflow-outcome').textContent).toContain(
+            'completed after the original response'
+        );
+    });
+
+    test.each([
+        ['failed', 'failed after the original response'],
+        ['cancelled', 'was cancelled after the original response']
+    ])('renders a durable %s workflow outcome honestly', (terminalStatus, expectedLead) => {
+        __testOnly_setDisplayedHistorySession('session-1');
+        __testOnly_applyConversationSituationPayload(situationPayload({
+            conversation_observations: [
+                {
+                    observation_id: `late-workflow-observation-${terminalStatus}`,
+                    kind: 'durable_workflow_terminal',
+                    observed_at_utc: '2026-07-29T09:13:00Z',
+                    request_id: `request-late-workflow-${terminalStatus}`,
+                    capability_name: 'Represent a person',
+                    workflow_id: '#V#person_representation_workflow',
+                    instance_id: `instance-late-workflow-${terminalStatus}`,
+                    terminal_status: terminalStatus,
+                    effect_status: terminalStatus,
+                    domain_postcondition_status: 'not_established_by_workflow_terminal'
+                }
+            ],
+            conversation_observation_state: {
+                retained_count: 1,
+                total_count: 1,
+                omitted_count: 0,
+                retention_limit: 12
+            }
+        }), 'session-1');
+
+        const card = document.querySelector('.chat-late-workflow-outcome');
+        expect(card).not.toBeNull();
+        expect(card.textContent).toContain(expectedLead);
+        expect(card.textContent).toContain(
+            'does not by itself prove every requested knowledge change'
+        );
+    });
+
+    test('a transient terminal observation refresh failure remains retryable', async () => {
+        const latePayload = situationPayload({
+            conversation_observations: [
+                {
+                    observation_id: 'late-workflow-observation-retry',
+                    kind: 'durable_workflow_terminal',
+                    observed_at_utc: '2026-07-29T09:14:00Z',
+                    request_id: 'request-late-workflow-retry',
+                    workflow_id: '#V#person_representation_workflow',
+                    instance_id: 'instance-late-workflow-retry',
+                    terminal_status: 'completed',
+                    effect_status: 'succeeded',
+                    domain_postcondition_status: 'not_established_by_workflow_terminal'
+                }
+            ],
+            conversation_observation_state: {
+                retained_count: 1,
+                total_count: 1,
+                omitted_count: 0,
+                retention_limit: 12
+            }
+        });
+        __testOnly_setDisplayedHistorySession('session-1');
+        setLlmDebugDataForTurn('history-assistant-late-retry', {
+            request_id: 'request-late-workflow-retry'
+        });
+        let historyReads = 0;
+        global.fetch = jest.fn((url) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/session/context')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        user_id: '#V#user',
+                        organisation_id: '#V#org',
+                        namespace: '#V#user@org'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                historyReads += 1;
+                if (historyReads === 1) {
+                    return Promise.reject(new Error('transient history failure'));
+                }
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => latePayload
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+        const terminalEvent = {
+            instance_id: 'instance-late-workflow-retry',
+            workflow_id: '#V#person_representation_workflow',
+            status: 'completed',
+            source_event_type: 'conversation_turn',
+            source_event_id: 'request-late-workflow-retry'
+        };
+
+        __testOnly_applyWorkflowStatusUpdate(terminalEvent);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        __testOnly_applyWorkflowStatusUpdate(terminalEvent);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(historyReads).toBe(2);
+        expect(document.querySelectorAll('.chat-late-workflow-outcome')).toHaveLength(1);
     });
 
     test('a canonical history read replaces the carrier after a reset lowers its revision and total', async () => {

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -8079,6 +8079,46 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     font-size: 12px;
 }
 
+.chat-late-workflow-outcome {
+    display: block;
+    margin-bottom: 15px;
+    padding: 12px 14px;
+    border: 1px solid #93c5fd;
+    border-left: 4px solid #2563eb;
+    border-radius: 8px;
+    background: #eff6ff;
+    color: #172554;
+}
+
+.chat-late-workflow-outcome-header {
+    margin-bottom: 6px;
+    color: #1d4ed8;
+    font-size: 0.9em;
+    font-weight: 700;
+}
+
+.chat-late-workflow-outcome-lead,
+.chat-late-workflow-outcome-qualification {
+    margin: 0 0 6px;
+    line-height: 1.45;
+}
+
+.chat-late-workflow-outcome-qualification {
+    color: #475569;
+    font-size: 0.9em;
+}
+
+.chat-late-workflow-outcome-details > summary {
+    cursor: pointer;
+    color: #1e40af;
+    font-size: 0.85em;
+    font-weight: 600;
+}
+
+.chat-late-workflow-outcome-details .chat-situation-observation-fields {
+    margin-top: 7px;
+}
+
 @media (max-width: 640px) {
     .chat-conversation-masthead {
         grid-template-columns: minmax(0, 1fr);

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -5079,7 +5079,7 @@ def test_canonical_literal_relationship_recovery_requires_same_object(
     assert denial["recovery_status"] == "mismatched"
     assert denial["attempted_recovery_effect_id"] == unrelated_recovery["effect_id"]
     assert "recovered_by_effect_id" not in denial
-    assert result.terminal_status == "effect_not_started"
+    assert result.terminal_status == "effect_partially_completed"
     assert result.response_text != "The scoped assertion was recorded."
 
 
@@ -12518,3 +12518,693 @@ def test_model_call_progress_reports_cumulative_usage_cost_and_exact_identity() 
             "call_count": 2,
         }
     ]
+
+
+def _run_explicit_scoped_recovery_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mismatched_index: int | None,
+    mismatch_kind: str = "target",
+    emit_exact_affordances: bool = True,
+) -> tuple[Any, list[dict[str, Any]]]:
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    facts = [
+        ("is_an_instance_of", "#V#academic_staff"),
+        ("affiliated_with", "#V#school_of_computer_science"),
+        ("has_job_title", "#V#associate_professor"),
+        ("employed_by", "#V#university_of_auckland"),
+        ("member_of", "#V#computer_science_staff"),
+        ("works_at", "#V#university_of_auckland_city_campus"),
+    ]
+    seen_arguments: list[dict[str, Any]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        assert name == "upsert_scoped_assertion"
+        seen_arguments.append(dict(arguments))
+        predicate = str(arguments["predicate"])
+        if not predicate.startswith("#V#"):
+            failure = {
+                "success": False,
+                "effect_status": "failed",
+                "changed": False,
+                "error_code": "invalid_scoped_assertion",
+                "error": "predicate must be a represented concept ID",
+            }
+            if emit_exact_affordances:
+                failure["recovery_affordances"] = [
+                    {
+                        "action_type": (
+                            "retry_exact_scoped_assertion_with_canonical_predicate_id"
+                        ),
+                        "tool": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": arguments[
+                                "subject_concept_id"
+                            ],
+                            "predicate": f"#V#{predicate}",
+                            "target_concept_id": arguments[
+                                "target_concept_id"
+                            ],
+                            "scope_mode": arguments["scope_mode"],
+                            "evidence": arguments["evidence"],
+                        },
+                    }
+                ]
+            return failure
+
+        assertion_id = f"ska_recovery_{len(seen_arguments)}"
+        scope_mode = str(arguments["scope_mode"])
+        organisation_id = arguments["organisation_concept_id"]
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": arguments["subject_concept_id"],
+            "predicate": predicate,
+            "object_kind": "concept",
+            "object_concept_id": arguments["target_concept_id"],
+            "object_text": None,
+            "scope": {
+                "mode": scope_mode,
+                "user_concept_id": arguments["acting_user_concept_id"],
+                "organisation_concept_id": organisation_id,
+                "namespace": arguments["namespace"],
+                "audience_keys": [f"org:{organisation_id}"],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": arguments[
+                    "acting_user_concept_id"
+                ],
+                "organisation_concept_id": organisation_id,
+                "namespace": arguments["namespace"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "canonical_read_back": readback,
+        }
+
+    malformed_calls = [
+        ToolCall(
+            tool_name="turn_invoke_capability",
+            call_id=f"malformed-scoped-fact-{index + 1}",
+            payload={
+                "name": "upsert_scoped_assertion",
+                "arguments": {
+                    "subject_concept_id": "#V#marc_example",
+                    "predicate": predicate,
+                    "target_concept_id": target,
+                    "scope_mode": "organisation",
+                    "evidence": {"source": "official staff page"},
+                },
+            },
+        )
+        for index, (predicate, target) in enumerate(facts)
+    ]
+    corrected_calls = []
+    for index, (predicate, target) in enumerate(facts):
+        corrected_arguments = {
+            "subject_concept_id": "#V#marc_example",
+            "predicate": f"#V#{predicate}",
+            "target_concept_id": target,
+            "scope_mode": "organisation",
+            "evidence": {"source": "official staff page"},
+        }
+        if index == mismatched_index:
+            if mismatch_kind == "target":
+                corrected_arguments["target_concept_id"] = (
+                    "#V#valid_but_wrong_target"
+                )
+            elif mismatch_kind == "scope":
+                corrected_arguments["scope_mode"] = "user"
+            elif mismatch_kind == "evidence":
+                corrected_arguments["evidence"] = {"source": "different page"}
+            else:
+                raise AssertionError(f"Unsupported mismatch kind: {mismatch_kind}")
+        corrected_calls.append(
+            ToolCall(
+                tool_name="turn_invoke_capability",
+                call_id=f"corrected-scoped-fact-{index + 1}",
+                payload={
+                    "name": "upsert_scoped_assertion",
+                    "arguments": corrected_arguments,
+                },
+            )
+        )
+
+    client = _SequenceClient(
+        LLMResponse(text_response="", tool_calls=malformed_calls),
+        LLMResponse(text_response="", tool_calls=corrected_calls),
+        LLMResponse(text_response="The six requested scoped facts are now present."),
+    )
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt="Represent Marc Example with these six organisation-scoped facts.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id=f"turn-explicit-scoped-recovery-{mismatched_index}",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    invoke_tool = next(
+        tool
+        for tool in client.calls[0]["available_tools"]
+        if tool.name == "turn_invoke_capability"
+    )
+    assert "satisfies_obligation_id" not in invoke_tool.input_schema["properties"]
+    assert all(
+        set(call.payload) == {"name", "arguments"}
+        for call in malformed_calls + corrected_calls
+    )
+    assert all(
+        "satisfies_obligation_id" not in arguments
+        for arguments in seen_arguments
+    )
+    return result, seen_arguments
+
+
+def test_all_explicit_exact_scoped_recoveries_complete_without_linkage_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, seen_arguments = _run_explicit_scoped_recovery_replay(
+        monkeypatch,
+        mismatched_index=None,
+    )
+
+    assert len(seen_arguments) == 12
+    failures = [
+        invocation
+        for invocation in result.tool_invocations
+        if str(invocation.get("call_id") or "").startswith("malformed-scoped-fact-")
+    ]
+    recoveries = [
+        invocation
+        for invocation in result.tool_invocations
+        if str(invocation.get("call_id") or "").startswith("corrected-scoped-fact-")
+    ]
+    assert len(failures) == len(recoveries) == 6
+    assert all(
+        invocation["effect_status"] == "failed"
+        and invocation["changed"] is False
+        and invocation["recovery_status"] == "succeeded"
+        and invocation.get("recovered_by_effect_id")
+        for invocation in failures
+    )
+    assert all(
+        invocation["effect_status"] == "succeeded"
+        and invocation["changed"] is True
+        and invocation.get("canonical_readback", {}).get("status") == "asserted"
+        for invocation in recoveries
+    )
+    assert result.terminal_status == "completed"
+    assert result.response_authority == "model"
+    assert result.response_text == "The six requested scoped facts are now present."
+
+
+@pytest.mark.parametrize("mismatch_kind", ["target", "scope", "evidence"])
+def test_one_valid_but_mismatched_scoped_recovery_keeps_turn_partial(
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch_kind: str,
+) -> None:
+    result, seen_arguments = _run_explicit_scoped_recovery_replay(
+        monkeypatch,
+        mismatched_index=5,
+        mismatch_kind=mismatch_kind,
+    )
+
+    failures = [
+        invocation
+        for invocation in result.tool_invocations
+        if str(invocation.get("call_id") or "").startswith("malformed-scoped-fact-")
+    ]
+    assert sum(
+        invocation.get("recovery_status") == "succeeded"
+        for invocation in failures
+    ) == 5
+    mismatched = next(
+        invocation
+        for invocation in failures
+        if invocation.get("recovery_status") == "mismatched"
+    )
+    wrong_recovery = next(
+        invocation
+        for invocation in result.tool_invocations
+        if invocation.get("call_id") == "corrected-scoped-fact-6"
+    )
+    assert mismatched["attempted_recovery_effect_id"] == wrong_recovery["effect_id"]
+    assert "recovered_by_effect_id" not in mismatched
+    recovery_arguments = seen_arguments[-1]
+    if mismatch_kind == "target":
+        assert wrong_recovery["canonical_readback"]["object_concept_id"] == (
+            "#V#valid_but_wrong_target"
+        )
+    elif mismatch_kind == "scope":
+        assert recovery_arguments["scope_mode"] == "user"
+    else:
+        assert recovery_arguments["evidence"] == {"source": "different page"}
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.response_authority == "canonical_outcome"
+    assert result.response_text != "The six requested scoped facts are now present."
+
+
+def test_malformed_scoped_failures_without_exact_affordances_are_not_fuzzily_reconciled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, _seen_arguments = _run_explicit_scoped_recovery_replay(
+        monkeypatch,
+        mismatched_index=None,
+        emit_exact_affordances=False,
+    )
+
+    failures = [
+        invocation
+        for invocation in result.tool_invocations
+        if str(invocation.get("call_id") or "").startswith("malformed-scoped-fact-")
+    ]
+    assert len(failures) == 6
+    assert all("recovery_status" not in invocation for invocation in failures)
+    assert all("recovered_by_effect_id" not in invocation for invocation in failures)
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.response_authority == "canonical_outcome"
+
+
+def test_catalogue_exact_predicate_affordances_reconcile_concept_and_text_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.integrations.internal_mcp.catalogue import (
+        build_default_catalogue,
+    )
+    from src.backend.services.text_relation_predicate_validation_service import (
+        TextRelationPredicateResolutionError,
+    )
+
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    monkeypatch.setattr(
+        "src.backend.security.access_control.can_access_concept",
+        lambda _concept_id: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service."
+        "resolve_existing_predicate_value_kind",
+        lambda predicate_id: (
+            "text" if predicate_id == "#V#has_email" else "concept"
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_text_relation_change_hook_service."
+        "maybe_sync_concept_text_relations_to_rag",
+        lambda **_kwargs: {"success": True, "skipped": True},
+    )
+
+    service_calls: list[dict[str, Any]] = []
+
+    def upsert(**arguments: Any) -> dict[str, Any]:
+        service_calls.append(dict(arguments))
+        predicate = str(arguments["predicate"])
+        if predicate == "affiliated_with":
+            raise ValueError("predicate must be an exact #V# concept ID")
+        if predicate == "has_email":
+            raise TextRelationPredicateResolutionError(
+                "unsupported_text_relation_predicate",
+                "Unsupported text-relation predicate 'has_email'.",
+                details={"predicate": "has_email"},
+            )
+        object_kind = "text" if arguments.get("target_text") else "concept"
+        assertion_id = f"ska_catalogue_recovery_{len(service_calls)}"
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": arguments["subject_concept_id"],
+            "predicate": predicate,
+            "object_kind": object_kind,
+            "object_concept_id": arguments.get("target_concept_id"),
+            "object_text": (
+                {
+                    "text": arguments["target_text"],
+                    "language": arguments.get("language") or "en-NZ",
+                }
+                if object_kind == "text"
+                else None
+            ),
+            "scope": {
+                "mode": arguments["scope_mode"],
+                "user_concept_id": arguments["acting_user_concept_id"],
+                "organisation_concept_id": arguments[
+                    "organisation_concept_id"
+                ],
+                "namespace": arguments["namespace"],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": arguments[
+                    "acting_user_concept_id"
+                ],
+                "evidence": arguments["evidence"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "assertion": readback,
+            "canonical_read_back": readback,
+            "canonical_publication": False,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.upsert_scoped_assertion",
+        upsert,
+    )
+    common = {
+        "subject_concept_id": "#V#marc_example",
+        "scope_mode": "organisation",
+        "evidence": {"source": "official staff page"},
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="catalogue-bare-concept-predicate",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            **common,
+                            "predicate": "affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                        },
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="catalogue-bare-text-predicate",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            **common,
+                            "predicate": "has_email",
+                            "target_text": "marc@example.test",
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="catalogue-exact-concept-predicate",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            **common,
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": "#V#school_of_computer_science",
+                        },
+                    },
+                ),
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="catalogue-exact-text-predicate",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            **common,
+                            "predicate": "#V#has_email",
+                            "target_text": "marc@example.test",
+                            "language": "en-NZ",
+                        },
+                    },
+                ),
+            ],
+        ),
+        LLMResponse(text_response="Both exact assertions are represented."),
+    )
+    result = execute_adaptive_turn(
+        gateway=InternalMCPGateway(
+            catalogue=build_default_catalogue(),
+            transport=InternalMCPTransport(
+                read_timeout_sec=1.0,
+                write_timeout_sec=1.0,
+            ),
+            enabled=True,
+        ),
+        prompt="Represent the exact School affiliation and email assertions.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-catalogue-exact-predicate-recovery",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    failures = result.tool_invocations[:2]
+    recoveries = result.tool_invocations[2:]
+    assert all(item["effect_status"] == "not_started" for item in failures)
+    assert all(item["recovery_status"] == "succeeded" for item in failures)
+    assert all(item.get("recovered_by_effect_id") for item in failures)
+    assert all(item["effect_status"] == "succeeded" for item in recoveries)
+    assert result.terminal_status == "completed"
+    assert result.response_authority == "model"
+    assert result.response_text == "Both exact assertions are represented."
+
+
+def test_existing_scoped_fact_canonical_read_completes_without_a_write() -> None:
+    seen_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        seen_calls.append((name, dict(arguments)))
+        assert name == "general_read"
+        return {
+            "success": True,
+            "found": True,
+            "canonical_read_back": {
+                "schema_version": "scoped_knowledge_assertion.v1",
+                "assertion_id": "ska_existing_affiliation",
+                "subject_concept_id": "#V#marc_example",
+                "predicate": "#V#affiliated_with",
+                "object_kind": "concept",
+                "object_concept_id": "#V#school_of_computer_science",
+                "scope_mode": "organisation",
+                "status": "asserted",
+            },
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-existing-scoped-fact",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {
+                            "subject_concept_id": "#V#marc_example",
+                            "predicate": "#V#affiliated_with",
+                            "target_concept_id": (
+                                "#V#school_of_computer_science"
+                            ),
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The existing scoped fact was verified."),
+    )
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt=(
+            "Ensure Marc Example's School affiliation is represented; read first "
+            "and do not write if it already exists."
+        ),
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="turn-existing-scoped-fact-read",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert seen_calls == [
+        (
+            "general_read",
+            {
+                "subject_concept_id": "#V#marc_example",
+                "predicate": "#V#affiliated_with",
+                "target_concept_id": "#V#school_of_computer_science",
+                "scope_mode": "organisation",
+            },
+        )
+    ]
+    assert all(
+        invocation.get("effect_id") is None
+        for invocation in result.tool_invocations
+    )
+    assert result.terminal_status == "completed"
+    assert result.response_authority == "model"
+    assert result.response_text == "The existing scoped fact was verified."
+
+
+@pytest.mark.parametrize(
+    ("recovery_language", "expected_recovery_status", "expected_terminal_status"),
+    (
+        ("en-NZ", "succeeded", "completed"),
+        ("fr-FR", "mismatched", "effect_partially_completed"),
+    ),
+)
+def test_scoped_text_recovery_uses_exact_defaulted_language(
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_language: str,
+    expected_recovery_status: str,
+    expected_terminal_status: str,
+) -> None:
+    _stub_same_turn_ontology_delegation(monkeypatch)
+    handler_calls: list[dict[str, Any]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        assert name == "upsert_scoped_assertion"
+        handler_calls.append(dict(arguments))
+        if len(handler_calls) == 1:
+            return {
+                "success": False,
+                "effect_status": "failed",
+                "changed": False,
+                "error_code": "scoped_assertion_write_failed",
+                "recovery_affordances": [
+                    {
+                        "action_type": (
+                            "retry_exact_scoped_assertion_with_canonical_predicate_id"
+                        ),
+                        "tool": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#marc_example",
+                            "predicate": "#V#has_note",
+                            "target_text": "Research note",
+                            "scope_mode": "organisation",
+                        },
+                    }
+                ],
+            }
+
+        assertion_id = "ska_text_language_recovery"
+        organisation_id = arguments["organisation_concept_id"]
+        readback = {
+            "schema_version": "scoped_knowledge_assertion.v1",
+            "assertion_id": assertion_id,
+            "subject_concept_id": arguments["subject_concept_id"],
+            "predicate": arguments["predicate"],
+            "object_kind": "text",
+            "object_concept_id": None,
+            "object_text": {
+                "text": arguments["target_text"],
+                "language": arguments["language"],
+            },
+            "scope": {
+                "mode": arguments["scope_mode"],
+                "user_concept_id": arguments["acting_user_concept_id"],
+                "organisation_concept_id": organisation_id,
+                "namespace": arguments["namespace"],
+                "audience_keys": [f"org:{organisation_id}"],
+            },
+            "provenance": {
+                "asserted_by_user_concept_id": arguments[
+                    "acting_user_concept_id"
+                ],
+                "organisation_concept_id": organisation_id,
+                "namespace": arguments["namespace"],
+            },
+            "canonical_publication": False,
+            "status": "asserted",
+        }
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "assertion_id": assertion_id,
+            "canonical_read_back": readback,
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="failed-default-language-assertion",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#marc_example",
+                            "predicate": "#V#has_note",
+                            "target_text": "Research note",
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="text-language-recovery",
+                    payload={
+                        "name": "upsert_scoped_assertion",
+                        "arguments": {
+                            "subject_concept_id": "#V#marc_example",
+                            "predicate": "#V#has_note",
+                            "target_text": "Research note",
+                            "language": recovery_language,
+                            "scope_mode": "organisation",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The text assertion was recovered."),
+    )
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler, include_scoped_assertion=True),
+        prompt="Record this organisation-scoped research note.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id=f"turn-text-language-recovery-{recovery_language}",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    failure, recovery = result.tool_invocations
+    assert failure["recovery_status"] == expected_recovery_status
+    if expected_recovery_status == "succeeded":
+        assert failure["recovered_by_effect_id"] == recovery["effect_id"]
+    else:
+        assert "recovered_by_effect_id" not in failure
+        assert failure["attempted_recovery_effect_id"] == recovery["effect_id"]
+    assert recovery["canonical_readback"]["object_text_identity_sha256"]
+    assert result.terminal_status == expected_terminal_status

--- a/tests/backend/test_concept_search_instance_retrieval_workflow_vontology_service.py
+++ b/tests/backend/test_concept_search_instance_retrieval_workflow_vontology_service.py
@@ -80,7 +80,6 @@ def test_bootstrap_materialises_concept_search_instance_retrieval_workflow(
         "zero-result exact search" in note
         for note in (discovery_exemplars.get("routing_notes") or [])
     )
-
     launch_contract, launch_source = resolve_workflow_launch_input_contract(
         CONCEPT_SEARCH_INSTANCE_RETRIEVAL_WORKFLOW_ID
     )
@@ -135,6 +134,18 @@ def test_bootstrap_materialises_concept_search_instance_retrieval_workflow(
         "find_relations_with_argument",
     ]
     assert llm_policy.get("max_tool_invocations") == 6
+    tool_argument_defaults = llm_policy.get("tool_argument_defaults") or {}
+    assert "fetch_concept" not in tool_argument_defaults
+    assert tool_argument_defaults.get("get_text_relations_summary") == {
+        "max_relation_ids_per_group": 20
+    }
+    assert tool_argument_defaults.get("find_relations_with_argument") == {
+        "argument_index": "any",
+        "relation_kind": "any",
+        "include_text_snippets": True,
+        "include_concept_preview": False,
+        "limit": 30,
+    }
     assert llm_policy.get("context_messages_context_key") == "augmented_context"
     assert "conversation_situation" in {
         field.get("context_key")

--- a/tests/backend/test_durable_workflow_system.py
+++ b/tests/backend/test_durable_workflow_system.py
@@ -606,12 +606,20 @@ class TestWorkflowInstanceManager:
     ) -> None:
         manager = WorkflowInstanceManager()
         reconciliations: list[dict[str, Any]] = []
+        terminal_events: list[str] = []
         monkeypatch.setattr(
             "src.backend.services.turn_execution_record_service.reconcile_durable_workflow_terminal_effect",
             lambda **kwargs: (
+                terminal_events.append("reconciled")
+                or
                 reconciliations.append(dict(kwargs))
                 or {"updated": True}
             ),
+        )
+        monkeypatch.setattr(
+            manager,
+            "_broadcast_instance",
+            lambda _instance: terminal_events.append("broadcast"),
         )
         instance_id = manager.create_instance(
             "#V#test_workflow",
@@ -621,6 +629,7 @@ class TestWorkflowInstanceManager:
             source_event_type="conversation_turn",
             source_event_id="request-durable-terminal",
         )
+        terminal_events.clear()
 
         success = manager.mark_completed(
             instance_id,
@@ -630,6 +639,7 @@ class TestWorkflowInstanceManager:
         )
 
         assert success is True
+        assert terminal_events == ["reconciled", "broadcast"]
         assert len(reconciliations) == 1
         reconciliation = reconciliations[0]
         assert reconciliation["request_id"] == "request-durable-terminal"

--- a/tests/backend/test_entity_representation_workflow_vontology_service.py
+++ b/tests/backend/test_entity_representation_workflow_vontology_service.py
@@ -53,7 +53,7 @@ def test_bootstrap_materialises_entity_representation_workflow_family(
     report = bootstrap_canonical_entity_representation_workflows()
 
     template_publication = report.get("template_publication") or {}
-    assert template_publication.get("repo_seed_version") == "5"
+    assert template_publication.get("repo_seed_version") == "6"
     assert (template_publication.get("counts") or {}).get("persisted_templates") == 4
 
     publication = report.get("publication") or {}
@@ -114,6 +114,10 @@ def test_bootstrap_materialises_entity_representation_workflow_family(
     assert discovery_source.startswith("text_relation:")
     assert "entity representation workflow" in (
         discovery_exemplars.get("keywords") or []
+    )
+    assert any(
+        "smallest adequate read-only capability plan" in str(note)
+        for note in discovery_exemplars.get("routing_notes") or []
     )
 
     dispatch_mapping_concept_ids: set[str] = set()

--- a/tests/backend/test_internal_mcp_scoped_assertion_authority.py
+++ b/tests/backend/test_internal_mcp_scoped_assertion_authority.py
@@ -395,6 +395,287 @@ def test_authenticated_actor_is_bound_across_every_scoped_assertion_path(
     assert calls["relations"][-1]["context_view"] == "actor_effective"
 
 
+def test_invalid_bare_predicate_exposes_one_exact_executable_scoped_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.security.access_control import override_current_actor
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.upsert_scoped_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            ValueError("predicate must be an exact #V# concept ID")
+        ),
+    )
+    accessed_concept_ids: list[str] = []
+
+    def can_access(concept_id: str) -> bool:
+        accessed_concept_ids.append(concept_id)
+        return True
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.can_access_concept",
+        can_access,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service."
+        "resolve_existing_predicate_value_kind",
+        lambda predicate_id: (
+            "concept" if predicate_id == "#V#affiliated_with" else None
+        ),
+    )
+
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        result = _gateway().invoke(
+            "upsert_scoped_assertion",
+            {
+                "subject_concept_id": "#V#subject",
+                "predicate": "affiliated_with",
+                "target_concept_id": "#V#target",
+                "scope_mode": "organisation",
+                "evidence": {"source": "official staff page"},
+            },
+        ).payload
+
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_scoped_assertion"
+    assert result["effect_status"] == "not_started"
+    assert result["mutation_outcome"] == "not_started"
+    assert result["changed"] is False
+    assert result["error_details"]["rejected_fields"] == ["predicate"]
+    assert accessed_concept_ids == [
+        "#V#subject",
+        "#V#affiliated_with",
+        "#V#target",
+    ]
+    recovery = result["recovery_affordances"]
+    assert recovery == [
+        {
+            "action_type": (
+                "retry_exact_scoped_assertion_with_canonical_predicate_id"
+            ),
+            "tool": "upsert_scoped_assertion",
+            "arguments": {
+                "subject_concept_id": "#V#subject",
+                "predicate": "#V#affiliated_with",
+                "target_concept_id": "#V#target",
+                "scope_mode": "organisation",
+                "evidence": {"source": "official staff page"},
+            },
+            "resolution": {
+                "kind": "canonical_code_identifier",
+                "input_predicate": "affiliated_with",
+                "predicate_concept_id": "#V#affiliated_with",
+                "value_kind": "concept",
+            },
+        }
+    ]
+    retry_arguments = recovery[0]["arguments"]
+    assert "acting_user_concept_id" not in retry_arguments
+    assert "organisation_concept_id" not in retry_arguments
+    assert "namespace" not in retry_arguments
+    assert "canonical_publication" not in retry_arguments
+
+
+def test_invalid_bare_text_predicate_exposes_one_exact_executable_scoped_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services.text_relation_predicate_validation_service import (
+        TextRelationPredicateResolutionError,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.upsert_scoped_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            TextRelationPredicateResolutionError(
+                "unsupported_text_relation_predicate",
+                "Unsupported text-relation predicate 'has_email'.",
+                details={"predicate": "has_email"},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.can_access_concept",
+        lambda _concept_id: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service."
+        "resolve_existing_predicate_value_kind",
+        lambda predicate_id: "text" if predicate_id == "#V#has_email" else None,
+    )
+
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        result = _gateway().invoke(
+            "upsert_scoped_assertion",
+            {
+                "subject_concept_id": "#V#subject",
+                "predicate": "has_email",
+                "target_text": "person@example.test",
+                "language": "en-NZ",
+                "scope_mode": "organisation",
+                "evidence": {"source": "official staff page"},
+            },
+        ).payload
+
+    assert result["effect_status"] == "not_started"
+    assert result["changed"] is False
+    assert result["error_details"]["rejected_fields"] == ["predicate"]
+    assert result["recovery_affordances"][0]["arguments"] == {
+        "subject_concept_id": "#V#subject",
+        "predicate": "#V#has_email",
+        "target_text": "person@example.test",
+        "language": "en-NZ",
+        "scope_mode": "organisation",
+        "evidence": {"source": "official staff page"},
+    }
+    assert result["recovery_affordances"][0]["resolution"]["value_kind"] == (
+        "text"
+    )
+
+
+def test_predicate_recovery_probe_failure_preserves_not_started_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.security.access_control import override_current_actor
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.upsert_scoped_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            ValueError("predicate must be an exact #V# concept ID")
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.can_access_concept",
+        lambda _concept_id: (_ for _ in ()).throw(RuntimeError("read unavailable")),
+    )
+
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        result = _gateway().invoke(
+            "upsert_scoped_assertion",
+            {
+                "subject_concept_id": "#V#subject",
+                "predicate": "affiliated_with",
+                "target_concept_id": "#V#target",
+            },
+        ).payload
+
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_scoped_assertion"
+    assert result["effect_status"] == "not_started"
+    assert result["mutation_outcome"] == "not_started"
+    assert result["changed"] is False
+    assert result["error_details"]["rejected_fields"] == ["predicate"]
+    assert "recovery_affordances" not in result
+
+
+@pytest.mark.parametrize(
+    (
+        "error_message",
+        "predicate",
+        "predicate_visible",
+        "predicate_kind",
+        "argument_overrides",
+    ),
+    [
+        (
+            "scope_mode must be 'user' or 'organisation'",
+            "affiliated_with",
+            True,
+            "concept",
+            {},
+        ),
+        (
+            "predicate must be an exact #V# concept ID",
+            "affiliated with",
+            True,
+            "concept",
+            {},
+        ),
+        (
+            "predicate must be an exact #V# concept ID",
+            "affiliated_with",
+            False,
+            "concept",
+            {},
+        ),
+        (
+            "predicate must be an exact #V# concept ID",
+            "affiliated_with",
+            True,
+            None,
+            {},
+        ),
+        (
+            "predicate must be an exact #V# concept ID",
+            "affiliated_with",
+            True,
+            "text",
+            {},
+        ),
+        (
+            "predicate must be an exact #V# concept ID",
+            "affiliated_with",
+            True,
+            "concept",
+            {"target_concept_id": "target"},
+        ),
+    ],
+    ids=[
+        "different-validation-error",
+        "not-a-code-identifier",
+        "hidden-predicate",
+        "untyped-predicate",
+        "wrong-value-kind",
+        "non-exact-target",
+    ],
+)
+def test_invalid_scoped_assertion_exposes_no_unexecutable_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    error_message: str,
+    predicate: str,
+    predicate_visible: bool,
+    predicate_kind: str | None,
+    argument_overrides: dict[str, Any],
+) -> None:
+    from src.backend.security.access_control import override_current_actor
+
+    monkeypatch.setattr(
+        "src.backend.services.scoped_assertion_service.upsert_scoped_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError(error_message)),
+    )
+    monkeypatch.setattr(
+        "src.backend.security.access_control.can_access_concept",
+        lambda concept_id: (
+            predicate_visible
+            if concept_id == "#V#affiliated_with"
+            else True
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.relationship_write_service."
+        "resolve_existing_predicate_value_kind",
+        lambda _predicate_id: predicate_kind,
+    )
+
+    with override_current_actor(TRUSTED_USER, TRUSTED_ORG):
+        arguments = {
+            "subject_concept_id": "#V#subject",
+            "predicate": predicate,
+            "target_concept_id": "#V#target",
+            "scope_mode": "organisation",
+            **argument_overrides,
+        }
+        result = _gateway().invoke(
+            "upsert_scoped_assertion",
+            arguments,
+        ).payload
+
+    assert result["effect_status"] == "not_started"
+    assert result["changed"] is False
+    assert "recovery_affordances" not in result
+    assert "predicate_resolution" not in result["error_details"]
+
+
 def test_scoped_list_forwards_offset_and_reports_bounded_page(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
+++ b/tests/backend/test_rag_turn_execution_records_mcp_read_tools.py
@@ -3397,11 +3397,11 @@ def test_turn_execution_build_selector_benchmark_supports_entity_representation_
     assert payload["success"] is True
     metrics = payload.get("metrics")
     assert isinstance(metrics, dict)
-    assert metrics.get("scanned_count") == 10
+    assert metrics.get("scanned_count") == 11
     assert metrics.get("matched_case_count") == metrics.get("scanned_count")
     assert metrics.get("selector_accuracy_pct") == 100.0
     assert metrics.get("baseline_accuracy_pct") == 0.0
-    assert metrics.get("outcome_label_counts", {}).get("successful_completion") == 10
+    assert metrics.get("outcome_label_counts", {}).get("successful_completion") == 11
     assert (
         metrics.get("outcome_label_counts", {}).get("abstain_escalate_no_safe_route")
         in {None, 0}
@@ -3432,6 +3432,7 @@ def test_turn_execution_build_selector_benchmark_supports_entity_representation_
         "entity_event_write_with_capture_verb",
         "entity_place_representation_success",
         "entity_ambiguity_low_imposition_route",
+        "entity_known_person_idempotence_verification",
     }
     follow_up_case = next(
         case
@@ -3440,6 +3441,19 @@ def test_turn_execution_build_selector_benchmark_supports_entity_representation_
         and case.get("case_id") == "entity_people_follow_up_reasoning_override"
     )
     assert follow_up_case["selected_workflow_id"] == "#V#entity_representation_workflow"
+    known_entity_case = next(
+        case
+        for case in replay_cases
+        if isinstance(case, dict)
+        and case.get("case_id") == "entity_known_person_idempotence_verification"
+    )
+    assert known_entity_case["selected_workflow_id"] in (
+        known_entity_case["expected_workflow_ids"]
+    )
+    assert (
+        "#V#entity_representation_workflow"
+        not in known_entity_case["expected_workflow_ids"]
+    )
 
     signal_by_id = {
         signal.get("signal_id"): signal

--- a/tests/backend/test_turn_execution_record_service_execution_summary.py
+++ b/tests/backend/test_turn_execution_record_service_execution_summary.py
@@ -235,6 +235,191 @@ def test_distinct_same_tool_effect_failure_is_not_masked_by_success() -> None:
     assert record["completion_gate"]["safe_to_claim_completion"] is False
 
 
+def test_exact_recovery_metadata_supersedes_unchanged_failed_effect() -> None:
+    record = _build_effect_projection_record(
+        "req-exact-recovery",
+        [
+            {
+                "tool": "add_relationship",
+                "status": "error",
+                "effective_arguments": {
+                    "source_id": "#V#person",
+                    "predicate": "#V#has_affiliation",
+                    "target_id": "#V#university",
+                },
+                "effect_id": "effect_attempt_failed",
+                "effect_status": "failed",
+                "changed": False,
+                "mutation_outcome": "not_started",
+                "recovery_status": "succeeded",
+                "recovered_by_effect_id": "effect_attempt_succeeded",
+                "error_code": "complex_create_requires_typed_effects",
+            },
+            {
+                "tool": "add_relationship",
+                "status": "ok",
+                "effective_arguments": {
+                    "source_id": "#V#person",
+                    "predicate": "#V#has_affiliation",
+                    "target_id": "#V#university",
+                },
+                "effect_id": "effect_attempt_succeeded",
+                "effect_status": "succeeded",
+                "changed": True,
+                "mutation_outcome": "succeeded",
+            },
+            {
+                "tool": "find_relations_with_argument",
+                "status": "ok",
+                "effective_payload": {
+                    "success": True,
+                    "hits": [
+                        {
+                            "source_concept_id": "#V#person",
+                            "predicate_concept_id": "#V#has_affiliation",
+                            "target_concept_id": "#V#university",
+                        }
+                    ],
+                },
+            },
+        ],
+    )
+
+    failed_effect = next(
+        effect
+        for effect in record["required_effects"]
+        if effect["effect_id"] == "effect_attempt_failed"
+    )
+    successful_effect = next(
+        effect
+        for effect in record["required_effects"]
+        if effect["effect_id"] == "effect_attempt_succeeded"
+    )
+    assert failed_effect["status"] == "satisfied"
+    assert failed_effect["failure_codes"] == []
+    assert failed_effect["recovery_status"] == "succeeded"
+    assert failed_effect["recovered_by_effect_id"] == "effect_attempt_succeeded"
+    assert failed_effect["postcondition_strategy"] == "execution_observed"
+    assert successful_effect["status"] == "satisfied"
+    checks = {
+        check["effect_id"]: check
+        for check in record["postcondition_checks"]
+        if check["effect_id"] in {"effect_attempt_failed", "effect_attempt_succeeded"}
+    }
+    assert checks["effect_attempt_failed"]["status"] == "verified"
+    assert checks["effect_attempt_failed"]["verification_mode"] == "execution_observed"
+    assert checks["effect_attempt_succeeded"]["status"] == "verified"
+    assert (
+        checks["effect_attempt_succeeded"]["verification_mode"]
+        == "state_requery_correlated"
+    )
+    assert record["completion_gate"]["decision"] == "completed"
+    assert record["completion_gate"]["safe_to_claim_completion"] is True
+    assert record["execution"]["tool_invocations"][0]["recovery_status"] == (
+        "succeeded"
+    )
+    assert (
+        record["execution"]["tool_invocations"][0]["recovered_by_effect_id"]
+        == "effect_attempt_succeeded"
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "recovery_status",
+        "recovered_by_effect_id",
+        "recovery_transport_succeeded",
+        "recovery_effect_status",
+    ),
+    [
+        ("succeeded", "effect_missing", True, "succeeded"),
+        ("succeeded", "effect_recovery", False, "failed"),
+        ("failed", "effect_recovery", True, "succeeded"),
+        ("succeeded", "effect_recovery", True, "partial"),
+    ],
+)
+def test_wrong_or_unlinked_recovery_metadata_remains_blocking(
+    recovery_status: str,
+    recovered_by_effect_id: str,
+    recovery_transport_succeeded: bool,
+    recovery_effect_status: str,
+) -> None:
+    recovery_invocation = {
+        "tool": "add_relationship",
+        "status": "ok" if recovery_transport_succeeded else "error",
+        "effective_arguments": {
+            "source_id": "#V#person",
+            "predicate": "#V#has_affiliation",
+            "target_id": "#V#university",
+        },
+        "effect_id": "effect_recovery",
+        "effect_status": recovery_effect_status,
+        "changed": recovery_transport_succeeded,
+        "mutation_outcome": recovery_effect_status,
+    }
+    invocations = [
+        {
+            "tool": "add_relationship",
+            "status": "error",
+            "effective_arguments": {
+                "source_id": "#V#person",
+                "predicate": "#V#has_affiliation",
+                "target_id": "#V#university",
+            },
+            "effect_id": "effect_failed",
+            "effect_status": "failed",
+            "changed": False,
+            "mutation_outcome": "not_started",
+            "recovery_status": recovery_status,
+            "recovered_by_effect_id": recovered_by_effect_id,
+        },
+        recovery_invocation,
+    ]
+    if recovery_effect_status == "succeeded":
+        invocations.append(
+            {
+                "tool": "find_relations_with_argument",
+                "status": "ok",
+                "effective_payload": {
+                    "success": True,
+                    "hits": [
+                        {
+                            "source_concept_id": "#V#person",
+                            "predicate_concept_id": "#V#has_affiliation",
+                            "target_concept_id": "#V#university",
+                        }
+                    ],
+                },
+            }
+        )
+
+    record = _build_effect_projection_record(
+        "req-invalid-recovery-"
+        f"{recovery_status}-{recovered_by_effect_id}-"
+        f"{recovery_transport_succeeded}-{recovery_effect_status}",
+        invocations,
+    )
+
+    failed_effect = next(
+        effect
+        for effect in record["required_effects"]
+        if effect["effect_id"] == "effect_failed"
+    )
+    assert failed_effect["status"] == "not_executed"
+    assert failed_effect["recovery_status"] == recovery_status
+    assert failed_effect["recovered_by_effect_id"] == recovered_by_effect_id
+    assert failed_effect["failure_codes"]
+    assert (
+        next(
+            check
+            for check in record["postcondition_checks"]
+            if check["effect_id"] == "effect_failed"
+        )["status"]
+        == "not_verified"
+    )
+    assert record["completion_gate"]["safe_to_claim_completion"] is False
+
+
 @pytest.mark.parametrize(
     ("invocation_status", "effect_status", "mutation_outcome"),
     [
@@ -1262,6 +1447,9 @@ def test_durable_workflow_terminal_reconciles_timed_out_turn_effect(
         "instance_id": "instance-durable-late",
         "terminal_status": "completed",
         "effect_status": "succeeded",
+        "domain_postcondition_status": (
+            "not_established_by_workflow_terminal"
+        ),
         "changed": True,
         "outcome_finality": "canonical_durable_terminal",
         "final_state": "#V#completed_state",

--- a/tests/backend/test_workflow_selector_benchmark_service.py
+++ b/tests/backend/test_workflow_selector_benchmark_service.py
@@ -181,7 +181,7 @@ def test_load_selector_routing_benchmark_cases_supports_entity_representation_ca
     assert result["case_set"] == "entity_representation_generalisation"
 
     cases = result["cases"]
-    assert len(cases) == 10
+    assert len(cases) == 11
     assert any(
         case.case_id == "entity_people_follow_up_reasoning_override"
         for case in cases
@@ -194,6 +194,15 @@ def test_load_selector_routing_benchmark_cases_supports_entity_representation_ca
         case.case_id == "entity_event_write_with_capture_verb"
         for case in cases
     )
+    known_entity_case = next(
+        case
+        for case in cases
+        if case.case_id == "entity_known_person_idempotence_verification"
+    )
+    assert known_entity_case.allowed_workflow_ids == (
+        "#V#concept_search_instance_retrieval_workflow",
+        "#V#tool_calling_workflow",
+    )
 
 
 def test_build_selector_routing_benchmark_report_for_entity_representation_case_set() -> None:
@@ -203,20 +212,20 @@ def test_build_selector_routing_benchmark_report_for_entity_representation_case_
 
     assert result["success"] is True
     metrics = result["metrics"]
-    assert metrics["scanned_count"] == 10
-    assert metrics["matched_case_count"] == 10
+    assert metrics["scanned_count"] == 11
+    assert metrics["matched_case_count"] == 11
     assert metrics["selector_accuracy_pct"] == 100.0
     assert metrics["baseline_accuracy_pct"] == 0.0
     assert metrics["accuracy_improvement_pct"] == 100.0
     assert metrics["abstain_case_count"] == 0
     assert metrics["abstain_matched_count"] == 0
     assert metrics["misrouting_count"] == 0
-    assert metrics["outcome_label_counts"]["successful_completion"] == 10
+    assert metrics["outcome_label_counts"]["successful_completion"] == 11
     assert metrics["outcome_label_counts"]["abstain_escalate_no_safe_route"] == 0
     assert metrics["outcome_label_counts"]["tool_or_workflow_misrouting"] == 0
 
     replay_cases = result["replay_cases"]
-    assert len(replay_cases) == 10
+    assert len(replay_cases) == 11
     follow_up_case = next(
         case
         for case in replay_cases
@@ -224,6 +233,19 @@ def test_build_selector_routing_benchmark_report_for_entity_representation_case_
     )
     assert follow_up_case["selected_workflow_id"] == "#V#entity_representation_workflow"
     assert follow_up_case["overall_outcome"] == "successful_completion"
+    known_entity_case = next(
+        case
+        for case in replay_cases
+        if case["case_id"] == "entity_known_person_idempotence_verification"
+    )
+    assert known_entity_case["selected_workflow_id"] in (
+        known_entity_case["expected_workflow_ids"]
+    )
+    assert (
+        "#V#entity_representation_workflow"
+        not in known_entity_case["expected_workflow_ids"]
+    )
+    assert known_entity_case["overall_outcome"] == "successful_completion"
 
     signal_by_id = {
         signal["signal_id"]: signal for signal in result["benchmark_signals"]

--- a/tests/backend/test_workflow_template_profile_service.py
+++ b/tests/backend/test_workflow_template_profile_service.py
@@ -145,6 +145,9 @@ def test_entity_template_seed_pins_origin_main_unversioned_authority_digests() -
             "4": [
                 "bebaf90d6603fa63acdd1dcb363f8cb932c61d5ed45270064a7401c1f1cef23b"
             ],
+            "5": [
+                "33321addf574eeed20ea11bb0aa879d31cbfdf821ff1b12bbc2e46284b3d41a7"
+            ],
         },
         WORKFLOW_CREATION_COMPANY_TEMPLATE_ID: {
             "unversioned": [
@@ -152,6 +155,9 @@ def test_entity_template_seed_pins_origin_main_unversioned_authority_digests() -
             ],
             "4": [
                 "1b567d6c833201a3e48953e6c8df416913c118dcc31b4b446f1a2f316658aeef"
+            ],
+            "5": [
+                "39336dd71db1c92a53506d7a9ae8b863109cc39d2aaced06a9fdbaa80d50c7a9"
             ],
         },
         WORKFLOW_CREATION_EVENT_TEMPLATE_ID: {
@@ -161,6 +167,9 @@ def test_entity_template_seed_pins_origin_main_unversioned_authority_digests() -
             "4": [
                 "5c13822c0a2bc0f782dfda7b50966a2173029cf18797af64816479bc43360623"
             ],
+            "5": [
+                "ee854744c22e256a8757061f5d549c0bff1b6ce1fc96e18111d9cffcd4f91a73"
+            ],
         },
         WORKFLOW_CREATION_PLACE_TEMPLATE_ID: {
             "unversioned": [
@@ -168,6 +177,9 @@ def test_entity_template_seed_pins_origin_main_unversioned_authority_digests() -
             ],
             "4": [
                 "7eee095c5dd2d63ed60f5500350fdba48dc3c5fd87c16a1300a7e94ae411140d"
+            ],
+            "5": [
+                "eb5380690cddfbfea3b405c673d36665bbe0017cdcea61542fcdd9dc6828c181"
             ],
         },
     }
@@ -296,7 +308,10 @@ def test_resolve_workflow_spec_template_renders_person_representation_template(
     assert materialise_transitions[0]["to_state"] == "render_existing_ambiguity"
     assert materialise_transitions[1]["condition_spec"] == {"kind": "always"}
     assert materialise_transitions[1]["to_state"] == "read_back_concept"
-    assert steps_by_id["read_back_concept"]["inputs"]["tool_name"] == ("fetch_concept")
+    assert steps_by_id["read_back_concept"]["inputs"] == {
+        "tool_name": "fetch_concept",
+        "concept_id": {"$context_key": "entity_representation_concept_id"},
+    }
     assert steps_by_id["read_back_has_names"]["inputs"] == {
         "tool_name": "get_text_relations",
         "concept_id": {"$context_key": "entity_representation_concept_id"},
@@ -358,6 +373,16 @@ def test_resolve_workflow_spec_template_renders_person_representation_template(
         isinstance(item, dict)
         and item.get("predicate") == "#V#hasWorkflowDiscoveryExemplarsJson"
         for item in text_relations
+    )
+    discovery_payload = next(
+        json.loads(str(item["text"]))
+        for item in text_relations
+        if isinstance(item, dict)
+        and item.get("predicate") == "#V#hasWorkflowDiscoveryExemplarsJson"
+    )
+    assert any(
+        "smallest adequate read-only capability plan" in str(note)
+        for note in discovery_payload.get("routing_notes") or []
     )
 
 
@@ -456,6 +481,10 @@ def test_nonperson_templates_preserve_requested_fact_coverage_until_complete(
     assert materialise_transitions[0]["to_state"] == "render_existing_ambiguity"
     assert materialise_transitions[1]["condition_spec"] == {"kind": "always"}
     assert materialise_transitions[1]["to_state"] == "read_back_concept"
+    assert steps_by_id["read_back_concept"]["inputs"] == {
+        "tool_name": "fetch_concept",
+        "concept_id": {"$context_key": "entity_representation_concept_id"},
+    }
 
     finalise_assignments = {
         assignment["key"]: assignment
@@ -592,7 +621,7 @@ def test_entity_templates_migrate_only_exact_known_unversioned_authority(
             limit=5,
         )
         profile = json.loads(str(profile_rows[0]["text"]))
-        assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "5"
+        assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "6"
 
 
 def test_template_migration_accepts_an_exact_registered_numeric_legacy_payload(
@@ -628,7 +657,7 @@ def test_template_migration_accepts_an_exact_registered_numeric_legacy_payload(
         limit=5,
     )[0]
     profile = json.loads(str(profile_row["text"]))
-    assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "5"
+    assert profile[WORKFLOW_TEMPLATE_REPO_SEED_VERSION_FIELD] == "6"
     receipt = dict(profile_row.get("context") or {}).get(
         service._SEED_MIGRATION_RECEIPT_CONTEXT_KEY
     )

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -372,6 +372,8 @@ def test_succeeded_person_core_only_workflow_receipt_requires_non_semantic_follo
     assert follow_up["semantic_effect"] is False
     assert follow_up["semantic_outcome"] == "follow_up_required"
     assert follow_up["semantic_outcome"] != "completed"
+    assert follow_up["change_kind"] == "workflow_instance_operational_state"
+    assert follow_up["operational_changed"] is True
 
 
 @pytest.mark.parametrize("semantic_outcome", ["blocked", "failed", "not_completed"])


### PR DESCRIPTION
## Outcome

- exposes a single executable missing-prefix recovery for concept-valued and custom text-valued scoped predicates after visibility, typing, and value-kind checks
- reconciles an unchanged failed attempt only against its exact successful recovery, including target, language, audience scope, and provenance
- preserves failed receipts while requiring the named recovery effect to pass its own canonical postcondition check
- types workflow-instance change as operational and appends late terminal outcomes to the existing conversation observation carrier without claiming domain success
- keeps exact read-only idempotence verification off mutation-capable entity representation while allowing either adequate read-only route

## Anti-ratchet boundary

This removes the rejected model-linked obligation ledger. It adds no model-supplied obligation IDs, universal finality controller, semantic classifier, retry loop, second journal, hard timeout, or route-specific runtime gate. The Marc selector case is a non-exclusive regression fixture, not a required execution route or end-to-end completion claim.

## Validation

- `tests/backend/test_adaptive_turn_service.py`: 199 passed
- scoped assertion, Turn Execution Record, workflow receipt, and affected durable-terminal coverage: changed cases pass
- routing/seed coverage: 40 passed; one unchanged PhD-template/default-marker baseline failure remains
- catalogue builds: 46 passed
- chat UI: 266 passed
- JSON parse, Python compilation, changed-file Ruff E9/F, frontend static lint, and diff check pass

A broad durable-workflow run also produced 196 passes and 11 unrelated worker-claim failures because the current environment requires `durable_exact_workflow_authority_snapshot.v1`; this candidate does not alter worker eligibility.

Jira: JVNAUTOSCI-2646
