### PR TITLE
Recover actor-private referents from ontology ID collisions

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -37,6 +37,10 @@ from pathlib import Path
 from typing import Any, List, Mapping, Sequence, cast
 
 from pymongo import DESCENDING
+from src.backend.services.actor_scoped_referent_identity_service import (
+    ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+    ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+)
 from src.backend.services.workflow_actor_scope_service import WorkflowActorScopeError
 
 from .dynamic_tool_loader import load_dynamic_method_definitions
@@ -1566,6 +1570,45 @@ def _create_concepts_input_placement_error(
                     "Use duplicate_resolution_mode='canonical_id_only' only "
                     "for deterministic stable identities"
                 ),
+            ],
+        )
+    collision_resolution_mode = arguments.get("collision_resolution_mode")
+    if (
+        collision_resolution_mode is not None
+        and collision_resolution_mode != ACTOR_SCOPED_REFERENT_COLLISION_MODE
+    ):
+        return make_error_response(
+            "invalid_parameter",
+            (
+                "Invalid collision_resolution_mode "
+                f"'{collision_resolution_mode}'."
+            ),
+            details={
+                "collision_resolution_mode": collision_resolution_mode,
+                "supported_collision_resolution_modes": [
+                    ACTOR_SCOPED_REFERENT_COLLISION_MODE
+                ],
+            },
+            suggestions=[
+                (
+                    "Use only the exact arguments from a "
+                    f"{ACTOR_SCOPED_REFERENT_RECOVERY_ACTION} affordance"
+                )
+            ],
+        )
+    if collision_resolution_mode == ACTOR_SCOPED_REFERENT_COLLISION_MODE and not (
+        isinstance(arguments.get("requested_concept_id"), str)
+        and str(arguments.get("requested_concept_id")).strip()
+    ):
+        return make_error_response(
+            "invalid_parameter",
+            "Actor-scoped referent recovery requires requested_concept_id.",
+            details={"missing": ["requested_concept_id"]},
+            suggestions=[
+                (
+                    "Execute the complete arguments from the original "
+                    f"{ACTOR_SCOPED_REFERENT_RECOVERY_ACTION} affordance"
+                )
             ],
         )
     return None
@@ -10131,7 +10174,9 @@ def _concepts_create_input_schema() -> Schema:
             "concepts": list,
         },
         optional={
+            "collision_resolution_mode": (str, type(None)),
             "duplicate_resolution_mode": (str, type(None)),
+            "requested_concept_id": (str, type(None)),
             "namespace": (str, type(None)),
             "scope_mode": (str, type(None)),
             "visibility_scope_mode": (str, type(None)),
@@ -10139,6 +10184,10 @@ def _concepts_create_input_schema() -> Schema:
             "organisation_concept_id": (str, type(None)),
         },
         enum_values={
+            "collision_resolution_mode": [
+                ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+                None,
+            ],
             "duplicate_resolution_mode": [
                 _CREATE_CONCEPTS_DUPLICATE_RESOLUTION_CANONICAL_ID_ONLY,
                 None,
@@ -10154,6 +10203,16 @@ def _concepts_create_input_schema() -> Schema:
             "relationship type. duplicate_resolution_mode='canonical_id_only' "
             "skips semantic name resolution after an exact concept-ID miss; "
             "omitting it preserves the default semantic fallback. This governed "
+            "effect idempotently reuses an exact actor-visible concept only when "
+            "canonical read-back verifies the requested core. When an actor-hidden "
+            "ID collision prevents an instance create, the failure may advertise "
+            f"one executable {ACTOR_SCOPED_REFERENT_RECOVERY_ACTION} action. "
+            "Use that action's complete arguments to opt into "
+            "collision_resolution_mode='actor_scoped_referent'; the server derives "
+            "the actor-private ID from trusted actor context and does not create an "
+            "alias or identity/equivalence assertion. Recovery mode treats "
+            "requested_concept_id only as an identity seed; it does not inspect or "
+            "confirm whether that ID is occupied. This governed "
             "effect does not accept batched concepts, external identity or identity "
             "review fields, attributes, tags, linked concepts, duplicate suffixing, "
             "or multiple parents. Add further classifications or relationships "
@@ -10176,17 +10235,27 @@ def _concepts_create_output_schema() -> Schema:
             "successful": int,
         },
         optional={
+            "actor_scoped_referent": (dict,),
+            "created_concept_ids": (list,),
             "scope_selection": (dict,),
             "success": (bool,),
             "effect_status": (str,),
             "changed": (bool, type(None)),
+            "idempotent_reuse": (bool,),
+            "resolved_concept_ids": (list,),
             "partial_failure_count": (int,),
             "partial_failures": (list,),
             "indeterminate_failure_count": (int,),
             "indeterminate_failures": (list,),
         },
         allow_unknown=True,
-        description="create_concepts output: results (list of creation results), total (int), successful (int)",
+        description=(
+            "create_concepts output: results, total, and successful describe the "
+            "single governed outcome. A compatible actor-visible exact reuse sets "
+            "changed=false, idempotent_reuse=true, and resolved_concept_ids. "
+            "Actor-scoped collision recovery also returns actor_scoped_referent "
+            "metadata that explicitly says no alias or equivalence was asserted."
+        ),
     )
 
 
@@ -37732,8 +37801,16 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "concept specification with name and optional concept_id, kind, "
                 "description, notes, vontology_path, or instance_of_type. kind is "
                 "'instance' for an individual, 'type' for a subtype/default, or "
-                "'predicate' for a relationship type. This governed effect does "
-                "not bundle batches, external identities, identity review, "
+                "'predicate' for a relationship type. This governed effect "
+                "idempotently reuses an exact actor-visible concept when canonical "
+                "read-back verifies the requested core. An actor-hidden instance-ID "
+                "collision can expose one explicit executable actor-private "
+                "referent recovery action; executing its complete arguments creates "
+                "or reuses a server-derived ID without aliasing or asserting "
+                "identity. Recovery mode uses the requested ID only as a seed and "
+                "does not inspect or confirm whether it is occupied. It does not "
+                "bundle batches, external identities, "
+                "identity review, "
                 "attributes, tags, links, duplicate suffixing, or multiple parents. "
                 "Use separate add_relationship effects with exact existing "
                 "predicate IDs for further classifications or relationships, and "

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -983,7 +983,7 @@
         },
         {
             "name": "create_concepts",
-            "description": "Create exactly one governed core concept per effect. Supply one concept specification with name and optional concept_id, kind, description, notes, vontology_path, or instance_of_type. kind is 'instance' for an individual, 'type' for a subtype/default, or 'predicate' for a relationship type. This governed effect does not bundle batches, external identities, identity review, attributes, tags, links, duplicate suffixing, or multiple parents. Use separate add_relationship effects with exact existing predicate IDs for further classifications or relationships, and use add_names afterward for alternative names or translations. Ordinary-turn creation is actor-private; direct governed callers may select a broader scope only with matching authority.",
+            "description": "Create exactly one governed core concept per effect. Supply one concept specification with name and optional concept_id, kind, description, notes, vontology_path, or instance_of_type. kind is 'instance' for an individual, 'type' for a subtype/default, or 'predicate' for a relationship type. This governed effect idempotently reuses an exact actor-visible concept when canonical read-back verifies the requested core. An actor-hidden instance-ID collision can expose one explicit executable actor-private referent recovery action; executing its complete arguments creates or reuses a server-derived ID without aliasing or asserting identity. Recovery mode uses the requested ID only as a seed and does not inspect or confirm whether it is occupied. It does not bundle batches, external identities, identity review, attributes, tags, links, duplicate suffixing, or multiple parents. Use separate add_relationship effects with exact existing predicate IDs for further classifications or relationships, and use add_names afterward for alternative names or translations. Ordinary-turn creation is actor-private; direct governed callers may select a broader scope only with matching authority.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -994,6 +994,16 @@
                         "type": "array",
                         "items": {}
                     },
+                    "collision_resolution_mode": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "enum": [
+                            "actor_scoped_referent",
+                            null
+                        ]
+                    },
                     "duplicate_resolution_mode": {
                         "type": [
                             "string",
@@ -1002,6 +1012,12 @@
                         "enum": [
                             "canonical_id_only",
                             null
+                        ]
+                    },
+                    "requested_concept_id": {
+                        "type": [
+                            "string",
+                            "null"
                         ]
                     },
                     "scope_mode": {
@@ -1030,7 +1046,7 @@
                     "concepts"
                 ],
                 "additionalProperties": true,
-                "description": "Governed create_concepts input: parent_id is one exact semantic type concept ID, and concepts must contain exactly one core concept specification: {name, concept_id?, kind?, description?, notes?, vontology_path?, instance_of_type?}. kind is 'instance' for an individual, 'type' for a subtype (the default), or 'predicate' for a relationship type. duplicate_resolution_mode='canonical_id_only' skips semantic name resolution after an exact concept-ID miss; omitting it preserves the default semantic fallback. This governed effect does not accept batched concepts, external identity or identity review fields, attributes, tags, linked concepts, duplicate suffixing, or multiple parents. Add further classifications or relationships after creation through separate add_relationship effects using exact existing predicate IDs. Governed creation defaults to actor-private visibility. Direct governed callers with matching authority may use scope_mode='organisation_general' or scope_mode='global_general'. Optional namespace is propagated for tenancy attribution. Unknown top-level fields remain tolerated for orchestrator-added context but do not enlarge the governed effect."
+                "description": "Governed create_concepts input: parent_id is one exact semantic type concept ID, and concepts must contain exactly one core concept specification: {name, concept_id?, kind?, description?, notes?, vontology_path?, instance_of_type?}. kind is 'instance' for an individual, 'type' for a subtype (the default), or 'predicate' for a relationship type. duplicate_resolution_mode='canonical_id_only' skips semantic name resolution after an exact concept-ID miss; omitting it preserves the default semantic fallback. This governed effect idempotently reuses an exact actor-visible concept only when canonical read-back verifies the requested core. When an actor-hidden ID collision prevents an instance create, the failure may advertise one executable create_actor_scoped_referent_after_id_conflict action. Use that action's complete arguments to opt into collision_resolution_mode='actor_scoped_referent'; the server derives the actor-private ID from trusted actor context and does not create an alias or identity/equivalence assertion. Recovery mode treats requested_concept_id only as an identity seed; it does not inspect or confirm whether that ID is occupied. This governed effect does not accept batched concepts, external identity or identity review fields, attributes, tags, linked concepts, duplicate suffixing, or multiple parents. Add further classifications or relationships after creation through separate add_relationship effects using exact existing predicate IDs. Governed creation defaults to actor-private visibility. Direct governed callers with matching authority may use scope_mode='organisation_general' or scope_mode='global_general'. Optional namespace is propagated for tenancy attribution. Unknown top-level fields remain tolerated for orchestrator-added context but do not enlarge the governed effect."
             }
         },
         {

--- a/src/backend/services/actor_scoped_referent_identity_service.py
+++ b/src/backend/services/actor_scoped_referent_identity_service.py
@@ -1,0 +1,67 @@
+"""Deterministic identities for actor-private concept referent recovery.
+
+This module owns only the mechanical identity rule used after an exact
+concept-ID collision.  A derived identifier denotes a new actor-private
+referent.  It does not alias, merge, or assert equivalence with the concept
+occupying the requested identifier.  The requested identifier is only a seed;
+this module does not inspect or confirm whether it is occupied.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+ACTOR_SCOPED_REFERENT_COLLISION_MODE = "actor_scoped_referent"
+ACTOR_SCOPED_REFERENT_RECOVERY_ACTION = "create_actor_scoped_referent_after_id_conflict"
+ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT = "ontology_actor_scoped_instance_referent.v1"
+ACTOR_SCOPED_REFERENT_SCOPE_MODE = "user_only_default"
+
+
+def actor_scoped_referent_concept_id(
+    *,
+    requested_concept_id: str,
+    actor_concept_id: str,
+) -> str:
+    """Return a stable actor-bound ID without exposing the actor identity.
+
+    The fixed scope and instance-only contract are included in the digest so a
+    future, semantically different recovery mode cannot accidentally share the
+    same identity space.
+    """
+
+    requested_id = canonicalise_vontology_concept_id(requested_concept_id)
+    actor_id = canonicalise_vontology_concept_id(actor_concept_id)
+    if not requested_id or not actor_id:
+        raise ValueError(
+            "requested_concept_id and trusted actor_concept_id are required"
+        )
+
+    material = json.dumps(
+        {
+            "actor_concept_id": actor_id,
+            "kind": "instance",
+            "requested_concept_id": requested_id,
+            "schema_version": ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+            "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(material).hexdigest()[:24]
+    requested_slug = requested_id.removeprefix("#V#")[:48].strip("_")
+    if not requested_slug:
+        requested_slug = "concept"
+    return f"#V#scoped_referent_{requested_slug}_{digest}"
+
+
+__all__ = [
+    "ACTOR_SCOPED_REFERENT_COLLISION_MODE",
+    "ACTOR_SCOPED_REFERENT_RECOVERY_ACTION",
+    "ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT",
+    "ACTOR_SCOPED_REFERENT_SCOPE_MODE",
+    "actor_scoped_referent_concept_id",
+]

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -42,6 +42,12 @@ from src.backend.languagemodels.structured_tool_calling.types import (
     ToolResult,
 )
 from src.backend.security.access_control import override_current_actor
+from src.backend.services.actor_scoped_referent_identity_service import (
+    ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+    ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+    ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+    ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+)
 from src.backend.services.llm_usage_cost_service import (
     build_llm_usage_cost_summary,
 )
@@ -56,6 +62,7 @@ from src.backend.services.turn_evidence_store import (
     TrustedTurnScope,
     TurnEvidenceStore,
 )
+from src.backend.utils.concept_id_utils import canonicalise_vontology_concept_id
 from src.backend.workflows.conversation_turn_llm_timeout import (
     coerce_conversation_turn_llm_advisory_sec,
     default_conversation_turn_llm_advisory_sec,
@@ -5373,15 +5380,19 @@ def _effect_requires_turn_finality(
         if isinstance(raw_payload, Mapping)
         else ""
     )
-    if (
-        effect_status == "not_started"
-        and changed is False
-        and isinstance(raw_payload, Mapping)
-        and raw_payload.get("error_code")
-        in {
-            "capability_arguments_invalid",
-            "effect_request_unchanged_after_terminal_failure",
-        }
+    error_code = (
+        raw_payload.get("error_code") if isinstance(raw_payload, Mapping) else None
+    )
+    if changed is False and (
+        (
+            effect_status == "not_started"
+            and error_code
+            in {
+                "capability_arguments_invalid",
+                "effect_request_unchanged_after_terminal_failure",
+            }
+        )
+        or error_code == "invalid_capability_arguments"
     ):
         # Input validation and exact-request suppression both run before the
         # handler. The feedback remains visible to the model, but neither guard
@@ -6238,9 +6249,73 @@ def execute_adaptive_turn(
             )
         return hashlib.sha256(_json_bytes(semantic_identity)).hexdigest()
 
+    def actor_scoped_referent_recovery_key(
+        capability_name: str,
+        arguments: Mapping[str, Any],
+        *,
+        recovery_contract: str,
+    ) -> str | None:
+        """Identify one server-authored actor-private referent recovery."""
+
+        if (
+            capability_name != "create_concepts"
+            or recovery_contract != ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT
+            or str(arguments.get("collision_resolution_mode") or "").strip()
+            != ACTOR_SCOPED_REFERENT_COLLISION_MODE
+            or str(arguments.get("scope_mode") or "").strip().lower()
+            != ACTOR_SCOPED_REFERENT_SCOPE_MODE
+        ):
+            return None
+        requested_id = str(arguments.get("requested_concept_id") or "").strip()
+        parent_id = str(arguments.get("parent_id") or "").strip()
+        concepts = arguments.get("concepts")
+        if (
+            not requested_id.startswith("#V#")
+            or not parent_id.startswith("#V#")
+            or not isinstance(concepts, Sequence)
+            or isinstance(concepts, (str, bytes, bytearray))
+            or len(concepts) != 1
+            or not isinstance(concepts[0], Mapping)
+        ):
+            return None
+        concept = concepts[0]
+        effective_id = str(concept.get("concept_id") or "").strip()
+        kind = str(concept.get("kind") or "").strip().lower()
+        if not effective_id.startswith("#V#") or kind not in {"instance", "individual"}:
+            return None
+        core_fields = {
+            key: concept.get(key)
+            for key in (
+                "concept_id",
+                "description",
+                "instance_of_type",
+                "kind",
+                "name",
+                "notes",
+                "vontology_path",
+            )
+            if key in concept
+        }
+        semantic_identity = {
+            "recovery_contract": recovery_contract,
+            "tool": capability_name,
+            "parent_id": parent_id,
+            "requested_concept_id": requested_id,
+            "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+            "duplicate_resolution_mode": str(
+                arguments.get("duplicate_resolution_mode") or ""
+            ).strip(),
+            "concept": core_fields,
+        }
+        return hashlib.sha256(_json_bytes(semantic_identity)).hexdigest()
+
     def remember_recovery_affordance(
         *,
         effect_id: str,
+        capability_name: str,
+        arguments: Mapping[str, Any],
+        effect_status: str,
+        changed: bool | None,
         payload: Any,
     ) -> None:
         if not isinstance(payload, Mapping):
@@ -6255,6 +6330,79 @@ def execute_adaptive_turn(
             if not isinstance(affordance, Mapping):
                 continue
             action_type = str(affordance.get("action_type") or "").strip()
+            if action_type == ACTOR_SCOPED_REFERENT_RECOVERY_ACTION:
+                if not (
+                    capability_name == "create_concepts"
+                    and effect_status == "not_started"
+                    and changed is False
+                    and payload.get("success") is False
+                    and payload.get("mutation_outcome") == "not_started"
+                    and payload.get("error_code")
+                    == "ontology_create_concept_id_conflict"
+                ):
+                    continue
+                recovery_contract = str(
+                    affordance.get("recovery_contract") or ""
+                ).strip()
+                if recovery_contract != ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT:
+                    continue
+                tool_name = str(affordance.get("tool") or "").strip()
+                alternative_arguments = affordance.get("arguments")
+                if not isinstance(alternative_arguments, Mapping):
+                    continue
+                recovery_key = actor_scoped_referent_recovery_key(
+                    tool_name,
+                    alternative_arguments,
+                    recovery_contract=recovery_contract,
+                )
+                original_concepts = arguments.get("concepts")
+                recovery_concepts = alternative_arguments.get("concepts")
+                original_concept = (
+                    original_concepts[0]
+                    if isinstance(original_concepts, Sequence)
+                    and not isinstance(original_concepts, (str, bytes, bytearray))
+                    and len(original_concepts) == 1
+                    and isinstance(original_concepts[0], Mapping)
+                    else None
+                )
+                recovery_concept = (
+                    recovery_concepts[0]
+                    if isinstance(recovery_concepts, Sequence)
+                    and not isinstance(recovery_concepts, (str, bytes, bytearray))
+                    and len(recovery_concepts) == 1
+                    and isinstance(recovery_concepts[0], Mapping)
+                    else None
+                )
+                original_requested_id = canonicalise_vontology_concept_id(
+                    (
+                        original_concept.get("concept_id")
+                        or original_concept.get("name")
+                    )
+                    if original_concept is not None
+                    else None
+                )
+                recovery_requested_id = canonicalise_vontology_concept_id(
+                    alternative_arguments.get("requested_concept_id")
+                )
+                original_parent_id = canonicalise_vontology_concept_id(
+                    arguments.get("parent_id")
+                )
+                recovery_parent_id = canonicalise_vontology_concept_id(
+                    alternative_arguments.get("parent_id")
+                )
+                affordance_matches_failure = bool(
+                    original_concept is not None
+                    and recovery_concept is not None
+                    and original_requested_id
+                    and original_requested_id == recovery_requested_id
+                    and original_parent_id
+                    and original_parent_id == recovery_parent_id
+                )
+                if recovery_key is not None and affordance_matches_failure:
+                    recoverable_effect_ids.setdefault(recovery_key, []).append(
+                        effect_id
+                    )
+                continue
             recovery_contract = {
                 "assert_in_actor_scope": "actor_scope_alternative",
                 "retry_exact_scoped_assertion_with_canonical_predicate_id": (
@@ -6282,12 +6430,80 @@ def execute_adaptive_turn(
         capability_name: str,
         arguments: Mapping[str, Any],
         effect_status: str,
+        payload: Any,
     ) -> None:
         nonlocal effect_state_generation
         if effect_status != "succeeded":
             return
         failed_effect_id = None
+        recovery_key = None
+        concepts = arguments.get("concepts")
+        referent_id = (
+            str(concepts[0].get("concept_id") or "").strip()
+            if isinstance(concepts, Sequence)
+            and not isinstance(concepts, (str, bytes, bytearray))
+            and len(concepts) == 1
+            and isinstance(concepts[0], Mapping)
+            else ""
+        )
+        referent_metadata = (
+            payload.get("actor_scoped_referent")
+            if isinstance(payload, Mapping)
+            else None
+        )
+        canonical_readback = (
+            payload.get("canonical_read_back")
+            if isinstance(payload, Mapping)
+            else None
+        )
+        readback_concepts = (
+            canonical_readback.get("concepts")
+            if isinstance(canonical_readback, Mapping)
+            else None
+        )
+        exact_actor_private_readback = bool(
+            referent_id
+            and isinstance(payload, Mapping)
+            and payload.get("success") is True
+            and isinstance(referent_metadata, Mapping)
+            and referent_metadata.get("schema_version")
+            == ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT
+            and referent_metadata.get("effective_concept_id") == referent_id
+            and referent_metadata.get("scope_mode")
+            == ACTOR_SCOPED_REFERENT_SCOPE_MODE
+            and referent_metadata.get("identity_status")
+            == "unreconciled_actor_scoped_referent"
+            and referent_metadata.get("equivalence_asserted") is False
+            and referent_metadata.get("alias_created") is False
+            and isinstance(readback_concepts, Sequence)
+            and not isinstance(readback_concepts, (str, bytes, bytearray))
+            and len(readback_concepts) == 1
+            and any(
+                isinstance(concept, Mapping)
+                and concept.get("concept_id") == referent_id
+                and concept.get("exists") is True
+                and isinstance(concept.get("publication_context"), Mapping)
+                and concept["publication_context"].get("kind") == "user"
+                and concept["publication_context"].get("concept_id")
+                == scope.user_concept_id
+                for concept in readback_concepts
+            )
+        )
+        if exact_actor_private_readback:
+            recovery_key = actor_scoped_referent_recovery_key(
+                capability_name,
+                arguments,
+                recovery_contract=ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+            )
+        if recovery_key is not None:
+            pending_effect_ids = recoverable_effect_ids.get(recovery_key)
+            if pending_effect_ids:
+                failed_effect_id = pending_effect_ids.pop(0)
+                if not pending_effect_ids:
+                    recoverable_effect_ids.pop(recovery_key, None)
         for recovery_contract in ("exact_retry", "actor_scope_alternative"):
+            if failed_effect_id is not None:
+                break
             recovery_key = scoped_assertion_recovery_key(
                 capability_name,
                 arguments,
@@ -8375,10 +8591,16 @@ def execute_adaptive_turn(
             )
             if not isinstance(arguments, Mapping):
                 raw_capability_results[index] = _ContainedCapabilityResult(
-                    raw_payload=_error_payload(
-                        "invalid_capability_arguments",
-                        "arguments must be an object.",
-                    ),
+                    raw_payload={
+                        **_error_payload(
+                            "capability_arguments_invalid",
+                            "arguments must be an object.",
+                        ),
+                        "status": "not_started",
+                        "effect_status": "not_started",
+                        "mutation_outcome": "not_started",
+                        "changed": False,
+                    },
                     transport_result=None,
                     arguments={},
                     capability_name=capability_name,
@@ -9436,6 +9658,10 @@ def execute_adaptive_turn(
                     )
                     remember_recovery_affordance(
                         effect_id=effect_identifier,
+                        capability_name=canonical_name,
+                        arguments=arguments,
+                        effect_status=effect_status,
+                        changed=changed,
                         payload=raw_payload,
                     )
                     reconcile_successful_recovery(
@@ -9443,6 +9669,7 @@ def execute_adaptive_turn(
                         capability_name=canonical_name,
                         arguments=arguments,
                         effect_status=effect_status,
+                        payload=raw_payload,
                     )
                     reconcile_successful_exact_absence_retry(
                         recovery_effect_id=effect_identifier,

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -26,6 +26,13 @@ from ..security.visibility_predicates import (
     SPECIFIC_TO_ORG_PREDICATES_READ,
     SPECIFIC_TO_USER_PREDICATES,
 )
+from .actor_scoped_referent_identity_service import (
+    ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+    ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+    ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+    ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+    actor_scoped_referent_concept_id,
+)
 from .concept_predicate_metadata_service import get_structural_inverse_map
 from .ontology_publication_authority_service import (
     RESERVED_GENERIC_MUTATION_PREDICATES,
@@ -62,6 +69,7 @@ class OntologyMutationCommandError(Exception):
     reason_code: str
     public_message: str
     error_details: Mapping[str, Any] | None = None
+    recovery_affordances: Sequence[Mapping[str, Any]] | None = None
 
     def __str__(self) -> str:
         return self.public_message
@@ -126,6 +134,18 @@ _INTENT_TRANSPORT_FIELDS = frozenset(
         "ontology_effect_id",
         "operator",
         "request_id",
+    }
+)
+
+_CREATE_CORE_CONCEPT_FIELDS = frozenset(
+    {
+        "concept_id",
+        "description",
+        "instance_of_type",
+        "kind",
+        "name",
+        "notes",
+        "vontology_path",
     }
 )
 
@@ -673,6 +693,12 @@ def _create_reference_concept_ids(arguments: Mapping[str, Any]) -> tuple[str, ..
             concept_id = None
         if concept_id:
             references.append(concept_id)
+    for item in arguments.get("concepts") or []:
+        if not isinstance(item, Mapping):
+            continue
+        instance_type = _normalise_concept_id(item.get("instance_of_type"))
+        if instance_type:
+            references.append(instance_type)
     # Predicate creation deterministically types the child under this canonical
     # parent even though the caller supplies a general semantic parent.
     if any(
@@ -916,7 +942,60 @@ def resolve_governed_ontology_arguments(
                     requested_instance = resolved.get("create_as_instance")
                 item["kind"] = "instance" if requested_instance is True else "type"
             canonical_concepts.append(item)
+
+        raw_top_level_instance_type = resolved.get("instance_of_type")
+        top_level_instance_type = (
+            canonicalise_vontology_concept_id(raw_top_level_instance_type)
+            if _clean_text(raw_top_level_instance_type)
+            else None
+        )
+        if _clean_text(raw_top_level_instance_type) and not top_level_instance_type:
+            raise OntologyMutationCommandError(
+                "invalid_create_instance_of_type",
+                "A governed create requires one exact instance_of_type concept ID.",
+                recovery_affordances=(),
+            )
+        consolidated_concepts: list[Any] = []
+        for item in canonical_concepts:
+            if not isinstance(item, Mapping):
+                consolidated_concepts.append(item)
+                continue
+            concept_item = dict(item)
+            raw_item_instance_type = concept_item.get("instance_of_type")
+            item_instance_type = (
+                canonicalise_vontology_concept_id(raw_item_instance_type)
+                if _clean_text(raw_item_instance_type)
+                else None
+            )
+            if _clean_text(raw_item_instance_type) and not item_instance_type:
+                raise OntologyMutationCommandError(
+                    "invalid_create_instance_of_type",
+                    (
+                        "A governed create requires one exact instance_of_type "
+                        "concept ID."
+                    ),
+                    recovery_affordances=(),
+                )
+            if (
+                top_level_instance_type
+                and item_instance_type
+                and top_level_instance_type != item_instance_type
+            ):
+                raise OntologyMutationCommandError(
+                    "conflicting_create_instance_of_type",
+                    (
+                        "Top-level and per-concept instance_of_type must identify "
+                        "the same exact concept."
+                    ),
+                    recovery_affordances=(),
+                )
+            canonical_instance_type = item_instance_type or top_level_instance_type
+            if canonical_instance_type:
+                concept_item["instance_of_type"] = canonical_instance_type
+            consolidated_concepts.append(concept_item)
+        canonical_concepts = consolidated_concepts
         resolved["concepts"] = canonical_concepts
+        resolved.pop("instance_of_type", None)
 
         parent_id = resolve_parent(resolved.get("parent_id"))
         if parent_id:
@@ -945,6 +1024,94 @@ def resolve_governed_ontology_arguments(
             if not parent_id and resolved_parent_ids:
                 resolved["parent_id"] = resolved_parent_ids[0]
                 resolved["authority_resolved_parent_id"] = resolved_parent_ids[0]
+
+        collision_mode = _clean_text(resolved.get("collision_resolution_mode"))
+        if collision_mode and collision_mode != ACTOR_SCOPED_REFERENT_COLLISION_MODE:
+            raise OntologyMutationCommandError(
+                "invalid_create_collision_resolution_mode",
+                "The requested concept-ID collision resolution mode is unsupported.",
+                error_details={
+                    "supported_modes": [ACTOR_SCOPED_REFERENT_COLLISION_MODE]
+                },
+                recovery_affordances=(),
+            )
+        if collision_mode == ACTOR_SCOPED_REFERENT_COLLISION_MODE:
+            if canonical_scope_mode != ACTOR_SCOPED_REFERENT_SCOPE_MODE:
+                raise OntologyMutationCommandError(
+                    "actor_scoped_referent_requires_user_only_scope",
+                    (
+                        "Actor-scoped referent recovery is available only for "
+                        "user_only_default creation."
+                    ),
+                    recovery_affordances=(),
+                )
+            if len(canonical_concepts) != 1 or not isinstance(
+                canonical_concepts[0], Mapping
+            ):
+                raise OntologyMutationCommandError(
+                    "actor_scoped_referent_requires_single_instance",
+                    (
+                        "Actor-scoped referent recovery requires exactly one "
+                        "instance concept."
+                    ),
+                    recovery_affordances=(),
+                )
+            referent_spec = dict(canonical_concepts[0])
+            referent_kind = _clean_text(referent_spec.get("kind")).lower()
+            if referent_kind == "individual":
+                referent_kind = "instance"
+            if referent_kind != "instance":
+                raise OntologyMutationCommandError(
+                    "actor_scoped_referent_requires_instance",
+                    (
+                        "Actor-scoped referent recovery is available only for "
+                        "instance concepts."
+                    ),
+                    recovery_affordances=(),
+                )
+            requested_concept_id = canonicalise_vontology_concept_id(
+                resolved.get("requested_concept_id")
+            )
+            if not requested_concept_id:
+                raise OntologyMutationCommandError(
+                    "actor_scoped_referent_requested_id_required",
+                    (
+                        "Actor-scoped referent recovery requires the requested "
+                        "concept ID used as its deterministic identity seed."
+                    ),
+                    recovery_affordances=(),
+                )
+            # This is a caller-supplied deterministic identity seed, not an
+            # authority-bearing conflict receipt. Direct recovery mode must not
+            # inspect, confirm, or disclose whether the requested ID is occupied.
+            actor_concept_id = get_effective_user_concept_id()
+            if not actor_concept_id:
+                raise OntologyMutationCommandError(
+                    "authenticated_actor_context_required",
+                    "Trusted actor context is required for referent recovery.",
+                    recovery_affordances=(),
+                )
+            effective_concept_id = actor_scoped_referent_concept_id(
+                requested_concept_id=requested_concept_id,
+                actor_concept_id=actor_concept_id,
+            )
+            supplied_referent_id = _normalise_concept_id(
+                referent_spec.get("concept_id")
+            )
+            if supplied_referent_id != effective_concept_id:
+                raise OntologyMutationCommandError(
+                    "actor_scoped_referent_identity_mismatch",
+                    (
+                        "The supplied recovery concept ID does not match the "
+                        "server-derived actor-scoped referent identity."
+                    ),
+                    recovery_affordances=(),
+                )
+            referent_spec["concept_id"] = effective_concept_id
+            referent_spec["kind"] = "instance"
+            resolved["concepts"] = [referent_spec]
+            resolved["requested_concept_id"] = requested_concept_id
+            resolved["collision_resolution_mode"] = collision_mode
     if _clean_text(method_name) == "add_relationship":
         predicate_ref = resolved.get("predicate_ref")
         if predicate_ref is not None:
@@ -1207,36 +1374,57 @@ def build_ontology_mutation_intent(
                 "invalid_create_concept_id",
                 "A governed create requires one exact canonical concept ID.",
             )
-        if _concept_exists_unfiltered(expected_concept_id):
-            # Existing visible and inaccessible IDs deliberately share one
-            # non-disclosing conflict. A create effect never reads or reuses
-            # the colliding concept.
-            raise OntologyMutationCommandError(
-                "ontology_create_concept_id_conflict",
-                "The requested concept ID cannot be created.",
-            )
-        reference_ids = _create_reference_concept_ids(arguments)
-        _visible_or_fail(reference_ids)
-        targets = tuple(
-            dict.fromkeys((*_concepts_from_create_arguments(arguments), *reference_ids))
-        )
         parent_id = _normalise_concept_id(arguments.get("parent_id"))
         if _clean_text(concept_spec.get("kind")).lower() == "predicate":
             from ..vontology.code_concepts_registry import PREDICATE_TYPE_ID
 
             parent_id = PREDICATE_TYPE_ID
+        instance_of_type = _normalise_concept_id(
+            arguments.get("instance_of_type") or concept_spec.get("instance_of_type")
+        )
+        actor_scoped_referent = (
+            _clean_text(arguments.get("collision_resolution_mode"))
+            == ACTOR_SCOPED_REFERENT_COLLISION_MODE
+        )
+        visible_exact_reuse = False
+        if _concept_exists_unfiltered(expected_concept_id):
+            required_context = (
+                publication_context.to_mapping() if actor_scoped_referent else None
+            )
+            visible_exact_reuse = can_access_concept(
+                expected_concept_id
+            ) and _visible_concept_satisfies_requested_core(
+                concept_id=expected_concept_id,
+                concept_spec=concept_spec,
+                parent_id=parent_id,
+                instance_of_type=instance_of_type,
+                required_publication_context=required_context,
+            )
+            if not visible_exact_reuse:
+                # Visible incompatible and inaccessible IDs retain the same
+                # non-disclosing error. Only an actor-invisible instance
+                # collision can advertise the bounded scoped-referent action.
+                raise _create_id_conflict_error(
+                    arguments=arguments,
+                    expected_concept_id=expected_concept_id,
+                )
+        reference_ids = _create_reference_concept_ids(arguments)
+        _visible_or_fail(reference_ids)
+        targets = tuple(
+            dict.fromkeys((*_concepts_from_create_arguments(arguments), *reference_ids))
+        )
         delta = {
             "concept_count": len(arguments.get("concepts") or []),
             "concepts": _create_intent_concepts(arguments),
             "expected_concept_id": expected_concept_id,
             "parent_id": parent_id,
             "parent_concept_ids": list(arguments.get("parent_concept_ids") or []),
-            "instance_of_type": _normalise_concept_id(
-                arguments.get("instance_of_type")
-            ),
+            "instance_of_type": instance_of_type,
             "referenced_concept_ids": list(reference_ids),
             "scope_mode": scope_projection["effective_scope_mode"],
             "stored_scope": scope_projection,
+            "visible_exact_reuse": visible_exact_reuse,
+            "actor_scoped_referent": actor_scoped_referent,
             # Parent inverses are deliberately not canonical side effects of
             # governed creation. The child's exact forward typing assertion is
             # authoritative; reverse traversal belongs to the derived extent.
@@ -1689,6 +1877,197 @@ def _concept_read_back(concept_id: str) -> dict[str, Any]:
     }
 
 
+def _visible_concept_satisfies_requested_core(
+    *,
+    concept_id: str,
+    concept_spec: Mapping[str, Any],
+    parent_id: str | None,
+    instance_of_type: str | None,
+    required_publication_context: Mapping[str, Any] | None = None,
+) -> bool:
+    """Verify actor-visible core compatibility without editing the concept."""
+
+    actual = _concept_read_back(concept_id)
+    if actual.get("exists") is not True or actual.get("concept_id") != concept_id:
+        return False
+    if required_publication_context is not None:
+        actual_context = actual.get("publication_context")
+        if not isinstance(actual_context, Mapping) or (
+            actual_context.get("kind") != required_publication_context.get("kind")
+            or actual_context.get("concept_id")
+            != required_publication_context.get("concept_id")
+        ):
+            return False
+
+    relationships = actual.get("forward_relationships")
+    if not isinstance(relationships, Mapping):
+        return False
+    type_parents = set(relationships.get("is_a_type_of") or [])
+    instance_types = set(relationships.get("is_an_instance_of") or [])
+    kind = _clean_text(concept_spec.get("kind")).lower()
+    if kind == "individual":
+        kind = "instance"
+    if instance_of_type:
+        if instance_of_type not in instance_types:
+            return False
+        if parent_id and parent_id not in type_parents:
+            return False
+    elif kind in {"instance", "predicate"}:
+        if parent_id and parent_id not in instance_types:
+            return False
+    elif parent_id and parent_id not in type_parents:
+        return False
+
+    requested_path = concept_spec.get("vontology_path")
+    if requested_path is not None and actual.get("vontology_path") != requested_path:
+        return False
+    texts = actual.get("text_relations")
+    if not isinstance(texts, list):
+        return False
+
+    def has_requested_text(
+        predicate: str,
+        value: Any,
+        *,
+        name_type: str | None = None,
+    ) -> bool:
+        if not isinstance(value, str) or not value.strip():
+            return True
+        return any(
+            isinstance(row, Mapping)
+            and row.get("predicate") == predicate
+            and row.get("text") == value.strip()
+            and (
+                name_type is None
+                or (
+                    isinstance(row.get("context"), Mapping)
+                    and row["context"].get("name_type") == name_type
+                )
+            )
+            for row in texts
+        )
+
+    return (
+        has_requested_text("hasName", concept_spec.get("name"), name_type="NL")
+        and has_requested_text("hasDescription", concept_spec.get("description"))
+        and has_requested_text("hasNote", concept_spec.get("notes"))
+    )
+
+
+def _actor_scoped_referent_result_metadata(concept_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+        "effective_concept_id": concept_id,
+        "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+        "identity_status": "unreconciled_actor_scoped_referent",
+        "equivalence_asserted": False,
+        "alias_created": False,
+    }
+
+
+def _create_id_conflict_error(
+    *,
+    arguments: Mapping[str, Any],
+    expected_concept_id: str,
+) -> OntologyMutationCommandError:
+    """Return a non-disclosing conflict with at most one executable recovery."""
+
+    affordances: list[dict[str, Any]] = []
+    collision_mode = _clean_text(arguments.get("collision_resolution_mode"))
+    concept_specs = arguments.get("concepts") or []
+    concept_spec = (
+        concept_specs[0]
+        if len(concept_specs) == 1 and isinstance(concept_specs[0], Mapping)
+        else None
+    )
+    actor_id = get_effective_user_concept_id()
+    scope_mode = _clean_text(arguments.get("scope_mode"))
+    kind = _clean_text((concept_spec or {}).get("kind")).lower()
+    if kind == "individual":
+        kind = "instance"
+    references = _create_reference_concept_ids(arguments)
+    parent_id = _normalise_concept_id(arguments.get("parent_id"))
+    recovery_is_eligible = (
+        not collision_mode
+        and concept_spec is not None
+        and kind == "instance"
+        and scope_mode == ACTOR_SCOPED_REFERENT_SCOPE_MODE
+        and bool(actor_id)
+        and bool(parent_id)
+        and bool(_clean_text(concept_spec.get("name")))
+        and not can_access_concept(expected_concept_id)
+        and all(can_access_concept(reference_id) for reference_id in references)
+    )
+    if recovery_is_eligible and actor_id:
+        effective_concept_id = actor_scoped_referent_concept_id(
+            requested_concept_id=expected_concept_id,
+            actor_concept_id=actor_id,
+        )
+        required_context = publication_context_for_creation(
+            scope_mode=ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+            actor_concept_id=actor_id,
+            organisation_concept_id=None,
+        ).to_mapping()
+        derived_id_available = not _concept_exists_unfiltered(effective_concept_id)
+        derived_id_compatible = can_access_concept(
+            effective_concept_id
+        ) and _visible_concept_satisfies_requested_core(
+            concept_id=effective_concept_id,
+            concept_spec=concept_spec,
+            parent_id=parent_id,
+            instance_of_type=_normalise_concept_id(
+                arguments.get("instance_of_type")
+                or concept_spec.get("instance_of_type")
+            ),
+            required_publication_context=required_context,
+        )
+        if derived_id_available or derived_id_compatible:
+            recovered_spec = {
+                key: _json_safe(value)
+                for key, value in concept_spec.items()
+                if key in _CREATE_CORE_CONCEPT_FIELDS
+            }
+            recovered_spec.update(
+                {
+                    "concept_id": effective_concept_id,
+                    "kind": "instance",
+                }
+            )
+            requested_instance_type = _normalise_concept_id(
+                arguments.get("instance_of_type")
+                or concept_spec.get("instance_of_type")
+            )
+            if requested_instance_type:
+                recovered_spec["instance_of_type"] = requested_instance_type
+            recovery_arguments = {
+                "parent_id": parent_id,
+                "concepts": [recovered_spec],
+                "duplicate_resolution_mode": "canonical_id_only",
+                "collision_resolution_mode": (ACTOR_SCOPED_REFERENT_COLLISION_MODE),
+                "requested_concept_id": expected_concept_id,
+                "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+            }
+            affordances.append(
+                {
+                    "action_type": ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+                    "tool": "create_concepts",
+                    "recovery_contract": (ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT),
+                    "arguments": recovery_arguments,
+                    "semantic_effect": (
+                        "Create or idempotently reuse an actor-private instance "
+                        "referent. This does not create an alias, assert identity "
+                        "or equivalence, publish knowledge, or access the concept "
+                        "occupying the requested ID."
+                    ),
+                }
+            )
+    return OntologyMutationCommandError(
+        "ontology_create_concept_id_conflict",
+        "The requested concept ID cannot be created.",
+        recovery_affordances=affordances,
+    )
+
+
 def _create_read_back_concept_ids(
     *,
     arguments: Mapping[str, Any],
@@ -1696,14 +2075,20 @@ def _create_read_back_concept_ids(
 ) -> list[str]:
     """Resolve created or reused subjects without mistaking parents for output."""
 
-    if result.get("success") is False or result.get("changed") is False:
+    if result.get("success") is False:
         return []
-    candidates: list[Any] = list(result.get("created_concept_ids") or [])
+    idempotent_reuse = bool(result.get("idempotent_reuse"))
+    if result.get("changed") is False and not idempotent_reuse:
+        return []
+    candidates: list[Any] = [
+        *(result.get("created_concept_ids") or []),
+        *(result.get("resolved_concept_ids") or []),
+    ]
     for row in result.get("results") or []:
         if (
             not isinstance(row, Mapping)
             or not bool(row.get("success"))
-            or row.get("changed") is False
+            or (row.get("changed") is False and not bool(row.get("idempotent_reuse")))
         ):
             continue
         candidates.extend(
@@ -2078,7 +2463,12 @@ def _safe_command_error(exc: OntologyMutationCommandError) -> dict[str, Any]:
     }
     if exc.error_details is not None:
         payload["error_details"] = dict(exc.error_details)
-    if exc.reason_code not in {
+    if exc.recovery_affordances is not None:
+        if exc.recovery_affordances:
+            payload["recovery_affordances"] = [
+                dict(affordance) for affordance in exc.recovery_affordances
+            ]
+    elif exc.reason_code not in {
         "complex_create_requires_typed_effects",
         "multi_create_requires_individual_effects",
     }:
@@ -2185,6 +2575,21 @@ def _verify_method_postcondition(
         actual = concepts[0]
         spec = specs[0]
         expected_id = _normalise_concept_id(spec.get("concept_id"))
+        if intent.delta.get("visible_exact_reuse"):
+            if result.get("idempotent_reuse") is not True or not expected_id:
+                return False
+            required_context = (
+                expected_context if intent.delta.get("actor_scoped_referent") else None
+            )
+            return _visible_concept_satisfies_requested_core(
+                concept_id=expected_id,
+                concept_spec=spec,
+                parent_id=_normalise_concept_id(intent.delta.get("parent_id")),
+                instance_of_type=_normalise_concept_id(
+                    intent.delta.get("instance_of_type") or spec.get("instance_of_type")
+                ),
+                required_publication_context=required_context,
+            )
         if (
             actual.get("exists") is not True
             or actual.get("concept_id") != expected_id
@@ -2304,6 +2709,41 @@ def _postcondition_reconciliation_contract(
         "intent_fingerprint": intent.fingerprint,
         "intent": intent.canonical_payload(),
     }
+
+
+def _visible_create_reuse_result(intent: OntologyMutationIntent) -> dict[str, Any]:
+    specs = intent.delta.get("concepts") or []
+    spec = specs[0] if len(specs) == 1 and isinstance(specs[0], Mapping) else {}
+    concept_id = _normalise_concept_id(spec.get("concept_id"))
+    result: dict[str, Any] = {
+        "success": True,
+        "effect_status": "succeeded",
+        "mutation_outcome": "succeeded",
+        "changed": False,
+        "idempotent_reuse": True,
+        "created_concept_ids": [],
+        "resolved_concept_ids": [concept_id] if concept_id else [],
+        "results": [
+            {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": False,
+                "idempotent_reuse": True,
+                "concept_id": concept_id,
+                "requested_name": spec.get("name"),
+                "requested_kind": spec.get("kind"),
+            }
+        ],
+        "total": 1,
+        "successful": 1,
+        "already_existed": 1,
+        "failed": 0,
+    }
+    if concept_id and intent.delta.get("actor_scoped_referent"):
+        result["actor_scoped_referent"] = _actor_scoped_referent_result_metadata(
+            concept_id
+        )
+    return result
 
 
 def _publication_context_from_payload(value: Any) -> PublicationContext | None:
@@ -2531,7 +2971,13 @@ def execute_governed_ontology_method(
         }
     result_holder: dict[str, Mapping[str, Any]] = {}
 
-    def perform_locked() -> Mapping[str, Any]:
+    def perform_locked(*, exact_create_reuse: bool = False) -> Mapping[str, Any]:
+        if method_name == "create_concepts" and (
+            exact_create_reuse or intent.delta.get("visible_exact_reuse")
+        ):
+            result = _visible_create_reuse_result(intent)
+            result_holder["result"] = result
+            return result
         if method_name == "delete_legacy_name":
             concept_id = _normalise_concept_id(arguments.get("concept_id")) or ""
             try:
@@ -2695,10 +3141,26 @@ def execute_governed_ontology_method(
                 ),
                 "concept": dict(result),
             }
+        if (
+            method_name == "create_concepts"
+            and intent.delta.get("actor_scoped_referent")
+            and result.get("success") is True
+        ):
+            effective_concept_id = _normalise_concept_id(
+                intent.delta.get("expected_concept_id")
+            )
+            if effective_concept_id:
+                result = {
+                    **dict(result),
+                    "actor_scoped_referent": (
+                        _actor_scoped_referent_result_metadata(effective_concept_id)
+                    ),
+                }
         result_holder["result"] = result
         return result
 
     def perform() -> Mapping[str, Any]:
+        exact_create_reuse = bool(intent.delta.get("visible_exact_reuse"))
         scope_fingerprints = intent.delta.get("affected_scope_fingerprints")
         expected = (
             dict(scope_fingerprints) if isinstance(scope_fingerprints, Mapping) else {}
@@ -2781,19 +3243,62 @@ def execute_governed_ontology_method(
                     expected_concept_id = _normalise_concept_id(
                         intent.delta.get("expected_concept_id")
                     )
-                    if expected_concept_id and _concept_exists_unfiltered(
+                    expected_exists = bool(
                         expected_concept_id
-                    ):
+                        and _concept_exists_unfiltered(expected_concept_id)
+                    )
+                    if exact_create_reuse and not expected_exists:
                         return _safe_command_error(
                             OntologyMutationCommandError(
-                                "ontology_create_concept_id_conflict",
-                                "The requested concept ID cannot be created.",
+                                "ontology_create_reuse_precondition_failed",
+                                (
+                                    "The compatible concept selected for reuse is "
+                                    "no longer available."
+                                ),
+                                recovery_affordances=(),
                             )
                         )
+                    if expected_exists:
+                        specs = intent.delta.get("concepts") or []
+                        spec = (
+                            specs[0]
+                            if len(specs) == 1 and isinstance(specs[0], Mapping)
+                            else None
+                        )
+                        required_context = (
+                            intent.publication_context.to_mapping()
+                            if intent.delta.get("actor_scoped_referent")
+                            else None
+                        )
+                        compatible_reuse = bool(
+                            expected_concept_id
+                            and spec is not None
+                            and can_access_concept(expected_concept_id)
+                            and _visible_concept_satisfies_requested_core(
+                                concept_id=expected_concept_id,
+                                concept_spec=spec,
+                                parent_id=_normalise_concept_id(
+                                    intent.delta.get("parent_id")
+                                ),
+                                instance_of_type=_normalise_concept_id(
+                                    intent.delta.get("instance_of_type")
+                                    or spec.get("instance_of_type")
+                                ),
+                                required_publication_context=required_context,
+                            )
+                        )
+                        if not compatible_reuse:
+                            return _safe_command_error(
+                                _create_id_conflict_error(
+                                    arguments=arguments,
+                                    expected_concept_id=(expected_concept_id or ""),
+                                )
+                            )
+                        exact_create_reuse = True
                 live_decision = authorise_ontology_mutation(intent)
                 if not live_decision.allowed:
                     return ontology_authority_denial_payload(live_decision, intent)
-                return perform_locked()
+                return perform_locked(exact_create_reuse=exact_create_reuse)
         except OntologyMutationResourceBusy:
             return {
                 "success": False,

--- a/tests/backend/test_actor_scoped_referent_identity_service.py
+++ b/tests/backend/test_actor_scoped_referent_identity_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.services.actor_scoped_referent_identity_service import (
+    actor_scoped_referent_concept_id,
+)
+
+
+def test_actor_scoped_referent_identity_is_stable_and_actor_bound() -> None:
+    first = actor_scoped_referent_concept_id(
+        requested_concept_id="#V#Burkhard-Wuensche",
+        actor_concept_id="#V#Member-One",
+    )
+    repeated = actor_scoped_referent_concept_id(
+        requested_concept_id="#v#burkhard_wuensche",
+        actor_concept_id="#v#member_one",
+    )
+    other_actor = actor_scoped_referent_concept_id(
+        requested_concept_id="#V#burkhard_wuensche",
+        actor_concept_id="#V#member_two",
+    )
+    other_requested_id = actor_scoped_referent_concept_id(
+        requested_concept_id="#V#another_person",
+        actor_concept_id="#V#member_one",
+    )
+
+    assert first == repeated
+    assert first.startswith("#V#scoped_referent_burkhard_wuensche_")
+    assert first != other_actor
+    assert first != other_requested_id
+    assert "member_one" not in first
+
+
+@pytest.mark.parametrize(
+    ("requested_concept_id", "actor_concept_id"),
+    [("", "#V#member"), ("#V#person", ""), ("###", "#V#member")],
+)
+def test_actor_scoped_referent_identity_requires_canonical_inputs(
+    requested_concept_id: str,
+    actor_concept_id: str,
+) -> None:
+    with pytest.raises(ValueError):
+        actor_scoped_referent_concept_id(
+            requested_concept_id=requested_concept_id,
+            actor_concept_id=actor_concept_id,
+        )

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -50,6 +50,7 @@ from src.backend.services.adaptive_turn_service import (
     _compact_evidence_envelope,
     _compact_evidence_index,
     _effect_id,
+    _effect_requires_turn_finality,
     _effect_result_target_ids,
     _effect_subject_authorised,
     _effect_subject_authority_denial,
@@ -2513,6 +2514,226 @@ def test_invalid_effect_arguments_are_returned_for_correction_without_poisoning_
     assert result.tool_invocations[0]["effect_status"] == "not_started"
     assert result.tool_invocations[0]["turn_finality_required"] is False
     assert result.tool_invocations[1]["effect_status"] == "succeeded"
+
+
+def test_non_object_effect_arguments_are_returned_for_correction_without_poisoning_turn() -> (
+    None
+):
+    invoked: list[dict[str, Any]] = []
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="record_source_processing_marker",
+            handler=lambda **arguments: (
+                invoked.append(dict(arguments))
+                or {
+                    "success": True,
+                    "effect_status": "succeeded",
+                    "changed": True,
+                }
+            ),
+            input_schema=Schema(
+                required={
+                    "source_system": str,
+                    "source_profile": str,
+                    "source_item_id": str,
+                },
+                allow_unknown=False,
+                description="Record one source-processing marker.",
+            ),
+            category="write",
+            ordinary_turn_effect=True,
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(write_timeout_sec=1.0),
+        enabled=True,
+    )
+    corrected_arguments = {
+        "source_system": "gmail",
+        "source_profile": "personal-gmail",
+        "source_item_id": "message-1",
+    }
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="marker-non-object-arguments",
+                    payload={
+                        "name": "record_source_processing_marker",
+                        "arguments": ["gmail", "personal-gmail", "message-1"],
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="marker-corrected-object-arguments",
+                    payload={
+                        "name": "record_source_processing_marker",
+                        "arguments": corrected_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The corrected marker write succeeded."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Record the exact source marker.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="correct-non-object-effect-arguments",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert invoked == [corrected_arguments]
+    validation_message = next(
+        item
+        for item in client.calls[1]["context"]
+        if item.get("tool_call_id") == "marker-non-object-arguments"
+    )
+    validation_result = json.loads(validation_message["content"])
+    validation_receipt = json.loads(validation_result["preview"])
+    assert validation_receipt["error_code"] == "capability_arguments_invalid"
+    assert validation_receipt["status"] == "not_started"
+    assert validation_receipt["effect_status"] == "not_started"
+    assert validation_receipt["mutation_outcome"] == "not_started"
+    assert validation_receipt["changed"] is False
+    invalid_invocation, corrected_invocation = result.tool_invocations
+    assert invalid_invocation["effect_status"] == "not_started"
+    assert invalid_invocation["turn_finality_required"] is False
+    assert corrected_invocation["effect_status"] == "succeeded"
+    assert result.terminal_status == "completed"
+    assert result.response_text == "The corrected marker write succeeded."
+
+
+def test_non_object_read_arguments_use_the_same_not_started_contract() -> None:
+    invoked: list[dict[str, Any]] = []
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="read_source_marker",
+            handler=lambda **arguments: (
+                invoked.append(dict(arguments))
+                or {"success": True, "source_item_id": arguments["source_item_id"]}
+            ),
+            input_schema=Schema(
+                required={"source_item_id": str},
+                allow_unknown=False,
+                description="Read one source-processing marker.",
+            ),
+            output_schema=Schema(required={"success": bool}, allow_unknown=True),
+            category="read",
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(write_timeout_sec=1.0),
+        enabled=True,
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-marker-non-object-arguments",
+                    payload={
+                        "name": "read_source_marker",
+                        "arguments": ["message-1"],
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-marker-corrected-arguments",
+                    payload={
+                        "name": "read_source_marker",
+                        "arguments": {"source_item_id": "message-1"},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The marker read succeeded."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=gateway,
+        prompt="Read the exact source marker.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="correct-non-object-read-arguments",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert invoked == [{"source_item_id": "message-1"}]
+    validation_message = next(
+        item
+        for item in client.calls[1]["context"]
+        if item.get("tool_call_id") == "read-marker-non-object-arguments"
+    )
+    validation_result = json.loads(validation_message["content"])
+    validation_receipt = json.loads(validation_result["preview"])
+    assert validation_receipt["error_code"] == "capability_arguments_invalid"
+    assert validation_receipt["status"] == "not_started"
+    assert validation_receipt["effect_status"] == "not_started"
+    assert validation_receipt["mutation_outcome"] == "not_started"
+    assert validation_receipt["changed"] is False
+    assert result.terminal_status == "completed"
+    assert result.response_text == "The marker read succeeded."
+
+
+@pytest.mark.parametrize(
+    ("error_code", "effect_status", "expected"),
+    (
+        ("capability_arguments_invalid", "not_started", False),
+        ("invalid_capability_arguments", "failed", False),
+        ("ontology_mutation_target_not_accessible", "not_started", True),
+    ),
+)
+def test_only_pre_dispatch_argument_rejections_are_exempt_from_turn_finality(
+    error_code: str,
+    effect_status: str,
+    expected: bool,
+) -> None:
+    assert (
+        _effect_requires_turn_finality(
+            capability_kind="registered_tool",
+            effect_status=effect_status,
+            changed=False,
+            raw_payload={
+                "success": False,
+                "status": "not_started",
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "error_code": error_code,
+            },
+        )
+        is expected
+    )
 
 
 def test_effect_subject_authority_matches_actor_or_organisation_scope(
@@ -11935,6 +12156,476 @@ def test_predelegation_create_failure_is_suppressed_but_corrected_call_runs(
     assert "recovery_affordances" not in repeated_receipt
     assert corrected["effect_status"] == "succeeded"
     assert corrected["changed"] is True
+
+
+@pytest.mark.parametrize(
+    (
+        "recovery_concept_id",
+        "receipt_concept_id",
+        "origin_error_code",
+        "recovery_succeeds",
+        "extra_readback_concept",
+        "original_omits_concept_id",
+        "expected_recovered",
+        "expected_terminal_status",
+    ),
+    (
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "ontology_create_concept_id_conflict",
+            True,
+            False,
+            False,
+            True,
+            "completed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_fedcba9876543210fedcba98",
+            "#V#scoped_referent_ava_example_fedcba9876543210fedcba98",
+            "ontology_create_concept_id_conflict",
+            True,
+            False,
+            False,
+            False,
+            "effect_partially_completed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_badbadbadbadbadbadbadbad",
+            "ontology_create_concept_id_conflict",
+            True,
+            False,
+            False,
+            False,
+            "effect_partially_completed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "ontology_create_concept_id_conflict",
+            False,
+            False,
+            False,
+            False,
+            "effect_failed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "unrelated_create_failure",
+            True,
+            False,
+            False,
+            False,
+            "effect_partially_completed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "ontology_create_concept_id_conflict",
+            True,
+            True,
+            False,
+            False,
+            "effect_partially_completed",
+        ),
+        (
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "#V#scoped_referent_ava_example_0123456789abcdef01234567",
+            "ontology_create_concept_id_conflict",
+            True,
+            False,
+            True,
+            True,
+            "completed",
+        ),
+    ),
+    ids=[
+        "exact-advertised-recovery",
+        "different-unadvertised-referent",
+        "wrong-success-readback",
+        "exact-recovery-failed",
+        "unrelated-origin-cannot-advertise-recovery",
+        "extra-readback-concept",
+        "name-only-original-create",
+    ],
+)
+def test_actor_scoped_referent_retires_only_exact_advertised_collision(
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_concept_id: str,
+    receipt_concept_id: str,
+    origin_error_code: str,
+    recovery_succeeds: bool,
+    extra_readback_concept: bool,
+    original_omits_concept_id: bool,
+    expected_recovered: bool,
+    expected_terminal_status: str,
+) -> None:
+    from src.backend.services.actor_scoped_referent_identity_service import (
+        ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+        ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+        ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+        ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+    )
+
+    requested_concept_id = "#V#ava_example"
+    advertised_referent_id = (
+        "#V#scoped_referent_ava_example_0123456789abcdef01234567"
+    )
+    core_concept = {
+        "concept_id": advertised_referent_id,
+        "name": "Ava Example",
+        "kind": "instance",
+        "description": "A represented person used by this test.",
+    }
+    advertised_arguments = {
+        "parent_id": "#V#person",
+        "concepts": [core_concept],
+        "duplicate_resolution_mode": "canonical_id_only",
+        "collision_resolution_mode": ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+        "requested_concept_id": requested_concept_id,
+        "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+    }
+    attempted_arguments = {
+        **advertised_arguments,
+        "concepts": [
+            {
+                **core_concept,
+                "concept_id": recovery_concept_id,
+            }
+        ],
+    }
+    delegation_calls: list[dict[str, Any]] = []
+
+    def issue_delegation(**kwargs: Any) -> dict[str, Any]:
+        delegation_calls.append(dict(kwargs))
+        if not kwargs["arguments"].get("collision_resolution_mode"):
+            return {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "retryable": False,
+                "error_code": origin_error_code,
+                "error": "The requested concept ID cannot be created.",
+                "recovery_affordances": [
+                    {
+                        "action_type": ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+                        "tool": "create_concepts",
+                        "recovery_contract": (
+                            ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT
+                        ),
+                        "arguments": advertised_arguments,
+                    }
+                ],
+            }
+        return {"delegation_id": f"delegation-{kwargs['effect_id']}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "issue_same_turn_method_delegation",
+        issue_delegation,
+    )
+    handler_calls: list[dict[str, Any]] = []
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        assert name == "create_concepts"
+        handler_calls.append(arguments)
+        if not recovery_succeeds:
+                return {
+                    "success": False,
+                    "effect_status": "failed",
+                    "mutation_outcome": "failed",
+                "changed": False,
+                "error_code": "actor_scoped_referent_create_failed",
+            }
+        readback_concepts = [
+            {
+                "concept_id": receipt_concept_id,
+                "exists": True,
+                "publication_context": {
+                    "kind": "user",
+                    "concept_id": "#V#person",
+                },
+            }
+        ]
+        if extra_readback_concept:
+            readback_concepts.append(
+                {
+                    "concept_id": "#V#unexpected_extra_concept",
+                    "exists": True,
+                    "publication_context": {
+                        "kind": "user",
+                        "concept_id": "#V#person",
+                    },
+                }
+            )
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "mutation_outcome": "succeeded",
+            "changed": True,
+            "created_concept_ids": [receipt_concept_id],
+            "actor_scoped_referent": {
+                "schema_version": ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+                "effective_concept_id": receipt_concept_id,
+                "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+                "identity_status": "unreconciled_actor_scoped_referent",
+                "equivalence_asserted": False,
+                "alias_created": False,
+            },
+            "canonical_read_back": {"concepts": readback_concepts},
+        }
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="colliding-person-create",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": {
+                            "parent_id": "#V#person",
+                            "concepts": [
+                                {
+                                    **(
+                                        {}
+                                        if original_omits_concept_id
+                                        else {"concept_id": requested_concept_id}
+                                    ),
+                                    "name": "Ava Example",
+                                    "kind": "instance",
+                                    "description": (
+                                        "A represented person used by this test."
+                                    ),
+                                }
+                            ],
+                            "duplicate_resolution_mode": "canonical_id_only",
+                        },
+                    },
+                )
+            ],
+        ),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="actor-scoped-person-recovery",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": attempted_arguments,
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The person referent was represented."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Represent this person despite an inaccessible ID collision.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id=(
+            "actor-scoped-referent-"
+            f"{origin_error_code}-{recovery_succeeds}-"
+            f"{receipt_concept_id[-8:]}-{extra_readback_concept}-"
+            f"{original_omits_concept_id}"
+        ),
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert len(delegation_calls) == 2
+    assert len(handler_calls) == 1
+    assert handler_calls[0]["concepts"][0]["concept_id"] == recovery_concept_id
+    collision, recovery = result.tool_invocations
+    assert collision["error_code"] == origin_error_code
+    assert recovery["effect_status"] == (
+        "succeeded" if recovery_succeeds else "failed"
+    )
+    assert result.terminal_status == expected_terminal_status
+    if expected_recovered:
+        assert collision["recovery_status"] == "succeeded"
+        assert collision["recovered_by_effect_id"] == recovery["effect_id"]
+        assert result.response_text == "The person referent was represented."
+    else:
+        assert "recovery_status" not in collision
+        assert "recovered_by_effect_id" not in collision
+        assert result.response_text != "The person referent was represented."
+
+
+def test_one_actor_scoped_referent_recovery_does_not_retire_another_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services.actor_scoped_referent_identity_service import (
+        ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+        ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+        ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+        ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+    )
+
+    people = {
+        "#V#ava_example": {
+            "name": "Ava Example",
+            "referent_id": (
+                "#V#scoped_referent_ava_example_0123456789abcdef01234567"
+            ),
+        },
+        "#V#ben_example": {
+            "name": "Ben Example",
+            "referent_id": (
+                "#V#scoped_referent_ben_example_0123456789abcdef01234567"
+            ),
+        },
+    }
+
+    def recovery_arguments(requested_id: str) -> dict[str, Any]:
+        person = people[requested_id]
+        return {
+            "parent_id": "#V#person",
+            "concepts": [
+                {
+                    "concept_id": person["referent_id"],
+                    "name": person["name"],
+                    "kind": "instance",
+                }
+            ],
+            "duplicate_resolution_mode": "canonical_id_only",
+            "collision_resolution_mode": ACTOR_SCOPED_REFERENT_COLLISION_MODE,
+            "requested_concept_id": requested_id,
+            "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+        }
+
+    def issue_delegation(**kwargs: Any) -> dict[str, Any]:
+        arguments = kwargs["arguments"]
+        if not arguments.get("collision_resolution_mode"):
+            requested_id = arguments["concepts"][0]["concept_id"]
+            return {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "retryable": False,
+                "error_code": "ontology_create_concept_id_conflict",
+                "error": "The requested concept ID cannot be created.",
+                "recovery_affordances": [
+                    {
+                        "action_type": ACTOR_SCOPED_REFERENT_RECOVERY_ACTION,
+                        "tool": "create_concepts",
+                        "recovery_contract": (
+                            ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT
+                        ),
+                        "arguments": recovery_arguments(requested_id),
+                    }
+                ],
+            }
+        return {"delegation_id": f"delegation-{kwargs['effect_id']}"}
+
+    monkeypatch.setattr(
+        "src.backend.services.ontology_mutation_command_service."
+        "issue_same_turn_method_delegation",
+        issue_delegation,
+    )
+
+    def handler(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        assert name == "create_concepts"
+        referent_id = arguments["concepts"][0]["concept_id"]
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "mutation_outcome": "succeeded",
+            "changed": True,
+            "created_concept_ids": [referent_id],
+            "actor_scoped_referent": {
+                "schema_version": ACTOR_SCOPED_REFERENT_RECOVERY_CONTRACT,
+                "effective_concept_id": referent_id,
+                "scope_mode": ACTOR_SCOPED_REFERENT_SCOPE_MODE,
+                "identity_status": "unreconciled_actor_scoped_referent",
+                "equivalence_asserted": False,
+                "alias_created": False,
+            },
+            "canonical_read_back": {
+                "concepts": [
+                    {
+                        "concept_id": referent_id,
+                        "exists": True,
+                        "publication_context": {
+                            "kind": "user",
+                            "concept_id": "#V#person",
+                        },
+                    }
+                ]
+            },
+        }
+
+    initial_calls = [
+        ToolCall(
+            tool_name="turn_invoke_capability",
+            call_id=f"collide-{requested_id.removeprefix('#V#')}",
+            payload={
+                "name": "create_concepts",
+                "arguments": {
+                    "parent_id": "#V#person",
+                    "concepts": [
+                        {
+                            "concept_id": requested_id,
+                            "name": person["name"],
+                            "kind": "instance",
+                        }
+                    ],
+                },
+            },
+        )
+        for requested_id, person in people.items()
+    ]
+    client = _SequenceClient(
+        LLMResponse(text_response="", tool_calls=initial_calls),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="recover-only-ava",
+                    payload={
+                        "name": "create_concepts",
+                        "arguments": recovery_arguments("#V#ava_example"),
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="Ava was represented."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_effect_gateway(handler),
+        prompt="Represent Ava and Ben despite inaccessible ID collisions.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="two-actor-scoped-referent-collisions",
+        turn_budget_seconds=20,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    ava_collision, ben_collision, ava_recovery = result.tool_invocations
+    assert ava_collision["recovery_status"] == "succeeded"
+    assert ava_collision["recovered_by_effect_id"] == ava_recovery["effect_id"]
+    assert "recovery_status" not in ben_collision
+    assert "recovered_by_effect_id" not in ben_collision
+    assert result.terminal_status == "effect_partially_completed"
+    assert result.response_text != "Ava was represented."
 
 
 def test_successful_core_create_continues_with_scoped_semantic_postconditions(

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -670,6 +670,57 @@ def test_duplicate_resolution_mode_schema_and_handler_reject_unknown_value() -> 
     ]
 
 
+def test_actor_scoped_collision_recovery_fields_are_explicit_in_catalogue() -> None:
+    schema = _concepts_create_input_schema()
+    assert schema.enum_values["collision_resolution_mode"] == [
+        "actor_scoped_referent",
+        None,
+    ]
+    assert "requested_concept_id" in schema.optional
+    assert "does not inspect or confirm whether that ID is occupied" in (
+        schema.description
+    )
+    valid, errors = validate_payload(
+        schema,
+        {
+            "parent_id": _PARENT_ID,
+            "concepts": [
+                {
+                    "concept_id": "#V#scoped_referent_person_0123456789abcdef01234567",
+                    "name": "Person",
+                    "kind": "instance",
+                }
+            ],
+            "collision_resolution_mode": "actor_scoped_referent",
+            "requested_concept_id": "#V#person",
+            "duplicate_resolution_mode": "canonical_id_only",
+            "scope_mode": "user_only_default",
+        },
+    )
+    assert valid is True
+    assert errors == []
+
+    invalid_mode = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[],
+        collision_resolution_mode="invent_alias",
+    )
+    assert invalid_mode["error_code"] == "invalid_parameter"
+    assert invalid_mode["error_details"][
+        "supported_collision_resolution_modes"
+    ] == ["actor_scoped_referent"]
+
+    missing_requested_id = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[],
+        collision_resolution_mode="actor_scoped_referent",
+    )
+    assert missing_requested_id["error_code"] == "invalid_parameter"
+    assert missing_requested_id["error_details"]["missing"] == [
+        "requested_concept_id"
+    ]
+
+
 def test_cancellation_after_duplicate_preflight_prevents_create(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/backend/test_ontology_create_authority_containment.py
+++ b/tests/backend/test_ontology_create_authority_containment.py
@@ -68,6 +68,68 @@ def test_governed_create_preserves_default_type_and_one_exact_parent(
         )
 
 
+def test_governed_create_rejects_conflicting_instance_types_before_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    mutation_calls = 0
+
+    def mutate() -> dict[str, Any]:
+        nonlocal mutation_calls
+        mutation_calls += 1
+        return {"success": True, "changed": True}
+
+    with authority.override_current_actor("#V#member", None):
+        result = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": "#V#research_object",
+                "instance_of_type": "#V#top_level_type",
+                "concepts": [
+                    {
+                        "concept_id": "#V#typed_record",
+                        "name": "Typed record",
+                        "kind": "type",
+                        "instance_of_type": "#V#per_concept_type",
+                    }
+                ],
+                "scope_mode": "user_only_default",
+            },
+            mutate=mutate,
+        )
+
+    assert mutation_calls == 0
+    assert result["success"] is False
+    assert result["effect_status"] == "not_started"
+    assert result["changed"] is False
+    assert result["error_code"] == "conflicting_create_instance_of_type"
+
+    resolved = command.resolve_governed_ontology_arguments(
+        "create_concepts",
+        {
+            "parent_id": "#V#research_object",
+            "instance_of_type": "#V#same_type",
+            "concepts": [
+                {
+                    "concept_id": "#V#typed_record",
+                    "name": "Typed record",
+                    "kind": "type",
+                    "instance_of_type": "#V#same_type",
+                }
+            ],
+        },
+    )
+    assert "instance_of_type" not in resolved
+    assert resolved["concepts"][0]["instance_of_type"] == "#V#same_type"
+
+
 def test_create_intent_fingerprints_exact_scope_and_complete_effect(
     monkeypatch,
 ) -> None:
@@ -826,4 +888,670 @@ def test_inaccessible_create_collision_is_non_disclosing(monkeypatch) -> None:
     assert result["error"] == "The requested concept ID cannot be created."
     assert "LEAK" not in repr(result)
     assert "private_parent" not in repr(result)
+    assert "recovery_affordances" not in result
     assert mutate_calls["count"] == 0
+
+
+def test_hidden_instance_id_conflict_advertises_only_executable_referent_recovery(
+    monkeypatch,
+) -> None:
+    from src.backend.services import actor_scoped_referent_identity_service as identity
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    requested_id = "#V#hidden_person"
+    actor_id = "#V#member"
+    parent_id = "#V#person"
+    effective_id = identity.actor_scoped_referent_concept_id(
+        requested_concept_id=requested_id,
+        actor_concept_id=actor_id,
+    )
+    hidden_document = {
+        "concept_id": requested_id,
+        "relationships": {
+            "#V#specific_to_user": ["#V#other_actor"],
+            "is_an_instance_of": ["#V#hidden_parent_sentinel"],
+        },
+        "attributes": {"hidden_metadata": "HIDDEN_METADATA_SENTINEL"},
+    }
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(
+        command.ConceptsRepository,
+        "find_one",
+        lambda query: (
+            hidden_document if query.get("concept_id") == requested_id else None
+        ),
+    )
+    monkeypatch.setattr(
+        command,
+        "can_access_concept",
+        lambda concept_id: concept_id == parent_id,
+    )
+
+    with authority.override_current_actor(actor_id, "#V#organisation_a"):
+        result = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": parent_id,
+                "concepts": [
+                    {
+                        "concept_id": requested_id,
+                        "name": "Hidden Person",
+                        "kind": "instance",
+                        "description": "A requested core description.",
+                    }
+                ],
+                "scope_mode": "user_only_default",
+            },
+            mutate=lambda: (_ for _ in ()).throw(
+                AssertionError("a colliding create must not mutate")
+            ),
+        )
+
+    assert result == {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "error_code": "ontology_create_concept_id_conflict",
+        "error": "The requested concept ID cannot be created.",
+        "recovery_affordances": [
+            {
+                "action_type": ("create_actor_scoped_referent_after_id_conflict"),
+                "tool": "create_concepts",
+                "recovery_contract": ("ontology_actor_scoped_instance_referent.v1"),
+                "arguments": {
+                    "parent_id": parent_id,
+                    "concepts": [
+                        {
+                            "concept_id": effective_id,
+                            "name": "Hidden Person",
+                            "kind": "instance",
+                            "description": "A requested core description.",
+                        }
+                    ],
+                    "duplicate_resolution_mode": "canonical_id_only",
+                    "collision_resolution_mode": "actor_scoped_referent",
+                    "requested_concept_id": requested_id,
+                    "scope_mode": "user_only_default",
+                },
+                "semantic_effect": (
+                    "Create or idempotently reuse an actor-private instance "
+                    "referent. This does not create an alias, assert identity "
+                    "or equivalence, publish knowledge, or access the concept "
+                    "occupying the requested ID."
+                ),
+            }
+        ],
+    }
+    assert "create_scoped_assertion" not in repr(result)
+    assert "request_ontology_administrator_delegation" not in repr(result)
+    assert actor_id not in repr(result["recovery_affordances"])
+    assert "HIDDEN_METADATA_SENTINEL" not in repr(result)
+    assert "hidden_parent_sentinel" not in repr(result)
+
+    raw_recovery_arguments = {
+        **result["recovery_affordances"][0]["arguments"],
+        "created_by_concept_id": "#V#untrusted_actor",
+        "organisation_concept_id": "#V#untrusted_organisation",
+    }
+    with authority.override_current_actor(actor_id, "#V#organisation_a"):
+        resolved = command.resolve_governed_ontology_arguments(
+            "create_concepts",
+            command.normalise_governed_ontology_arguments(
+                "create_concepts",
+                raw_recovery_arguments,
+            ),
+        )
+
+    assert resolved["concepts"][0]["concept_id"] == effective_id
+    assert resolved["created_by_concept_id"] == actor_id
+    assert resolved["organisation_concept_id"] == "#V#organisation_a"
+
+
+def test_direct_actor_scoped_referent_mode_never_probes_requested_id(
+    monkeypatch,
+) -> None:
+    from src.backend.services import actor_scoped_referent_identity_service as identity
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    requested_id = "#V#opaque_requested_id"
+    actor_id = "#V#member"
+    effective_id = identity.actor_scoped_referent_concept_id(
+        requested_concept_id=requested_id,
+        actor_concept_id=actor_id,
+    )
+    probed_ids: list[str] = []
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+
+    def record_unfiltered_probe(concept_id: str) -> bool:
+        probed_ids.append(concept_id)
+        if concept_id == requested_id:
+            raise AssertionError("recovery mode must not inspect the requested ID")
+        return False
+
+    monkeypatch.setattr(command, "_concept_exists_unfiltered", record_unfiltered_probe)
+
+    def visible(concept_id: str) -> bool:
+        if concept_id == requested_id:
+            raise AssertionError("recovery mode must not inspect requested visibility")
+        return concept_id == "#V#person"
+
+    monkeypatch.setattr(command, "can_access_concept", visible)
+    arguments = {
+        "parent_id": "#V#person",
+        "concepts": [
+            {
+                "concept_id": effective_id,
+                "name": "Opaque requested person",
+                "kind": "instance",
+            }
+        ],
+        "collision_resolution_mode": "actor_scoped_referent",
+        "requested_concept_id": requested_id,
+        "duplicate_resolution_mode": "canonical_id_only",
+        "scope_mode": "user_only_default",
+    }
+
+    with authority.override_current_actor(actor_id, None):
+        resolved = command.resolve_governed_ontology_arguments(
+            "create_concepts",
+            arguments,
+        )
+
+    assert resolved["concepts"][0]["concept_id"] == effective_id
+    assert probed_ids == []
+
+    with (
+        authority.override_current_actor(actor_id, None),
+        pytest.raises(command.OntologyMutationCommandError) as exc_info,
+    ):
+        command.resolve_governed_ontology_arguments(
+            "create_concepts",
+            {
+                **arguments,
+                "concepts": [
+                    {
+                        "concept_id": requested_id,
+                        "name": "Opaque requested person",
+                        "kind": "instance",
+                    }
+                ],
+            },
+        )
+
+    assert exc_info.value.reason_code == "actor_scoped_referent_identity_mismatch"
+    assert probed_ids == []
+
+
+def test_visible_incompatible_and_hidden_conflicts_share_generic_public_failure(
+    monkeypatch,
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    requested_id = "#V#colliding_person"
+    parent_id = "#V#person"
+    requested_is_visible = {"value": False}
+    arguments = {
+        "parent_id": parent_id,
+        "concepts": [
+            {
+                "concept_id": requested_id,
+                "name": "Colliding Person",
+                "kind": "instance",
+            }
+        ],
+        "scope_mode": "user_only_default",
+    }
+    monkeypatch.setattr(
+        command,
+        "_concept_exists_unfiltered",
+        lambda concept_id: concept_id == requested_id,
+    )
+    monkeypatch.setattr(
+        command,
+        "can_access_concept",
+        lambda concept_id: concept_id == parent_id
+        or (concept_id == requested_id and requested_is_visible["value"]),
+    )
+    monkeypatch.setattr(
+        command,
+        "_visible_concept_satisfies_requested_core",
+        lambda **_kwargs: False,
+    )
+
+    with authority.override_current_actor("#V#member", None):
+        hidden = command._safe_command_error(
+            command._create_id_conflict_error(
+                arguments=arguments,
+                expected_concept_id=requested_id,
+            )
+        )
+        requested_is_visible["value"] = True
+        visible_incompatible = command._safe_command_error(
+            command._create_id_conflict_error(
+                arguments=arguments,
+                expected_concept_id=requested_id,
+            )
+        )
+
+    hidden_base = {
+        key: value for key, value in hidden.items() if key != "recovery_affordances"
+    }
+    assert hidden_base == visible_incompatible
+    assert hidden_base == {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "error_code": "ontology_create_concept_id_conflict",
+        "error": "The requested concept ID cannot be created.",
+    }
+    assert hidden["recovery_affordances"][0]["arguments"][
+        "requested_concept_id"
+    ] == requested_id
+    assert "recovery_affordances" not in visible_incompatible
+
+
+def test_actor_scoped_referent_first_create_and_repeat_are_explicitly_idempotent(
+    monkeypatch,
+) -> None:
+    from contextlib import nullcontext
+    from types import SimpleNamespace
+
+    from src.backend.services import actor_scoped_referent_identity_service as identity
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    requested_id = "#V#hidden_person"
+    actor_id = "#V#member"
+    parent_id = "#V#person"
+    effective_id = identity.actor_scoped_referent_concept_id(
+        requested_concept_id=requested_id,
+        actor_concept_id=actor_id,
+    )
+    state = {"created": False}
+    mutation_calls = {"count": 0}
+    canonical_concept = {
+        "concept_id": effective_id,
+        "exists": True,
+        "publication_context": authority.PublicationContext.user(actor_id).to_mapping(),
+        "forward_relationships": {
+            "is_a_type_of": [],
+            "is_an_instance_of": [parent_id],
+            "linked_to": [],
+        },
+        "attributes": {},
+        "system_tags": [],
+        "user_tags": [],
+        "vontology_path": None,
+        "text_relations": [
+            {
+                "predicate": "hasName",
+                "text": "Hidden Person",
+                "context": {"name_type": "NL"},
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(
+        command,
+        "_concept_exists_unfiltered",
+        lambda concept_id: (
+            concept_id == requested_id
+            or (concept_id == effective_id and state["created"])
+        ),
+    )
+    monkeypatch.setattr(
+        command,
+        "can_access_concept",
+        lambda concept_id: (
+            concept_id == parent_id or (concept_id == effective_id and state["created"])
+        ),
+    )
+    monkeypatch.setattr(
+        command,
+        "_concept_read_back",
+        lambda concept_id: (
+            dict(canonical_concept)
+            if concept_id == effective_id and state["created"]
+            else {"concept_id": concept_id, "exists": False}
+        ),
+    )
+
+    def scope_read_back(concept_id: str) -> dict[str, Any]:
+        if concept_id == effective_id and not state["created"]:
+            raise LookupError(concept_id)
+        return {"scope_fingerprint": f"scope:{concept_id}"}
+
+    monkeypatch.setattr(command, "scope_read_back", scope_read_back)
+    monkeypatch.setattr(
+        command,
+        "ontology_mutation_resource_lock",
+        lambda _resource_key: nullcontext(),
+    )
+    monkeypatch.setattr(command, "ontology_authority_resource_keys", lambda _intent: ())
+    monkeypatch.setattr(
+        command,
+        "authorise_ontology_mutation",
+        lambda _intent: SimpleNamespace(allowed=True),
+    )
+
+    def execute_authorised(**kwargs: Any) -> dict[str, Any]:
+        kwargs["read_before"]()
+        result = dict(kwargs["mutate"]())
+        canonical_state = kwargs["read_back"]()
+        assert kwargs["verify_read_back"](result, canonical_state) is True
+        return {**result, "canonical_read_back": canonical_state}
+
+    monkeypatch.setattr(
+        command,
+        "execute_authorised_ontology_mutation",
+        execute_authorised,
+    )
+    recovery_arguments = {
+        "parent_id": parent_id,
+        "concepts": [
+            {
+                "concept_id": effective_id,
+                "name": "Hidden Person",
+                "kind": "instance",
+            }
+        ],
+        "duplicate_resolution_mode": "canonical_id_only",
+        "collision_resolution_mode": "actor_scoped_referent",
+        "requested_concept_id": requested_id,
+        "scope_mode": "user_only_default",
+    }
+
+    def create_once() -> dict[str, Any]:
+        mutation_calls["count"] += 1
+        state["created"] = True
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "created_concept_ids": [effective_id],
+            "results": [
+                {
+                    "success": True,
+                    "changed": True,
+                    "concept_id": effective_id,
+                }
+            ],
+            "total": 1,
+            "successful": 1,
+        }
+
+    with authority.override_current_actor(actor_id, "#V#organisation_a"):
+        first = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments=recovery_arguments,
+            mutate=create_once,
+        )
+        repeated = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments=recovery_arguments,
+            mutate=lambda: (_ for _ in ()).throw(
+                AssertionError("compatible repeat must not mutate")
+            ),
+        )
+
+    expected_metadata = {
+        "schema_version": "ontology_actor_scoped_instance_referent.v1",
+        "effective_concept_id": effective_id,
+        "scope_mode": "user_only_default",
+        "identity_status": "unreconciled_actor_scoped_referent",
+        "equivalence_asserted": False,
+        "alias_created": False,
+    }
+    assert mutation_calls["count"] == 1
+    assert first["changed"] is True
+    assert first["created_concept_ids"] == [effective_id]
+    assert first["actor_scoped_referent"] == expected_metadata
+    assert repeated["success"] is True
+    assert repeated["changed"] is False
+    assert repeated["idempotent_reuse"] is True
+    assert repeated["created_concept_ids"] == []
+    assert repeated["resolved_concept_ids"] == [effective_id]
+    assert repeated["actor_scoped_referent"] == expected_metadata
+
+
+def test_visible_compatible_exact_create_is_reused_without_mutation(
+    monkeypatch,
+) -> None:
+    from contextlib import nullcontext
+    from types import SimpleNamespace
+
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    concept_id = "#V#visible_person"
+    actor_id = "#V#member"
+    parent_id = "#V#person"
+    canonical_concept = {
+        "concept_id": concept_id,
+        "exists": True,
+        "publication_context": authority.PublicationContext.global_context().to_mapping(),
+        "forward_relationships": {
+            "is_a_type_of": [],
+            "is_an_instance_of": [parent_id],
+            "linked_to": ["#V#additional_visible_context"],
+        },
+        "attributes": {},
+        "system_tags": [],
+        "user_tags": [],
+        "vontology_path": None,
+        "text_relations": [
+            {
+                "predicate": "hasName",
+                "text": "Visible Person",
+                "context": {"name_type": "NL"},
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+    monkeypatch.setattr(command, "_concept_exists_unfiltered", lambda _concept_id: True)
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        command, "_concept_read_back", lambda _concept_id: canonical_concept
+    )
+    monkeypatch.setattr(
+        command,
+        "scope_read_back",
+        lambda value: {"scope_fingerprint": f"scope:{value}"},
+    )
+    monkeypatch.setattr(
+        command,
+        "ontology_mutation_resource_lock",
+        lambda _resource_key: nullcontext(),
+    )
+    monkeypatch.setattr(command, "ontology_authority_resource_keys", lambda _intent: ())
+    monkeypatch.setattr(
+        command,
+        "authorise_ontology_mutation",
+        lambda _intent: SimpleNamespace(allowed=True),
+    )
+
+    def execute_authorised(**kwargs: Any) -> dict[str, Any]:
+        result = dict(kwargs["mutate"]())
+        canonical_state = kwargs["read_back"]()
+        assert kwargs["verify_read_back"](result, canonical_state) is True
+        return {**result, "canonical_read_back": canonical_state}
+
+    monkeypatch.setattr(
+        command,
+        "execute_authorised_ontology_mutation",
+        execute_authorised,
+    )
+    with authority.override_current_actor(actor_id, None):
+        result = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": parent_id,
+                "concepts": [
+                    {
+                        "concept_id": concept_id,
+                        "name": "Visible Person",
+                        "kind": "instance",
+                    }
+                ],
+                "scope_mode": "user_only_default",
+            },
+            mutate=lambda: (_ for _ in ()).throw(
+                AssertionError("visible compatible reuse must not mutate")
+            ),
+        )
+
+    assert result["success"] is True
+    assert result["changed"] is False
+    assert result["idempotent_reuse"] is True
+    assert result["created_concept_ids"] == []
+    assert result["resolved_concept_ids"] == [concept_id]
+    assert "actor_scoped_referent" not in result
+
+
+def test_actor_scoped_referent_created_concurrently_is_reused_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from contextlib import nullcontext
+    from types import SimpleNamespace
+
+    from src.backend.services import actor_scoped_referent_identity_service as identity
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    actor_id = "#V#member"
+    requested_id = "#V#concurrent_person"
+    parent_id = "#V#person"
+    effective_id = identity.actor_scoped_referent_concept_id(
+        requested_concept_id=requested_id,
+        actor_concept_id=actor_id,
+    )
+    existence_checks = 0
+    canonical_concept = {
+        "concept_id": effective_id,
+        "exists": True,
+        "publication_context": authority.PublicationContext.user(actor_id).to_mapping(),
+        "forward_relationships": {
+            "is_a_type_of": [],
+            "is_an_instance_of": [parent_id],
+            "linked_to": [],
+        },
+        "attributes": {},
+        "system_tags": [],
+        "user_tags": [],
+        "vontology_path": None,
+        "text_relations": [
+            {
+                "predicate": "hasName",
+                "text": "Concurrent Person",
+                "context": {"name_type": "NL"},
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        "src.backend.services.create_concepts_parent_resolution_service."
+        "resolve_parent_for_create_concepts",
+        _parent_resolution,
+    )
+
+    def concept_exists(concept_id: str) -> bool:
+        nonlocal existence_checks
+        assert concept_id == effective_id
+        existence_checks += 1
+        return existence_checks > 1
+
+    monkeypatch.setattr(command, "_concept_exists_unfiltered", concept_exists)
+    monkeypatch.setattr(
+        command,
+        "can_access_concept",
+        lambda concept_id: concept_id in {parent_id, effective_id},
+    )
+    monkeypatch.setattr(
+        command,
+        "_concept_read_back",
+        lambda concept_id: (
+            dict(canonical_concept)
+            if concept_id == effective_id
+            else {"concept_id": concept_id, "exists": False}
+        ),
+    )
+    monkeypatch.setattr(
+        command,
+        "scope_read_back",
+        lambda value: {"scope_fingerprint": f"scope:{value}"},
+    )
+    monkeypatch.setattr(
+        command,
+        "ontology_mutation_resource_lock",
+        lambda _resource_key: nullcontext(),
+    )
+    monkeypatch.setattr(command, "ontology_authority_resource_keys", lambda _intent: ())
+    monkeypatch.setattr(
+        command,
+        "authorise_ontology_mutation",
+        lambda _intent: SimpleNamespace(allowed=True),
+    )
+
+    def execute_authorised(**kwargs: Any) -> dict[str, Any]:
+        result = dict(kwargs["mutate"]())
+        canonical_state = kwargs["read_back"]()
+        assert kwargs["verify_read_back"](result, canonical_state) is True
+        return {**result, "canonical_read_back": canonical_state}
+
+    monkeypatch.setattr(
+        command,
+        "execute_authorised_ontology_mutation",
+        execute_authorised,
+    )
+    with authority.override_current_actor(actor_id, None):
+        result = command.execute_governed_ontology_method(
+            method_name="create_concepts",
+            arguments={
+                "parent_id": parent_id,
+                "concepts": [
+                    {
+                        "concept_id": effective_id,
+                        "name": "Concurrent Person",
+                        "kind": "instance",
+                    }
+                ],
+                "duplicate_resolution_mode": "canonical_id_only",
+                "collision_resolution_mode": "actor_scoped_referent",
+                "requested_concept_id": requested_id,
+                "scope_mode": "user_only_default",
+            },
+            mutate=lambda: (_ for _ in ()).throw(
+                AssertionError("a compatible concurrent create must not mutate")
+            ),
+        )
+
+    assert existence_checks == 2
+    assert result["success"] is True
+    assert result["changed"] is False
+    assert result["idempotent_reuse"] is True
+    assert result["resolved_concept_ids"] == [effective_id]
+    assert result["actor_scoped_referent"]["effective_concept_id"] == effective_id


### PR DESCRIPTION
Summary
- add a non-disclosing, actor-private referent recovery for inaccessible instance-ID collisions
- require exact canonical read-back before the original collision is treated as recovered
- make compatible exact creates idempotent, including concurrent occupation after preflight
- normalise pre-dispatch invalid-capability receipts so they do not poison turn finality

Authority and anti-ratchet boundary
- trusted actor context derives the private identity and user-only publication scope
- no alias, equivalence, hidden occupant metadata, or hidden-ID probe is introduced
- requested concept ID is only a deterministic seed during recovery execution
- real authority and target denials remain final

Validation
- 212 adaptive-turn tests
- 67 focused authority, collision, identity, typing, catalogue, and manifest tests
- 80 neighbouring create tests excluding four sessionless stdio cases
- Ruff F/E9, py_compile, manifest parity, and diff check

Known baseline
- one old stdio duplicate-guard test fails identically on origin/main because sessionless ontology delegation is unsupported; it is outside this actor-bound change

Jira: JVNAUTOSCI-2663, JVNAUTOSCI-2664