### PR TITLE
JVNAUTOSCI-2425 Show conversation metadata in Thinking results

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -17810,6 +17810,10 @@ _DELEGATED_TELEMETRY_PAGE_CONTEXT_FIELDS = (
     "requested_user_id",
     "namespace",
     "access_mode",
+    "session_name",
+    "session_name_source",
+    "last_message_at",
+    "created_at",
     "identifier_binding",
     "history_coverage",
 )
@@ -18277,6 +18281,36 @@ def _chat_history_get_segments(**kwargs):
         segments, meta = result, {"history_truncated": False}
 
     meta_mapping = meta if isinstance(meta, Mapping) else {}
+    session_name = _clean_optional_string(meta_mapping.get("session_name"))
+    session_name_source = "conversation" if session_name is not None else None
+    metadata_warnings: list[str] = []
+    if access.get("access_mode") != "owner":
+        from ...services.conversation_management_service import (
+            ConversationManagementError,
+            apply_conversation_preferences,
+        )
+
+        try:
+            preference_rows = apply_conversation_preferences(
+                actor_user_id=str(access["requested_user_id"]),
+                conversations=[
+                    {
+                        "session_id": str(access["session_id"]),
+                        "session_name": session_name,
+                    }
+                ],
+            )
+            preference_row = preference_rows[0] if preference_rows else {}
+            session_name = _clean_optional_string(preference_row.get("session_name"))
+            session_name_source = _clean_optional_string(
+                preference_row.get("session_name_source")
+            ) or ("conversation" if session_name is not None else None)
+        except ConversationManagementError as exc:
+            session_name = None
+            session_name_source = None
+            metadata_warnings.append(
+                f"conversation_name_preference_unavailable:{type(exc).__name__}"
+            )
     raw_situation = meta_mapping.get("conversation_situation")
     conversation_situation = (
         dict(raw_situation) if isinstance(raw_situation, Mapping) else None
@@ -18320,6 +18354,10 @@ def _chat_history_get_segments(**kwargs):
         "requested_user_id": access.get("requested_user_id"),
         "namespace": access.get("read_namespace"),
         "access_mode": access.get("access_mode"),
+        "session_name": session_name,
+        "session_name_source": session_name_source,
+        "last_message_at": _clean_optional_string(meta_mapping.get("last_message_at")),
+        "created_at": _clean_optional_string(meta_mapping.get("created_at")),
         "identifier_binding": access.get("identifier_binding"),
         "segments": segments,
         "segment_count": len(segments) if isinstance(segments, list) else 0,
@@ -18329,6 +18367,8 @@ def _chat_history_get_segments(**kwargs):
         "conversation_observations": conversation_observations,
         "conversation_observation_state": conversation_observation_state,
     }
+    if metadata_warnings:
+        payload["warnings"] = metadata_warnings
     if authorisation.get("delegated"):
         payload["read_delegation"] = authorisation.get("read_delegation")
     provenanced_payload = _with_rag_provenance(
@@ -18351,6 +18391,10 @@ def _chat_history_get_segments(**kwargs):
             "requested_user_id",
             "namespace",
             "access_mode",
+            "session_name",
+            "session_name_source",
+            "last_message_at",
+            "created_at",
             "identifier_binding",
             "read_delegation",
         ):
@@ -24557,6 +24601,10 @@ def _conversation_read_output_schema(*, list_result: bool) -> Schema:
             "requested_user_id": (str, type(None)),
             "namespace": (str, type(None)),
             "access_mode": (str, type(None)),
+            "session_name": (str, type(None)),
+            "session_name_source": (str, type(None)),
+            "last_message_at": (str, type(None)),
+            "created_at": (str, type(None)),
             "segments": (list, type(None)),
             "segment_count": (int, type(None)),
             "history_truncated": (bool, type(None)),

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -1969,6 +1969,25 @@ def _conversation_state_from_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _conversation_read_metadata_from_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Return bounded identity and dates from the same actor-scoped history read."""
+
+    created_at = _infer_created_timestamp(doc)
+    last_message_at = _infer_last_message_timestamp(
+        {
+            "history": doc.get("history"),
+            "created_at": created_at,
+        }
+    )
+    return {
+        "session_name": _normalise_session_name(doc.get("session_name")),
+        "last_message_at": (
+            last_message_at.isoformat() if last_message_at is not None else None
+        ),
+        "created_at": created_at.isoformat() if created_at is not None else None,
+    }
+
+
 def append_chat_history_conversation_observation(
     *,
     user_id: str,
@@ -2566,6 +2585,9 @@ def get_chat_history_segments(
         projection = (
             {
                 "history": 1,
+                "session_name": 1,
+                "created_at": 1,
+                "updated_at": 1,
                 "conversation_situation": 1,
                 "conversation_observations": 1,
                 "conversation_observation_total": 1,
@@ -2594,6 +2616,9 @@ def get_chat_history_segments(
                     if include_conversation_state:
                         tail_projection.update(
                             {
+                                "session_name": 1,
+                                "created_at": 1,
+                                "updated_at": 1,
                                 "conversation_situation": 1,
                                 "conversation_observations": 1,
                                 "conversation_observation_total": 1,
@@ -2643,6 +2668,7 @@ def get_chat_history_segments(
             empty_meta = {"history_truncated": False}
             if include_conversation_state:
                 empty_meta.update(_conversation_state_from_doc({}))
+                empty_meta.update(_conversation_read_metadata_from_doc({}))
             return ([], empty_meta) if return_meta else []
 
         history = _normalise_chat_history_entries(
@@ -2654,6 +2680,7 @@ def get_chat_history_segments(
             empty_history_meta = {"history_truncated": False}
             if include_conversation_state:
                 empty_history_meta.update(_conversation_state_from_doc(doc))
+                empty_history_meta.update(_conversation_read_metadata_from_doc(doc))
             return ([], empty_history_meta) if return_meta else []
         if history_length is None:
             history_length_raw = doc.get("history_length")
@@ -2701,6 +2728,7 @@ def get_chat_history_segments(
             result_meta = {"history_truncated": history_truncated}
             if include_conversation_state:
                 result_meta.update(_conversation_state_from_doc(doc))
+                result_meta.update(_conversation_read_metadata_from_doc(doc))
             return result, result_meta
         return result
     except PyMongoError as e:

--- a/src/backend/services/thinking_semantic_projection_service.py
+++ b/src/backend/services/thinking_semantic_projection_service.py
@@ -96,6 +96,7 @@ _OBSERVATION_DETAIL_SPECS = {
     "authorised_email": ("Mailbox", "email"),
     "sender": ("Sender", "text"),
     "date": ("Date", "text"),
+    "last_message_at": ("Date", "datetime"),
     "token_status": ("Authorisation", "status"),
 }
 _OBSERVATION_IDENTIFIER_KINDS = frozenset({"predicate", "message"})
@@ -280,6 +281,7 @@ def _observation_item(value: Any) -> dict[str, str] | None:
                     "title",
                     "display_name",
                     "subject",
+                    "session_name",
                     "authorised_email",
                 )
             )

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1851,6 +1851,7 @@ const THINKING_SEMANTIC_OBSERVATION_DETAIL_SPECS = new Map([
     ['authorised_email', { label: 'Mailbox', valueKind: 'email' }],
     ['sender', { label: 'Sender', valueKind: 'text' }],
     ['date', { label: 'Date', valueKind: 'text' }],
+    ['last_message_at', { label: 'Date', valueKind: 'datetime' }],
     ['token_status', { label: 'Authorisation', valueKind: 'status' }]
 ]);
 const THINKING_SEMANTIC_OBSERVATION_IDENTIFIER_KINDS = new Set(['predicate', 'message']);
@@ -6277,6 +6278,10 @@ export function __testOnly_bindThinkingCardControls(cardRoot = null, options = {
     bindThinkingCardControls(cardRoot, options);
 }
 
+export function __testOnly_bindThinkingDiagnosticToggles(container, request = null) {
+    bindThinkingDiagnosticToggles(container, request || getThinkingCardDisplayRequest());
+}
+
 export function __testOnly_updateThinkingCardMeta(request, progress) {
     updateThinkingCardMeta(request, progress);
 }
@@ -8744,7 +8749,7 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
 
     const renderMode = normaliseThinkingCardMode(mode);
     const items = [];
-    for (const entry of toolHistory) {
+    for (const [entryIndex, entry] of toolHistory.entries()) {
         const tool = entry && typeof entry.tool === 'string' ? entry.tool : '';
         const workflowTask = entry && typeof entry.workflowTask === 'string' ? entry.workflowTask : '';
         if (!tool && !workflowTask) {
@@ -8753,6 +8758,12 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
         const batchSize = entry && Number.isFinite(entry.batchSize) ? Number(entry.batchSize) : null;
         const capabilityDescriptor = getThinkingCapabilityDescriptor(entry);
         const semanticOperation = capabilityDescriptor?.semanticOperation || null;
+        const invocationIdentity = normaliseThinkingActivityString(
+            entry?.callId
+            || entry?.call_id
+            || semanticOperation?.operationId
+            || semanticOperation?.operation_id
+        );
         const resultSummary = replaceOpaqueThinkingCapabilityLabel(
             entry && typeof entry.resultSummary === 'string' ? entry.resultSummary : '',
             capabilityDescriptor
@@ -8797,7 +8808,12 @@ function renderToolHistoryHTML(request, mode = THINKING_CARD_MODE_DEFAULT) {
             detail: toolDetail,
             detailHtml: '',
             state: statusClass,
-            diagnosticKey: buildThinkingDiagnosticKey('tool', tool || workflowTask, batchSize || ''),
+            diagnosticKey: buildThinkingDiagnosticKey(
+                'tool',
+                tool || workflowTask,
+                invocationIdentity || `legacy-${entryIndex}`,
+                batchSize ?? ''
+            ),
             diagnosticHtml: renderMode === THINKING_CARD_MODE_DEFAULT
                 ? ''
                 : buildToolHistoryDiagnosticsHTML(entry, renderMode)

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -70,6 +70,7 @@ import {
     __testOnly_getThinkingCardMode,
     __testOnly_bindConceptSelectionClicks,
     __testOnly_bindThinkingCardControls,
+    __testOnly_bindThinkingDiagnosticToggles,
     __testOnly_updateThinkingCardMeta,
     __testOnly_persistThinkingCardBodyHeightFromDom,
     __testOnly_syncThinkingCanonicalHistoriesFromProgress,
@@ -3507,6 +3508,61 @@ describe('thinking activity history normalisation', () => {
         });
         expect(fallbackHtml).toContain('fetch_concept');
         expect(fallbackHtml).toContain('Fetched');
+    });
+
+    test('keeps repeated tool disclosures independent across rerenders', () => {
+        const request = {
+            thinkingCardMode: 'expert',
+            latestProgress: {
+                status: 'completed',
+                stage: 'completed',
+                tool_history: [
+                    {
+                        tool: 'conversation_get',
+                        callId: 'call_conversation_1',
+                        resultSummary: 'Finished first conversation get.',
+                        success: true
+                    },
+                    {
+                        tool: 'conversation_get',
+                        callId: 'call_conversation_2',
+                        resultSummary: 'Finished second conversation get.',
+                        success: true
+                    }
+                ]
+            }
+        };
+        const container = document.createElement('div');
+        const renderAndBind = () => {
+            container.innerHTML = __testOnly_renderThinkingCardBodyHTML(
+                request,
+                { mode: 'expert' }
+            );
+            __testOnly_bindThinkingDiagnosticToggles(container, request);
+            return [...container.querySelectorAll('details[data-thinking-diagnostic-key]')];
+        };
+
+        let rows = renderAndBind();
+        expect(rows).toHaveLength(2);
+        expect(rows.map((row) => row.dataset.thinkingDiagnosticKey)).toEqual([
+            'tool::conversation_get::call_conversation_1',
+            'tool::conversation_get::call_conversation_2'
+        ]);
+
+        rows[0].open = true;
+        rows[0].dispatchEvent(new Event('toggle'));
+        expect(request.expandedThinkingDiagnosticKeys).toEqual(
+            new Set(['tool::conversation_get::call_conversation_1'])
+        );
+        expect(rows[1].open).toBe(false);
+
+        rows = renderAndBind();
+        expect(rows[0].open).toBe(true);
+        expect(rows[1].open).toBe(false);
+
+        rows[0].open = false;
+        rows[0].dispatchEvent(new Event('toggle'));
+        expect(request.expandedThinkingDiagnosticKeys).toEqual(new Set());
     });
 
     test('renders a semantic relation summary in Default thinking without raw receipts', () => {

--- a/tests/backend/test_chat_history_service_segments.py
+++ b/tests/backend/test_chat_history_service_segments.py
@@ -526,6 +526,9 @@ def test_get_chat_history_segments_can_return_carried_state_with_empty_history_i
                     {
                         "history": [],
                         "history_length": 0,
+                        "session_name": "Durable workflow follow-up",
+                        "created_at": datetime(2026, 7, 29, 8, 0, tzinfo=timezone.utc),
+                        "updated_at": datetime(2026, 7, 29, 9, 5, tzinfo=timezone.utc),
                         "conversation_situation": situation,
                         "conversation_observations": observations,
                         "conversation_observation_total": 3,
@@ -556,6 +559,9 @@ def test_get_chat_history_segments_can_return_carried_state_with_empty_history_i
     assert segments == []
     assert meta["conversation_situation"]["text"] == situation["text"]
     assert meta["conversation_situation"]["revision"] == 2
+    assert meta["session_name"] == "Durable workflow follow-up"
+    assert meta["last_message_at"] == "2026-07-29T08:00:00+00:00"
+    assert meta["created_at"] == "2026-07-29T08:00:00+00:00"
     assert meta["conversation_observations"] == observations
     assert meta["conversation_observation_state"] == {
         "schema_version": "conversation_observation_state.v1",
@@ -566,9 +572,59 @@ def test_get_chat_history_segments_can_return_carried_state_with_empty_history_i
     }
     projected = collection.pipeline[-1]["$project"]
     assert projected["conversation_situation"] == 1
+    assert projected["session_name"] == 1
+    assert projected["created_at"] == 1
+    assert projected["updated_at"] == 1
     assert projected["conversation_observations"] == 1
     assert projected["conversation_observation_total"] == 1
     assert collection.aggregate_calls == 1
+
+
+def test_get_chat_history_segments_projects_name_and_message_date_from_same_tail_read(
+    monkeypatch,
+):
+    from src.backend.services import chat_history_service
+
+    docs = [
+        {
+            "_id": "1",
+            "user_id": "#V#u",
+            "session_id": "s1",
+            "session_name": "Mars project planning",
+            "created_at": datetime(2026, 8, 20, 8, 0, tzinfo=timezone.utc),
+            "updated_at": datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc),
+            "history": [
+                {
+                    "role": "user",
+                    "content": "Earlier",
+                    "timestamp": datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc),
+                },
+                {
+                    "role": "assistant",
+                    "content": "Latest",
+                    "timestamp": datetime(2026, 8, 21, 10, 30, tzinfo=timezone.utc),
+                },
+            ],
+        }
+    ]
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: _FakeCollection(docs),
+    )
+
+    segments, meta = chat_history_service.get_chat_history_segments(
+        "#V#u",
+        "s1",
+        history_tail_limit=1,
+        return_meta=True,
+        include_conversation_state=True,
+    )
+
+    assert segments[0][0]["content"] == "Latest"
+    assert meta["session_name"] == "Mars project planning"
+    assert meta["last_message_at"] == "2026-08-21T10:30:00+00:00"
+    assert meta["created_at"] == "2026-08-20T08:00:00+00:00"
 
 
 def test_get_chat_history_segments_keeps_debug_blob_refs_compact_by_default(

--- a/tests/backend/test_internal_mcp_conversation_management.py
+++ b/tests/backend/test_internal_mcp_conversation_management.py
@@ -127,6 +127,9 @@ def test_conversation_get_pages_oversized_carrier_without_debug_payload(monkeypa
         lambda **kwargs: {
             "success": True,
             "session_id": kwargs["session_id"],
+            "session_name": "Large research conversation",
+            "last_message_at": "2026-08-21T10:30:00+00:00",
+            "created_at": "2026-08-20T08:00:00+00:00",
             "segments": [[{"role": "user", "content": "x" * 90_000}]],
             "history_coverage": {"history_truncated": False},
         },
@@ -143,6 +146,77 @@ def test_conversation_get_pages_oversized_carrier_without_debug_payload(monkeypa
     assert payload["bounded_read"]["has_more"] is True
     assert payload["bounded_read"]["next_offset"] is not None
     assert payload["bounded_read"]["total_chars"] > 90_000
+    assert payload["session_name"] == "Large research conversation"
+    assert payload["last_message_at"] == "2026-08-21T10:30:00+00:00"
+    assert payload["created_at"] == "2026-08-20T08:00:00+00:00"
+
+
+def test_conversation_get_applies_actor_visible_name_to_shared_history(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.services import (
+        chat_history_service,
+        conversation_management_service,
+    )
+
+    monkeypatch.setattr(
+        catalogue,
+        "_authorise_internal_mcp_telemetry_read",
+        lambda payload, **_kwargs: {
+            "success": True,
+            "payload": dict(payload),
+            "delegated": False,
+            "read_delegation": None,
+        },
+    )
+    monkeypatch.setattr(
+        catalogue,
+        "_resolve_chat_history_read_target",
+        lambda _payload: {
+            "success": True,
+            "session_id": "shared-session",
+            "chat_session_id": "shared-session",
+            "read_user_id": "#V#owner",
+            "requested_user_id": "#V#alice",
+            "read_namespace": "#V#owner@org",
+            "access_mode": "invitee",
+            "identifier_binding": {"mode": "raw_parameters"},
+        },
+    )
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_segments",
+        lambda *args, **kwargs: (
+            [[{"role": "assistant", "content": "Shared result"}]],
+            {
+                "history_truncated": False,
+                "session_name": "Owner label",
+                "last_message_at": "2026-08-21T10:30:00+00:00",
+                "created_at": "2026-08-20T08:00:00+00:00",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        conversation_management_service,
+        "apply_conversation_preferences",
+        lambda *, actor_user_id, conversations: [
+            {
+                **conversations[0],
+                "session_name": "Alice's research label",
+                "session_name_source": "actor_preference",
+            }
+        ],
+    )
+
+    payload = catalogue._conversation_get(
+        session_id="shared-session",
+        user_concept_id="#V#alice",
+    )
+
+    assert payload["session_name"] == "Alice's research label"
+    assert payload["session_name_source"] == "actor_preference"
+    assert payload["last_message_at"] == "2026-08-21T10:30:00+00:00"
+    assert payload["created_at"] == "2026-08-20T08:00:00+00:00"
+    _assert_success_schema("conversation_get", payload)
 
 
 def test_conversation_manage_rename_returns_canonical_read_back(monkeypatch):

--- a/tests/backend/test_thinking_semantic_projection_service.py
+++ b/tests/backend/test_thinking_semantic_projection_service.py
@@ -580,6 +580,44 @@ def test_gmail_reads_project_mailbox_and_bounded_message_metadata_without_body()
     assert normalise_semantic_operation_projection(fetched) == fetched
 
 
+def test_conversation_get_projects_name_and_date_without_transcript_content() -> None:
+    projection = build_semantic_operation_projection(
+        operation_id="call-conversation-get",
+        capability_name="conversation_get",
+        execution_method="conversation_get",
+        capability_kind="registered_tool",
+        arguments={"session_id": "session-1"},
+        lifecycle_status="succeeded",
+        success=True,
+        result={
+            "success": True,
+            "session_name": "Mars project planning",
+            "last_message_at": "2026-08-21T10:30:00+00:00",
+            "created_at": "2026-08-20T08:00:00+00:00",
+            "segments": [[{"role": "user", "content": "Private transcript content"}]],
+        },
+    )
+
+    assert projection["observation"] == {
+        "items": [{"name": "Mars project planning"}],
+        "count_is_lower_bound": False,
+        "details": [
+            {
+                "label": "Date",
+                "source_field": "last_message_at",
+                "value_kind": "datetime",
+                "value": "2026-08-21T10:30:00+00:00",
+            }
+        ],
+    }
+    assert projection["summary"] == (
+        "Conversation Get returned Mars project planning "
+        "(Date: 2026-08-21T10:30:00+00:00)."
+    )
+    assert "Private transcript content" not in projection["summary"]
+    assert normalise_semantic_operation_projection(projection) == projection
+
+
 def test_fetch_concept_projects_requested_and_returned_concept() -> None:
     projection = build_semantic_operation_projection(
         operation_id="call-fetch",


### PR DESCRIPTION
Merge decision: ready — completed conversation_get results now identify the returned conversation and repeated same-tool disclosures remain independently expandable.

## User outcome

Finished conversation_get rows show the actor-visible conversation name and available recency date, while expanding one repeated tool result does not expand the others.

## Material changes

- Carry bounded actor-visible conversation name and last-message date through the existing actor-scoped conversation read and delegated paging path.
- Project only allow-listed name/date facts into the generic Thinking Result; transcript content remains excluded.
- Key tool-history disclosures by call ID, semantic operation ID, or deterministic ordinal fallback so repeated same-tool invocations retain independent state across rerenders.
- Add focused backend and frontend regression coverage.

Governed by JVNAUTOSCI-2425 under the UI improvements epic JVNAUTOSCI-537.

## Evidence

- Backend focused suite: 48 passed.
- Frontend Thinking suite: 268 passed; final focused rerun: 1 passed.
- ESLint on changed frontend JS: clean.
- git diff --check: clean.
- Authenticated AgentTest browser replay of a persisted completed Thinking card showed the name and date on both conversation_get Results. First-open/second-closed survived an Expert-mode rerender, then first-closed/second-open was verified.
- Browser console errors: none.
- AgentTest issued zero model calls and was stopped after validation.

## Ship boundary

- **Minimum ship criteria:** actor-visible name/date in the completed Result, independent stable disclosure state for repeated tools, focused automated coverage, and authenticated browser evidence on the affected path.
- **Stop-ship conditions:** actor-scope leakage, transcript content copied into semantic observations, metadata lost during paging, coupled disclosure state, or a candidate-caused failing affected check.
- **Non-blocking observations:** whole-file Ruff reports legacy findings and formatter drift in the large catalogue/history modules; candidate-specific checks are clean.
- **Non-goals:** deployment or runtime activation, transcript redesign, broad Thinking-card changes, and repository-wide legacy formatting cleanup.