### PR TITLE
JVNAUTOSCI-2645: Fix authority recovery and turn finality

### DIFF
--- a/docs/engineering/ontology_publication_authority.md
+++ b/docs/engineering/ontology_publication_authority.md
@@ -194,9 +194,12 @@ non-success or indeterminate state with enough information for bounded
 reconciliation. Scope transitions use compensation where possible, but
 compensation is not a substitute for reporting the final canonical state.
 
-Denials are typed and non-leaking: callers receive the missing authority or
-delegation condition without disclosure of inaccessible concepts, roles, or
-contexts.
+Denials are typed and non-leaking. A disabling denial identifies the exact
+missing authority context, the authority-bearing mutation subject, and the
+bounded next action needed to ask for or establish that authority, without
+disclosing inaccessible concepts, roles, or contexts. A relationship target is
+not presented as needing a publication-scope change merely because it appears
+in the intended postcondition.
 
 ## 6. Bootstrap and operational limits
 

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -3908,10 +3908,26 @@ def _canonical_effect_readback_receipt(raw_payload: Any) -> dict[str, Any] | Non
             "relation_present",
             "inverse_predicate",
             "inverse_relationship_present",
+            "inverse_relationship_required",
             "publication_context",
         )
         if key in readback
     }
+    raw_concepts = readback.get("concepts")
+    if isinstance(raw_concepts, Sequence) and not isinstance(
+        raw_concepts,
+        (str, bytes, bytearray),
+    ):
+        projected["concept_count"] = len(raw_concepts)
+        projected["concepts"] = [
+            {
+                key: concept.get(key)
+                for key in ("concept_id", "exists")
+                if key in concept
+            }
+            for concept in raw_concepts[:4]
+            if isinstance(concept, Mapping)
+        ]
     assertion_id = str(readback.get("assertion_id") or "").strip()
     subject_concept_id = str(readback.get("subject_concept_id") or "").strip()
     object_kind = str(readback.get("object_kind") or "").strip().lower()
@@ -4052,8 +4068,58 @@ def _canonical_relation_readback_matches_invocation(
         return False
     if readback.get("source_exists") is not True:
         return False
+    inverse_required = readback.get("inverse_relationship_required")
+    if inverse_required is True:
+        return readback.get("inverse_relationship_present") is expected_present
+    if inverse_required is False:
+        return True
+    if method == "add_relationship":
+        # Governed add_relationship has been source-owned since PR #422. Keep
+        # older durable receipts verifiable without inferring an inverse
+        # obligation merely because the read-back names the structural inverse.
+        return True
     return not bool(readback.get("inverse_predicate")) or (
         readback.get("inverse_relationship_present") is expected_present
+    )
+
+
+def _canonical_create_readback_matches_invocation(
+    invocation: Mapping[str, Any],
+    readback: Mapping[str, Any] | None,
+) -> bool:
+    """Verify one governed create against its exact effective concept ID."""
+
+    if not isinstance(readback, Mapping):
+        return False
+    method = str(
+        invocation.get("execution_method") or invocation.get("tool") or ""
+    ).strip()
+    if method != "create_concepts":
+        return False
+    arguments = invocation.get("effective_arguments")
+    concepts = arguments.get("concepts") if isinstance(arguments, Mapping) else None
+    if (
+        not isinstance(concepts, Sequence)
+        or isinstance(concepts, (str, bytes, bytearray))
+        or len(concepts) != 1
+        or not isinstance(concepts[0], Mapping)
+    ):
+        return False
+    expected_concept_id = str(concepts[0].get("concept_id") or "").strip()
+    observed_concepts = readback.get("concepts")
+    if (
+        not expected_concept_id
+        or readback.get("concept_count") != 1
+        or not isinstance(observed_concepts, Sequence)
+        or isinstance(observed_concepts, (str, bytes, bytearray))
+        or len(observed_concepts) != 1
+        or not isinstance(observed_concepts[0], Mapping)
+    ):
+        return False
+    observed = observed_concepts[0]
+    return bool(
+        observed.get("exists") is True
+        and str(observed.get("concept_id") or "").strip() == expected_concept_id
     )
 
 
@@ -4154,6 +4220,126 @@ def _canonical_scoped_assertion_readback_matches_invocation(
     )
 
 
+def _canonical_ontology_postcondition_matches_invocation(
+    invocation: Mapping[str, Any],
+    readback: Mapping[str, Any] | None,
+) -> bool:
+    method = str(
+        invocation.get("execution_method") or invocation.get("tool") or ""
+    ).strip()
+    if method in _ONTOLOGY_RELATION_POSTCONDITION_METHODS:
+        return _canonical_relation_readback_matches_invocation(invocation, readback)
+    if method == "create_concepts":
+        return _canonical_create_readback_matches_invocation(invocation, readback)
+    if method == "upsert_scoped_assertion":
+        return _canonical_scoped_assertion_readback_matches_invocation(
+            invocation,
+            readback,
+        )
+    return False
+
+
+def _effect_postcondition_identity(
+    invocation: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    """Return a report-only exact identity for supported governed outcomes."""
+
+    method = str(
+        invocation.get("execution_method") or invocation.get("tool") or ""
+    ).strip()
+    arguments = invocation.get("effective_arguments")
+    if not isinstance(arguments, Mapping):
+        return None
+    identity: dict[str, Any]
+    if method == "create_concepts":
+        concepts = arguments.get("concepts")
+        if (
+            not isinstance(concepts, Sequence)
+            or isinstance(concepts, (str, bytes, bytearray))
+            or len(concepts) != 1
+            or not isinstance(concepts[0], Mapping)
+        ):
+            return None
+        concept_id = str(concepts[0].get("concept_id") or "").strip()
+        if not concept_id:
+            return None
+        identity = {
+            "kind": "concept_exists",
+            "concept_id": concept_id,
+        }
+    elif method in _ONTOLOGY_RELATION_POSTCONDITION_METHODS:
+        source_id = str(arguments.get("source_id") or "").strip()
+        predicate = _normalise_relation_identity(arguments.get("predicate"))
+        target = str(arguments.get("target") or "").strip()
+        if not source_id or not predicate or not target:
+            return None
+        identity = {
+            "kind": "canonical_relationship",
+            "source_id": source_id,
+            "predicate": predicate,
+            "target": target,
+            "relationship_present": method == "add_relationship",
+        }
+    else:
+        return None
+    return hashlib.sha256(_json_bytes(identity)).hexdigest(), identity
+
+
+def _reconcile_effect_attempts_by_postcondition(
+    *,
+    tool_invocations: Sequence[Mapping[str, Any]],
+    effect_snapshot: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Resolve no-change attempts when the exact outcome succeeded in this turn.
+
+    This projection does not alter durable receipts. It only prevents attempts
+    at one exact user outcome from becoming separate terminal obligations.
+    """
+
+    projected = {effect_id: dict(state) for effect_id, state in effect_snapshot.items()}
+    successful_by_identity: dict[str, tuple[int, str]] = {}
+    identities_by_effect: dict[str, tuple[int, str]] = {}
+    for index, invocation in enumerate(tool_invocations):
+        effect_id = str(invocation.get("effect_id") or "").strip()
+        if not effect_id or effect_id not in projected:
+            continue
+        postcondition = _effect_postcondition_identity(invocation)
+        if postcondition is None:
+            continue
+        identity_key, _identity = postcondition
+        identities_by_effect[effect_id] = (index, identity_key)
+        state = projected[effect_id]
+        readback = state.get("canonical_readback")
+        if (
+            state.get("effect_status") == "succeeded"
+            and isinstance(readback, Mapping)
+            and _canonical_ontology_postcondition_matches_invocation(
+                invocation,
+                readback,
+            )
+        ):
+            successful_by_identity[identity_key] = (index, effect_id)
+
+    for effect_id, (index, identity_key) in identities_by_effect.items():
+        success = successful_by_identity.get(identity_key)
+        if success is None or success[1] == effect_id:
+            continue
+        state = projected[effect_id]
+        if (
+            state.get("effect_status") not in {"failed", "not_started"}
+            or state.get("changed") is not False
+        ):
+            continue
+        state["recovered_by_effect_id"] = success[1]
+        state["recovery_status"] = "succeeded"
+        state["reconciliation_basis"] = (
+            "later_exact_postcondition_success"
+            if success[0] > index
+            else "prior_exact_postcondition_success"
+        )
+    return projected
+
+
 def _cited_mutation_success_claim_fragment(
     response_text: str,
     *,
@@ -4220,17 +4406,28 @@ def _cited_ontology_mutation_claim_conflicts(
         reason: str | None = None
         if effect_status != "succeeded":
             reason = "effect_not_succeeded"
-        elif method in _ONTOLOGY_RELATION_POSTCONDITION_METHODS:
+        elif method in {
+            *_ONTOLOGY_RELATION_POSTCONDITION_METHODS,
+            "create_concepts",
+        }:
             embedded_readback = state.get("canonical_readback")
-            relation_verified = _canonical_relation_readback_matches_invocation(
-                invocation,
-                embedded_readback if isinstance(embedded_readback, Mapping) else None,
+            postcondition_verified = (
+                _canonical_ontology_postcondition_matches_invocation(
+                    invocation,
+                    embedded_readback
+                    if isinstance(embedded_readback, Mapping)
+                    else None,
+                )
             )
             if (
-                not relation_verified
+                not postcondition_verified
                 and effect_id not in canonically_verified_effect_ids
             ):
-                reason = "canonical_relation_not_verified"
+                reason = (
+                    "canonical_create_not_verified"
+                    if method == "create_concepts"
+                    else "canonical_relation_not_verified"
+                )
         if reason is None or effect_id in seen_effect_ids:
             continue
         seen_effect_ids.add(effect_id)
@@ -4319,9 +4516,11 @@ def _canonically_verified_material_effect_ids(
                 invocation,
                 embedded_readback,
             )
+            or _canonical_create_readback_matches_invocation(
+                invocation, embedded_readback
+            )
             or _canonical_scoped_assertion_readback_matches_invocation(
-                invocation,
-                embedded_readback,
+                invocation, embedded_readback
             )
         ):
             verified_effect_ids.add(effect_id)
@@ -5051,6 +5250,74 @@ def _is_workflow_instance_operational_readback(
     )
 
 
+def _group_effect_outcome_facts(
+    facts: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Present one exact supported postcondition once while retaining attempts."""
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    ordered: list[tuple[str, Any]] = []
+    for raw_fact in facts:
+        fact = dict(raw_fact)
+        identity = fact.get("postcondition_identity")
+        if not isinstance(identity, Mapping):
+            ordered.append(("fact", fact))
+            continue
+        identity_key = hashlib.sha256(_json_bytes(dict(identity))).hexdigest()
+        if identity_key not in grouped:
+            grouped[identity_key] = []
+            ordered.append(("group", identity_key))
+        grouped[identity_key].append(fact)
+
+    result: list[dict[str, Any]] = []
+    for item_kind, value in ordered:
+        if item_kind == "fact":
+            result.append(dict(value))
+            continue
+        attempts = grouped[str(value)]
+        verified_successes = [
+            fact
+            for fact in attempts
+            if fact.get("effect_status") == "succeeded"
+            and fact.get("canonical_readback_verified") is True
+        ]
+        representative = dict((verified_successes or attempts)[-1])
+        effect_ids = [
+            str(fact.get("effect_id") or "").strip()
+            for fact in attempts
+            if str(fact.get("effect_id") or "").strip()
+        ]
+        status_counts: dict[str, int] = {}
+        error_codes: list[str] = []
+        for fact in attempts:
+            status = str(fact.get("effect_status") or "unknown").strip() or "unknown"
+            status_counts[status] = status_counts.get(status, 0) + 1
+            error_code = str(fact.get("error_code") or "").strip()
+            if error_code and error_code not in error_codes:
+                error_codes.append(error_code)
+        representative["attempt_count"] = len(attempts)
+        representative["attempt_effect_ids"] = effect_ids
+        representative["attempt_status_counts"] = {
+            key: status_counts[key] for key in sorted(status_counts)
+        }
+        if error_codes:
+            representative["attempt_error_codes"] = error_codes
+        recovered_attempt_count = sum(
+            1
+            for fact in attempts
+            if fact.get("recovered_by_effect_id")
+            or (
+                fact.get("effect_status") in {"failed", "not_started"}
+                and fact.get("changed") is False
+                and verified_successes
+            )
+        )
+        if recovered_attempt_count:
+            representative["recovered_attempt_count"] = recovered_attempt_count
+        result.append(representative)
+    return result
+
+
 def _build_effect_outcome_report(
     *,
     terminal_status: str,
@@ -5128,20 +5395,33 @@ def _build_effect_outcome_report(
             or state.get("execution_method")
             or ""
         ).strip()
-        if execution_method in _ONTOLOGY_RELATION_POSTCONDITION_METHODS:
+        if execution_method in {
+            *_ONTOLOGY_RELATION_POSTCONDITION_METHODS,
+            "create_concepts",
+            "upsert_scoped_assertion",
+        }:
             canonical_readback_verified = (
-                _canonical_relation_readback_matches_invocation(
+                _canonical_ontology_postcondition_matches_invocation(
                     invocation,
                     canonical_readback,
                 )
             )
-        elif execution_method == "upsert_scoped_assertion":
-            canonical_readback_verified = (
-                _canonical_scoped_assertion_readback_matches_invocation(
-                    invocation,
-                    canonical_readback,
+            if (
+                execution_method == "create_concepts"
+                and _effect_postcondition_identity(invocation) is None
+                and isinstance(canonical_readback, Mapping)
+            ):
+                # Preserve older domain-effect receipts which had no exact
+                # governed create arguments but did carry a trusted generic
+                # verification marker. Exact governed creates take the strict
+                # concept-ID matcher above.
+                canonical_readback_verified = bool(
+                    canonical_readback.get("verified") is True
+                    or str(canonical_readback.get("status") or "")
+                    .strip()
+                    .lower()
+                    == "verified"
                 )
-            )
         else:
             canonical_readback_verified = bool(
                 isinstance(canonical_readback, Mapping)
@@ -5208,11 +5488,15 @@ def _build_effect_outcome_report(
             "recovered_by_effect_id": state.get("recovered_by_effect_id"),
             "argument_identity": argument_identity or None,
         }
+        postcondition = _effect_postcondition_identity(invocation)
+        if postcondition is not None:
+            fact["postcondition_identity"] = postcondition[1]
         facts.append({key: value for key, value in fact.items() if value is not None})
         scope_fact = _effect_scope_fact(state, trusted_scope=trusted_scope)
         if scope_fact and scope_fact not in scope_facts:
             scope_facts.append(scope_fact)
 
+    facts = _group_effect_outcome_facts(facts)
     heading = {
         "effect_partially_completed": "This turn completed only partially.",
         "effect_outcome_indeterminate": (
@@ -5308,6 +5592,13 @@ def _build_effect_outcome_report(
                     detail = "reported `succeeded`"
             else:
                 detail = f"receipt `{status}` was recovered by a later effect"
+            if int(fact.get("attempt_count") or 1) > 1:
+                detail += f" across {fact['attempt_count']} exact attempts"
+                if fact.get("recovered_attempt_count"):
+                    detail += (
+                        f", including {fact['recovered_attempt_count']} recovered "
+                        "earlier attempt(s)"
+                    )
             handles = []
             if fact.get("instance_id"):
                 handles.append(f"instance `{fact['instance_id']}`")
@@ -5330,6 +5621,10 @@ def _build_effect_outcome_report(
             label = f"`{fact['tool']}`"
             status = str(fact.get("effect_status") or "unknown")
             details = [f"status `{status}`"]
+            if int(fact.get("attempt_count") or 1) > 1:
+                details.append(
+                    f"{fact['attempt_count']} attempts for this exact postcondition"
+                )
             if fact.get("changed") is False:
                 details.append("reported no change")
             elif fact.get("changed") is True:
@@ -5540,6 +5835,16 @@ def _effect_requires_turn_finality(
     error_code = (
         raw_payload.get("error_code") if isinstance(raw_payload, Mapping) else None
     )
+    if (
+        changed is False
+        and isinstance(raw_payload, Mapping)
+        and raw_payload.get("preview") is True
+        and raw_payload.get("operational_state_effect") is True
+        and raw_payload.get("semantic_effect") is False
+    ):
+        # A governed preview has a durable authority receipt and remains visible
+        # in telemetry, but it does not change the requested domain outcome.
+        return False
     if changed is False and (
         (
             effect_status == "not_started"
@@ -5632,7 +5937,16 @@ def _exact_scoped_relationship_predicate(
     if isinstance(predicate, str) and predicate.strip():
         if predicate_ref is not None:
             return None
-        predicate_id = _exact_represented_concept_id(predicate)
+        try:
+            from .text_relation_predicate_validation_service import (
+                predicate_concept_id_for_storage,
+            )
+
+            predicate_id = _exact_represented_concept_id(
+                predicate_concept_id_for_storage(predicate)
+            )
+        except Exception:  # noqa: BLE001 - recovery must fail closed
+            return None
     else:
         if not isinstance(predicate_ref, Mapping):
             return None
@@ -6362,14 +6676,11 @@ def execute_adaptive_turn(
         predicate = str(arguments.get("predicate") or "").strip()
         if not subject_id or not predicate:
             return None
-        try:
-            from .text_relation_predicate_validation_service import (
-                predicate_concept_id_for_storage,
-            )
+        from .text_relation_predicate_validation_service import (
+            predicate_concept_id_for_storage,
+        )
 
-            predicate = predicate_concept_id_for_storage(predicate) or predicate
-        except Exception:
-            pass
+        predicate = predicate_concept_id_for_storage(predicate) or predicate
         target_text = arguments.get("target_text")
         target_concept_id = str(arguments.get("target_concept_id") or "").strip()
         has_text = isinstance(target_text, str) and bool(target_text.strip())
@@ -7594,9 +7905,13 @@ def execute_adaptive_turn(
         model_answer_completed = status == "completed"
         reconcile_indeterminate_ontology_effects()
         with effect_state_lock:
-            effect_snapshot = {
+            raw_effect_snapshot = {
                 effect_id: dict(state) for effect_id, state in effect_states.items()
             }
+        effect_snapshot = _reconcile_effect_attempts_by_postcondition(
+            tool_invocations=tool_invocations,
+            effect_snapshot=raw_effect_snapshot,
+        )
         incomplete_effects = [
             state
             for state in effect_snapshot.values()

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -1678,6 +1678,7 @@ def build_ontology_mutation_intent(
             source_contexts = (concept_publication_context(target_id),)
         targets = tuple(item for item in visible_targets if item)
         delta = {
+            "authority_subject_concept_ids": [source_id],
             "target_concept_id": target_id,
             "target_text_sha256": (
                 None if target_id else _text_sha256(arguments.get("target"))
@@ -1736,6 +1737,7 @@ def build_ontology_mutation_intent(
         source_contexts = contexts[:-1]
         targets = all_affected_ids
         delta = {
+            "authority_subject_concept_ids": list(source_ids),
             "relationship_count": len(bulk_rows),
             "selectors_sha256": _effect_arguments_sha256({"relationships": bulk_rows}),
             "selector_projection_sha256": _effect_arguments_sha256(
@@ -2269,6 +2271,15 @@ def _relationship_read_back(
         "relationship_present": target_value in values,
         "inverse_predicate": inverse_predicate,
         "inverse_relationship_present": inverse_present,
+        # This is derived by the governed command boundary, not by caller
+        # arguments.  Adaptive finality can therefore distinguish a
+        # deliberately source-owned relationship from a command whose exact
+        # postcondition also includes the inverse edge.
+        "inverse_relationship_required": bool(
+            inspect_inverse
+            and inverse_predicate
+            and target_value.startswith("#V#")
+        ),
         "publication_context": concept_publication_context(source_id).to_mapping(),
     }
 
@@ -2616,6 +2627,14 @@ def _scoped_assertion_recovery_is_executable(
 
     source_id = _normalise_concept_id(resolved.get("source_id"))
     predicate_id = _clean_text(resolved.get("predicate"))
+    try:
+        from .text_relation_predicate_validation_service import (
+            predicate_concept_id_for_storage,
+        )
+
+        predicate_id = predicate_concept_id_for_storage(predicate_id) or predicate_id
+    except Exception:  # noqa: BLE001 - recovery eligibility must fail closed
+        return False
     target = resolved.get("target")
     if (
         not source_id
@@ -3703,6 +3722,7 @@ def issue_same_turn_method_delegation(
     effect_id: str,
     turn_id: str | None,
 ) -> dict[str, Any]:
+    intent: OntologyMutationIntent | None = None
     try:
         intent = build_ontology_mutation_intent(
             method_name=method_name,
@@ -3739,14 +3759,19 @@ def issue_same_turn_method_delegation(
     except OntologyMutationCommandError as exc:
         return _safe_command_error(exc)
     except PermissionError as exc:
-        payload: dict[str, Any] = {
-            "success": False,
-            "effect_status": "not_started",
-            "mutation_outcome": "not_started",
-            "changed": False,
-            "error_code": str(exc),
-            "error": "Semantic ontology authority is required for this effect.",
-        }
+        decision = authorise_ontology_mutation(intent) if intent is not None else None
+        payload: dict[str, Any]
+        if decision is not None and not decision.allowed:
+            payload = ontology_authority_denial_payload(decision, intent)
+        else:
+            payload = {
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "error_code": str(exc),
+                "error": "The exact same-turn ontology delegation was not issued.",
+            }
         # This internal marker is immediately replaced by adaptive turn's fully
         # populated upsert_scoped_assertion call before model exposure.
         return _with_proven_scoped_recovery_marker(

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -364,6 +364,7 @@ class OntologyAuthorityDecision:
     executing_agent_concept_id: str | None = None
     audience: str | None = None
     trust_source: str | None = None
+    required_publication_context: PublicationContext | None = None
 
     def public_projection(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -387,6 +388,10 @@ class OntologyAuthorityDecision:
                 for item in self.role_evidence
             ],
         }
+        if self.required_publication_context is not None:
+            payload["required_publication_context"] = (
+                self.required_publication_context.to_mapping()
+            )
         return payload
 
 
@@ -892,6 +897,7 @@ def _decision(
     delegation_id: str | None = None,
     invocation: OntologyInvocationContext | None = None,
     trust_source: str | None = None,
+    required_publication_context: PublicationContext | None = None,
 ) -> OntologyAuthorityDecision:
     return OntologyAuthorityDecision(
         allowed=allowed,
@@ -908,6 +914,7 @@ def _decision(
         ),
         audience=invocation.audience if invocation else None,
         trust_source=trust_source,
+        required_publication_context=required_publication_context,
     )
 
 
@@ -977,6 +984,7 @@ def _direct_authority_decision(
             organisation_concept_id=active_org_id,
             invocation=invocation,
             trust_source=trust_source,
+            required_publication_context=unresolved_contexts[0],
         )
 
     # A dedicated, optimistic scope adoption is the one operation that may
@@ -1004,6 +1012,9 @@ def _direct_authority_decision(
                 organisation_concept_id=active_org_id,
                 invocation=invocation,
                 trust_source=trust_source,
+                required_publication_context=PublicationContext.global_context(
+                    source="historical_scope_adoption_authority"
+                ),
             )
 
     gathered: list[AuthorityRoleEvidence] = list(historical_adoption_evidence)
@@ -1072,6 +1083,7 @@ def _direct_authority_decision(
                 organisation_concept_id=active_org_id,
                 invocation=invocation,
                 trust_source=trust_source,
+                required_publication_context=context,
             )
         gathered.extend(context_evidence)
 
@@ -1681,7 +1693,7 @@ def ontology_authority_denial_payload(
     decision: OntologyAuthorityDecision,
     intent: OntologyMutationIntent,
 ) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "success": False,
         "effect_status": "not_started",
         "mutation_outcome": "not_started",
@@ -1692,6 +1704,86 @@ def ontology_authority_denial_payload(
         "authority_decision": decision.public_projection(),
         "publication_context": intent.publication_context.to_mapping(),
     }
+    authority_kind = {
+        "authenticated_actor_context_required": "trusted_actor_context",
+        "explicit_scope_adoption_required": "explicit_publication_scope_adoption",
+        "global_ontology_admin_authority_required": (
+            "global_ontology_administrator"
+        ),
+        "organisation_ontology_admin_authority_required": (
+            "organisation_ontology_administrator"
+        ),
+        "private_scope_canonical_publication_not_delegated": (
+            "private_publication_context_owner"
+        ),
+        "ontology_publication_authority_required": "ontology_publication_authority",
+    }.get(decision.reason_code)
+    if authority_kind is None:
+        return payload
+
+    raw_authority_subjects = intent.delta.get("authority_subject_concept_ids")
+    authority_subject_concept_ids = tuple(
+        dict.fromkeys(
+            str(item).strip()
+            for item in (
+                raw_authority_subjects
+                if isinstance(raw_authority_subjects, Sequence)
+                and not isinstance(raw_authority_subjects, (str, bytes))
+                else ()
+            )
+            if str(item).strip() in intent.target_concept_ids
+        )
+    )
+    if not authority_subject_concept_ids:
+        authority_subject_concept_ids = (
+            intent.target_concept_ids[:1]
+            if intent.operation.startswith("relationship.")
+            else intent.target_concept_ids
+        )
+
+    required_context = decision.required_publication_context
+    required_authority: dict[str, Any] = {
+        "authority_kind": authority_kind,
+        "operation": intent.operation,
+        "affected_concept_ids": list(intent.target_concept_ids),
+        "authority_subject_concept_ids": list(authority_subject_concept_ids),
+        "same_effect_retry_supported": decision.reason_code
+        != "explicit_scope_adoption_required",
+    }
+    if required_context is not None:
+        required_authority["publication_context"] = required_context.to_mapping()
+    payload["required_authority"] = required_authority
+
+    if decision.reason_code == "explicit_scope_adoption_required":
+        fingerprints = intent.delta.get("affected_scope_fingerprints")
+        fingerprint_by_concept = (
+            dict(fingerprints) if isinstance(fingerprints, Mapping) else {}
+        )
+        scope_subjects = [
+            {
+                "concept_id": concept_id,
+                **(
+                    {"scope_fingerprint": fingerprint_by_concept[concept_id]}
+                    if concept_id in fingerprint_by_concept
+                    else {}
+                ),
+            }
+            for concept_id in authority_subject_concept_ids
+        ]
+        payload["authority_recovery"] = {
+            "action_type": "inspect_scope_then_ask_for_explicit_adoption",
+            "inspection_tool": "get_concept_publication_scope",
+            "preview_tool": "preview_concept_publication_scope_change",
+            "scope_subjects": scope_subjects,
+            "automatic_scope_change_allowed": False,
+        }
+    else:
+        payload["authority_recovery"] = {
+            "action_type": "ask_for_exact_ontology_authority",
+            "required_authority": dict(required_authority),
+            "automatic_scope_change_allowed": False,
+        }
+    return payload
 
 
 def _bounded_projection(value: Any, *, max_chars: int = 16_000) -> Any:

--- a/src/backend/services/ontology_scope_change_service.py
+++ b/src/backend/services/ontology_scope_change_service.py
@@ -565,6 +565,8 @@ def change_concept_publication_scope(
                 "mutation_outcome": "not_started",
                 "changed": False,
                 "preview": True,
+                "operational_state_effect": True,
+                "semantic_effect": False,
                 "from": source.to_mapping(),
                 "to": destination.to_mapping(),
                 "resolved_scope_edit": (

--- a/src/backend/services/text_relation_predicate_validation_service.py
+++ b/src/backend/services/text_relation_predicate_validation_service.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from ..models.text_value_models import RelationPredicate
 from . import concept_service
-
 
 _CORE_TEXT_PREDICATE_STORAGE_BY_CONCEPT_ID: dict[str, str] = {
     f"#V#{RelationPredicate.HAS_NAME}": RelationPredicate.HAS_NAME,
@@ -59,6 +59,26 @@ def predicate_concept_id_for_storage(predicate: Any) -> str | None:
         return predicate_text
     if predicate_text.startswith("#V#"):
         return predicate_text
+    # Structural relationships are stored under field names such as
+    # ``is_an_instance_of`` while their represented predicate identity remains
+    # ``#V#is_an_instance_of``. Resolve only a unique mapping from the live
+    # structural metadata; arbitrary natural-language predicates still fail.
+    try:
+        from .concept_predicate_metadata_service import (
+            get_structural_predicate_aliases,
+        )
+
+        candidates = sorted(
+            concept_id
+            for concept_id, storage_predicate in (
+                get_structural_predicate_aliases().items()
+            )
+            if storage_predicate == predicate_text and concept_id.startswith("#V#")
+        )
+        if len(candidates) == 1:
+            return candidates[0]
+    except Exception:  # noqa: BLE001 - callers must fail closed without metadata
+        return None
     return None
 
 
@@ -190,8 +210,8 @@ def resolve_text_relation_predicate_for_write(
 
 
 __all__ = [
-    "predicate_concept_id_for_storage",
     "TextRelationPredicateResolution",
     "TextRelationPredicateResolutionError",
+    "predicate_concept_id_for_storage",
     "resolve_text_relation_predicate_for_write",
 ]

--- a/src/backend/services/turn_failure_capsule_service.py
+++ b/src/backend/services/turn_failure_capsule_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime, timezone
-from typing import Any, Mapping, Sequence
-
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
 
 TURN_FAILURE_CAPSULE_SCHEMA_VERSION = "turn_failure_capsule.v1"
 TURN_FAILURE_CAPSULE_MAX_BYTES = 8 * 1024
@@ -91,7 +91,7 @@ _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _compact_json_bytes(value: Mapping[str, Any]) -> bytes:
@@ -501,6 +501,53 @@ def build_turn_failure_capsule(
     )
     total_count = len(indexed_facts)
     initial_omitted_count = max(0, total_count - len(effects))
+    attempt_status_counts: dict[str, int] = {}
+    attempt_count = 0
+    canonically_verified_outcome_count = 0
+    unfinished_outcome_count = 0
+    for _index, fact in indexed_facts:
+        raw_attempt_counts = fact.get("attempt_status_counts")
+        if isinstance(raw_attempt_counts, Mapping) and all(
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 0
+            for value in raw_attempt_counts.values()
+        ):
+            counts = {
+                str(status or "unknown").strip() or "unknown": count
+                for status, count in raw_attempt_counts.items()
+            }
+        else:
+            status = str(fact.get("effect_status") or "unknown").strip() or "unknown"
+            counts = {status: 1}
+        for status, count in counts.items():
+            bounded_status = (
+                status
+                if status
+                in {
+                    "succeeded",
+                    "failed",
+                    "partial",
+                    "indeterminate",
+                    "not_started",
+                    "blocked",
+                    "error",
+                    "unknown",
+                }
+                else "other"
+            )
+            attempt_status_counts[bounded_status] = (
+                attempt_status_counts.get(bounded_status, 0) + count
+            )
+            attempt_count += count
+        if fact.get("canonical_readback_verified") is True:
+            canonically_verified_outcome_count += 1
+        if (
+            str(fact.get("effect_status") or "").strip() in _FAILURE_STATUSES
+            and fact.get("outcome_resolved") is not True
+            and not fact.get("recovered_by_effect_id")
+        ):
+            unfinished_outcome_count += 1
     producer = {
         key: value
         for key, value in (
@@ -523,6 +570,15 @@ def build_turn_failure_capsule(
             "total_count": total_count,
             "included_count": len(effects),
             "omitted_count": initial_omitted_count,
+            "attempt_count": attempt_count,
+            "attempt_status_counts": {
+                key: attempt_status_counts[key]
+                for key in sorted(attempt_status_counts)
+            },
+            "canonically_verified_outcome_count": (
+                canonically_verified_outcome_count
+            ),
+            "unfinished_outcome_count": unfinished_outcome_count,
         },
         "canonical_scope_modes": scope_modes,
         "redaction": {
@@ -698,7 +754,7 @@ def project_stored_turn_failure_capsule(
     summary_raw = value.get("effect_summary")
     if not isinstance(summary_raw, Mapping):
         return None
-    summary_values: dict[str, int] = {}
+    summary_values: dict[str, Any] = {}
     for key in ("total_count", "included_count", "omitted_count"):
         raw_count = summary_raw.get(key)
         if (
@@ -714,6 +770,64 @@ def project_stored_turn_failure_capsule(
         != summary_values["included_count"] + summary_values["omitted_count"]
     ):
         return None
+    optional_summary_counts: dict[str, int] = {}
+    for key in (
+        "attempt_count",
+        "canonically_verified_outcome_count",
+        "unfinished_outcome_count",
+    ):
+        raw_count = summary_raw.get(key)
+        if raw_count is None:
+            continue
+        if (
+            not isinstance(raw_count, int)
+            or isinstance(raw_count, bool)
+            or raw_count < 0
+        ):
+            return None
+        optional_summary_counts[key] = raw_count
+    raw_attempt_status_counts = summary_raw.get("attempt_status_counts")
+    attempt_status_counts: dict[str, int] | None = None
+    if raw_attempt_status_counts is not None:
+        if not isinstance(raw_attempt_status_counts, Mapping):
+            return None
+        attempt_status_counts = {}
+        allowed_attempt_statuses = {
+            "succeeded",
+            "failed",
+            "partial",
+            "indeterminate",
+            "not_started",
+            "blocked",
+            "error",
+            "unknown",
+            "other",
+        }
+        for status, raw_count in raw_attempt_status_counts.items():
+            if (
+                status not in allowed_attempt_statuses
+                or not isinstance(raw_count, int)
+                or isinstance(raw_count, bool)
+                or raw_count < 0
+            ):
+                return None
+            attempt_status_counts[str(status)] = raw_count
+        if (
+            "attempt_count" not in optional_summary_counts
+            or sum(attempt_status_counts.values())
+            != optional_summary_counts["attempt_count"]
+        ):
+            return None
+    if (
+        optional_summary_counts.get("canonically_verified_outcome_count", 0)
+        > summary_values["total_count"]
+        or optional_summary_counts.get("unfinished_outcome_count", 0)
+        > summary_values["total_count"]
+    ):
+        return None
+    summary_values.update(optional_summary_counts)
+    if attempt_status_counts is not None:
+        summary_values["attempt_status_counts"] = attempt_status_counts
 
     raw_scope_modes = value.get("canonical_scope_modes")
     if not isinstance(raw_scope_modes, list) or len(raw_scope_modes) > 3:

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -40,6 +40,7 @@ from src.backend.services.adaptive_turn_service import (
     _bound_tool_results_for_model,
     _bounded_conversation_observation_projection,
     _build_effect_outcome_report,
+    _canonical_create_readback_matches_invocation,
     _canonical_effect_readback_receipt,
     _canonical_relation_readback_matches_invocation,
     _canonical_scoped_assertion_readback_matches_invocation,
@@ -50,14 +51,17 @@ from src.backend.services.adaptive_turn_service import (
     _compact_evidence_envelope,
     _compact_evidence_index,
     _effect_id,
+    _effect_postcondition_identity,
     _effect_requires_turn_finality,
     _effect_result_target_ids,
     _effect_subject_authorised,
     _effect_subject_authority_denial,
     _extract_conversation_situation_sidecar,
     _final_synthesis_context,
+    _group_effect_outcome_facts,
     _json_bytes,
     _ordinary_effect_argument_denial,
+    _reconcile_effect_attempts_by_postcondition,
     _scope_message,
     _trusted_tool_payload,
     build_effect_outcome_narration_context,
@@ -400,6 +404,261 @@ def test_embedded_ontology_relation_readback_verifies_the_exact_effect() -> None
         invocation,
         wrong_case_readback,
     )
+
+
+def test_source_owned_relationship_readback_does_not_invent_inverse_requirement() -> None:
+    invocation = {
+        "effect_id": "effect-source-owned",
+        "execution_method": "add_relationship",
+        "effective_arguments": {
+            "source_id": "#V#student_a",
+            "predicate": "is_an_instance_of",
+            "target": "#V#alumni",
+        },
+    }
+    readback = _canonical_effect_readback_receipt(
+        {
+            "canonical_read_back": {
+                "source_id": "#V#student_a",
+                "source_exists": True,
+                "predicate": "is_an_instance_of",
+                "target": "#V#alumni",
+                "relationship_present": True,
+                "inverse_predicate": "has_instance",
+                "inverse_relationship_present": None,
+                "inverse_relationship_required": False,
+            }
+        }
+    )
+
+    assert _canonical_relation_readback_matches_invocation(invocation, readback)
+    absent_forward = dict(readback or {})
+    absent_forward["relationship_present"] = False
+    assert not _canonical_relation_readback_matches_invocation(
+        invocation,
+        absent_forward,
+    )
+    wrong_target = dict(readback or {})
+    wrong_target["target"] = "#V#different_collection"
+    assert not _canonical_relation_readback_matches_invocation(
+        invocation,
+        wrong_target,
+    )
+
+
+def test_governed_create_projection_verifies_only_one_exact_existing_concept() -> None:
+    invocation = {
+        "effect_id": "effect-create",
+        "execution_method": "create_concepts",
+        "effective_arguments": {
+            "parent_id": "#V#first_order_collection",
+            "concepts": [
+                {
+                    "concept_id": "#V#sail_phd_alumni",
+                    "name": "SAIL PhD Alumni",
+                    "kind": "type",
+                }
+            ],
+            "scope_mode": "organisation_general",
+        },
+    }
+    readback = _canonical_effect_readback_receipt(
+        {
+            "canonical_read_back": {
+                "concepts": [
+                    {
+                        "concept_id": "#V#sail_phd_alumni",
+                        "exists": True,
+                        "publication_context": {
+                            "kind": "organisation",
+                            "concept_id": "#V#strong_ai_lab",
+                        },
+                        "text_relations": [
+                            {"text": "must not be copied into the turn receipt"}
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+
+    assert readback == {
+        "concept_count": 1,
+        "concepts": [
+            {"concept_id": "#V#sail_phd_alumni", "exists": True}
+        ],
+    }
+    assert _canonical_create_readback_matches_invocation(invocation, readback)
+    wrong_id = {
+        **(readback or {}),
+        "concepts": [{"concept_id": "#V#other", "exists": True}],
+    }
+    assert not _canonical_create_readback_matches_invocation(invocation, wrong_id)
+    missing = {
+        **(readback or {}),
+        "concepts": [{"concept_id": "#V#sail_phd_alumni", "exists": False}],
+    }
+    assert not _canonical_create_readback_matches_invocation(invocation, missing)
+    multiple = {
+        "concept_count": 2,
+        "concepts": [
+            {"concept_id": "#V#sail_phd_alumni", "exists": True},
+            {"concept_id": "#V#other", "exists": True},
+        ],
+    }
+    assert not _canonical_create_readback_matches_invocation(invocation, multiple)
+
+
+def test_exact_later_create_reconciles_bad_parent_attempt_without_erasing_it() -> None:
+    failed_invocation = {
+        "effect_id": "effect-bad-parent",
+        "execution_method": "create_concepts",
+        "effective_arguments": {
+            "parent_id": "#V#thing",
+            "concepts": [
+                {"concept_id": "#V#sail_phd_alumni", "name": "SAIL PhD Alumni"}
+            ],
+        },
+    }
+    successful_invocation = {
+        "effect_id": "effect-good-parent",
+        "execution_method": "create_concepts",
+        "effective_arguments": {
+            "parent_id": "#V#first_order_collection",
+            "concepts": [
+                {"concept_id": "#V#sail_phd_alumni", "name": "SAIL PhD Alumni"}
+            ],
+        },
+    }
+    snapshot = {
+        "effect-bad-parent": {
+            "effect_status": "failed",
+            "changed": False,
+            "turn_finality_required": True,
+        },
+        "effect-good-parent": {
+            "effect_status": "succeeded",
+            "changed": True,
+            "turn_finality_required": True,
+            "canonical_readback": {
+                "concept_count": 1,
+                "concepts": [
+                    {"concept_id": "#V#sail_phd_alumni", "exists": True}
+                ],
+            },
+        },
+    }
+
+    reconciled = _reconcile_effect_attempts_by_postcondition(
+        tool_invocations=[failed_invocation, successful_invocation],
+        effect_snapshot=snapshot,
+    )
+
+    assert reconciled["effect-bad-parent"]["recovered_by_effect_id"] == (
+        "effect-good-parent"
+    )
+    assert reconciled["effect-bad-parent"]["recovery_status"] == "succeeded"
+    assert reconciled["effect-bad-parent"]["reconciliation_basis"] == (
+        "later_exact_postcondition_success"
+    )
+    assert snapshot["effect-bad-parent"].get("recovered_by_effect_id") is None
+    assert _effect_postcondition_identity(failed_invocation) == (
+        _effect_postcondition_identity(successful_invocation)
+    )
+
+
+def test_prior_exact_create_success_satisfies_redundant_later_failure() -> None:
+    effective_arguments = {
+        "concepts": [{"concept_id": "#V#sail_phd_alumni"}],
+    }
+    invocations = [
+        {
+            "effect_id": "effect-created",
+            "execution_method": "create_concepts",
+            "effective_arguments": effective_arguments,
+        },
+        {
+            "effect_id": "effect-redundant-conflict",
+            "execution_method": "create_concepts",
+            "effective_arguments": effective_arguments,
+        },
+    ]
+    snapshot = {
+        "effect-created": {
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_readback": {
+                "concept_count": 1,
+                "concepts": [
+                    {"concept_id": "#V#sail_phd_alumni", "exists": True}
+                ],
+            },
+        },
+        "effect-redundant-conflict": {
+            "effect_status": "not_started",
+            "changed": False,
+            "error_code": "ontology_create_concept_id_conflict",
+        },
+    }
+
+    reconciled = _reconcile_effect_attempts_by_postcondition(
+        tool_invocations=invocations,
+        effect_snapshot=snapshot,
+    )
+
+    redundant = reconciled["effect-redundant-conflict"]
+    assert redundant["recovered_by_effect_id"] == "effect-created"
+    assert redundant["recovery_status"] == "succeeded"
+    assert redundant["reconciliation_basis"] == (
+        "prior_exact_postcondition_success"
+    )
+
+
+def test_outcome_facts_group_retries_by_exact_relationship_postcondition() -> None:
+    relationship_identity = {
+        "kind": "canonical_relationship",
+        "source_id": "#V#aaron_keesing",
+        "predicate": "is_an_instance_of",
+        "target": "#V#sail_phd_alumni",
+        "relationship_present": True,
+    }
+    facts = [
+        {
+            "effect_id": f"effect-aaron-{index}",
+            "tool": "add_relationship",
+            "effect_status": "not_started",
+            "changed": False,
+            "error_code": "explicit_scope_adoption_required",
+            "postcondition_identity": relationship_identity,
+        }
+        for index in range(4)
+    ]
+    facts.append(
+        {
+            "effect_id": "effect-beryl",
+            "tool": "add_relationship",
+            "effect_status": "not_started",
+            "changed": False,
+            "error_code": "organisation_ontology_admin_authority_required",
+            "postcondition_identity": {
+                **relationship_identity,
+                "source_id": "#V#beryl_qi",
+            },
+        }
+    )
+
+    grouped = _group_effect_outcome_facts(facts)
+
+    assert len(grouped) == 2
+    assert grouped[0]["attempt_count"] == 4
+    assert grouped[0]["attempt_status_counts"] == {"not_started": 4}
+    assert grouped[0]["attempt_effect_ids"] == [
+        "effect-aaron-0",
+        "effect-aaron-1",
+        "effect-aaron-2",
+        "effect-aaron-3",
+    ]
+    assert grouped[1]["attempt_count"] == 1
 
 
 def test_embedded_scoped_assertion_readback_verifies_the_exact_effect() -> None:
@@ -2803,6 +3062,42 @@ def test_only_pre_dispatch_argument_rejections_are_exempt_from_turn_finality(
             },
         )
         is expected
+    )
+
+
+def test_governed_scope_preview_is_receipted_but_not_semantic_finality() -> None:
+    assert (
+        _effect_requires_turn_finality(
+            capability_kind="registered_tool",
+            effect_status="not_started",
+            changed=False,
+            raw_payload={
+                "success": True,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "preview": True,
+                "operational_state_effect": True,
+                "semantic_effect": False,
+                "authority_receipt": {"status": "previewed"},
+            },
+        )
+        is False
+    )
+    assert (
+        _effect_requires_turn_finality(
+            capability_kind="registered_tool",
+            effect_status="not_started",
+            changed=False,
+            raw_payload={
+                "success": False,
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+                "preview": True,
+            },
+        )
+        is True
     )
 
 
@@ -5480,8 +5775,22 @@ def test_non_exact_relationship_denial_has_no_scoped_recovery(
             "concept",
             None,
         ),
+        (
+            {
+                "source_id": "#V#subject",
+                "predicate": "is_an_instance_of",
+                "target": "#V#sail_phd_alumni",
+            },
+            "concept",
+            "target_concept_id",
+        ),
     ],
-    ids=["concept-literal", "text-represented-looking-literal", "lowercase-id"],
+    ids=[
+        "concept-literal",
+        "text-represented-looking-literal",
+        "lowercase-id",
+        "structural-storage-alias",
+    ],
 )
 def test_relationship_recovery_uses_represented_predicate_kind(
     monkeypatch: pytest.MonkeyPatch,
@@ -5489,12 +5798,20 @@ def test_relationship_recovery_uses_represented_predicate_kind(
     canonical_kind: str,
     expected_target_field: str | None,
 ) -> None:
-    from src.backend.services import relationship_write_service
+    from src.backend.services import (
+        concept_predicate_metadata_service,
+        relationship_write_service,
+    )
 
     monkeypatch.setattr(
         relationship_write_service,
         "resolve_existing_predicate_value_kind",
         lambda _predicate: canonical_kind,
+    )
+    monkeypatch.setattr(
+        concept_predicate_metadata_service,
+        "get_structural_predicate_aliases",
+        lambda: {"#V#is_an_instance_of": "is_an_instance_of"},
     )
 
     denial = _effect_subject_authority_denial(
@@ -5510,7 +5827,14 @@ def test_relationship_recovery_uses_represented_predicate_kind(
         assert len(affordances) == 1
         recovery_arguments = affordances[0]["arguments"]
         assert recovery_arguments[expected_target_field] == arguments["target"]
-        assert "target_concept_id" not in recovery_arguments
+        unexpected_target_field = (
+            "target_text"
+            if expected_target_field == "target_concept_id"
+            else "target_concept_id"
+        )
+        assert unexpected_target_field not in recovery_arguments
+        if arguments.get("predicate") == "is_an_instance_of":
+            assert recovery_arguments["predicate"] == "#V#is_an_instance_of"
 
 
 def test_existing_predicate_value_kind_comes_from_canonical_typing() -> None:

--- a/tests/backend/test_internal_mcp_ontology_scope_change.py
+++ b/tests/backend/test_internal_mcp_ontology_scope_change.py
@@ -263,6 +263,8 @@ def test_preview_then_execute_uses_exact_same_turn_delegations_and_read_back(
     assert preview["success"] is True
     assert preview["preview"] is True
     assert preview["changed"] is False
+    assert preview["operational_state_effect"] is True
+    assert preview["semantic_effect"] is False
     assert preview["canonical_read_back"]["scope_fingerprint"] == "scope-before"
     assert mutations == []
 

--- a/tests/backend/test_multi_person_representation_acceptance.py
+++ b/tests/backend/test_multi_person_representation_acceptance.py
@@ -469,6 +469,10 @@ def test_multi_person_resolution_create_reuse_link_and_repeat_are_complete(
         result["canonical_read_back"]["inverse_relationship_present"] is None
         for result in link_results
     )
+    assert all(
+        result["canonical_read_back"]["inverse_relationship_required"] is False
+        for result in link_results
+    )
     assert all(result["changed"] is False for result in repeat_results)
     assert all(
         docs[source_id]["relationships"][structural_predicate] == [target_id]

--- a/tests/backend/test_ontology_authority_tier3_regressions.py
+++ b/tests/backend/test_ontology_authority_tier3_regressions.py
@@ -303,23 +303,29 @@ def test_motivating_candidature_and_taxonomy_changes_execute_with_read_back(
     assert all(
         result.get("authority_receipt", {}).get("status") == "succeeded"
         and result.get("canonical_read_back", {}).get("relationship_present") is True
+        and result.get("canonical_read_back", {}).get("inverse_relationship_required")
+        is False
         and result.get("canonical_read_back", {}).get("inverse_relationship_present")
-        is True
+        is None
         for result in results
     )
     for source_id in BLOCKED_CANDIDATURE_SOURCE_IDS:
         assert concepts.find_one({"concept_id": source_id})["relationships"][
             "is_an_instance_of"
         ] == ["#V#student"]
-    assert set(
-        concepts.find_one({"concept_id": "#V#student"})["relationships"]["has_instance"]
-    ) == set(BLOCKED_CANDIDATURE_SOURCE_IDS)
+    assert (
+        "has_instance"
+        not in concepts.find_one({"concept_id": "#V#student"})["relationships"]
+    )
     assert concepts.find_one({"concept_id": "#V#graduate_student"})["relationships"][
         "is_a_type_of"
     ] == ["#V#university_student"]
-    assert concepts.find_one({"concept_id": "#V#university_student"})["relationships"][
+    assert (
         "has_subtype"
-    ] == ["#V#graduate_student"]
+        not in concepts.find_one({"concept_id": "#V#university_student"})[
+            "relationships"
+        ]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_ontology_mutation_recovery_and_reuse.py
+++ b/tests/backend/test_ontology_mutation_recovery_and_reuse.py
@@ -244,6 +244,21 @@ def test_authority_denial_retains_only_proven_scoped_recovery_marker(
             PermissionError("global_ontology_admin_authority_required")
         ),
     )
+    decision = authority.OntologyAuthorityDecision(
+        allowed=False,
+        decision_id="decision-global-required",
+        reason_code="global_ontology_admin_authority_required",
+        message="Global ontology publication authority is required.",
+        actor_concept_id="#V#member",
+        organisation_concept_id=None,
+        intent_fingerprint=intent.fingerprint,
+        required_publication_context=authority.PublicationContext.global_context(),
+    )
+    monkeypatch.setattr(
+        command,
+        "authorise_ontology_mutation",
+        lambda _intent: decision,
+    )
     monkeypatch.setattr(
         command,
         "_scoped_assertion_recovery_is_executable",
@@ -268,6 +283,12 @@ def test_authority_denial_retains_only_proven_scoped_recovery_marker(
     assert result["recovery_affordances"] == [
         {"action_type": "create_scoped_assertion"}
     ]
+    assert result["required_authority"]["authority_kind"] == (
+        "global_ontology_administrator"
+    )
+    assert result["authority_recovery"]["action_type"] == (
+        "ask_for_exact_ontology_authority"
+    )
     assert "request_ontology_administrator_delegation" not in repr(result)
 
 
@@ -325,6 +346,41 @@ def test_direct_authority_denial_adds_only_proven_scoped_recovery(
     assert "request_ontology_administrator_delegation" not in repr(result)
 
 
+def test_structural_storage_alias_proves_exact_scoped_recovery(monkeypatch) -> None:
+    from src.backend.services import (
+        concept_predicate_metadata_service,
+        relationship_write_service,
+    )
+    from src.backend.services import (
+        ontology_mutation_command_service as command,
+    )
+    from src.backend.services import (
+        ontology_publication_authority_service as authority,
+    )
+
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        concept_predicate_metadata_service,
+        "get_structural_predicate_aliases",
+        lambda: {"#V#is_an_instance_of": "is_an_instance_of"},
+    )
+    monkeypatch.setattr(
+        relationship_write_service,
+        "resolve_existing_predicate_value_kind",
+        lambda predicate: "concept" if predicate == "#V#is_an_instance_of" else None,
+    )
+
+    with authority.override_current_actor("#V#member", "#V#organisation_a"):
+        assert command._scoped_assertion_recovery_is_executable(
+            method_name="add_relationship",
+            arguments={
+                "source_id": "#V#aaron_keesing",
+                "predicate": "is_an_instance_of",
+                "target": "#V#sail_phd_alumni",
+            },
+        )
+
+
 def test_governed_add_relationship_authorises_and_reads_only_the_source(
     monkeypatch,
 ) -> None:
@@ -364,6 +420,7 @@ def test_governed_add_relationship_authorises_and_reads_only_the_source(
     assert intent.publication_context.kind.value == "user"
     assert intent.source_contexts == ()
     assert intent.target_concept_ids == (source_id, target_id)
+    assert intent.delta["authority_subject_concept_ids"] == [source_id]
     assert intent.delta["maintain_inverse"] is False
     assert (
         command.normalise_governed_ontology_arguments(

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -161,6 +161,9 @@ def test_exact_composite_requires_each_component_authority(
         denied = service.authorise_ontology_mutation(intent)
     assert denied.allowed is False
     assert denied.reason_code == "organisation_ontology_admin_authority_required"
+    assert denied.required_publication_context == (
+        service.PublicationContext.organisation("#V#organisation_a")
+    )
 
     organisation_role = _evidence(
         service,
@@ -180,6 +183,104 @@ def test_exact_composite_requires_each_component_authority(
     assert service.ontology_authority_resource_keys(intent) == (
         "ontology-authority-role:organisation_ontology_administrator:#V#organisation_a",
     )
+
+
+def test_composite_denial_names_exact_missing_authority_and_preserves_retry() -> None:
+    from src.backend.services import ontology_publication_authority_service as service
+
+    composite = service.PublicationContext.composite(
+        user_concept_id="#V#member",
+        organisation_concept_id="#V#organisation_a",
+    )
+    intent = _intent(service, context=composite)
+    decision = service.OntologyAuthorityDecision(
+        allowed=False,
+        decision_id="decision-composite-denial",
+        reason_code="organisation_ontology_admin_authority_required",
+        message="Ontology publication authority for the exact organisation context is required.",
+        actor_concept_id="#V#member",
+        organisation_concept_id="#V#organisation_a",
+        intent_fingerprint=intent.fingerprint,
+        required_publication_context=service.PublicationContext.organisation(
+            "#V#organisation_a"
+        ),
+    )
+
+    payload = service.ontology_authority_denial_payload(decision, intent)
+
+    assert payload["changed"] is False
+    assert payload["required_authority"] == {
+        "authority_kind": "organisation_ontology_administrator",
+        "operation": "relationship.add",
+        "affected_concept_ids": [
+            "#V#graduate_student",
+            "#V#university_student",
+        ],
+        "authority_subject_concept_ids": ["#V#graduate_student"],
+        "same_effect_retry_supported": True,
+        "publication_context": {
+            "kind": "organisation",
+            "concept_id": "#V#organisation_a",
+            "source": "explicit",
+        },
+    }
+    assert payload["authority_recovery"] == {
+        "action_type": "ask_for_exact_ontology_authority",
+        "required_authority": payload["required_authority"],
+        "automatic_scope_change_allowed": False,
+    }
+
+
+def test_legacy_scope_denial_exposes_inspection_not_automatic_promotion() -> None:
+    from src.backend.services import ontology_publication_authority_service as service
+
+    historical = service.PublicationContext(
+        service.PublicationContextKind.HISTORICAL,
+        None,
+        "legacy_visibility",
+        ("specific_to_org",),
+    )
+    intent = service.OntologyMutationIntent(
+        operation="relationship.add",
+        publication_context=historical,
+        target_concept_ids=("#V#legacy_person", "#V#alumni"),
+        tool_name="add_relationship",
+        predicate="#V#is_an_instance_of",
+        delta={
+            "affected_scope_fingerprints": {
+                "#V#legacy_person": "legacy-person-scope-fingerprint"
+            }
+        },
+    )
+    decision = service.OntologyAuthorityDecision(
+        allowed=False,
+        decision_id="decision-legacy-denial",
+        reason_code="explicit_scope_adoption_required",
+        message="Historical scope requires explicit adoption.",
+        actor_concept_id="#V#member",
+        organisation_concept_id="#V#organisation_a",
+        intent_fingerprint=intent.fingerprint,
+        required_publication_context=historical,
+    )
+
+    payload = service.ontology_authority_denial_payload(decision, intent)
+
+    assert payload["required_authority"]["authority_kind"] == (
+        "explicit_publication_scope_adoption"
+    )
+    assert payload["required_authority"]["same_effect_retry_supported"] is False
+    assert payload["authority_recovery"] == {
+        "action_type": "inspect_scope_then_ask_for_explicit_adoption",
+        "inspection_tool": "get_concept_publication_scope",
+        "preview_tool": "preview_concept_publication_scope_change",
+        "scope_subjects": [
+            {
+                "concept_id": "#V#legacy_person",
+                "scope_fingerprint": "legacy-person-scope-fingerprint",
+            },
+        ],
+        "automatic_scope_change_allowed": False,
+    }
 
 
 def test_publication_context_identity_requires_exact_composite_components() -> None:

--- a/tests/backend/test_scoped_assertion_service.py
+++ b/tests/backend/test_scoped_assertion_service.py
@@ -415,6 +415,11 @@ def test_scoped_assertions_do_not_cross_actor_or_organisation(monkeypatch):
         lambda: collection,
     )
     monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
     service.upsert_scoped_assertion(
         subject_concept_id="#V#gillian_dobbie",
         predicate="hasDescription",
@@ -1136,6 +1141,11 @@ def test_concept_target_assertion_is_retrievable_from_either_argument(monkeypatc
     monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
     monkeypatch.setattr(
         service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+    monkeypatch.setattr(
+        service,
         "validate_predicate_concept",
         lambda _predicate: (True, None, None),
     )
@@ -1203,7 +1213,7 @@ def test_trusted_tool_payload_replaces_model_supplied_scope():
     )
 
     assert payload["acting_user_concept_id"] == "#V#michael_witbrock"
-    assert payload["organisation_concept_id"] == "#V#trusted_org"
+    assert payload["organisation_concept_id"] is None
     assert payload["namespace"] == "#V#michael_witbrock@trusted_org"
     assert payload["turn_id"] == "trusted-turn"
     assert payload["canonical_publication"] is False
@@ -1224,6 +1234,11 @@ def test_actor_effective_text_read_merges_visible_scoped_assertions(monkeypatch)
         scoped_service,
         "can_access_concept",
         lambda _concept_id: True,
+    )
+    monkeypatch.setattr(
+        scoped_service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
     )
     monkeypatch.setattr(
         text_value_service.TextRelationsRepository,

--- a/tests/backend/test_turn_failure_capsule_service.py
+++ b/tests/backend/test_turn_failure_capsule_service.py
@@ -5,6 +5,7 @@ import json
 from src.backend.services.turn_failure_capsule_service import (
     TURN_FAILURE_CAPSULE_MAX_BYTES,
     build_turn_failure_capsule,
+    project_stored_turn_failure_capsule,
     turn_failure_capsule_size_bytes,
 )
 
@@ -104,6 +105,14 @@ def test_capsule_projects_exact_paper_lock_incident_without_private_scope() -> N
         "total_count": 3,
         "included_count": 3,
         "omitted_count": 0,
+        "attempt_count": 3,
+        "attempt_status_counts": {
+            "failed": 1,
+            "indeterminate": 1,
+            "succeeded": 1,
+        },
+        "canonically_verified_outcome_count": 1,
+        "unfinished_outcome_count": 1,
     }
 
     download = next(
@@ -129,6 +138,7 @@ def test_capsule_projects_exact_paper_lock_incident_without_private_scope() -> N
     assert create["evidence_id"] == "evidence-paper-readback"
 
     assert capsule["pre_presentation_draft"]["authority"] == "non_authoritative"
+    assert project_stored_turn_failure_capsule(capsule) == capsule
     serialised = json.dumps(capsule, sort_keys=True)
     for forbidden in (
         "#V#michael_witbrock",
@@ -309,27 +319,82 @@ def test_capsule_hard_bound_is_deterministic_and_keeps_direct_failure() -> None:
         "canonical_scopes": [{"mode": "user"}],
         "model_draft": {"preview": "draft " + "d" * 20_000},
     }
-    kwargs = dict(
-        request_id="hard-bound",
-        terminal_status="effect_failed",
-        response_authority="canonical_outcome",
-        visible_response="visible " + "v" * 30_000,
-        outcome_report=report,
-        code_version="version-" + "c" * 500,
-        git_commit="a" * 500,
-        generated_at_utc="2026-08-18T00:00:00Z",
-    )
+    kwargs = {
+        "request_id": "hard-bound",
+        "terminal_status": "effect_failed",
+        "response_authority": "canonical_outcome",
+        "visible_response": "visible " + "v" * 30_000,
+        "outcome_report": report,
+        "code_version": "version-" + "c" * 500,
+        "git_commit": "a" * 500,
+        "generated_at_utc": "2026-08-18T00:00:00Z",
+    }
 
     first = build_turn_failure_capsule(**kwargs)
     second = build_turn_failure_capsule(**kwargs)
 
     assert first == second
     assert turn_failure_capsule_size_bytes(first) <= TURN_FAILURE_CAPSULE_MAX_BYTES
+    assert project_stored_turn_failure_capsule(first) == first
     assert first["terminal_status"] == "effect_failed"
     assert first["effects"][0]["error"]["code"] == "direct_failure_0"
     assert first["effect_summary"]["total_count"] == 100
     assert first["effect_summary"]["omitted_count"] > 0
+    assert first["effect_summary"]["attempt_count"] == 100
+    assert first["effect_summary"]["attempt_status_counts"] == {"failed": 100}
+    assert first["effect_summary"]["unfinished_outcome_count"] == 50
     assert first["redaction"]["truncated"] is True
+
+
+def test_error_first_capsule_keeps_all_fact_success_and_attempt_counts() -> None:
+    facts = [
+        {
+            "effect_id": f"failure-{index}",
+            "tool": "add_relationship",
+            "effect_status": "not_started",
+            "changed": False,
+            "canonical_readback_present": False,
+            "canonical_readback_verified": False,
+            "error_code": "organisation_ontology_admin_authority_required",
+        }
+        for index in range(12)
+    ]
+    facts.extend(
+        {
+            "effect_id": f"success-{index}",
+            "tool": "add_relationship",
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_readback_present": True,
+            "canonical_readback_verified": True,
+        }
+        for index in range(5)
+    )
+
+    capsule = build_turn_failure_capsule(
+        request_id="error-first-all-fact-counts",
+        terminal_status="effect_partially_completed",
+        response_authority="canonical_outcome",
+        visible_response="Twelve outcomes remain unfinished; five were verified.",
+        outcome_report={
+            "schema_version": "adaptive_turn_effect_outcome_report.v1",
+            "facts": facts,
+            "canonical_scopes": [],
+        },
+        generated_at_utc="2026-08-22T00:00:00Z",
+    )
+
+    assert len(capsule["effects"]) == 8
+    assert all(effect["status"] == "not_started" for effect in capsule["effects"])
+    assert capsule["effect_summary"] == {
+        "total_count": 17,
+        "included_count": 8,
+        "omitted_count": 9,
+        "attempt_count": 17,
+        "attempt_status_counts": {"not_started": 12, "succeeded": 5},
+        "canonically_verified_outcome_count": 5,
+        "unfinished_outcome_count": 12,
+    }
 
 
 def test_completed_turn_capsule_has_no_fabricated_failure() -> None:
@@ -350,6 +415,10 @@ def test_completed_turn_capsule_has_no_fabricated_failure() -> None:
         "total_count": 0,
         "included_count": 0,
         "omitted_count": 0,
+        "attempt_count": 0,
+        "attempt_status_counts": {},
+        "canonically_verified_outcome_count": 0,
+        "unfinished_outcome_count": 0,
     }
     assert "turn_error" not in capsule
 


### PR DESCRIPTION
## Outcome

Repairs the failure-finality and authority-recovery defects exposed by the SAIL PhD Alumni turn while preserving the publication-authority contract from PR #426.

- verifies exact governed creates by effective concept ID;
- treats exact same-turn attempts as one user outcome when any attempt has canonically verified the postcondition, without rewriting durable receipts;
- verifies source-owned relationship adds from the forward edge without inventing a target inverse obligation;
- keeps governed previews observable but non-semantic for turn finality;
- groups repeated exact attempts in the canonical outcome report while retaining attempt totals and statuses in the failure capsule;
- emits typed disabling denials with the exact missing authority context, authority-bearing subject, and bounded ask/inspection action;
- resolves unique structural storage aliases to represented predicate IDs for an executable scoped-assertion alternative.

## Authority boundary

Ordinary create remains free to choose user, organisation, or global scope within live authority. Exact user plus organisation composites remain canonical. True historical or malformed scope remains fail-closed. No private-first creation ladder, automatic scope promotion, target-side inverse write, or human Concept-tab ritual is introduced.

JVNAUTOSCI-2671 separately owns represented type/predicate publication profiles and blocks the final domain-data completion of JVNAUTOSCI-2645. This PR is the independent finality and denial-information slice; it does not implement those profiles or mutate live SAIL data.

## Validation

- 230 adaptive-turn tests passed
- 341 adjacent authority, gateway, scoped-assertion, and Tier 3 regression tests passed
- 48 focused authority, mutation-recovery, preview, multi-person, and capsule tests passed
- 8 failure-capsule projection and hard-bound tests passed
- changed-source syntax and diff checks passed
- Ruff passes for the newly isolated authority/capsule files; the two large legacy modules retain only their pre-existing lint findings

## Non-goals

- runtime deployment or activation
- live Vontology or SAIL data mutation
- type/predicate publication-profile implementation
- broad changes to existing lint or formatting debt

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2645