### PR TITLE
JVNAUTOSCI-2678 Reframe concept interaction as Q&A

### DIFF
--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1561,7 +1561,7 @@ function resetInteractionUiToStep1(statusMessage, suffix = '') {
     submitBtn.disabled = true;
   }
 
-  const msg = statusMessage || 'Interaction session expired. Please start a new interaction.';
+  const msg = statusMessage || 'Concept Q&A session expired. Start a new Q&A to improve the concept.';
   if (step1Status) {
     step1Status.textContent = msg;
     step1Status.style.color = 'orange';
@@ -1672,14 +1672,14 @@ function ensureInteractionSaveButtonState() {
   }
 }
 
-// Handle start interaction button click
+// Handle specialised concept-improvement Q&A button click.
 export async function handleStartInteraction() {
   const currentlySelectedconceptId = getCurrentlySelectedConceptId();
   console.log("handleStartInteraction called. Currently selected concept ID:", currentlySelectedconceptId);
   const displayNames = getConceptTypeDisplayNames(getCurrentConceptType());
 
   if (!currentlySelectedconceptId) {
-    alert(`Please select a ${displayNames.singular.toLowerCase()} to start an interaction.`);
+    alert(`Please select a ${displayNames.singular.toLowerCase()} to improve by Q&A.`);
     return;
   }
 
@@ -1694,11 +1694,11 @@ export async function handleStartInteraction() {
 
   if (missingCritical.length) {
     console.error(`[handleStartInteraction] Missing critical DOM elements: ${missingCritical.join(', ')}`);
-    alert("Error: UI elements for interaction are missing. Cannot proceed.");
+    alert("Error: UI elements for concept Q&A are missing. Cannot proceed.");
     return;
   }
 
-  elements.conceptStep1Status.textContent = "Starting interaction...";
+  elements.conceptStep1Status.textContent = "Starting concept Q&A...";
   elements.conceptStep1Status.style.color = "blue";
 
   // Immediately update UI for responsiveness
@@ -1752,7 +1752,7 @@ export async function handleStartInteraction() {
     }
   }
   if (elements.updatedNotesTitle) {
-    elements.updatedNotesTitle.textContent = 'concept Notes'; // Reset title
+    elements.updatedNotesTitle.textContent = 'Concept notes'; // Reset title
   }
 
   // Hide any previously displayed Q&A exchange
@@ -1787,7 +1787,7 @@ export async function handleStartInteraction() {
     });
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ error: "Failed to start interaction. Server returned an error." }));
+      const errorData = await response.json().catch(() => ({ error: "Failed to start concept Q&A. Server returned an error." }));
       throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
     }
 
@@ -1892,7 +1892,7 @@ async function handleCancelInteraction() {
       conceptStep3Content.innerHTML = '';
     }
     if (conceptStep1Status) {
-      conceptStep1Status.textContent = 'Interaction cancelled';
+      conceptStep1Status.textContent = 'Concept Q&A cancelled';
       conceptStep1Status.style.color = 'orange';
     }
 
@@ -1948,7 +1948,7 @@ async function handleEndInteraction() {
 
     // Clear any interaction UI elements
     if (conceptStep1Status) {
-      conceptStep1Status.textContent = 'Interaction ended';
+      conceptStep1Status.textContent = 'Concept Q&A ended';
       conceptStep1Status.style.color = 'blue';
     }
 
@@ -1985,7 +1985,7 @@ async function handleSubmitAnswer() {
   const currentQuestion = elements.followUpQuestionP ? elements.followUpQuestionP.textContent : "";
 
   if (!currentInteractionId) {
-    resetInteractionUiToStep1('No active interaction session. Please start a new interaction.', getActiveConceptTabSuffix());
+    resetInteractionUiToStep1('No active concept Q&A session. Start a new Q&A to improve the concept.', getActiveConceptTabSuffix());
     return;
   }
   if (!answer) {
@@ -1997,7 +1997,7 @@ async function handleSubmitAnswer() {
   if (!elements.conceptStep2Status || !elements.conceptStep3Div || !elements.finalResultP ||
     !elements.resetConceptTabButton || !elements.conceptStep2Div || !elements.conceptAnswerInput) {
     console.error("handleSubmitAnswer: One or more required DOM elements for concept tab interaction are missing.");
-    alert("Error: UI elements for interaction are missing. Cannot proceed.");
+    alert("Error: UI elements for concept Q&A are missing. Cannot proceed.");
     return;
   }
 
@@ -2019,10 +2019,10 @@ async function handleSubmitAnswer() {
     });
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ error: "Failed to submit answer. Server returned an error." }));
+      const errorData = await response.json().catch(() => ({ error: "Failed to submit concept Q&A answer. Server returned an error." }));
       const msg = errorData.error || `HTTP error! status: ${response.status}`;
       if (isMissingInteractionSessionMessage(msg)) {
-        resetInteractionUiToStep1('Interaction session expired. Please start a new interaction.', getActiveConceptTabSuffix());
+        resetInteractionUiToStep1('Concept Q&A session expired. Start a new Q&A to improve the concept.', getActiveConceptTabSuffix());
         return;
       }
       throw new Error(msg);
@@ -2083,7 +2083,7 @@ async function handleSubmitAnswer() {
       // Show completion message
       if (elements.conceptStep2Div) elements.conceptStep2Div.style.display = 'none';
       if (elements.conceptStep3Div) elements.conceptStep3Div.style.display = 'block';
-      if (elements.finalResultP) elements.finalResultP.textContent = data.message || "Interaction completed.";
+      if (elements.finalResultP) elements.finalResultP.textContent = data.message || "Concept Q&A completed.";
 
       // Set up the reset button to return to concept view
       if (elements.resetConceptTabButton) {
@@ -2127,7 +2127,7 @@ async function handleSubmitAnswer() {
   } catch (error) {
     console.error("Error in handleSubmitAnswer:", error);
     if (isMissingInteractionSessionMessage(error?.message)) {
-      resetInteractionUiToStep1('Interaction session expired. Please start a new interaction.', getActiveConceptTabSuffix());
+      resetInteractionUiToStep1('Concept Q&A session expired. Start a new Q&A to improve the concept.', getActiveConceptTabSuffix());
       return;
     }
     elements.conceptStep2Status.textContent = `Error: ${error.message}`;
@@ -2144,7 +2144,7 @@ function returnToconceptView() {
     elements.conceptStep1Div.style.backgroundColor = '';
   }
   if (elements.resetConceptTabButton) {
-    elements.resetConceptTabButton.textContent = "Start New Interaction";
+    elements.resetConceptTabButton.textContent = "Improve concept by Q&A again";
     elements.resetConceptTabButton.onclick = null;
   }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1966,6 +1966,13 @@ body {
     padding: 5px 10px;
 }
 
+.concept-interaction-disclosure {
+    margin: 5px 0 10px;
+    color: #475569;
+    font-size: 0.84rem;
+    line-height: 1.35;
+}
+
 .task-discuss-btn:hover,
 .message-discuss-btn:hover,
 .concept-discuss-button:hover {

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -22,12 +22,14 @@
   </div>
   <div id="conceptSummaryRendererMount" class="concept-summary-renderer-mount"></div>
   <!-- Legacy single-note notes UI removed; multi-note relations UI injected dynamically -->
-  <!-- Ordinary discussion is distinct from the legacy Q&A interaction below. -->
+  <!-- Ordinary discussion is distinct from the specialised concept-improvement Q&A below. -->
   <button id="discussConceptButton" class="concept-discuss-button"
     title="Discuss this concept with Von">Discuss</button>
-  <!-- Keep Start Interaction Button -->
   <button id="startInteractionButton"
-    title="Begin an interactive Q&A session to gather information about this concept">Start Interaction</button>
+    title="Answer guided questions to improve this concept; your answers may update its notes">Improve concept by Q&amp;A</button>
+  <p id="conceptInteractionDisclosure" class="concept-interaction-disclosure">
+    Guided Q&amp;A may update this concept's notes.
+  </p>
   <!-- Add Save Notes Button (initially hidden/disabled) -->
   <button id="saveNotesButton" class="concept-save-button" title="Save changes to concept notes">Save</button>
   <button id="suggestInfoButton" class="concept-save-button"
@@ -35,7 +37,7 @@
   <p id="conceptStep1Status" class="concept-status"></p>
 </div>
 
-<!-- Step 2: Follow-up Question and Answer -->
+<!-- Step 2: Guided concept-improvement Q&A -->
 <div id="conceptStep2" class="concept-step">
   <!-- Display of concept notes for editing during interaction -->
   <div id="updatedNotesDisplay" class="concept-notes-display">
@@ -79,7 +81,7 @@
 <!-- Step 3: Final Result -->
 <div id="conceptStep3" class="concept-step">
   <p id="finalResult" class="concept-final-result"></p>
-  <button id="resetConceptTabButton" title="Reset the tab to start a new interaction">Start New Interaction</button>
+  <button id="resetConceptTabButton" title="Reset the tab to start another guided concept-improvement Q&A">Improve concept by Q&amp;A again</button>
 </div>
 
 <!-- Concept list display area moved under Instances section -->

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -56,12 +56,12 @@
   <div class="concept-answer-container">
     <input type="text" id="conceptAnswer" name="conceptAnswer" class="concept-answer-input"
       title="Enter your answer to the follow-up question">
-    <button id="submitAnswerButton" title="Submit your answer and continue the interaction">Submit Answer</button>
+    <button id="submitAnswerButton" title="Submit your answer and continue the concept Q&amp;A">Submit Answer</button>
   </div>
   <button id="cancelInteractionButton" class="concept-cancel-button"
-    title="Cancel the current interaction session">Cancel Interaction</button>
+    title="Cancel the current concept-improvement Q&amp;A">Cancel Q&amp;A</button>
   <button id="endInteractionButton" class="concept-end-button"
-    title="End the interaction and finalize the information gathered">End Interaction</button>
+    title="Finish the concept Q&amp;A and apply the gathered information">Finish Q&amp;A</button>
 
   <!-- Display of the last Q&A exchange -->
   <div id="lastQADisplay" class="concept-last-qa-display">

--- a/tests/frontend/conceptInteractionQandAReframe.test.js
+++ b/tests/frontend/conceptInteractionQandAReframe.test.js
@@ -13,12 +13,25 @@ describe('concept-improvement Q&A entry point', () => {
         const discuss = document.getElementById('discussConceptButton');
         const improveByQa = document.getElementById('startInteractionButton');
         const disclosure = document.getElementById('conceptInteractionDisclosure');
+        const submitAnswer = document.getElementById('submitAnswerButton');
+        const cancelQa = document.getElementById('cancelInteractionButton');
+        const finishQa = document.getElementById('endInteractionButton');
         const restart = document.getElementById('resetConceptTabButton');
 
         expect(discuss.textContent.trim()).toBe('Discuss');
         expect(improveByQa.textContent.trim()).toBe('Improve concept by Q&A');
         expect(improveByQa.title).toContain('may update its notes');
         expect(disclosure.textContent).toMatch(/guided q&a may update this concept's notes/i);
+        expect(submitAnswer.title).toContain('continue the concept Q&A');
+        expect(cancelQa.textContent.trim()).toBe('Cancel Q&A');
+        expect(cancelQa.title).toContain('concept-improvement Q&A');
+        expect(finishQa.textContent.trim()).toBe('Finish Q&A');
+        expect(finishQa.title).toContain('apply the gathered information');
         expect(restart.textContent.trim()).toBe('Improve concept by Q&A again');
+
+        const visibleControlCopy = [improveByQa, submitAnswer, cancelQa, finishQa, restart]
+            .map((element) => element.textContent.trim())
+            .join(' ');
+        expect(visibleControlCopy).not.toMatch(/\binteraction\b/i);
     });
 });

--- a/tests/frontend/conceptInteractionQandAReframe.test.js
+++ b/tests/frontend/conceptInteractionQandAReframe.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const conceptTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/concept_tab.html'),
+    'utf8',
+);
+
+describe('concept-improvement Q&A entry point', () => {
+    test('keeps Discuss separate and discloses the specialised notes-updating flow', () => {
+        document.body.innerHTML = conceptTemplate;
+
+        const discuss = document.getElementById('discussConceptButton');
+        const improveByQa = document.getElementById('startInteractionButton');
+        const disclosure = document.getElementById('conceptInteractionDisclosure');
+        const restart = document.getElementById('resetConceptTabButton');
+
+        expect(discuss.textContent.trim()).toBe('Discuss');
+        expect(improveByQa.textContent.trim()).toBe('Improve concept by Q&A');
+        expect(improveByQa.title).toContain('may update its notes');
+        expect(disclosure.textContent).toMatch(/guided q&a may update this concept's notes/i);
+        expect(restart.textContent.trim()).toBe('Improve concept by Q&A again');
+    });
+});

--- a/tests/frontend/interactionSessionRecovery.test.js
+++ b/tests/frontend/interactionSessionRecovery.test.js
@@ -3,7 +3,7 @@
 /**
  * Regression test for JVNAUTOSCI-895
  * When the backend reports a missing/expired interaction session, the UI should
- * reset to Step 1 and prompt the user to start a new interaction.
+ * reset to Step 1 and prompt the user to restart the specialised concept Q&A.
  */
 
 import {
@@ -92,8 +92,8 @@ describe("Concept interaction session recovery", () => {
         await new Promise((r) => setTimeout(r, 0));
 
         const status = document.getElementById("conceptStep1Status_s1").textContent;
-        expect(status.toLowerCase()).toContain("interaction session");
-        expect(status.toLowerCase()).toContain("start");
+        expect(status.toLowerCase()).toContain("concept q&a session");
+        expect(status.toLowerCase()).toContain("improve the concept");
 
         expect(step1.style.display).toBe("block");
         expect(step2.style.display).toBe("none");


### PR DESCRIPTION
## Outcome

Distinguishes ordinary Discuss from the specialised concept-improvement Q&A flow.

## Changes

- Renames Start Interaction to Improve concept by Q&A.
- Adds visible disclosure that guided answers may update concept notes.
- Rewords Q&A progress, recovery, cancellation and completion states.
- Preserves all interaction-session endpoints, IDs, persistence and recovery semantics.

## Validation

- Full frontend suite: 80 suites, 434 tests passed.
- Targeted Q&A/recovery suites: 2 suites, 4 tests passed.
- Changed-file ESLint: 0 errors; 13 pre-existing warnings in conceptTab.js.
- git diff --check passed.

No deployment or live activation is included.