### PR TITLE
Clarify Jira Blocks link direction

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -24204,7 +24204,8 @@ def _jira_link_issue_input_schema() -> Schema:
         },
         optional={
             # Preferred semantic aliases. source_issue_key maps to Jira inwardIssue,
-            # target_issue_key maps to Jira outwardIssue.
+            # target_issue_key maps to Jira outwardIssue. For a Blocks link, the
+            # source issue blocks the target issue.
             "source_issue_key": (str, type(None)),
             "target_issue_key": (str, type(None)),
             # Backward-compatible Jira-native fields.
@@ -24222,6 +24223,9 @@ def _jira_link_issue_input_schema() -> Schema:
             "jira_link_issue input: link_type (required; e.g. 'Relates'). "
             "Preferred issue fields: source_issue_key + target_issue_key "
             "(source maps to Jira inwardIssue; target maps to Jira outwardIssue). "
+            "For a directional link, source is the subject of the outward relation: "
+            "with link_type='Blocks', source blocks target; do not pass the blocked "
+            "issue as source. "
             "Backward-compatible fields: inward_issue_key + outward_issue_key. "
             "Optional comment. Guardrails: dry_run defaults to true (preview only); "
             "pass approved=true (or alias confirm=true) to execute. execute=true plus "
@@ -39978,7 +39982,10 @@ def _build_default_catalogue_external_integration_definitions() -> List[
             category="write",
             timeout_sec=20.0,
             description=(
-                "Create a Jira issue link (e.g. Relates) with safety guardrails. Default dry_run=true (no mutation). "
+                "Create a Jira issue link (e.g. Relates or Blocks) with safety guardrails. "
+                "For a directional link, source_issue_key is the subject of the outward relation: "
+                "with Blocks, source blocks target; do not pass the blocked issue as source. "
+                "Default dry_run=true (no mutation). "
                 "Both issue projects must be allow-listed. "
                 "To execute, pass approved=true (or alias confirm=true). "
                 "execute=true plus VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 bypasses per-write approval for batched flows."

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -3561,7 +3561,7 @@
         },
         {
             "name": "jira_link_issue",
-            "description": "Create a Jira issue link (e.g. Relates) with safety guardrails. Default dry_run=true (no mutation). Both issue projects must be allow-listed. To execute, pass approved=true (or alias confirm=true). execute=true plus VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 bypasses per-write approval for batched flows.",
+            "description": "Create a Jira issue link (e.g. Relates or Blocks) with safety guardrails. For a directional link, source_issue_key is the subject of the outward relation: with Blocks, source blocks target; do not pass the blocked issue as source. Default dry_run=true (no mutation). Both issue projects must be allow-listed. To execute, pass approved=true (or alias confirm=true). execute=true plus VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 bypasses per-write approval for batched flows.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3621,7 +3621,7 @@
                     "link_type"
                 ],
                 "additionalProperties": true,
-                "description": "jira_link_issue input: link_type (required; e.g. 'Relates'). Preferred issue fields: source_issue_key + target_issue_key (source maps to Jira inwardIssue; target maps to Jira outwardIssue). Backward-compatible fields: inward_issue_key + outward_issue_key. Optional comment. Guardrails: dry_run defaults to true (preview only); pass approved=true (or alias confirm=true) to execute. execute=true plus VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 bypasses per-write approval."
+                "description": "jira_link_issue input: link_type (required; e.g. 'Relates'). Preferred issue fields: source_issue_key + target_issue_key (source maps to Jira inwardIssue; target maps to Jira outwardIssue). For a directional link, source is the subject of the outward relation: with link_type='Blocks', source blocks target; do not pass the blocked issue as source. Backward-compatible fields: inward_issue_key + outward_issue_key. Optional comment. Guardrails: dry_run defaults to true (preview only); pass approved=true (or alias confirm=true) to execute. execute=true plus VON_INTERNAL_MCP_JIRA_EXECUTE_MODE=1 bypasses per-write approval."
             }
         },
         {

--- a/tests/backend/test_internal_mcp_jira_tools.py
+++ b/tests/backend/test_internal_mcp_jira_tools.py
@@ -325,17 +325,21 @@ def test_jira_write_tools_allowlist_and_dry_run_defaults(monkeypatch):
     assert ok_link.get("source_issue_key") == "JVNAUTOSCI-1"
     assert ok_link.get("target_issue_key") == "JVNAUTOSCI-2"
 
+    blocker_issue_key = "JVNAUTOSCI-10"
+    blocked_issue_key = "JVNAUTOSCI-11"
     ok_link_semantic = _jira_link_issue(
-        source_issue_key="JVNAUTOSCI-10",
-        target_issue_key="JVNAUTOSCI-11",
+        source_issue_key=blocker_issue_key,
+        target_issue_key=blocked_issue_key,
         link_type="Blocks",
     )
     assert ok_link_semantic.get("success") is True
     assert ok_link_semantic.get("dry_run") is True
     assert ok_link_semantic.get("executed") is False
     proposed = ok_link_semantic.get("proposed_payload", {})
-    assert proposed.get("inwardIssue", {}).get("key") == "JVNAUTOSCI-10"
-    assert proposed.get("outwardIssue", {}).get("key") == "JVNAUTOSCI-11"
+    # Jira renders the inward/source issue with the outward phrase, so this
+    # payload means "JVNAUTOSCI-10 blocks JVNAUTOSCI-11".
+    assert proposed.get("inwardIssue", {}).get("key") == blocker_issue_key
+    assert proposed.get("outwardIssue", {}).get("key") == blocked_issue_key
 
     err_conflicting_pair = _jira_link_issue(
         source_issue_key="JVNAUTOSCI-10",

--- a/tests/backend/test_mcp_manifest_parity.py
+++ b/tests/backend/test_mcp_manifest_parity.py
@@ -127,6 +127,18 @@ def test_predicate_relation_tools_explain_concept_id_anchor_contract() -> None:
     )
 
 
+def test_jira_link_issue_contract_states_blocks_direction() -> None:
+    canonical_payload = {
+        item["name"]: item for item in get_surface_tool_payloads(SURFACE_MANIFEST)
+    }
+
+    jira_link_issue = canonical_payload["jira_link_issue"]
+    assert "with Blocks, source blocks target" in jira_link_issue["description"]
+    assert "with link_type='Blocks', source blocks target" in (
+        jira_link_issue["inputSchema"]["description"]
+    )
+
+
 def test_create_concepts_contract_matches_the_governed_core_boundary() -> None:
     canonical_payload = {
         item["name"]: item for item in get_surface_tool_payloads(SURFACE_MANIFEST)


### PR DESCRIPTION
## Outcome

Make the Jira link contract explicitly state that for a Blocks link, source blocks target, preventing blocker/blocked argument inversions.

## Changes

- clarify the canonical model-facing tool and input-schema descriptions
- regenerate the MCP manifest
- make the existing payload test name blocker and blocked roles explicitly
- add contract regression coverage for both descriptions

## Validation

- 43 focused Jira, write-intent, manifest-parity, and stdio tests passed
- fatal Ruff checks passed
- Python compilation and git diff checks passed

This is intentionally independent of JVNAUTOSCI-2671 implementation work.