### PR TITLE
Fix namespaced conversation deletion (JVNAUTOSCI-2666)

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -17125,8 +17125,16 @@ def delete_chat_session():
     """
     MAX_DELETABLE_TURNS = 4
     try:
-        user_concept_id = session.get("user_concept_id")
-        if not user_concept_id:
+        from ...security.access_control import (
+            LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+            get_effective_user_concept_id_with_source,
+        )
+
+        user_concept_id, actor_source = get_effective_user_concept_id_with_source()
+        if (
+            not user_concept_id
+            or actor_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE
+        ):
             return jsonify({"error": "Not authenticated"}), 401
 
         data = request.get_json(silent=True) or {}
@@ -17140,21 +17148,30 @@ def delete_chat_session():
         effective = get_effective_context(
             window_session_id, dict(session), user_concept_id
         )
-        namespace = effective.get(
-            "namespace"
-        ) or chat_history_service.resolve_chat_history_namespace(user_concept_id)
+        namespace = effective.get("namespace") or (
+            chat_history_service.resolve_chat_history_namespace(user_concept_id)
+        )
+        if not isinstance(namespace, str) or not namespace.strip():
+            return (
+                jsonify(
+                    {
+                        "error": "Conversation namespace unavailable; deletion not attempted",
+                        "error_code": "conversation_namespace_unavailable",
+                    }
+                ),
+                503,
+            )
+        namespace = namespace.strip()
 
-        # Verify session exists and check message count
-        session_doc = chat_history_service.get_chat_history_session_summary(
+        # Count only the exact namespaced session without loading its full history.
+        message_count = chat_history_service.get_chat_history_session_message_count(
             user_id=user_concept_id,
             session_id=session_id,
             namespace=namespace,
-            summary_mode="light",
         )
-        if not session_doc:
+        if message_count is None:
             return jsonify({"error": "Session not found"}), 404
 
-        message_count = session_doc.get("message_count", 0)
         turn_count = max(0, (message_count + 1) // 2)
         if turn_count >= MAX_DELETABLE_TURNS:
             return (
@@ -17167,20 +17184,84 @@ def delete_chat_session():
                 403,
             )
 
-        chat_history_service.delete_chat_history(user_concept_id, session_id)
+        receipt = chat_history_service.delete_chat_history(
+            user_concept_id,
+            session_id,
+            namespace=namespace,
+        )
+        acknowledged = receipt.get("acknowledged") is True
+        deleted_count = receipt.get("deleted_count")
+        canonical_absent = receipt.get("canonical_absent") is True
+        deleted_once = (
+            isinstance(deleted_count, int)
+            and not isinstance(deleted_count, bool)
+            and deleted_count == 1
+        )
+        if not acknowledged or not deleted_once or not canonical_absent:
+            current_app.logger.warning(
+                "Conversation deletion could not be verified for %s: %s",
+                session_id,
+                receipt,
+            )
+            return (
+                jsonify(
+                    {
+                        "status": "delete_unverified",
+                        "error": "Conversation deletion could not be verified",
+                        "error_code": "conversation_delete_unverified",
+                        "session_id": session_id,
+                        "acknowledged": acknowledged,
+                        "deleted_count": deleted_count,
+                        "canonical_absent": canonical_absent,
+                    }
+                ),
+                409,
+            )
 
         return (
             jsonify(
                 {
                     "status": "deleted",
                     "session_id": session_id,
+                    "acknowledged": True,
+                    "deleted_count": 1,
+                    "canonical_absent": True,
                 }
             ),
             200,
         )
-    except Exception as e:
-        print(f"Error deleting chat session: {e}")
-        return jsonify({"error": str(e)}), 500
+    except WindowSessionOwnershipError:
+        return (
+            jsonify(
+                {
+                    "error": "Window session does not belong to the authenticated user",
+                    "error_code": "window_session_actor_mismatch",
+                }
+            ),
+            403,
+        )
+    except chat_history_service.ChatHistoryServiceError as exc:
+        current_app.logger.warning("Conversation deletion failed: %s", exc)
+        return (
+            jsonify(
+                {
+                    "error": "Chat history unavailable; deletion not confirmed",
+                    "error_code": "chat_history_unavailable",
+                }
+            ),
+            503,
+        )
+    except Exception:
+        current_app.logger.exception("Unexpected error deleting chat session")
+        return (
+            jsonify(
+                {
+                    "error": "Unexpected error deleting conversation",
+                    "error_code": "conversation_delete_failed",
+                }
+            ),
+            500,
+        )
 
 
 @von_bp.route("/api/session/chat_session_links", methods=["GET", "POST"])

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -3508,37 +3508,153 @@ def add_reset_marker_to_history(user_id: str, session_id: str) -> None:
         raise ChatHistoryServiceError(f"Could not add reset marker: {e}") from e
 
 
-def delete_chat_history(user_id: str, session_id: str) -> None:
-    """
-    Deletes the chat history for a specific user and session.
-    Note: This is kept for backward compatibility but add_reset_marker_to_history() is preferred.
+def get_chat_history_session_message_count(
+    user_id: str,
+    session_id: str,
+    *,
+    namespace: str,
+) -> Optional[int]:
+    """Return the exact session's non-reset message count without loading history."""
 
-    Args:
-        user_id: The user's concept ID
-        session_id: The session UUID
-    """
-    if not user_id or not session_id:
+    user_id_value = _safe_str(user_id)
+    session_id_value = _safe_str(session_id)
+    namespace_value = _safe_str(namespace)
+    if not user_id_value or not session_id_value:
         raise ChatHistoryServiceError("user_id and session_id are required.")
+    if not namespace_value:
+        raise ChatHistoryServiceError("namespace is required.")
+
+    chat_history_coll = get_chat_history_collection_service(read_only=True)
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    _guard_chat_history_read("get_chat_history_session_message_count")
+    query = build_chat_history_query(
+        user_id=user_id_value,
+        session_id=session_id_value,
+        namespace=namespace_value,
+        include_legacy=False,
+    )
+    pipeline = [
+        {"$match": query},
+        {
+            "$project": {
+                "_id": 0,
+                "message_count": {
+                    "$size": {
+                        "$filter": {
+                            "input": _history_array_expr(),
+                            "as": "msg",
+                            "cond": {
+                                "$or": [
+                                    {"$ne": ["$$msg.role", "system"]},
+                                    {"$ne": ["$$msg.content", "__RESET__"]},
+                                ]
+                            },
+                        }
+                    }
+                },
+            }
+        },
+        {"$limit": 1},
+    ]
+
+    try:
+        summary = next(
+            _read_aggregate(
+                chat_history_coll,
+                pipeline,
+                operation="get_chat_history_session_message_count.aggregate",
+            ),
+            None,
+        )
+        if summary is None:
+            _record_chat_history_read_success()
+            return None
+        raw_count = summary.get("message_count") if isinstance(summary, dict) else None
+        if (
+            not isinstance(raw_count, int)
+            or isinstance(raw_count, bool)
+            or raw_count < 0
+        ):
+            raise ChatHistoryServiceError(
+                "Chat history session returned an invalid message count."
+            )
+        _record_chat_history_read_success()
+        return raw_count
+    except PyMongoError as e:
+        _record_chat_history_read_failure(
+            "get_chat_history_session_message_count", e
+        )
+        logger.exception(
+            "Error retrieving chat history session message count: %s",
+            e,
+        )
+        raise ChatHistoryServiceError(
+            f"Could not retrieve chat history session message count: {e}"
+        ) from e
+
+
+def delete_chat_history(
+    user_id: str,
+    session_id: str,
+    *,
+    namespace: str,
+) -> Dict[str, Any]:
+    """Delete one exact namespaced chat session and read back its absence."""
+
+    user_id_value = _safe_str(user_id)
+    session_id_value = _safe_str(session_id)
+    namespace_value = _safe_str(namespace)
+    if not user_id_value or not session_id_value:
+        raise ChatHistoryServiceError("user_id and session_id are required.")
+    if not namespace_value:
+        raise ChatHistoryServiceError("namespace is required.")
 
     chat_history_coll = get_chat_history_collection_service()
     if chat_history_coll is None:
         raise ChatHistoryServiceError("Could not connect to chat history collection.")
 
+    query = build_chat_history_query(
+        user_id=user_id_value,
+        session_id=session_id_value,
+        namespace=namespace_value,
+        include_legacy=False,
+    )
     try:
-        result = chat_history_coll.delete_one(
-            {"user_id": user_id, "session_id": session_id}
+        result = chat_history_coll.delete_one(query)
+        acknowledged = bool(getattr(result, "acknowledged", True))
+        raw_deleted_count = getattr(result, "deleted_count", 0)
+        deleted_count = (
+            raw_deleted_count
+            if isinstance(raw_deleted_count, int)
+            and not isinstance(raw_deleted_count, bool)
+            and raw_deleted_count >= 0
+            else 0
         )
-
-        if result.deleted_count > 0:
-            logger.info(
-                f"Deleted chat history for user {user_id}, session {session_id}"
+        canonical_absent = (
+            _read_find_one(
+                chat_history_coll,
+                query,
+                {"_id": 1},
+                operation="delete_chat_history.canonical_readback",
             )
-        else:
-            logger.warning(
-                f"No history found to delete for user {user_id}, session {session_id}"
-            )
+            is None
+        )
+        receipt = {
+            "acknowledged": acknowledged,
+            "deleted_count": deleted_count,
+            "canonical_absent": canonical_absent,
+        }
+        logger.info(
+            "Chat history deletion receipt for user %s, session %s: %s",
+            user_id_value,
+            session_id_value,
+            receipt,
+        )
+        return receipt
     except PyMongoError as e:
-        logger.error(f"Error deleting chat history: {e}", exc_info=True)
+        logger.exception("Error deleting chat history: %s", e)
         raise ChatHistoryServiceError(f"Could not delete chat history: {e}") from e
 
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1710,7 +1710,7 @@ function toggleShowAgentCreatedSessions() {
 async function deleteConversation(sessionId) {
     if (!sessionId) return;
     try {
-        const resp = await fetch('/api/session/delete_chat_session', {
+        const resp = await fetch('/von/api/session/delete_chat_session', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -1718,10 +1718,27 @@ async function deleteConversation(sessionId) {
             },
             body: JSON.stringify({ session_id: sessionId })
         });
-        const data = await resp.json();
+        let data = null;
+        try {
+            data = await resp.json();
+        } catch (_) {
+            // Preserve the HTTP failure below when a proxy or route returns HTML.
+        }
         if (!resp.ok) {
-            const errorMsg = data?.error || 'Failed to delete conversation';
+            const errorMsg = data?.error
+                || `Failed to delete conversation (HTTP ${resp.status || 'unknown'})`;
             showToast(errorMsg, 'error');
+            return false;
+        }
+        if (
+            data?.status !== 'deleted'
+            || data?.deleted_count !== 1
+            || data?.canonical_absent !== true
+        ) {
+            showToast(
+                data?.error || 'Conversation deletion could not be verified',
+                'error'
+            );
             return false;
         }
         // Remove from cache and re-render
@@ -37680,6 +37697,12 @@ export function __testOnly_setSessionTabsCache(sessions = []) {
     sessionTabsCache = normaliseConversationSessionViewModels(
         Array.isArray(sessions) ? sessions : []
     );
+}
+export function __testOnly_getSessionTabsCache() {
+    return sessionTabsCache.map((session) => ({ ...session }));
+}
+export async function __testOnly_deleteConversation(sessionId) {
+    return deleteConversation(sessionId);
 }
 export async function __testOnly_refreshChatPromptQueueFromServer() {
     return refreshChatPromptQueueFromServer({ silent: false });

--- a/tests/backend/test_chat_history_length_resilience.py
+++ b/tests/backend/test_chat_history_length_resilience.py
@@ -56,6 +56,81 @@ def test_get_chat_history_session_count_uses_aggregate_pipeline(monkeypatch):
     assert pipeline[0]["$match"]["namespace"] == "#V#u@org"
 
 
+def test_get_chat_history_session_message_count_is_exact_and_metadata_safe(
+    monkeypatch,
+):
+    coll = _AggregateCollection({"message_count": 0})
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **kwargs: coll,
+    )
+
+    total = chat_history_service.get_chat_history_session_message_count(
+        "#V#u",
+        "empty-session",
+        namespace="#V#u@org",
+    )
+
+    assert total == 0
+    assert len(coll.aggregate_calls) == 1
+    pipeline = coll.aggregate_calls[0]["pipeline"]
+    assert pipeline[0] == {
+        "$match": {
+            "user_id": "#V#u",
+            "session_id": "empty-session",
+            "namespace": "#V#u@org",
+        }
+    }
+    assert pipeline[-1] == {"$limit": 1}
+    assert "$size" in pipeline[1]["$project"]["message_count"]
+
+
+def test_get_chat_history_session_message_count_returns_none_when_absent(
+    monkeypatch,
+):
+    class _EmptyAggregateCollection:
+        def aggregate(self, _pipeline, **_kwargs):
+            return iter([])
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **kwargs: _EmptyAggregateCollection(),
+    )
+
+    assert (
+        chat_history_service.get_chat_history_session_message_count(
+            "#V#u",
+            "missing-session",
+            namespace="#V#u@org",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("raw_count", [True, -1, None, "0"])
+def test_get_chat_history_session_message_count_rejects_invalid_counts(
+    monkeypatch, raw_count
+):
+    coll = _AggregateCollection({"message_count": raw_count})
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **kwargs: coll,
+    )
+
+    with pytest.raises(
+        chat_history_service.ChatHistoryServiceError,
+        match="invalid message count",
+    ):
+        chat_history_service.get_chat_history_session_message_count(
+            "#V#u",
+            "session-1",
+            namespace="#V#u@org",
+        )
+
+
 def test_chat_history_length_retries_despite_recent_transient_timeout(monkeypatch):
     class _FailingAggregateCollection:
         def __init__(self):

--- a/tests/backend/test_chat_history_session_management.py
+++ b/tests/backend/test_chat_history_session_management.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 
 def test_create_chat_session_sets_name_and_namespace(monkeypatch):
     from src.backend.services import chat_history_service
@@ -214,3 +216,148 @@ def test_agent_created_provenance_backfill_marks_only_reliable_candidates(
     assert docs[2]["is_agent_created"] is True
     assert docs[2]["test_artifact_kind"] == "live_kb_tool_prompt_sampler_chat_session"
     assert "is_agent_created" not in docs[3]
+
+
+def test_delete_chat_history_targets_exact_namespace_and_reads_back(monkeypatch):
+    from src.backend.services import chat_history_service
+
+    docs = [
+        {
+            "_id": "target",
+            "user_id": "#V#user",
+            "session_id": "same-session",
+            "namespace": "#V#user@org-a",
+        },
+        {
+            "_id": "other-namespace",
+            "user_id": "#V#user",
+            "session_id": "same-session",
+            "namespace": "#V#user@org-b",
+        },
+        {
+            "_id": "legacy",
+            "user_id": "#V#user",
+            "session_id": "same-session",
+        },
+    ]
+    calls = {"delete": [], "find": []}
+
+    def _matches(doc, query):
+        return all(doc.get(key) == value for key, value in query.items())
+
+    class _FakeColl:
+        def delete_one(self, query):
+            calls["delete"].append(dict(query))
+            for index, doc in enumerate(docs):
+                if _matches(doc, query):
+                    docs.pop(index)
+                    return types.SimpleNamespace(acknowledged=True, deleted_count=1)
+            return types.SimpleNamespace(acknowledged=True, deleted_count=0)
+
+        def find_one(self, query, projection=None, **_kwargs):
+            calls["find"].append(dict(query))
+            return next((dict(doc) for doc in docs if _matches(doc, query)), None)
+
+    coll = _FakeColl()
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: coll,
+    )
+
+    receipt = chat_history_service.delete_chat_history(
+        "#V#user",
+        "same-session",
+        namespace="#V#user@org-a",
+    )
+
+    assert receipt == {
+        "acknowledged": True,
+        "deleted_count": 1,
+        "canonical_absent": True,
+    }
+    assert calls["delete"] == [
+        {
+            "user_id": "#V#user",
+            "session_id": "same-session",
+            "namespace": "#V#user@org-a",
+        }
+    ]
+    assert calls["find"] == calls["delete"]
+    assert {doc["_id"] for doc in docs} == {"other-namespace", "legacy"}
+
+
+@pytest.mark.parametrize("namespace", ["", "   ", None])
+def test_delete_chat_history_requires_exact_namespace(monkeypatch, namespace):
+    from src.backend.services import chat_history_service
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: pytest.fail("collection should not be accessed"),
+    )
+
+    with pytest.raises(chat_history_service.ChatHistoryServiceError, match="namespace"):
+        chat_history_service.delete_chat_history(
+            "#V#user",
+            "session-1",
+            namespace=namespace,
+        )
+
+
+def test_delete_chat_history_receipt_exposes_zero_delete(monkeypatch):
+    from src.backend.services import chat_history_service
+
+    class _FakeColl:
+        def delete_one(self, _query):
+            return types.SimpleNamespace(acknowledged=True, deleted_count=0)
+
+        def find_one(self, _query, _projection=None, **_kwargs):
+            return None
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: _FakeColl(),
+    )
+
+    receipt = chat_history_service.delete_chat_history(
+        "#V#user",
+        "missing-session",
+        namespace="#V#user@org",
+    )
+
+    assert receipt == {
+        "acknowledged": True,
+        "deleted_count": 0,
+        "canonical_absent": True,
+    }
+
+
+def test_delete_chat_history_receipt_exposes_remaining_duplicate(monkeypatch):
+    from src.backend.services import chat_history_service
+
+    class _FakeColl:
+        def delete_one(self, _query):
+            return types.SimpleNamespace(acknowledged=True, deleted_count=1)
+
+        def find_one(self, _query, _projection=None, **_kwargs):
+            return {"_id": "duplicate-remains"}
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: _FakeColl(),
+    )
+
+    receipt = chat_history_service.delete_chat_history(
+        "#V#user",
+        "duplicate-session",
+        namespace="#V#user@org",
+    )
+
+    assert receipt == {
+        "acknowledged": True,
+        "deleted_count": 1,
+        "canonical_absent": False,
+    }

--- a/tests/backend/test_conversation_management_routes.py
+++ b/tests/backend/test_conversation_management_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import types
+
 import pytest
 from flask import Flask
 
@@ -130,3 +132,277 @@ def test_shared_conversation_rename_is_an_actor_specific_display_name(
     payload = response.get_json()
     assert payload["access_mode"] == "invitee"
     assert payload["session_name"] == "My useful label"
+
+
+def test_delete_conversation_route_deletes_empty_exact_session(monkeypatch, app_client):
+    count_call = {}
+    delete_call = {}
+    monkeypatch.setattr(von_routes, "get_effective_context", _effective_context)
+
+    def _message_count(*args, **kwargs):
+        count_call.update({"args": args, "kwargs": kwargs})
+        return 0
+
+    def _delete(*args, **kwargs):
+        delete_call.update({"args": args, "kwargs": kwargs})
+        return {
+            "acknowledged": True,
+            "deleted_count": 1,
+            "canonical_absent": True,
+        }
+
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        _message_count,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "delete_chat_history",
+        _delete,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "empty-session"},
+        headers={"X-Von-Window-Session": "window-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "deleted",
+        "session_id": "empty-session",
+        "acknowledged": True,
+        "deleted_count": 1,
+        "canonical_absent": True,
+    }
+    assert count_call == {
+        "args": (),
+        "kwargs": {
+            "user_id": "#V#alice",
+            "session_id": "empty-session",
+            "namespace": "#V#alice@org",
+        },
+    }
+    assert delete_call == {
+        "args": ("#V#alice", "empty-session"),
+        "kwargs": {"namespace": "#V#alice@org"},
+    }
+
+
+def test_delete_conversation_route_returns_not_found_without_delete(
+    monkeypatch, app_client
+):
+    delete = pytest.fail
+    monkeypatch.setattr(von_routes, "get_effective_context", _effective_context)
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "delete_chat_history",
+        delete,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "missing-session"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()["error"] == "Session not found"
+
+
+def test_delete_conversation_route_denies_four_turns_without_delete(
+    monkeypatch, app_client
+):
+    monkeypatch.setattr(von_routes, "get_effective_context", _effective_context)
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        lambda **_kwargs: 8,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "delete_chat_history",
+        pytest.fail,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "substantial-session"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["turn_count"] == 4
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        {
+            "acknowledged": True,
+            "deleted_count": 0,
+            "canonical_absent": True,
+        },
+        {
+            "acknowledged": True,
+            "deleted_count": 1,
+            "canonical_absent": False,
+        },
+        {
+            "acknowledged": False,
+            "deleted_count": 1,
+            "canonical_absent": True,
+        },
+    ],
+)
+def test_delete_conversation_route_never_claims_unverified_success(
+    monkeypatch, app_client, receipt
+):
+    monkeypatch.setattr(von_routes, "get_effective_context", _effective_context)
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        lambda **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "delete_chat_history",
+        lambda *_args, **_kwargs: receipt,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "empty-session"},
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["status"] == "delete_unverified"
+    assert payload["error_code"] == "conversation_delete_unverified"
+
+
+def test_delete_conversation_route_fails_closed_without_namespace(
+    monkeypatch, app_client
+):
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": None},
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "resolve_chat_history_namespace",
+        lambda _user_id: None,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        pytest.fail,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "empty-session"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "conversation_namespace_unavailable"
+
+
+def test_delete_conversation_route_rejects_legacy_identity_header(
+    monkeypatch, app_client
+):
+    from src.backend.security import access_control
+
+    with app_client.session_transaction() as flask_session:
+        flask_session.clear()
+    monkeypatch.setattr(
+        access_control,
+        "_validate_person_concept",
+        lambda concept_id: concept_id,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_message_count",
+        pytest.fail,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "empty-session"},
+        headers={"X-User-Concept-ID": "#V#alice"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Not authenticated"
+
+
+def test_delete_conversation_route_and_service_remove_disposable_exact_session(
+    monkeypatch, app_client
+):
+    docs = [
+        {
+            "_id": "disposable",
+            "user_id": "#V#alice",
+            "session_id": "disposable-empty-session",
+            "namespace": "#V#alice@org",
+            "history": [],
+        },
+        {
+            "_id": "other-scope",
+            "user_id": "#V#alice",
+            "session_id": "disposable-empty-session",
+            "namespace": "#V#alice@other-org",
+            "history": [],
+        },
+    ]
+
+    def _matches(doc, query):
+        return all(doc.get(key) == value for key, value in query.items())
+
+    class _DisposableCollection:
+        def aggregate(self, pipeline, **_kwargs):
+            query = pipeline[0]["$match"]
+            doc = next((item for item in docs if _matches(item, query)), None)
+            if doc is None:
+                return iter([])
+            count = sum(
+                1
+                for message in doc.get("history", [])
+                if not (
+                    message.get("role") == "system"
+                    and message.get("content") == "__RESET__"
+                )
+            )
+            return iter([{"message_count": count}])
+
+        def delete_one(self, query):
+            for index, doc in enumerate(docs):
+                if _matches(doc, query):
+                    docs.pop(index)
+                    return types.SimpleNamespace(acknowledged=True, deleted_count=1)
+            return types.SimpleNamespace(acknowledged=True, deleted_count=0)
+
+        def find_one(self, query, _projection=None, **_kwargs):
+            return next((dict(doc) for doc in docs if _matches(doc, query)), None)
+
+    collection = _DisposableCollection()
+    monkeypatch.setattr(von_routes, "get_effective_context", _effective_context)
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: collection,
+    )
+
+    response = app_client.post(
+        "/von/api/session/delete_chat_session",
+        json={"session_id": "disposable-empty-session"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["canonical_absent"] is True
+    assert {doc["_id"] for doc in docs} == {"other-scope"}

--- a/tests/frontend/chatSessionDeletion.test.js
+++ b/tests/frontend/chatSessionDeletion.test.js
@@ -1,0 +1,180 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    fetchWithTimeout: jest.fn(),
+    getJsonDetailed: jest.fn(),
+    getUserContext: jest.fn(),
+    getWindowSessionId: jest.fn(() => 'test-window-session'),
+    postJson: jest.fn(),
+    WINDOW_SESSION_HEADER: 'X-Von-Window-Session'
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    getCurrentUserConceptId: jest.fn(() => '#V#delete_user'),
+    renderSpanSuggestions: jest.fn()
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    applyCartoucheAppearance: jest.fn(),
+    cartouchifyElementText: jest.fn(),
+    createVontologyAliasCartouche: jest.fn(),
+    createVontologyCartouche: jest.fn(),
+    findPotentialConceptAliasMatches: jest.fn(() => []),
+    getCartoucheAppearanceSettings: jest.fn(() => ({
+        useShortestName: false,
+        showName: true,
+        showId: true,
+        showKind: true,
+        kindAsBackground: false
+    })),
+    linkifyVontologyTokensInElement: jest.fn(),
+    normalisePotentialConceptAlias: jest.fn(() => ''),
+    normalisePotentialConceptId: jest.fn(() => ''),
+    replaceTextNodeWithVontologyAliasCartouches: jest.fn(() => [])
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn()
+}));
+
+describe('chat session deletion', () => {
+    let originalMatchMedia;
+
+    beforeEach(() => {
+        jest.resetModules();
+        originalMatchMedia = window.matchMedia;
+        window.matchMedia = jest.fn(() => ({ matches: false }));
+        document.body.innerHTML = `
+            <div id="chatTab">
+                <div id="conversationWorkspace" data-tabs-layout="horizontal"
+                    data-effective-tabs-layout="horizontal">
+                    <div id="chatSessionTabs"></div>
+                    <div id="chatSessionCount"></div>
+                    <div id="chatSessionMetadata"></div>
+                    <div id="scrollableField"></div>
+                </div>
+            </div>
+        `;
+        localStorage.clear();
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        localStorage.clear();
+        window.matchMedia = originalMatchMedia;
+    });
+
+    function seedSessions(chatTab) {
+        const timestamp = new Date().toISOString();
+        chatTab.__testOnly_setSessionTabsCache([
+            {
+                session_id: 'delete-me',
+                session_name: 'Delete me',
+                namespace: '#V#delete_user@org',
+                last_message_at: timestamp,
+                message_count: 0
+            },
+            {
+                session_id: 'keep-me',
+                session_name: 'Keep me',
+                namespace: '#V#delete_user@org',
+                last_message_at: timestamp,
+                message_count: 2
+            }
+        ]);
+    }
+
+    test('uses the mounted route and removes the tab only after verified success', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                status: 'deleted',
+                session_id: 'delete-me',
+                acknowledged: true,
+                deleted_count: 1,
+                canonical_absent: true
+            })
+        });
+        const chatTab = require(chatTabModulePath);
+        const { showToast } = require(
+            '../../src/frontend/web/von_interface/static/js/utils/toast.js'
+        );
+        seedSessions(chatTab);
+
+        const deleted = await chatTab.__testOnly_deleteConversation('delete-me');
+
+        expect(deleted).toBe(true);
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/von/api/session/delete_chat_session',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ session_id: 'delete-me' })
+            })
+        );
+        expect(global.fetch.mock.calls[0][1].headers).toEqual(expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-Von-Window-Session': 'test-window-session',
+            'X-User-Concept-ID': '#V#delete_user'
+        }));
+        expect(
+            chatTab.__testOnly_getSessionTabsCache().map((session) => session.session_id)
+        ).toEqual(['keep-me']);
+        expect(showToast).toHaveBeenCalledWith('Conversation deleted', 'success');
+    });
+
+    test('retains the tab and reports the HTTP error when the response is not JSON', async () => {
+        global.fetch.mockResolvedValue({
+            ok: false,
+            status: 404,
+            json: async () => {
+                throw new SyntaxError('Unexpected token <');
+            }
+        });
+        const chatTab = require(chatTabModulePath);
+        const { showToast } = require(
+            '../../src/frontend/web/von_interface/static/js/utils/toast.js'
+        );
+        seedSessions(chatTab);
+
+        const deleted = await chatTab.__testOnly_deleteConversation('delete-me');
+
+        expect(deleted).toBe(false);
+        expect(
+            chatTab.__testOnly_getSessionTabsCache().map((session) => session.session_id)
+        ).toEqual(['delete-me', 'keep-me']);
+        expect(showToast).toHaveBeenCalledWith(
+            'Failed to delete conversation (HTTP 404)',
+            'error'
+        );
+    });
+
+    test('retains the tab when a 200 response lacks a deletion receipt', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: 'deleted', session_id: 'delete-me' })
+        });
+        const chatTab = require(chatTabModulePath);
+        const { showToast } = require(
+            '../../src/frontend/web/von_interface/static/js/utils/toast.js'
+        );
+        seedSessions(chatTab);
+
+        const deleted = await chatTab.__testOnly_deleteConversation('delete-me');
+
+        expect(deleted).toBe(false);
+        expect(
+            chatTab.__testOnly_getSessionTabsCache().map((session) => session.session_id)
+        ).toEqual(['delete-me', 'keep-me']);
+        expect(showToast).toHaveBeenCalledWith(
+            'Conversation deletion could not be verified',
+            'error'
+        );
+    });
+});


### PR DESCRIPTION
## Outcome

Repairs the conversation-list Delete action for short conversations. The frontend now reaches the mounted route, and the backend only reports success after deleting one exact actor/session/namespace record and reading back its canonical absence.

## Changes

- post deletion to `/von/api/session/delete_chat_session`
- handle HTML/non-JSON failures without masking the HTTP error
- require a trusted authenticated actor and exact effective namespace
- count messages with a bounded aggregation instead of relying on metadata-only summaries
- return a structured deletion receipt and fail closed on zero deletion or failed absence read-back
- preserve same-ID conversations in other namespaces and legacy rows

## Validation

- 44 focused backend tests passed, including a disposable route-to-service deletion replay
- 9 focused frontend and neighbouring context-menu tests passed
- targeted ESLint/static lint and JavaScript syntax passed
- Python high-signal Ruff checks and Python 3.11 minimum-syntax validation passed
- `git diff --check` passed

## Scope

No deployment or runtime activation. No MCP deletion capability, undo workflow, substantial-conversation policy change, or broader storage-erasure redesign.

Jira: JVNAUTOSCI-2666