### PR TITLE
Fix governed Concept-tab scope controls (JVNAUTOSCI-2668)

### DIFF
--- a/src/backend/server/routes/ontology_authority_routes.py
+++ b/src/backend/server/routes/ontology_authority_routes.py
@@ -43,6 +43,8 @@ from ...services.ontology_publication_authority_service import (
     revoke_agent_delegation,
 )
 from ...services.ontology_scope_change_service import (
+    EXECUTE_SCOPE_CHANGE_TOOL_NAME,
+    PREVIEW_SCOPE_CHANGE_TOOL_NAME,
     change_concept_publication_scope,
 )
 from ...services.von_operational_administrator_service import (
@@ -427,22 +429,58 @@ def concept_scope(concept_id: str):
 
 @ontology_authority_bp.route("/concepts/<path:concept_id>/scope", methods=["POST"])
 def change_concept_scope(concept_id: str):
-    if not _authenticated_actor():
+    actor_id = _authenticated_actor()
+    if not actor_id:
         return _actor_required_response()
     payload = _payload()
+    destination_kind = _clean(payload.get("destination_kind"))
+    destination_kind_normalised = destination_kind.lower().replace("-", "_")
+    destination_concept_id = _clean(payload.get("destination_concept_id")) or None
+
+    # The Concept-tab self/organisation controls name the destination kind but
+    # deliberately do not send browser-held identity. Resolve those defaults
+    # from the authenticated request context. An explicit destination remains
+    # supported for administrator-selected transitions and is still checked by
+    # the shared source-and-destination authority service.
+    if not destination_concept_id and destination_kind_normalised in {
+        "user",
+        "private_user",
+    }:
+        destination_concept_id = actor_id
+    if not destination_concept_id and destination_kind_normalised in {
+        "organisation",
+        "organization",
+        "org",
+    }:
+        destination_concept_id = get_effective_organisation_concept_id()
+        if not destination_concept_id:
+            return jsonify(
+                {
+                    "error": "organisation_context_required",
+                    "message": (
+                        "Choose an organisation context before changing the "
+                        "concept publication scope."
+                    ),
+                }
+            ), 400
+    preview = bool(payload.get("preview", True))
+    invocation_tool_name = (
+        PREVIEW_SCOPE_CHANGE_TOOL_NAME
+        if preview
+        else EXECUTE_SCOPE_CHANGE_TOOL_NAME
+    )
     try:
         result = change_concept_publication_scope(
             concept_id=concept_id,
-            destination_kind=_clean(payload.get("destination_kind")),
-            destination_concept_id=(
-                _clean(payload.get("destination_concept_id")) or None
-            ),
+            destination_kind=destination_kind,
+            destination_concept_id=destination_concept_id,
             expected_scope_fingerprint=_clean(
                 payload.get("expected_scope_fingerprint")
             ),
             request_id=_clean(payload.get("request_id")),
-            preview=bool(payload.get("preview", True)),
+            preview=preview,
             reason=_clean(payload.get("reason")) or None,
+            invocation_tool_name=invocation_tool_name,
         )
     except ValueError as exc:
         return jsonify(

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -5359,7 +5359,7 @@ def toggle_organization_relation():
                     "scope-change API with an explicit preview fingerprint."
                 ),
                 "recovery_affordances": [
-                    {"action_type": "preview_concept_publication_scope"},
+                    {"action_type": "preview_concept_publication_scope_change"},
                     {"action_type": "change_concept_publication_scope"},
                 ],
             }
@@ -5487,7 +5487,7 @@ def toggle_user_relation():
                     "scope-change API with an explicit preview fingerprint."
                 ),
                 "recovery_affordances": [
-                    {"action_type": "preview_concept_publication_scope"},
+                    {"action_type": "preview_concept_publication_scope_change"},
                     {"action_type": "change_concept_publication_scope"},
                 ],
             }

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -16,6 +16,11 @@ import { activateTab } from './tabNavigation.js';
 import { createVontologyCartouche, normalisePotentialConceptId } from './utils/textDecorator.js';
 import { copyJsonTextWithButtonFeedback, resetCopyJsonButtonPreCopyState } from './utils/copyJsonButtonState.js';
 import { mountJsonInspector } from './utils/jsonInspector.js';
+import {
+    describePublicationContext,
+    executeGovernedScopeControlChange,
+    publicationScopeFlags
+} from './utils/governedPublicationScope.js';
 import { showToast } from './utils/toast.js';
 import {
     armRetryableLoadState,
@@ -24,8 +29,7 @@ import {
 } from './utils/retryableLoadState.js';
 import {
     buildNamespaceScopedStorageKey,
-    getSessionScopedNamespace,
-    getSessionScopedOrgId
+    getSessionScopedNamespace
 } from './utils/sessionScopedStorage.js';
 import { initialiseResizableViewport } from './utils/resizableViewport.js';
 import { getKeyConceptIds, updateTabHeaderStarButtons, updateTreeKeyConceptBadge } from './vontology.js';
@@ -7600,7 +7604,7 @@ export function deriveFileCopyActionState(nodePayload = null) {
     };
 }
 
-function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
+export function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
     try {
         if (!headerDiv || !conceptId) return;
 
@@ -7629,8 +7633,8 @@ function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
         // 2. Organization Relation Button
         const orgBtn = document.createElement('button');
         orgBtn.className = 'org-relation-button';
-        orgBtn.title = 'Toggle organization relation';
-        orgBtn.setAttribute('aria-label', 'Toggle specific_to_organisation relationship');
+        orgBtn.title = 'Move publication scope to the current organisation';
+        orgBtn.setAttribute('aria-label', 'Change publication scope to the current organisation');
         orgBtn.setAttribute('data-keep-title', 'true');
         orgBtn.innerHTML = '🏢'; // Building emoji
         orgBtn.style.padding = '2px 6px';
@@ -7644,8 +7648,8 @@ function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
         // 3. User Relation Button
         const userBtn = document.createElement('button');
         userBtn.className = 'user-relation-button';
-        userBtn.title = 'Toggle user relation';
-        userBtn.setAttribute('aria-label', 'Toggle specific_to_user relationship');
+        userBtn.title = 'Move publication scope to your user context';
+        userBtn.setAttribute('aria-label', 'Change publication scope to your user context');
         userBtn.setAttribute('data-keep-title', 'true');
         userBtn.innerHTML = '👤'; // Person emoji
         userBtn.style.padding = '2px 6px';
@@ -7656,13 +7660,28 @@ function attachAnalysisButtons(headerDiv, conceptId, kind, nodePayload = null) {
         userBtn.style.cursor = 'pointer';
         userBtn.style.fontSize = '0.9rem';
 
-        // Load initial states
-        loadButtonStates(conceptId, flagBtn, orgBtn, userBtn);
+        // The raw document is display state, not a prerequisite for the
+        // governed control. Ignore a late initial scope snapshot once either
+        // control has started its authoritative GET/preview/execute path.
+        let scopeInteractionStarted = false;
+        void loadButtonStates(
+            conceptId,
+            flagBtn,
+            orgBtn,
+            userBtn,
+            () => !scopeInteractionStarted
+        );
 
         // Event listeners
         flagBtn.addEventListener('click', () => toggleConceptFlag(conceptId, flagBtn));
-        orgBtn.addEventListener('click', () => toggleOrganizationRelation(conceptId, orgBtn));
-        userBtn.addEventListener('click', () => toggleUserRelation(conceptId, userBtn));
+        orgBtn.addEventListener('click', () => {
+            scopeInteractionStarted = true;
+            void toggleOrganizationRelation(conceptId, orgBtn, userBtn);
+        });
+        userBtn.addEventListener('click', () => {
+            scopeInteractionStarted = true;
+            void toggleUserRelation(conceptId, userBtn, orgBtn);
+        });
 
         // Add buttons to group
         buttonGroup.appendChild(flagBtn);
@@ -7802,7 +7821,7 @@ if (typeof window !== 'undefined') {
 }
 
 // Load initial button states from concept data
-async function loadButtonStates(conceptId, flagBtn, orgBtn, userBtn) {
+async function loadButtonStates(conceptId, flagBtn, orgBtn, userBtn, shouldApplyScope = null) {
     try {
         const encoded = encodeURIComponent(conceptId);
         const response = await fetch(`/vontology/api/vontology/node_content?identifier=${encoded}`);
@@ -7810,6 +7829,7 @@ async function loadButtonStates(conceptId, flagBtn, orgBtn, userBtn) {
 
         const data = await response.json();
         const concept = data.raw_doc || data;
+        const applyScopeState = typeof shouldApplyScope !== 'function' || shouldApplyScope();
 
         // Update flag button state
         if (flagBtn) {
@@ -7818,7 +7838,7 @@ async function loadButtonStates(conceptId, flagBtn, orgBtn, userBtn) {
         }
 
         // Update organization button state
-        if (orgBtn) {
+        if (orgBtn && applyScopeState) {
             const orgRelations = getCanonicalRelationshipTargets(
                 concept.relationships,
                 '#V#specific_to_organisation'
@@ -7828,7 +7848,7 @@ async function loadButtonStates(conceptId, flagBtn, orgBtn, userBtn) {
         }
 
         // Update user button state
-        if (userBtn) {
+        if (userBtn && applyScopeState) {
             const userRelations = getCanonicalRelationshipTargets(
                 concept.relationships,
                 '#V#specific_to_user'
@@ -7867,93 +7887,49 @@ async function toggleConceptFlag(conceptId, flagBtn) {
     }
 }
 
-// Toggle organization relation
-async function toggleOrganizationRelation(conceptId, orgBtn) {
-    try {
-        const hasRelation = orgBtn.dataset.hasRelation === 'true';
-        const action = hasRelation ? 'remove' : 'add';
-        orgBtn.disabled = true;
-        // JVNAUTOSCI-1011: Use central helper for session-scoped org context
-        const orgId = getSessionScopedOrgId();
-        if (action === 'add' && !orgId) {
-            showToast('Organisation context unavailable', 'error');
-            return;
-        }
-        const response = await fetch('/vontology/api/vontology/concept/organization-relation', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            // Use NZ spelling primary key; backend tolerates multiple synonyms.
-            body: JSON.stringify({ concept_id: conceptId, action, organisation_concept_id: orgId })
-        });
-
-        const result = await response.json();
-        if (!result.success && !result.changed) {
-            showToast(result.error || 'No change applied', 'error');
-            // Force removal still available for cleanup scenarios, but no context mismatch logic needed
-        } else if (result.success) {
-            const newHasRelation = Array.isArray(result.specific_to_organisation) && result.specific_to_organisation.length > 0;
-            updateOrgButtonState(orgBtn, newHasRelation);
-            showToast(`Organization relation ${action === 'add' ? 'added' : 'removed'}`);
-        } else if (result.changed === false) {
-            showToast('No organization relation updated', 'error');
-        }
-        // Context mismatch no longer relevant - client localStorage is sole authority
-        // Refresh authoritative state from server doc
-        await loadButtonStates(conceptId, null, orgBtn, null);
-    } catch (e) {
-        console.error('Failed to toggle organization relation:', e);
-        showToast('Failed to toggle organization relation', 'error');
-    } finally { orgBtn.disabled = false; }
+export function applyPublicationScopeReadBack(scopeReadBack, orgBtn, userBtn) {
+    const flags = publicationScopeFlags(scopeReadBack);
+    if (orgBtn) updateOrgButtonState(orgBtn, flags.hasOrganisationScope);
+    if (userBtn) updateUserButtonState(userBtn, flags.hasUserScope);
+    return flags;
 }
 
-// Toggle user relation
-async function toggleUserRelation(conceptId, userBtn) {
+async function togglePublicationScopeControl(conceptId, controlKind, orgBtn, userBtn) {
+    const buttons = [orgBtn, userBtn].filter(Boolean);
+    buttons.forEach((button) => { button.disabled = true; });
     try {
-        const hasRelation = userBtn.dataset.hasRelation === 'true';
-        const action = hasRelation ? 'remove' : 'add';
-        userBtn.disabled = true;
-        // Get current user concept id from localStorage (client authoritative identity)
-        let userId = (
-            window.localStorage.getItem('von_current_user') ||
-            window.localStorage.getItem('vonCurrentUser') ||
-            null
-        );
-        // Extract concept_id if localStorage contains JSON object
-        if (userId && typeof userId === 'string' && userId.startsWith('{')) {
-            try {
-                const userObj = JSON.parse(userId);
-                userId = userObj.concept_id || userId;
-            } catch (e) {
-                // Keep original string if JSON parse fails
-            }
+        const result = await executeGovernedScopeControlChange({ conceptId, controlKind });
+        applyPublicationScopeReadBack(result.canonical_read_back, orgBtn, userBtn);
+        if (result.cancelled) {
+            showToast('Publication scope change cancelled');
+            return result;
         }
-        if (action === 'add' && !userId) {
-            showToast('User context unavailable', 'error');
-            return;
-        }
-        const response = await fetch('/vontology/api/vontology/concept/user-relation', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ concept_id: conceptId, action, user_concept_id: userId })
+        showToast(`Publication scope changed to ${describePublicationContext(result.preview?.to)}`);
+        dispatchConceptUpdated([conceptId], {
+            reason: 'publication_scope_changed',
+            source: 'concept_scope_controls'
         });
-
-        const result = await response.json();
-        if (!result.success && !result.changed) {
-            showToast(result.error || 'No change applied', 'error');
-            // Force removal still available for cleanup scenarios, but no context mismatch logic needed
-        } else if (result.success) {
-            const newHasRelation = Array.isArray(result.specific_to_user) && result.specific_to_user.length > 0;
-            updateUserButtonState(userBtn, newHasRelation);
-            showToast(`User relation ${action === 'add' ? 'added' : 'removed'}`);
-        } else if (result.changed === false) {
-            showToast('No user relation updated', 'error');
+        return result;
+    } catch (error) {
+        console.error('Failed to change publication scope:', error);
+        if (error?.canonicalReadBack) {
+            applyPublicationScopeReadBack(error.canonicalReadBack, orgBtn, userBtn);
         }
-        // Context mismatch no longer relevant - client localStorage is sole authority
-        await loadButtonStates(conceptId, null, null, userBtn);
-    } catch (e) {
-        console.error('Failed to toggle user relation:', e);
-        showToast('Failed to toggle user relation', 'error');
-    } finally { userBtn.disabled = false; }
+        showToast(`Publication scope change failed: ${error.message}`, 'error');
+        return { success: false, error };
+    } finally {
+        buttons.forEach((button) => { button.disabled = false; });
+    }
+}
+
+// The existing icon controls now request governed whole-scope transitions;
+// they no longer toggle raw visibility relations or send browser identity.
+export async function toggleOrganizationRelation(conceptId, orgBtn, userBtn = null) {
+    return togglePublicationScopeControl(conceptId, 'organisation', orgBtn, userBtn);
+}
+
+export async function toggleUserRelation(conceptId, userBtn, orgBtn = null) {
+    return togglePublicationScopeControl(conceptId, 'user', orgBtn, userBtn);
 }
 
 // Update button states visually
@@ -7976,11 +7952,13 @@ function updateOrgButtonState(orgBtn, hasRelation) {
     if (hasRelation) {
         orgBtn.style.background = '#dbeafe'; // Blue background when related
         orgBtn.style.borderColor = '#3b82f6';
-        orgBtn.title = 'Remove organization relation';
+        orgBtn.title = 'Change publication scope away from this organisation';
+        orgBtn.setAttribute('aria-label', 'Change publication scope away from this organisation');
     } else {
         orgBtn.style.background = '#f9fafb';
         orgBtn.style.borderColor = '#d1d5db';
-        orgBtn.title = 'Add organization relation';
+        orgBtn.title = 'Move publication scope to the current organisation';
+        orgBtn.setAttribute('aria-label', 'Change publication scope to the current organisation');
     }
 }
 
@@ -7990,43 +7968,15 @@ function updateUserButtonState(userBtn, hasRelation) {
     if (hasRelation) {
         userBtn.style.background = '#dcfce7'; // Green background when related
         userBtn.style.borderColor = '#10b981';
-        userBtn.title = 'Remove user relation';
+        userBtn.title = 'Change publication scope away from this user context';
+        userBtn.setAttribute('aria-label', 'Change publication scope away from this user context');
     } else {
         userBtn.style.background = '#f9fafb';
         userBtn.style.borderColor = '#d1d5db';
-        userBtn.title = 'Add user relation';
+        userBtn.title = 'Move publication scope to your user context';
+        userBtn.setAttribute('aria-label', 'Change publication scope to your user context');
     }
 }
-
-// Helper functions to get current user/org info
-async function getCurrentUserOrganization() {
-    try {
-        const response = await fetch('/api/settings/user/current');
-        if (!response.ok) throw new Error('Failed to get user info');
-        const user = await response.json();
-        if (!user.organization_id) throw new Error('Missing organization context');
-        return user.organization_id;
-    } catch (e) {
-        console.warn('Could not get current user organization');
-        showToast('Organisation context unavailable', 'error');
-        return null;
-    }
-}
-
-async function getCurrentUserId() {
-    try {
-        const response = await fetch('/api/settings/user/current');
-        if (!response.ok) throw new Error('Failed to get user info');
-        const user = await response.json();
-        if (!user.user_id) throw new Error('Missing user context');
-        return user.user_id;
-    } catch (e) {
-        console.warn('Could not get current user ID');
-        showToast('User context unavailable', 'error');
-        return null;
-    }
-}
-
 
 // Explicit exports for tests / external modules that need to force relabeling
 export { initializeRelationshipsUI, relabelAllDynamicConceptTabs, reloadConceptTab, updateTabLabelWithShortestName, getCanonicalRelationshipTargets };

--- a/src/frontend/web/von_interface/static/js/test/dynamicTabsScopeChange.test.js
+++ b/src/frontend/web/von_interface/static/js/test/dynamicTabsScopeChange.test.js
@@ -1,0 +1,451 @@
+import {
+    attachAnalysisButtons,
+    toggleUserRelation
+} from '../dynamicTabs.js';
+import {
+    deriveScopeControlDestination,
+    executeGovernedScopeControlChange
+} from '../utils/governedPublicationScope.js';
+
+function jsonResponse(payload, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: jest.fn().mockResolvedValue(payload)
+    };
+}
+
+function globalScope(conceptId = '#V#scope_fixture') {
+    return {
+        concept_id: conceptId,
+        publication_context: { kind: 'global', concept_id: null, source: 'concept_visibility' },
+        scope_edges: {},
+        scope_fingerprint: 'scope-global-before'
+    };
+}
+
+function userScope(conceptId = '#V#scope_fixture') {
+    return {
+        concept_id: conceptId,
+        publication_context: {
+            kind: 'user',
+            concept_id: '#V#signed_in_user',
+            source: 'concept_visibility'
+        },
+        scope_edges: {
+            '#V#specific_to_user': ['#V#signed_in_user']
+        },
+        scope_fingerprint: 'scope-user-before'
+    };
+}
+
+function previewPayload({ from, to, remove = [], add = [] }) {
+    return {
+        success: true,
+        preview: true,
+        changed: false,
+        from,
+        to,
+        scope_delta: { remove, add }
+    };
+}
+
+async function flushUntil(predicate, attempts = 30) {
+    for (let index = 0; index < attempts; index += 1) {
+        await Promise.resolve();
+        if (predicate()) return;
+    }
+    throw new Error('Asynchronous scope-control condition was not reached.');
+}
+
+describe('governed Concept-tab publication scope controls', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        document.body.innerHTML = '';
+        window.localStorage.clear();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        global.fetch = originalFetch;
+    });
+
+    test.each([
+        [
+            'user-only removal publishes globally',
+            { scope_edges: { '#V#specific_to_user': ['#V#person'] } },
+            'user',
+            { destination_kind: 'global' }
+        ],
+        [
+            'organisation-only removal publishes globally',
+            { scope_edges: { specific_to_org: ['#V#org'] } },
+            'organisation',
+            { destination_kind: 'global' }
+        ],
+        [
+            'global to user relies on the authenticated actor',
+            { scope_edges: {} },
+            'user',
+            { destination_kind: 'user' }
+        ],
+        [
+            'global to organisation relies on trusted current context',
+            { scope_edges: {} },
+            'organisation',
+            { destination_kind: 'organisation' }
+        ],
+        [
+            'mixed removal preserves the one exact organisation',
+            {
+                scope_edges: {
+                    specific_to_user: ['#V#person'],
+                    '#V#specific_to_org': ['#V#org']
+                }
+            },
+            'user',
+            { destination_kind: 'organisation', destination_concept_id: '#V#org' }
+        ],
+        [
+            'mixed removal preserves the one exact user',
+            {
+                scope_edges: {
+                    '#V#specific_to_user': ['#V#person'],
+                    specific_to_organisation: ['#V#org']
+                }
+            },
+            'organisation',
+            { destination_kind: 'user', destination_concept_id: '#V#person' }
+        ]
+    ])('%s', (_name, scopeReadBack, controlKind, expected) => {
+        expect(deriveScopeControlDestination(scopeReadBack, controlKind)).toEqual(expected);
+    });
+
+    test('refuses to guess a remaining destination in ambiguous mixed scope', () => {
+        expect(() => deriveScopeControlDestination({
+            scope_edges: {
+                '#V#specific_to_user': ['#V#person'],
+                '#V#specific_to_organisation': ['#V#org_a', '#V#org_b']
+            }
+        }, 'user')).toThrow('multiple or historical publication contexts');
+        expect(() => deriveScopeControlDestination({
+            scope_edges: {
+                '#V#specific_to_user': ['#V#person_a', '#V#person_b']
+            }
+        }, 'user')).toThrow('No change was attempted');
+    });
+
+    test('user-only button follows GET, preview, confirmation and execute before changing state', async () => {
+        const events = [];
+        const before = userScope('#V#private_note');
+        const preview = previewPayload({
+            from: before.publication_context,
+            to: { kind: 'global', concept_id: null, source: 'scope_change_request' },
+            remove: [{ predicate: '#V#specific_to_user', target: '#V#signed_in_user' }]
+        });
+        const after = {
+            ...globalScope('#V#private_note'),
+            scope_fingerprint: 'scope-global-after'
+        };
+        const governedResponses = [
+            jsonResponse(before),
+            jsonResponse(preview),
+            jsonResponse({
+                success: true,
+                effect_status: 'succeeded',
+                mutation_outcome: 'succeeded',
+                canonical_read_back: after
+            })
+        ];
+        let resolveInitialState;
+        let initialStateJson;
+        const initialStateResponse = new Promise((resolve) => {
+            resolveInitialState = () => {
+                const response = jsonResponse({
+                    raw_doc: {
+                        relationships: {
+                            '#V#specific_to_user': ['#V#signed_in_user']
+                        }
+                    }
+                });
+                initialStateJson = response.json;
+                resolve(response);
+            };
+        });
+        global.fetch = jest.fn((...args) => {
+            if (String(args[0]).startsWith('/vontology/api/vontology/node_content')) {
+                return initialStateResponse;
+            }
+            events.push(args[1]?.method || 'GET');
+            return Promise.resolve(governedResponses.shift());
+        });
+        jest.spyOn(window, 'confirm').mockImplementation((message) => {
+            events.push('confirm');
+            expect(message).toContain('global Vontology publication');
+            expect(message).toContain('removes the user/organisation-only publication restriction');
+            return true;
+        });
+
+        const header = document.createElement('div');
+        document.body.appendChild(header);
+        attachAnalysisButtons(header, '#V#private_note', 'individual');
+        const orgBtn = header.querySelector('.org-relation-button');
+        const userBtn = header.querySelector('.user-relation-button');
+        expect(orgBtn.disabled).toBe(false);
+        expect(userBtn.disabled).toBe(false);
+
+        // The click remains executable while the display read is pending; its
+        // fresh governed GET, rather than DOM state, decides the transition.
+        userBtn.click();
+        await flushUntil(() => events.length === 4 && userBtn.disabled === false);
+        expect(userBtn.getAttribute('aria-pressed')).toBe('false');
+
+        // The older user-only response arrives after canonical global
+        // read-back and must not overwrite either scope control.
+        resolveInitialState();
+        await flushUntil(() => initialStateJson?.mock.calls.length === 1);
+        await Promise.resolve();
+
+        expect(events).toEqual(['GET', 'POST', 'confirm', 'POST']);
+        expect(global.fetch).toHaveBeenCalledTimes(4);
+        const governedCalls = global.fetch.mock.calls.filter(([url]) =>
+            String(url).startsWith('/api/ontology-authority/concepts/')
+        );
+        const urls = governedCalls.map(([url]) => url);
+        expect(urls.every((url) => url === '/api/ontology-authority/concepts/%23V%23private_note/scope')).toBe(true);
+        expect(urls.some((url) => url.includes('/concept/user-relation'))).toBe(false);
+        const previewBody = JSON.parse(governedCalls[1][1].body);
+        const executeBody = JSON.parse(governedCalls[2][1].body);
+        expect(previewBody).toMatchObject({
+            destination_kind: 'global',
+            expected_scope_fingerprint: 'scope-user-before',
+            preview: true,
+            reason: 'concept_tab_publication_scope_change'
+        });
+        expect(executeBody).toMatchObject({
+            destination_kind: 'global',
+            expected_scope_fingerprint: 'scope-user-before',
+            preview: false,
+            reason: 'concept_tab_publication_scope_change'
+        });
+        expect(previewBody.request_id).toBeTruthy();
+        expect(executeBody.request_id).toBeTruthy();
+        expect(executeBody.request_id).not.toBe(previewBody.request_id);
+        expect(userBtn.getAttribute('aria-pressed')).toBe('false');
+        expect(orgBtn.getAttribute('aria-pressed')).toBe('false');
+        expect(userBtn.disabled).toBe(false);
+        expect(orgBtn.disabled).toBe(false);
+    });
+
+    test.each([
+        [
+            'user',
+            '#V#signed_in_user',
+            '#V#specific_to_user'
+        ],
+        [
+            'organisation',
+            '#V#trusted_organisation',
+            '#V#specific_to_organisation'
+        ]
+    ])('trusted %s default is resolved by preview and bound into execute', async (
+        destinationKind,
+        trustedDestination,
+        predicate
+    ) => {
+        window.localStorage.setItem('von_current_user', '#V#forged_browser_user');
+        window.localStorage.setItem('von:organisation', '#V#forged_browser_org');
+        const before = globalScope();
+        const to = {
+            kind: destinationKind,
+            concept_id: trustedDestination,
+            source: 'scope_change_request'
+        };
+        const after = {
+            concept_id: '#V#scope_fixture',
+            publication_context: to,
+            scope_edges: { [predicate]: [trustedDestination] },
+            scope_fingerprint: 'scope-after'
+        };
+        const fetchImpl = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(before))
+            .mockResolvedValueOnce(jsonResponse(previewPayload({
+                from: before.publication_context,
+                to,
+                add: [{ predicate, target: trustedDestination }]
+            })))
+            .mockResolvedValueOnce(jsonResponse({
+                success: true,
+                effect_status: 'succeeded',
+                canonical_read_back: after
+            }));
+
+        const result = await executeGovernedScopeControlChange({
+            conceptId: '#V#scope_fixture',
+            controlKind: destinationKind,
+            fetchImpl,
+            confirmImpl: () => true,
+            requestIdFactory: (phase) => `request-${phase}`
+        });
+
+        expect(result.success).toBe(true);
+        const previewRequest = JSON.parse(fetchImpl.mock.calls[1][1].body);
+        const executeRequest = JSON.parse(fetchImpl.mock.calls[2][1].body);
+        expect(previewRequest.destination_kind).toBe(destinationKind);
+        expect(previewRequest).not.toHaveProperty('destination_concept_id');
+        expect(previewRequest).not.toHaveProperty('user_concept_id');
+        expect(previewRequest).not.toHaveProperty('organisation_concept_id');
+        expect(executeRequest.destination_concept_id).toBe(trustedDestination);
+        const requestHeaders = fetchImpl.mock.calls.map(([, options]) => options?.headers || {});
+        requestHeaders.forEach((headers) => {
+            expect(headers).not.toHaveProperty('X-User-Concept-ID');
+            expect(headers).not.toHaveProperty('X-User-Client-ID');
+            expect(headers).not.toHaveProperty('X-Organisation-Concept-ID');
+            expect(headers['X-Von-Window-Session']).toMatch(/^ws_/);
+        });
+        expect(requestHeaders[1]['Content-Type']).toBe('application/json');
+        expect(requestHeaders[2]['Content-Type']).toBe('application/json');
+        expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/concept/user-relation'))).toBe(false);
+        expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/concept/organization-relation'))).toBe(false);
+    });
+
+    test('confirmation cancellation stops after preview and leaves canonical state unchanged', async () => {
+        const before = userScope();
+        const fetchImpl = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(before))
+            .mockResolvedValueOnce(jsonResponse(previewPayload({
+                from: before.publication_context,
+                to: { kind: 'global', concept_id: null },
+                remove: [{ predicate: '#V#specific_to_user', target: '#V#signed_in_user' }]
+            })));
+
+        const result = await executeGovernedScopeControlChange({
+            conceptId: '#V#scope_fixture',
+            controlKind: 'user',
+            fetchImpl,
+            confirmImpl: () => false,
+            requestIdFactory: (phase) => `cancel-${phase}`
+        });
+
+        expect(result).toMatchObject({ success: false, cancelled: true });
+        expect(result.canonical_read_back).toEqual(before);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    test('preview denial never executes', async () => {
+        const fetchImpl = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(userScope()))
+            .mockResolvedValueOnce(jsonResponse({
+                success: false,
+                error_code: 'global_ontology_admin_authority_required',
+                error: 'Global ontology administrator authority is required.'
+            }, 409));
+
+        await expect(executeGovernedScopeControlChange({
+            conceptId: '#V#scope_fixture',
+            controlKind: 'user',
+            fetchImpl,
+            confirmImpl: () => true,
+            requestIdFactory: (phase) => `denied-${phase}`
+        })).rejects.toMatchObject({ code: 'global_ontology_admin_authority_required' });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    test('preview cannot substitute a different destination', async () => {
+        const before = globalScope();
+        const fetchImpl = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(before))
+            .mockResolvedValueOnce(jsonResponse(previewPayload({
+                from: before.publication_context,
+                to: { kind: 'user', concept_id: '#V#signed_in_user' },
+                add: [{ predicate: '#V#specific_to_user', target: '#V#signed_in_user' }]
+            })));
+
+        await expect(executeGovernedScopeControlChange({
+            conceptId: '#V#scope_fixture',
+            controlKind: 'organisation',
+            fetchImpl,
+            confirmImpl: () => true,
+            requestIdFactory: (phase) => `mismatch-${phase}`
+        })).rejects.toMatchObject({ code: 'scope_preview_destination_mismatch' });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    test('success response is rejected when canonical read-back disagrees', async () => {
+        const before = userScope();
+        const fetchImpl = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(before))
+            .mockResolvedValueOnce(jsonResponse(previewPayload({
+                from: before.publication_context,
+                to: { kind: 'global', concept_id: null },
+                remove: [{ predicate: '#V#specific_to_user', target: '#V#signed_in_user' }]
+            })))
+            .mockResolvedValueOnce(jsonResponse({
+                success: true,
+                effect_status: 'succeeded',
+                canonical_read_back: before
+            }));
+
+        await expect(executeGovernedScopeControlChange({
+            conceptId: '#V#scope_fixture',
+            controlKind: 'user',
+            fetchImpl,
+            confirmImpl: () => true,
+            requestIdFactory: (phase) => `readback-mismatch-${phase}`
+        })).rejects.toMatchObject({ code: 'scope_change_canonical_read_back_mismatch' });
+        expect(fetchImpl).toHaveBeenCalledTimes(3);
+    });
+
+    test('stale execute refreshes both controls from canonical read-back without retry', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const before = userScope('#V#stale_scope');
+        const concurrent = {
+            concept_id: '#V#stale_scope',
+            publication_context: {
+                kind: 'organisation',
+                concept_id: '#V#concurrent_org'
+            },
+            scope_edges: {
+                '#V#specific_to_organisation': ['#V#concurrent_org']
+            },
+            scope_fingerprint: 'scope-concurrently-changed'
+        };
+        global.fetch = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(before))
+            .mockResolvedValueOnce(jsonResponse(previewPayload({
+                from: before.publication_context,
+                to: { kind: 'global', concept_id: null },
+                remove: [{ predicate: '#V#specific_to_user', target: '#V#signed_in_user' }]
+            })))
+            .mockResolvedValueOnce(jsonResponse({
+                success: false,
+                changed: false,
+                error_code: 'scope_precondition_failed',
+                error: 'The concept scope changed after the preview was obtained.',
+                canonical_read_back: concurrent
+            }, 409));
+        jest.spyOn(window, 'confirm').mockReturnValue(true);
+        const orgBtn = document.createElement('button');
+        const userBtn = document.createElement('button');
+
+        const result = await toggleUserRelation('#V#stale_scope', userBtn, orgBtn);
+
+        expect(result.success).toBe(false);
+        expect(result.error.code).toBe('scope_precondition_failed');
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+        expect(orgBtn.getAttribute('aria-pressed')).toBe('true');
+        expect(userBtn.getAttribute('aria-pressed')).toBe('false');
+        expect(orgBtn.disabled).toBe(false);
+        expect(userBtn.disabled).toBe(false);
+    });
+});

--- a/src/frontend/web/von_interface/static/js/utils/governedPublicationScope.js
+++ b/src/frontend/web/von_interface/static/js/utils/governedPublicationScope.js
@@ -1,0 +1,241 @@
+import { getWindowSessionId, WINDOW_SESSION_HEADER } from '../apiService.js';
+
+const CHANGE_REASON = 'concept_tab_publication_scope_change';
+const USER_PREDICATE = '#V#specific_to_user';
+const ORGANISATION_PREDICATE = '#V#specific_to_organisation';
+const PREDICATE_ALIASES = Object.freeze({
+    specific_to_user: USER_PREDICATE,
+    specific_to_org: ORGANISATION_PREDICATE,
+    specific_to_organisation: ORGANISATION_PREDICATE,
+    '#V#specific_to_org': ORGANISATION_PREDICATE
+});
+
+function normaliseKind(value) {
+    const kind = String(value || '').trim().toLowerCase().replace('-', '_');
+    if (kind === 'user' || kind === 'private_user') return 'user';
+    if (kind === 'organisation' || kind === 'organization' || kind === 'org') return 'organisation';
+    if (kind === 'global' || kind === 'base' || kind === 'base_publication') return 'global';
+    return '';
+}
+
+function scopeTargets(scopeReadBack, canonicalPredicate) {
+    const edges = scopeReadBack?.scope_edges;
+    if (!edges || typeof edges !== 'object') return [];
+    const seen = new Set();
+    Object.entries(edges).forEach(([predicate, values]) => {
+        const canonical = PREDICATE_ALIASES[predicate] || predicate;
+        if (canonical !== canonicalPredicate) return;
+        (Array.isArray(values) ? values : [values]).forEach((value) => {
+            const target = typeof value === 'string' ? value.trim() : '';
+            if (target) seen.add(target);
+        });
+    });
+    return [...seen];
+}
+
+function scopeError(code, message, payload = null) {
+    const error = new Error(message);
+    error.code = code;
+    error.payload = payload;
+    error.canonicalReadBack = payload?.canonical_read_back || null;
+    return error;
+}
+
+export function publicationScopeFlags(scopeReadBack) {
+    return {
+        hasOrganisationScope: scopeTargets(scopeReadBack, ORGANISATION_PREDICATE).length > 0,
+        hasUserScope: scopeTargets(scopeReadBack, USER_PREDICATE).length > 0
+    };
+}
+
+export function deriveScopeControlDestination(scopeReadBack, controlKind) {
+    const kind = normaliseKind(controlKind);
+    if (!['user', 'organisation'].includes(kind)) {
+        throw scopeError('invalid_scope_control', 'A user or organisation publication-scope control is required.');
+    }
+    const userTargets = scopeTargets(scopeReadBack, USER_PREDICATE);
+    const organisationTargets = scopeTargets(scopeReadBack, ORGANISATION_PREDICATE);
+    const selectedTargets = kind === 'user' ? userTargets : organisationTargets;
+    if (selectedTargets.length === 0) {
+        // The server resolves the authenticated actor/current organisation;
+        // browser-held identity is deliberately absent.
+        return { destination_kind: kind };
+    }
+    if (selectedTargets.length !== 1 || !selectedTargets[0].startsWith('#V#')) {
+        throw scopeError(
+            'ambiguous_publication_scope_transition',
+            'This quick control cannot safely choose a destination for multiple or historical publication contexts. No change was attempted.'
+        );
+    }
+
+    const remainingKind = kind === 'user' ? 'organisation' : 'user';
+    const remainingTargets = kind === 'user' ? organisationTargets : userTargets;
+    if (remainingTargets.length === 0) return { destination_kind: 'global' };
+    if (remainingTargets.length === 1 && remainingTargets[0].startsWith('#V#')) {
+        return {
+            destination_kind: remainingKind,
+            destination_concept_id: remainingTargets[0]
+        };
+    }
+    throw scopeError(
+        'ambiguous_publication_scope_transition',
+        'This quick control cannot safely choose a destination for multiple or historical publication contexts. No change was attempted.'
+    );
+}
+
+export function describePublicationContext(context) {
+    const kind = normaliseKind(context?.kind);
+    const conceptId = typeof context?.concept_id === 'string' ? context.concept_id.trim() : '';
+    if (kind === 'global') return 'global Vontology publication';
+    if (kind === 'organisation') return conceptId ? `organisation scope ${conceptId}` : 'the current organisation scope';
+    if (kind === 'user') return conceptId ? `user-only scope ${conceptId}` : 'your user-only scope';
+    return 'the recorded historical or mixed scope';
+}
+
+function describeEdge(edge) {
+    return [edge?.predicate, edge?.target]
+        .map((value) => String(value || '').trim())
+        .filter(Boolean)
+        .join(' → ');
+}
+
+export function buildScopeChangeReviewMessage(conceptId, preview) {
+    const removed = (Array.isArray(preview?.scope_delta?.remove) ? preview.scope_delta.remove : [])
+        .map(describeEdge).filter(Boolean);
+    const added = (Array.isArray(preview?.scope_delta?.add) ? preview.scope_delta.add : [])
+        .map(describeEdge).filter(Boolean);
+    const lines = [
+        `Change publication scope for ${conceptId}?`,
+        '',
+        `From: ${describePublicationContext(preview?.from)}`,
+        `To: ${describePublicationContext(preview?.to)}`,
+        `Remove: ${removed.length ? removed.join(', ') : 'no scope edges'}`,
+        `Add: ${added.length ? added.join(', ') : 'no scope edge (global)'}`
+    ];
+    if (normaliseKind(preview?.to?.kind) === 'global') {
+        lines.push('', 'This removes the user/organisation-only publication restriction.');
+    }
+    return [...lines, '', 'Apply this reviewed change?'].join('\n');
+}
+
+function requestId(phase) {
+    let token = '';
+    try { token = globalThis.crypto?.randomUUID?.() || ''; } catch (_) { /* fallback */ }
+    if (!token) token = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return `concept-scope-${phase}-${token}`;
+}
+
+function headers(json = false) {
+    return {
+        ...(json ? { 'Content-Type': 'application/json' } : {}),
+        [WINDOW_SESSION_HEADER]: getWindowSessionId()
+    };
+}
+
+async function responseJson(response, fallback, requireSuccess = false) {
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || (requireSuccess && payload.success !== true)) {
+        throw scopeError(
+            payload.error_code || payload.error || `http_${response.status}`,
+            payload.message || payload.error || fallback || `HTTP ${response.status}`,
+            payload
+        );
+    }
+    return payload;
+}
+
+function destinationFromPreview(requested, preview) {
+    const kind = normaliseKind(preview?.to?.kind);
+    const conceptId = typeof preview?.to?.concept_id === 'string'
+        ? preview.to.concept_id.trim()
+        : '';
+    if (!kind || kind !== normaliseKind(requested.destination_kind)) {
+        throw scopeError('scope_preview_destination_mismatch', 'The governed preview did not return the requested publication destination.', preview);
+    }
+    if (kind !== 'global' && !conceptId.startsWith('#V#')) {
+        throw scopeError('scope_preview_destination_required', 'The governed preview did not bind an exact destination concept.', preview);
+    }
+    if (requested.destination_concept_id && requested.destination_concept_id !== conceptId) {
+        throw scopeError('scope_preview_destination_mismatch', 'The governed preview changed the explicit publication destination.', preview);
+    }
+    return {
+        destination_kind: kind,
+        ...(kind === 'global' ? {} : { destination_concept_id: conceptId })
+    };
+}
+
+function readBackMatches(scopeReadBack, destination) {
+    const users = scopeTargets(scopeReadBack, USER_PREDICATE);
+    const organisations = scopeTargets(scopeReadBack, ORGANISATION_PREDICATE);
+    if (destination.destination_kind === 'global') return users.length === 0 && organisations.length === 0;
+    if (destination.destination_kind === 'user') {
+        return organisations.length === 0 && users.length === 1 && users[0] === destination.destination_concept_id;
+    }
+    return users.length === 0 && organisations.length === 1 && organisations[0] === destination.destination_concept_id;
+}
+
+export async function executeGovernedScopeControlChange({
+    conceptId,
+    controlKind,
+    fetchImpl = globalThis.fetch,
+    confirmImpl = globalThis.confirm,
+    requestIdFactory = requestId
+}) {
+    if (!conceptId || typeof fetchImpl !== 'function') {
+        throw scopeError('scope_change_request_invalid', 'A concept and HTTP client are required.');
+    }
+    const endpoint = `/api/ontology-authority/concepts/${encodeURIComponent(conceptId)}/scope`;
+    const read = await responseJson(await fetchImpl(endpoint, {
+        credentials: 'same-origin',
+        headers: headers()
+    }), 'Could not read the current publication scope.');
+    const fingerprint = String(read.scope_fingerprint || '').trim();
+    if (!fingerprint) {
+        throw scopeError('scope_fingerprint_required', 'The current publication scope did not include a review fingerprint.', read);
+    }
+
+    const requested = deriveScopeControlDestination(read, controlKind);
+    const previewRequestId = String(requestIdFactory('preview') || '').trim();
+    if (!previewRequestId) throw scopeError('scope_request_id_required', 'A preview request identifier is required.');
+    const preview = await responseJson(await fetchImpl(endpoint, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: headers(true),
+        body: JSON.stringify({
+            ...requested,
+            expected_scope_fingerprint: fingerprint,
+            request_id: previewRequestId,
+            preview: true,
+            reason: CHANGE_REASON
+        })
+    }), 'The publication-scope preview was denied.', true);
+    const destination = destinationFromPreview(requested, preview);
+    if (!(typeof confirmImpl === 'function' && confirmImpl(buildScopeChangeReviewMessage(conceptId, preview)))) {
+        return { success: false, cancelled: true, preview, canonical_read_back: read };
+    }
+
+    let executeRequestId = String(requestIdFactory('execute') || '').trim();
+    if (!executeRequestId) throw scopeError('scope_request_id_required', 'An execution request identifier is required.');
+    if (executeRequestId === previewRequestId) executeRequestId += ':execute';
+    const result = await responseJson(await fetchImpl(endpoint, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: headers(true),
+        body: JSON.stringify({
+            ...destination,
+            expected_scope_fingerprint: fingerprint,
+            request_id: executeRequestId,
+            preview: false,
+            reason: CHANGE_REASON
+        })
+    }), 'The publication-scope change did not complete.', true);
+    const canonicalReadBack = result?.canonical_read_back;
+    if (!canonicalReadBack || !readBackMatches(canonicalReadBack, destination)) {
+        throw scopeError(
+            'scope_change_canonical_read_back_mismatch',
+            'Canonical read-back did not prove the reviewed publication-scope change.',
+            result
+        );
+    }
+    return { ...result, success: true, preview, destination, canonical_read_back: canonicalReadBack };
+}

--- a/tests/backend/test_ontology_authority_routes.py
+++ b/tests/backend/test_ontology_authority_routes.py
@@ -377,10 +377,114 @@ def test_scope_preview_and_execute_are_distinct_effects(monkeypatch) -> None:
     assert execute.status_code == 200
     assert [call["request_id"] for call in calls] == ["scope-preview", "scope-execute"]
     assert [call["preview"] for call in calls] == [True, False]
+    assert [call["invocation_tool_name"] for call in calls] == [
+        routes.PREVIEW_SCOPE_CHANGE_TOOL_NAME,
+        routes.EXECUTE_SCOPE_CHANGE_TOOL_NAME,
+    ]
     assert (
         preview.get_json()["authority_receipt"]
         != execute.get_json()["authority_receipt"]
     )
+
+
+def test_scope_route_defaults_user_destination_to_authenticated_actor(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def change(**kwargs):
+        captured.update(kwargs)
+        return {"success": True, "to": {"kind": "user", "concept_id": "#V#member"}}
+
+    monkeypatch.setattr(routes, "change_concept_publication_scope", change)
+    response = _authenticated_client("#V#member").post(
+        "/api/ontology-authority/concepts/%23V%23private-note/scope",
+        json={
+            "destination_kind": "user",
+            "expected_scope_fingerprint": "before",
+            "request_id": "scope-user-preview",
+            "preview": True,
+            "user_concept_id": "#V#forged-browser-user",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "concept_id": "#V#private-note",
+        "destination_kind": "user",
+        "destination_concept_id": "#V#member",
+        "expected_scope_fingerprint": "before",
+        "request_id": "scope-user-preview",
+        "preview": True,
+        "reason": None,
+        "invocation_tool_name": routes.PREVIEW_SCOPE_CHANGE_TOOL_NAME,
+    }
+
+
+def test_scope_route_defaults_organisation_destination_to_trusted_context(
+    monkeypatch,
+) -> None:
+    captured = {}
+    monkeypatch.setattr(
+        routes,
+        "get_effective_organisation_concept_id",
+        lambda: "#V#trusted_organisation",
+    )
+
+    def change(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "to": {
+                "kind": "organisation",
+                "concept_id": "#V#trusted_organisation",
+            },
+        }
+
+    monkeypatch.setattr(routes, "change_concept_publication_scope", change)
+    response = _authenticated_client("#V#member").post(
+        "/api/ontology-authority/concepts/%23V%23global-note/scope",
+        json={
+            "destination_kind": "organisation",
+            "expected_scope_fingerprint": "before",
+            "request_id": "scope-organisation-preview",
+            "preview": True,
+            "organisation_concept_id": "#V#forged-browser-organisation",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["destination_concept_id"] == "#V#trusted_organisation"
+    assert captured["destination_kind"] == "organisation"
+
+
+def test_scope_route_requires_trusted_organisation_context_for_default(
+    monkeypatch,
+) -> None:
+    calls = []
+    monkeypatch.setattr(
+        routes, "get_effective_organisation_concept_id", lambda: None
+    )
+    monkeypatch.setattr(
+        routes,
+        "change_concept_publication_scope",
+        lambda **kwargs: calls.append(kwargs) or {"success": True},
+    )
+
+    response = _authenticated_client("#V#member").post(
+        "/api/ontology-authority/concepts/%23V%23global-note/scope",
+        json={
+            "destination_kind": "organisation",
+            "expected_scope_fingerprint": "before",
+            "request_id": "scope-no-organisation",
+            "preview": True,
+            "organisation_concept_id": "#V#forged-browser-organisation",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "organisation_context_required"
+    assert calls == []
 
 
 @pytest.mark.parametrize("preview", [True, False])
@@ -457,6 +561,7 @@ def test_scope_route_drops_forged_legacy_authority_payload(monkeypatch) -> None:
         "request_id": "forged-legacy-scope",
         "preview": False,
         "reason": None,
+        "invocation_tool_name": routes.EXECUTE_SCOPE_CHANGE_TOOL_NAME,
     }
 
 

--- a/tests/backend/test_ontology_http_mutation_authority_routes.py
+++ b/tests/backend/test_ontology_http_mutation_authority_routes.py
@@ -29,6 +29,10 @@ def test_legacy_scope_route_fails_closed_even_with_forged_force_and_org():
     payload = response.get_json()
     assert payload["error_code"] == "governed_scope_change_required"
     assert payload["effect_status"] == "not_started"
+    assert payload["recovery_affordances"] == [
+        {"action_type": "preview_concept_publication_scope_change"},
+        {"action_type": "change_concept_publication_scope"},
+    ]
 
 
 def test_legacy_user_scope_route_fails_closed_even_with_forged_user_and_force():
@@ -43,7 +47,11 @@ def test_legacy_user_scope_route_fails_closed_even_with_forged_user_and_force():
     )
 
     assert response.status_code == 410
-    assert response.get_json()["error_code"] == "governed_scope_change_required"
+    payload = response.get_json()
+    assert payload["error_code"] == "governed_scope_change_required"
+    assert payload["recovery_affordances"][0] == {
+        "action_type": "preview_concept_publication_scope_change"
+    }
 
 
 def test_relationship_route_does_not_forward_client_identity_or_override(monkeypatch):


### PR DESCRIPTION
Merge decision: ready — the Concept-tab scope controls now complete the governed preview/review/execute path, and the affected frontend and authority suites pass without a candidate-caused material regression.

## User outcome

A user can remove a user-only publication scope (or make the analogous organisation-scope change) from the existing Concept-tab controls instead of receiving the deterministic retired-route 410 response.

## Material changes

- Route both scope controls through canonical GET, governed preview, explicit review, and governed execute.
- Reuse one reviewed scope fingerprint, bind execution to the preview-resolved destination, use distinct preview/execute request and tool identities, and require matching canonical read-back.
- Derive self and current-organisation defaults only from trusted server context; do not send browser-held identity as authority.
- Keep controls usable while legacy display state is loading and prevent a late display response from overwriting canonical state.
- Refuse ambiguous multi-target transitions without mutation and correct the retired routes' executable recovery affordance.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2668

## Evidence

- Affected frontend slice: 6 Jest suites, 76 tests passed, including an actual user-only button click through GET -> preview -> confirmation -> execute and late-display-response coverage.
- Affected backend/authority slice: 60 pytest tests passed.
- Post-rebase focused checks: 15 frontend and 33 backend tests passed.
- JavaScript syntax, Python compile, and `git diff --check` passed.
- ESLint reported 0 errors and 15 pre-existing warnings in `dynamicTabs.js`.
- Independent behaviour, simplicity/anti-ratchet, and authority/security reviews found no merge blocker.

## Ship boundary

- **Minimum ship criteria:** the existing controls no longer call the retired endpoints; the user-only-to-global shape is reviewed and executed with trusted identity, fingerprint continuity, distinct effect identities, and canonical read-back; affected tests pass.
- **Stop-ship conditions:** any path bypasses preview/review, trusts browser identity, treats mismatched read-back as success, retries a denied/stale effect, remains disabled behind a legacy read, or required CI fails because of this candidate.
- **Non-blocking observations:** a broader Tier 3 inverse-read-back test fails identically on untouched `origin/main`; post-execute transport-loss reconciliation remains possible hardening but is not needed to correct the deterministic 410 regression.
- **Non-goals:** deployment or live ontology mutation; redesigning the full scope editor; repairing the separate turn-ledger/effect-planning defects from the attached failed conversation.
