### PR TITLE
JVNAUTOSCI-2676: Actor-scoped conversation projections

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -17110,80 +17110,15 @@ def _authorised_focal_concepts(
 ) -> tuple[list[str], list[dict[str, Any]], list[str]]:
     """Resolve ordered focal IDs through the actor-filtered concept repository."""
 
-    raw_values = [raw_ids] if isinstance(raw_ids, str) else raw_ids
-    if raw_values is None:
-        return [], [], []
-    if not isinstance(raw_values, list):
-        return [], [], ["invalid_focal_concept_ids"]
-    requested: list[str] = []
-    invalid: list[str] = []
-    for value in raw_values:
-        if not isinstance(value, str) or not value.strip():
-            invalid.append(str(value))
-            continue
-        concept_id = value.strip()
-        if (
-            not concept_id.startswith("#V#")
-            or len(concept_id) > 512
-            or any(character.isspace() for character in concept_id)
-        ):
-            invalid.append(concept_id)
-            continue
-        if concept_id not in requested:
-            requested.append(concept_id)
-    if len(requested) > maximum:
-        invalid.extend(requested[maximum:])
-        requested = requested[:maximum]
-    if invalid and not allow_partial:
-        return [], [], invalid
-    if not requested:
-        return [], [], []
-    from ...db.repositories.concepts_repository import ConceptsRepository
-    from ...vontology.utils_vontology import (
-        get_concept_display_name_with_names_fallback,
+    from ...services.conversation_projection_service import (
+        authorise_focal_concepts,
     )
 
-    visible_docs = list(
-        ConceptsRepository.find(
-            {"concept_id": {"$in": requested}},
-            {"concept_id": 1, "name": 1, "names": 1, "relationships": 1},
-            limit=maximum,
-        )
+    return authorise_focal_concepts(
+        raw_ids,
+        maximum=maximum,
+        allow_partial=allow_partial,
     )
-    by_id = {
-        doc.get("concept_id"): doc
-        for doc in visible_docs
-        if isinstance(doc, Mapping) and isinstance(doc.get("concept_id"), str)
-    }
-    missing = [concept_id for concept_id in requested if concept_id not in by_id]
-    if missing and not allow_partial:
-        return [], [], missing
-    visible_ids = [concept_id for concept_id in requested if concept_id in by_id]
-    projection: list[dict[str, Any]] = []
-    for concept_id in visible_ids:
-        doc = dict(by_id[concept_id])
-        relationships = doc.get("relationships")
-        raw_type_ids = (
-            relationships.get("is_an_instance_of")
-            if isinstance(relationships, Mapping)
-            else None
-        )
-        if isinstance(raw_type_ids, str):
-            type_ids = [raw_type_ids]
-        elif isinstance(raw_type_ids, list):
-            type_ids = raw_type_ids
-        else:
-            type_ids = []
-        projection.append(
-            {
-                "concept_id": concept_id,
-                "name": get_concept_display_name_with_names_fallback(doc)
-                or doc.get("name")
-                or concept_id,
-                "type_ids": [item for item in type_ids if isinstance(item, str)],
-            }
-        )
-    return visible_ids, projection, [*invalid, *missing]
 
 
 @von_bp.route("/api/session/create_chat_session", methods=["POST"])
@@ -17769,16 +17704,21 @@ def chat_session_links():
 
 @von_bp.route("/api/session/chat_session_focus", methods=["GET", "POST"])
 def chat_session_focus():
-    """Read or change source-owned focal objects for an authorised conversation."""
+    """Read source-backed focus cards or owner-update a conversation's focus."""
 
     try:
         from ...security.access_control import (
             LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
             get_effective_user_concept_id_with_source,
         )
+        from ...services.conversation_projection_service import (
+            ConversationProjectionAccessChangedError,
+            ConversationProjectionNotFoundError,
+            get_conversation_projection_for_session,
+            list_focal_conversation_backlinks,
+        )
         from ...services.shared_conversation_service import (
             get_accepted_invite_for_user_session,
-            list_accepted_invites_for_user,
         )
 
         user_concept_id, actor_identity_source = (
@@ -17808,159 +17748,43 @@ def chat_session_focus():
             "namespace"
         ) or chat_history_service.resolve_chat_history_namespace(user_concept_id)
 
-        if (
-            request.method == "GET"
-            and isinstance(focal_concept_id, str)
-            and focal_concept_id.strip()
-        ):
-            focal_id = focal_concept_id.strip()
-            _, _, invalid = _authorised_focal_concepts([focal_id])
-            if invalid:
-                return jsonify({"error": "focal_concept_not_authorised"}), 404
-            results = chat_history_service.list_chat_sessions_for_focal_concept(
-                user_id=user_concept_id,
-                focal_concept_id=focal_id,
-                namespace=actor_namespace,
-            )
-            authorised_owner_results: list[dict[str, Any]] = []
-            for result in results:
-                owner_focal_ids, _, _ = _authorised_focal_concepts(
-                    result.get("focal_concept_ids"),
-                    allow_partial=True,
-                )
-                if focal_id not in owner_focal_ids:
-                    continue
-                authorised_owner_results.append(
-                    {**result, "focal_concept_ids": owner_focal_ids}
-                )
-            results = authorised_owner_results
-            # Accepted shared conversations are actor-visible catalogue rows,
-            # but their owner-scoped focus and every focal object still require
-            # a fresh check for the current actor.
+        if request.method == "GET":
             try:
-                accepted_invites = list_accepted_invites_for_user(
-                    user_concept_id=user_concept_id,
-                    limit=50,
-                )
-            except Exception as exc:
-                current_app.logger.warning(
-                    "Focused-conversation shared catalogue unavailable: %s", exc
-                )
-                accepted_invites = []
-            for invite in accepted_invites:
-                shared_session_id = invite.get("session_id")
-                owner_id = (
-                    invite.get("conversation_owner_user_id")
-                    or invite.get("inviter_user_id")
-                )
-                if not isinstance(shared_session_id, str) or not isinstance(
-                    owner_id, str
-                ):
-                    continue
-                try:
-                    focus = chat_history_service.get_chat_session_focus(
-                        user_id=owner_id,
-                        session_id=shared_session_id,
-                        namespace=None,
+                if isinstance(focal_concept_id, str) and focal_concept_id.strip():
+                    result = list_focal_conversation_backlinks(
+                        actor_user_id=user_concept_id,
+                        focal_concept_id=focal_concept_id.strip(),
+                        actor_namespace=actor_namespace,
                     )
-                except Exception:
-                    continue
-                shared_focal_ids = focus.get("focal_concept_ids", [])
-                if focal_id not in shared_focal_ids:
-                    continue
-                visible_shared_focal_ids, _, _ = _authorised_focal_concepts(
-                    shared_focal_ids,
-                    allow_partial=True,
-                )
-                if focal_id not in visible_shared_focal_ids:
-                    continue
-                try:
-                    summary = chat_history_service.get_chat_history_session_summary(
-                        user_id=owner_id,
-                        session_id=shared_session_id,
-                        namespace=None,
-                        summary_mode="light",
+                else:
+                    if not isinstance(session_id, str) or not session_id.strip():
+                        return jsonify({"error": "session_id required"}), 400
+                    result = get_conversation_projection_for_session(
+                        actor_user_id=user_concept_id,
+                        session_id=session_id.strip(),
+                        actor_namespace=actor_namespace,
+                        organisation_concept_id=effective.get("organisation_id"),
                     )
-                except Exception:
-                    continue
-                if not isinstance(summary, Mapping):
-                    continue
-                results.append(
-                    {
-                        **summary,
-                        **focus,
-                        "focal_concept_ids": visible_shared_focal_ids,
-                        "access_mode": "shared",
-                        "shared_owner_user_id": owner_id,
-                    }
-                )
-                if len(results) >= 50:
-                    break
-            results.sort(
-                key=lambda row: str(
-                    row.get("updated_at") or row.get("created_at") or ""
-                ),
-                reverse=True,
-            )
-            return (
-                jsonify(
-                    {
-                        "status": "ok",
-                        "focal_concept_id": focal_id,
-                        "sessions": results[:25],
-                        "access_scope": "actor",
-                    }
-                ),
-                200,
-            )
+                return jsonify({"status": "ok", **result}), 200
+            except ConversationProjectionAccessChangedError:
+                return jsonify({"error": "focused_conversation_access_changed"}), 403
+            except ConversationProjectionNotFoundError as exc:
+                return jsonify({"error": str(exc)}), 404
 
         if not isinstance(session_id, str) or not session_id.strip():
             return jsonify({"error": "session_id required"}), 400
         session_id = session_id.strip()
-        invite = get_accepted_invite_for_user_session(
+        if get_accepted_invite_for_user_session(
             user_concept_id=user_concept_id, session_id=session_id
-        )
-        owner_id = (
-            (invite.get("conversation_owner_user_id") or invite.get("inviter_user_id"))
-            if isinstance(invite, Mapping)
-            else user_concept_id
-        )
-        if not isinstance(owner_id, str) or not owner_id.strip():
-            return jsonify({"error": "Session not found"}), 404
-        if invite is None and not chat_history_service.has_chat_history_session(
-            user_concept_id, session_id, namespace=actor_namespace
-        ):
-            return jsonify({"error": "Session not found"}), 404
-
-        if request.method == "GET":
-            focus = chat_history_service.get_chat_session_focus(
-                user_id=owner_id,
-                session_id=session_id,
-                namespace=None if invite else actor_namespace,
-            )
-            visible_ids, focal_concepts, unavailable = _authorised_focal_concepts(
-                focus.get("focal_concept_ids")
-            )
-            if invite is not None and unavailable:
-                return jsonify({"error": "focused_conversation_access_changed"}), 403
-            return (
-                jsonify(
-                    {
-                        "status": "ok",
-                        "session_id": session_id,
-                        "focal_concept_ids": visible_ids,
-                        "focal_concepts": focal_concepts,
-                        "access_mode": "shared" if invite else "owner",
-                    }
-                ),
-                200,
-            )
-
-        if invite is not None:
+        ) is not None:
             return (
                 jsonify({"error": "Only the conversation owner may change focus"}),
                 403,
             )
+        if not chat_history_service.has_chat_history_session(
+            user_concept_id, session_id, namespace=actor_namespace
+        ):
+            return jsonify({"error": "Session not found"}), 404
         focal_ids, focal_concepts, invalid = _authorised_focal_concepts(
             payload.get("focal_concept_ids")
         )

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -4858,6 +4858,85 @@ def list_chat_sessions_for_focal_concept(
         ) from exc
 
 
+def get_chat_history_session_summaries_for_owner_sessions(
+    owner_session_pairs: Iterable[tuple[Any, Any]], *, limit: int = 50
+) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Read accepted-shared session metadata in one bounded exact query.
+
+    Invite acceptance supplies the `(owner, session)` candidate set.  This is
+    intentionally a source-store helper rather than a discovery API: it never
+    scans by session ID alone and returns no transcript content.
+    """
+
+    safe_limit = min(max(int(limit or 50), 1), 50)
+    pairs: list[tuple[str, str]] = []
+    for raw_owner_id, raw_session_id in owner_session_pairs:
+        if not isinstance(raw_owner_id, str) or not isinstance(raw_session_id, str):
+            continue
+        owner_id = raw_owner_id.strip()
+        session_id = raw_session_id.strip()
+        if not owner_id or not session_id or (owner_id, session_id) in pairs:
+            continue
+        pairs.append((owner_id, session_id))
+        if len(pairs) == safe_limit:
+            break
+    if not pairs:
+        return {}
+    chat_history_coll = get_chat_history_collection_service(read_only=True)
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+    _guard_chat_history_read("get_chat_history_session_summaries_for_owner_sessions")
+    projection = _add_chat_session_provenance_projection(
+        {
+            "_id": 0,
+            "user_id": 1,
+            "session_id": 1,
+            "session_name": 1,
+            "created_at": 1,
+            "updated_at": 1,
+            "focal_concept_ids": 1,
+            "focal_concept_ids_source": 1,
+            "focal_concept_ids_updated_at": 1,
+        }
+    )
+    try:
+        cursor = _read_find(
+            chat_history_coll,
+            {
+                "$or": [
+                    {"user_id": owner_id, "session_id": session_id}
+                    for owner_id, session_id in pairs
+                ]
+            },
+            projection,
+            operation="get_chat_history_session_summaries_for_owner_sessions.find",
+        )
+        result: Dict[tuple[str, str], Dict[str, Any]] = {}
+        wanted = set(pairs)
+        for document in cursor:
+            if not isinstance(document, dict):
+                continue
+            owner_id = document.get("user_id")
+            session_id = document.get("session_id")
+            if not isinstance(owner_id, str) or not isinstance(session_id, str):
+                continue
+            key = (owner_id, session_id)
+            if key not in wanted:
+                continue
+            summary = _build_session_summary_from_metadata(document)
+            if summary is not None:
+                result[key] = summary
+        _record_chat_history_read_success()
+        return result
+    except PyMongoError as exc:
+        _record_chat_history_read_failure(
+            "get_chat_history_session_summaries_for_owner_sessions", exc
+        )
+        raise ChatHistoryServiceError(
+            f"Could not list accepted shared chat sessions: {exc}"
+        ) from exc
+
+
 def _assistant_opening_result_from_doc(
     doc: Mapping[str, Any] | None,
 ) -> Dict[str, Any] | None:

--- a/src/backend/services/conversation_concept_service.py
+++ b/src/backend/services/conversation_concept_service.py
@@ -13,7 +13,7 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..services.text_value_service import upsert_text_for_concept
@@ -60,6 +60,202 @@ def _generate_conversation_concept_id(session_id: str) -> str:
 
     hash_suffix = hashlib.sha256(session_id.encode()).hexdigest()[:12]
     return f"#V#conversation_{hash_suffix}"
+
+
+def _normalise_projection_focal_concepts(values: Iterable[Any]) -> list[dict[str, Any]]:
+    """Return bounded focal cards already authorised by the caller.
+
+    This service deliberately does not determine concept visibility.  The
+    route that resolves an actor's current access supplies this small
+    projection after its own fresh authorisation check.
+    """
+
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        concept_id = value.get("concept_id")
+        if not isinstance(concept_id, str):
+            continue
+        concept_id = concept_id.strip()
+        if not concept_id or not concept_id.startswith("#V#"):
+            continue
+        if concept_id in seen:
+            continue
+        seen.add(concept_id)
+        name = value.get("name")
+        type_ids = value.get("type_ids")
+        result.append(
+            {
+                "concept_id": concept_id,
+                "display_name": (
+                    name.strip()
+                    if isinstance(name, str) and name.strip()
+                    else concept_id
+                ),
+                "type_ids": [
+                    item for item in type_ids if isinstance(item, str) and item.strip()
+                ]
+                if isinstance(type_ids, list)
+                else [],
+            }
+        )
+    return result
+
+
+def build_source_backed_conversation_projection(
+    *,
+    session_id: str,
+    owner_concept_id: str,
+    authorised_focal_concepts: Iterable[Any],
+    access_mode: str,
+    session_name: Optional[str] = None,
+    last_activity_at: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+    namespace: Optional[str] = None,
+    materialise_owner_projection: bool = False,
+    materialised_concept_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the renderer-ready identity projection for one conversation.
+
+    Chat history remains authoritative for the transcript, title, lifecycle,
+    and current focus.  The card contains only a small current source
+    projection.  A session owner may lazily materialise the private Vontology
+    identity; an accepted participant receives an equally useful source card
+    without widening that concept's visibility.
+    """
+
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ConversationConceptError("session_id is required")
+    if not isinstance(owner_concept_id, str) or not owner_concept_id.strip():
+        raise ConversationConceptError("owner_concept_id is required")
+    if access_mode not in {"owner", "shared"}:
+        raise ConversationConceptError("access_mode is invalid")
+
+    session_id = session_id.strip()
+    owner_concept_id = owner_concept_id.strip()
+    conversation_concept_id = (
+        materialised_concept_id.strip()
+        if isinstance(materialised_concept_id, str)
+        and materialised_concept_id.strip()
+        else None
+    )
+    materialisation = "source_backed"
+    if conversation_concept_id:
+        materialisation = "materialised"
+    elif materialise_owner_projection:
+        try:
+            conversation_concept_id = get_or_create_conversation_concept(
+                session_id=session_id,
+                owner_concept_id=owner_concept_id,
+                organisation_concept_id=organisation_concept_id,
+                namespace=namespace,
+            )
+            materialisation = "materialised"
+        except Exception as exc:
+            # The conversation session remains usable.  A later owner read
+            # may repair this derived projection without copying source data
+            # into Vontology.
+            logger.warning(
+                "Conversation concept projection pending for session %s: %s",
+                session_id,
+                exc,
+            )
+            materialisation = "pending"
+
+    title = (
+        session_name.strip()
+        if isinstance(session_name, str) and session_name.strip()
+        else "Conversation"
+    )
+    return {
+        "schema_version": "conversation_projection.v1",
+        "conversation_concept_id": conversation_concept_id,
+        "title": title,
+        "last_activity_at": (
+            last_activity_at.strip()
+            if isinstance(last_activity_at, str) and last_activity_at.strip()
+            else None
+        ),
+        "access_mode": access_mode,
+        "focal_concepts": _normalise_projection_focal_concepts(
+            authorised_focal_concepts
+        ),
+        "projection_status": materialisation,
+        "open_action": {"kind": "open_conversation", "session_id": session_id},
+    }
+
+
+def get_visible_materialised_conversation_ids_for_sessions(
+    session_ids: Iterable[Any],
+) -> Dict[str, str]:
+    """Return actor-visible deterministic projection IDs in one bounded read.
+
+    This intentionally does not perform the legacy session lookup: catalogue
+    rendering must not fan out into compatibility scans.  Stage 1 focused
+    sessions use deterministic IDs, while older or pending sessions remain
+    useful source-backed cards.
+    """
+
+    normalised_session_ids: list[str] = []
+    for raw_session_id in session_ids:
+        if not isinstance(raw_session_id, str):
+            continue
+        session_id = raw_session_id.strip()
+        if session_id and session_id not in normalised_session_ids:
+            normalised_session_ids.append(session_id)
+    normalised_session_ids = normalised_session_ids[:25]
+    if not normalised_session_ids:
+        return {}
+
+    expected_by_concept_id = {
+        _generate_conversation_concept_id(session_id): session_id
+        for session_id in normalised_session_ids
+    }
+    try:
+        documents = ConceptsRepository.find(
+            {
+                "concept_id": {"$in": list(expected_by_concept_id)},
+                "relationships.is_an_instance_of": CONVERSATION_TYPE_ID,
+            },
+            projection={"concept_id": 1, "relationships.is_an_instance_of": 1},
+            limit=len(expected_by_concept_id),
+        )
+    except Exception:
+        return {}
+    result: Dict[str, str] = {}
+    for document in documents:
+        concept_id = _visible_conversation_id(document)
+        if concept_id and concept_id in expected_by_concept_id:
+            result[expected_by_concept_id[concept_id]] = concept_id
+    return result
+
+
+def build_focal_conversation_backlinks(
+    *,
+    source_concept_id: str,
+    items: Iterable[Any],
+    more_count: int = 0,
+) -> Dict[str, Any]:
+    """Return a bounded source-backed backlink list for one focal concept.
+
+    It is intentionally not a Vontology relation: focus can change and the
+    transcript/session store is its authority.  Callers must only invoke this
+    after checking both the requested focal object and the session's complete
+    stored focus against the current actor.
+    """
+
+    if not isinstance(source_concept_id, str) or not source_concept_id.strip():
+        raise ConversationConceptError("source_concept_id is required")
+    source_concept_id = source_concept_id.strip()
+    projected_items = [item for item in items if isinstance(item, dict)][:25]
+    return {
+        "schema_version": "conversation_backlinks.v1",
+        "source_concept_id": source_concept_id,
+        "items": projected_items,
+        "more_count": max(int(more_count or 0), 0),
+    }
 
 
 def _session_id_text_fingerprint(session_id: str) -> str:
@@ -358,27 +554,9 @@ def get_or_create_conversation_concept(
         except Exception as e:
             logger.warning(f"Failed to store topic: {e}")
 
-    # Try to get conversation name from chat history
-    try:
-        from .chat_history_service import get_chat_history_session_summary
-
-        # Get summary to retrieve session name
-        summary = get_chat_history_session_summary(
-            user_id=owner_concept_id or "",
-            session_id=session_id,
-            summary_mode="light",
-        )
-        if summary:
-            session_name = summary.get("session_name")
-            if session_name:
-                upsert_text_for_concept(
-                    subject_concept_id=conversation_concept_id,
-                    predicate=PREDICATE_HAS_NAME,
-                    text=session_name,
-                    lang="en-NZ",
-                )
-    except Exception as e:
-        logger.debug(f"Could not retrieve conversation name from chat history: {e}")
+    # Deliberately do not copy a session title, transcript, or lifecycle state
+    # into the concept.  Those fields are source-owned chat-history data and
+    # are projected afresh only to an authorised viewer.
 
     return conversation_concept_id
 
@@ -533,6 +711,9 @@ def update_conversation_topic(conversation_concept_id: str, topic: str) -> bool:
 __all__ = [
     "CONVERSATION_TYPE_ID",
     "ConversationConceptError",
+    "build_source_backed_conversation_projection",
+    "build_focal_conversation_backlinks",
+    "get_visible_materialised_conversation_ids_for_sessions",
     "get_conversation_concept_by_session_id",
     "get_or_create_conversation_concept",
     "get_conversation_concept",

--- a/src/backend/services/conversation_projection_service.py
+++ b/src/backend/services/conversation_projection_service.py
@@ -1,0 +1,457 @@
+"""Actor-scoped, source-backed cards for materialised conversation identities.
+
+Conversation concepts are private derived identities.  Chat history and the
+accepted-invite record remain authoritative for whether a current actor may
+receive a card or backlink, and for every displayed source field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from . import chat_history_service
+from .conversation_concept_service import (
+    build_focal_conversation_backlinks,
+    build_source_backed_conversation_projection,
+    get_visible_materialised_conversation_ids_for_sessions,
+)
+from . import shared_conversation_service
+
+
+class ConversationProjectionNotFoundError(LookupError):
+    """The current actor does not have a visible conversation source."""
+
+
+class ConversationProjectionAccessChangedError(PermissionError):
+    """A shared conversation's stored focus is no longer actor-visible."""
+
+
+def authorise_focal_concepts(
+    raw_ids: Any,
+    *,
+    maximum: int = 4,
+    allow_partial: bool = False,
+) -> tuple[list[str], list[dict[str, Any]], list[str]]:
+    """Resolve focal concepts through the request's actor-filtered repository."""
+
+    from ..db.repositories.concepts_repository import ConceptsRepository
+    from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
+
+    raw_values = [raw_ids] if isinstance(raw_ids, str) else raw_ids
+    if raw_values is None:
+        return [], [], []
+    if not isinstance(raw_values, list):
+        return [], [], ["invalid_focal_concept_ids"]
+
+    requested: list[str] = []
+    invalid: list[str] = []
+    for value in raw_values:
+        if not isinstance(value, str) or not value.strip():
+            invalid.append(str(value))
+            continue
+        concept_id = value.strip()
+        if (
+            not concept_id.startswith("#V#")
+            or len(concept_id) > 512
+            or any(character.isspace() for character in concept_id)
+        ):
+            invalid.append(concept_id)
+            continue
+        if concept_id not in requested:
+            requested.append(concept_id)
+    safe_maximum = min(max(int(maximum or 4), 1), 25)
+    if len(requested) > safe_maximum:
+        invalid.extend(requested[safe_maximum:])
+        requested = requested[:safe_maximum]
+    if invalid and not allow_partial:
+        return [], [], invalid
+    if not requested:
+        return [], [], []
+
+    visible_docs = list(
+        ConceptsRepository.find(
+            {"concept_id": {"$in": requested}},
+            {"concept_id": 1, "name": 1, "names": 1, "relationships": 1},
+            limit=safe_maximum,
+        )
+    )
+    by_id = {
+        doc.get("concept_id"): doc
+        for doc in visible_docs
+        if isinstance(doc, Mapping) and isinstance(doc.get("concept_id"), str)
+    }
+    missing = [concept_id for concept_id in requested if concept_id not in by_id]
+    if missing and not allow_partial:
+        return [], [], [*invalid, *missing]
+    visible_ids = [concept_id for concept_id in requested if concept_id in by_id]
+    concepts: list[dict[str, Any]] = []
+    for concept_id in visible_ids:
+        doc = dict(by_id[concept_id])
+        relationships = doc.get("relationships")
+        raw_type_ids = (
+            relationships.get("is_an_instance_of")
+            if isinstance(relationships, Mapping)
+            else None
+        )
+        type_ids = [raw_type_ids] if isinstance(raw_type_ids, str) else raw_type_ids
+        concepts.append(
+            {
+                "concept_id": concept_id,
+                "name": get_concept_display_name_with_names_fallback(doc)
+                or doc.get("name")
+                or concept_id,
+                "type_ids": [
+                    item for item in type_ids if isinstance(item, str)
+                ]
+                if isinstance(type_ids, list)
+                else [],
+            }
+        )
+    return visible_ids, concepts, [*invalid, *missing]
+
+
+def _card_activity(summary: Mapping[str, Any]) -> Any:
+    return (
+        summary.get("last_message_at")
+        or summary.get("updated_at")
+        or summary.get("created_at")
+    )
+
+
+def _normalise_row_focal_ids(raw_ids: Any) -> list[str]:
+    """Normalise stored focus without making an authority decision."""
+
+    raw_values = [raw_ids] if isinstance(raw_ids, str) else raw_ids
+    if not isinstance(raw_values, list):
+        return []
+    result: list[str] = []
+    for value in raw_values:
+        if not isinstance(value, str):
+            continue
+        concept_id = value.strip()
+        if (
+            not concept_id.startswith("#V#")
+            or len(concept_id) > 512
+            or any(character.isspace() for character in concept_id)
+            or concept_id in result
+        ):
+            continue
+        result.append(concept_id)
+        if len(result) == 4:
+            break
+    return result
+
+
+def _authorise_focal_concepts_batch(
+    raw_focal_lists: list[Any], *, maximum: int = 200
+) -> dict[str, dict[str, Any]]:
+    """Resolve all catalogue focus IDs in one actor-filtered repository read."""
+
+    from ..db.repositories.concepts_repository import ConceptsRepository
+    from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
+
+    requested: list[str] = []
+    for raw_ids in raw_focal_lists:
+        for concept_id in _normalise_row_focal_ids(raw_ids):
+            if concept_id not in requested:
+                requested.append(concept_id)
+            if len(requested) >= maximum:
+                break
+        if len(requested) >= maximum:
+            break
+    if not requested:
+        return {}
+    documents = list(
+        ConceptsRepository.find(
+            {"concept_id": {"$in": requested}},
+            {"concept_id": 1, "name": 1, "names": 1, "relationships": 1},
+            limit=len(requested),
+        )
+    )
+    by_id: dict[str, dict[str, Any]] = {}
+    for document in documents:
+        if not isinstance(document, Mapping):
+            continue
+        concept_id = document.get("concept_id")
+        if not isinstance(concept_id, str) or concept_id not in requested:
+            continue
+        relationships = document.get("relationships")
+        raw_type_ids = (
+            relationships.get("is_an_instance_of")
+            if isinstance(relationships, Mapping)
+            else None
+        )
+        type_ids = [raw_type_ids] if isinstance(raw_type_ids, str) else raw_type_ids
+        by_id[concept_id] = {
+            "concept_id": concept_id,
+            "name": get_concept_display_name_with_names_fallback(dict(document))
+            or document.get("name")
+            or concept_id,
+            "type_ids": [item for item in type_ids if isinstance(item, str)]
+            if isinstance(type_ids, list)
+            else [],
+        }
+    return by_id
+
+
+def _visible_row_focus(
+    row: Mapping[str, Any], visible_by_id: Mapping[str, dict[str, Any]]
+) -> tuple[list[str], list[dict[str, Any]]]:
+    focal_ids = _normalise_row_focal_ids(row.get("focal_concept_ids"))
+    visible_ids = [concept_id for concept_id in focal_ids if concept_id in visible_by_id]
+    return visible_ids, [visible_by_id[concept_id] for concept_id in visible_ids]
+
+
+def _legacy_session_projection(row: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Keep the legacy launcher payload deliberately free of private metadata."""
+
+    session_id = row.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+    session_name = row.get("session_name")
+    return {
+        "session_id": session_id.strip(),
+        "session_name": (
+            session_name.strip()
+            if isinstance(session_name, str) and session_name.strip()
+            else None
+        ),
+        "last_activity_at": _card_activity(row),
+    }
+
+
+def get_conversation_projection_for_session(
+    *,
+    actor_user_id: str,
+    session_id: str,
+    actor_namespace: str | None,
+    organisation_concept_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a fresh card for an owner or accepted shared conversation."""
+
+    if not isinstance(actor_user_id, str) or not actor_user_id.strip():
+        raise ConversationProjectionNotFoundError("Session not found")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ConversationProjectionNotFoundError("Session not found")
+    actor_user_id = actor_user_id.strip()
+    session_id = session_id.strip()
+    invite = shared_conversation_service.get_accepted_invite_for_user_session(
+        user_concept_id=actor_user_id, session_id=session_id
+    )
+    owner_id = (
+        (invite.get("conversation_owner_user_id") or invite.get("inviter_user_id"))
+        if isinstance(invite, Mapping)
+        else actor_user_id
+    )
+    if not isinstance(owner_id, str) or not owner_id.strip():
+        raise ConversationProjectionNotFoundError("Session not found")
+    owner_id = owner_id.strip()
+    source_namespace = None if invite else actor_namespace
+    if invite is None and not chat_history_service.has_chat_history_session(
+        actor_user_id, session_id, namespace=source_namespace
+    ):
+        raise ConversationProjectionNotFoundError("Session not found")
+
+    focus = chat_history_service.get_chat_session_focus(
+        user_id=owner_id,
+        session_id=session_id,
+        namespace=source_namespace,
+    )
+    visible_ids, focal_concepts, unavailable = authorise_focal_concepts(
+        focus.get("focal_concept_ids")
+    )
+    if invite is not None and unavailable:
+        raise ConversationProjectionAccessChangedError(
+            "focused_conversation_access_changed"
+        )
+    summary = chat_history_service.get_chat_history_session_summary(
+        user_id=owner_id,
+        session_id=session_id,
+        namespace=source_namespace,
+        summary_mode="light",
+    )
+    if not isinstance(summary, Mapping):
+        raise ConversationProjectionNotFoundError("Session not found")
+    card = build_source_backed_conversation_projection(
+        session_id=session_id,
+        owner_concept_id=owner_id,
+        authorised_focal_concepts=focal_concepts,
+        access_mode="shared" if invite else "owner",
+        session_name=summary.get("session_name"),
+        last_activity_at=_card_activity(summary),
+        organisation_concept_id=(
+            invite.get("organisation_concept_id")
+            if isinstance(invite, Mapping)
+            else organisation_concept_id
+        ),
+        namespace=source_namespace,
+        materialise_owner_projection=invite is None,
+    )
+    return {
+        "session_id": session_id,
+        "focal_concept_ids": visible_ids,
+        "focal_concepts": focal_concepts,
+        "access_mode": "shared" if invite else "owner",
+        "conversation_projection": card,
+    }
+
+
+def list_focal_conversation_backlinks(
+    *,
+    actor_user_id: str,
+    focal_concept_id: str,
+    actor_namespace: str | None,
+    limit: int = 25,
+) -> dict[str, Any]:
+    """List bounded cards where a currently visible concept is focal.
+
+    The initial focal check and one batched actor-filtered concept read are the
+    only concept-visibility reads on this catalogue path.  Accepted invites
+    supply exact owner/session candidates; their minimal chat metadata is read
+    once as a bounded batch.
+    """
+
+    if not isinstance(actor_user_id, str) or not actor_user_id.strip():
+        raise ConversationProjectionNotFoundError("focal_concept_not_authorised")
+    if not isinstance(focal_concept_id, str) or not focal_concept_id.strip():
+        raise ConversationProjectionNotFoundError("focal_concept_not_authorised")
+    actor_user_id = actor_user_id.strip()
+    focal_concept_id = focal_concept_id.strip()
+    _, _, invalid = authorise_focal_concepts([focal_concept_id])
+    if invalid:
+        raise ConversationProjectionNotFoundError("focal_concept_not_authorised")
+    safe_limit = min(max(int(limit or 25), 1), 25)
+    candidate_limit = 50
+
+    candidates: list[dict[str, Any]] = [
+        {**row, "_projection_owner_id": actor_user_id, "_projection_access_mode": "owner"}
+        for row in chat_history_service.list_chat_sessions_for_focal_concept(
+            user_id=actor_user_id,
+            focal_concept_id=focal_concept_id,
+            namespace=actor_namespace,
+        )[:candidate_limit]
+        if isinstance(row, Mapping)
+    ]
+
+    try:
+        accepted_invites = shared_conversation_service.list_accepted_invites_for_user(
+            user_concept_id=actor_user_id, limit=candidate_limit
+        )
+    except Exception:
+        # A transient sharing-store fault must not hide the actor's own cards.
+        accepted_invites = []
+    accepted_pairs: list[tuple[str, str]] = []
+    accepted_invites_by_pair: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for invite in accepted_invites:
+        if not isinstance(invite, Mapping):
+            continue
+        session_id = invite.get("session_id")
+        owner_id = invite.get("conversation_owner_user_id") or invite.get(
+            "inviter_user_id"
+        )
+        if not isinstance(session_id, str) or not isinstance(owner_id, str):
+            continue
+        key = (owner_id.strip(), session_id.strip())
+        if not key[0] or not key[1] or key in accepted_invites_by_pair:
+            continue
+        accepted_pairs.append(key)
+        accepted_invites_by_pair[key] = invite
+        if len(accepted_pairs) == candidate_limit:
+            break
+    try:
+        accepted_summaries = (
+            chat_history_service.get_chat_history_session_summaries_for_owner_sessions(
+                accepted_pairs, limit=candidate_limit
+            )
+        )
+    except chat_history_service.ChatHistoryServiceError:
+        accepted_summaries = {}
+    for (owner_id, session_id), summary in accepted_summaries.items():
+        if not isinstance(summary, Mapping):
+            continue
+        # This only narrows the invite-derived candidate set.  The batch
+        # visibility map below makes the real actor authority decision.
+        if focal_concept_id not in _normalise_row_focal_ids(
+            summary.get("focal_concept_ids")
+        ):
+            continue
+        candidates.append(
+            {
+                **summary,
+                "_projection_owner_id": owner_id,
+                "_projection_access_mode": "shared",
+            }
+        )
+
+    visible_by_id = _authorise_focal_concepts_batch(
+        [row.get("focal_concept_ids") for row in candidates]
+    )
+    visible_candidates: list[
+        tuple[dict[str, Any], list[str], list[dict[str, Any]]]
+    ] = []
+    for candidate in candidates:
+        visible_ids, visible_concepts = _visible_row_focus(candidate, visible_by_id)
+        if focal_concept_id in visible_ids:
+            visible_candidates.append((candidate, visible_ids, visible_concepts))
+    visible_candidates.sort(
+        key=lambda item: str(_card_activity(item[0]) or ""),
+        reverse=True,
+    )
+
+    selected = visible_candidates[:safe_limit]
+    materialised_by_session = get_visible_materialised_conversation_ids_for_sessions(
+        [
+            row.get("session_id")
+            for row, _, _ in selected
+            if row.get("_projection_access_mode") == "owner"
+        ]
+    )
+    cards: list[dict[str, Any]] = []
+    sessions: list[dict[str, Any]] = []
+    for row, _, visible_concepts in selected:
+        session_id = row.get("session_id")
+        owner_id = row.get("_projection_owner_id")
+        access_mode = row.get("_projection_access_mode")
+        if (
+            not isinstance(session_id, str)
+            or not session_id.strip()
+            or not isinstance(owner_id, str)
+            or access_mode not in {"owner", "shared"}
+        ):
+            continue
+        cards.append(
+            build_source_backed_conversation_projection(
+                session_id=session_id,
+                owner_concept_id=owner_id,
+                authorised_focal_concepts=visible_concepts,
+                access_mode=access_mode,
+                session_name=row.get("session_name"),
+                last_activity_at=_card_activity(row),
+                materialised_concept_id=(
+                    materialised_by_session.get(session_id)
+                    if access_mode == "owner"
+                    else None
+                ),
+            )
+        )
+        legacy_row = _legacy_session_projection(row)
+        if legacy_row is not None:
+            sessions.append(legacy_row)
+    return {
+        "focal_concept_id": focal_concept_id,
+        "sessions": sessions,
+        "conversation_backlinks": build_focal_conversation_backlinks(
+            source_concept_id=focal_concept_id,
+            items=cards,
+            more_count=max(len(visible_candidates) - safe_limit, 0),
+        ),
+        "access_scope": "actor",
+    }
+
+__all__ = [
+    "ConversationProjectionAccessChangedError",
+    "ConversationProjectionNotFoundError",
+    "authorise_focal_concepts",
+    "get_conversation_projection_for_session",
+    "list_focal_conversation_backlinks",
+]

--- a/tests/backend/test_chat_history_session_management.py
+++ b/tests/backend/test_chat_history_session_management.py
@@ -399,6 +399,65 @@ def test_recent_focus_lookup_queries_exact_indexable_field(monkeypatch):
     assert [item["session_id"] for item in result] == ["focused-session"]
 
 
+def test_shared_session_metadata_batch_is_exact_bounded_and_transcript_free(
+    monkeypatch,
+):
+    from src.backend.services import chat_history_service
+
+    calls = []
+
+    class _FakeColl:
+        def find(self, query, projection=None, **kwargs):
+            calls.append((query, projection, kwargs))
+            return [
+                {
+                    "user_id": "#V#owner_0",
+                    "session_id": "shared-0",
+                    "session_name": "Shared discussion",
+                    "focal_concept_ids": ["#V#task"],
+                },
+                {
+                    "user_id": "#V#not_requested",
+                    "session_id": "other-session",
+                    "session_name": "Must be ignored",
+                    "focal_concept_ids": ["#V#task"],
+                },
+            ]
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: _FakeColl(),
+    )
+    monkeypatch.setattr(
+        chat_history_service, "_guard_chat_history_read", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        chat_history_service, "_record_chat_history_read_success", lambda: None
+    )
+
+    result = chat_history_service.get_chat_history_session_summaries_for_owner_sessions(
+        [(f"#V#owner_{index}", f"shared-{index}") for index in range(55)],
+        limit=100,
+    )
+
+    assert list(result) == [("#V#owner_0", "shared-0")]
+    query, projection, _ = calls[0]
+    assert len(query["$or"]) == 50
+    assert query["$or"][0] == {
+        "user_id": "#V#owner_0",
+        "session_id": "shared-0",
+    }
+    assert query["$or"][-1] == {
+        "user_id": "#V#owner_49",
+        "session_id": "shared-49",
+    }
+    assert projection["user_id"] == 1
+    assert projection["session_id"] == 1
+    assert "history" not in projection
+    assert "messages" not in projection
+
+
 def test_implicit_session_creation_does_not_derive_name_from_first_user_message(
     monkeypatch,
 ):

--- a/tests/backend/test_chat_session_links_routes.py
+++ b/tests/backend/test_chat_session_links_routes.py
@@ -145,6 +145,9 @@ def test_authorised_focal_projection_preserves_string_type_id(monkeypatch):
 
 def test_recent_focus_lookup_is_explicitly_owner_scoped(app_client, monkeypatch):
     _, client = app_client
+    from src.backend.services.conversation_concept_service import (
+        _generate_conversation_concept_id,
+    )
 
     with client.session_transaction() as sess:
         sess["user_concept_id"] = "#V#test_user"
@@ -157,15 +160,28 @@ def test_recent_focus_lookup_is_explicitly_owner_scoped(app_client, monkeypatch)
         "src.backend.server.routes.von_routes.get_effective_context",
         lambda *_args, **_kwargs: {"namespace": "#V#test_user@org"},
     )
-    monkeypatch.setattr(
-        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
-        lambda *_args, **_kwargs: [
+    materialised_id = _generate_conversation_concept_id("focused-session")
+
+    def _visible_concepts(query, *_args, **_kwargs):  # noqa: ANN001
+        requested = query.get("concept_id", {}).get("$in", [])
+        if materialised_id in requested:
+            return [
+                {
+                    "concept_id": materialised_id,
+                    "relationships": {"is_an_instance_of": ["#V#conversation"]},
+                }
+            ]
+        return [
             {
                 "concept_id": "#V#task",
                 "name": "Task",
                 "relationships": {"is_an_instance_of": ["#V#task_type"]},
             }
-        ],
+        ]
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        _visible_concepts,
     )
     lookup = MagicMock(
         return_value=[
@@ -181,7 +197,9 @@ def test_recent_focus_lookup_is_explicitly_owner_scoped(app_client, monkeypatch)
     )
     monkeypatch.setattr(
         "src.backend.services.shared_conversation_service.list_accepted_invites_for_user",
-        lambda **_kwargs: [],
+        lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("sharing catalogue unavailable")
+        ),
     )
 
     response = client.get(
@@ -196,6 +214,9 @@ def test_recent_focus_lookup_is_explicitly_owner_scoped(app_client, monkeypatch)
         "focal_concept_id": "#V#task",
         "namespace": "#V#test_user@org",
     }
+    card = response.get_json()["conversation_backlinks"]["items"][0]
+    assert card["conversation_concept_id"] == materialised_id
+    assert card["projection_status"] == "materialised"
 
 
 def test_recent_focus_lookup_omits_inaccessible_secondary_owner_focus(
@@ -253,7 +274,8 @@ def test_recent_focus_lookup_omits_inaccessible_secondary_owner_focus(
     assert response.get_json()["sessions"] == [
         {
             "session_id": "focused-session",
-            "focal_concept_ids": ["#V#task"],
+            "session_name": None,
+            "last_activity_at": None,
         }
     ]
     assert "#V#private_secondary" not in response.get_data(as_text=True)
@@ -362,17 +384,14 @@ def test_recent_focus_lookup_includes_authorised_accepted_shared_session(
         ],
     )
     monkeypatch.setattr(
-        "src.backend.services.chat_history_service.get_chat_session_focus",
-        lambda **_kwargs: {
-            "focal_concept_ids": ["#V#task", "#V#private_secondary"]
-        },
-    )
-    monkeypatch.setattr(
-        "src.backend.services.chat_history_service.get_chat_history_session_summary",
-        lambda **_kwargs: {
-            "session_id": "shared-focused",
-            "session_name": "Shared task discussion",
-            "updated_at": "2026-08-22T10:00:00+00:00",
+        "src.backend.services.chat_history_service.get_chat_history_session_summaries_for_owner_sessions",
+        lambda *_args, **_kwargs: {
+            ("#V#owner", "shared-focused"): {
+                "session_id": "shared-focused",
+                "session_name": "Shared task discussion",
+                "last_message_at": "2026-08-22T10:00:00+00:00",
+                "focal_concept_ids": ["#V#task", "#V#private_secondary"],
+            }
         },
     )
 
@@ -384,15 +403,379 @@ def test_recent_focus_lookup_includes_authorised_accepted_shared_session(
     rows = response.get_json()["sessions"]
     assert rows == [
         {
-            "access_mode": "shared",
-            "focal_concept_ids": ["#V#task"],
             "session_id": "shared-focused",
             "session_name": "Shared task discussion",
-            "shared_owner_user_id": "#V#owner",
-            "updated_at": "2026-08-22T10:00:00+00:00",
+            "last_activity_at": "2026-08-22T10:00:00+00:00",
         }
     ]
     assert "#V#private_secondary" not in response.get_data(as_text=True)
+    assert "#V#owner" not in response.get_data(as_text=True)
+    backlinks = response.get_json()["conversation_backlinks"]
+    assert backlinks["schema_version"] == "conversation_backlinks.v1"
+    assert backlinks["source_concept_id"] == "#V#task"
+    assert backlinks["items"][0]["access_mode"] == "shared"
+    assert backlinks["items"][0]["conversation_concept_id"] is None
+    assert backlinks["items"][0]["open_action"] == {
+        "kind": "open_conversation",
+        "session_id": "shared-focused",
+    }
+
+
+def test_owner_focus_point_returns_materialised_source_card(app_client, monkeypatch):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#owner"
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#owner", "session"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {
+            "namespace": "#V#owner@org",
+            "organisation_id": "#V#org",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_session_focus",
+        lambda **_kwargs: {"focal_concept_ids": ["#V#task"]},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_history_session_summary",
+        lambda **_kwargs: {
+            "session_id": "owner-session",
+            "session_name": "Talk about task",
+            "updated_at": "2026-08-22T12:00:00+00:00",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        lambda *_args, **_kwargs: [
+            {
+                "concept_id": "#V#task",
+                "name": "Task",
+                "relationships": {"is_an_instance_of": ["#V#task"]},
+            }
+        ],
+    )
+    expected_id = "#V#conversation_owner_session"
+    materialise = MagicMock(return_value=expected_id)
+    monkeypatch.setattr(
+        "src.backend.services.conversation_concept_service.get_or_create_conversation_concept",
+        materialise,
+    )
+
+    response = client.get(
+        "/von/api/session/chat_session_focus?session_id=owner-session"
+    )
+
+    assert response.status_code == 200, response.get_json()
+    card = response.get_json()["conversation_projection"]
+    assert card == {
+        "schema_version": "conversation_projection.v1",
+        "conversation_concept_id": expected_id,
+        "title": "Talk about task",
+        "last_activity_at": "2026-08-22T12:00:00+00:00",
+        "access_mode": "owner",
+        "focal_concepts": [
+            {
+                "concept_id": "#V#task",
+                "display_name": "Task",
+                "type_ids": ["#V#task"],
+            }
+        ],
+        "projection_status": "materialised",
+        "open_action": {"kind": "open_conversation", "session_id": "owner-session"},
+    }
+    assert materialise.call_args.kwargs["owner_concept_id"] == "#V#owner"
+    assert "owner_concept_id" not in card
+    assert "history" not in card
+
+
+def test_shared_focus_point_is_source_backed_without_widening_owner_concept(
+    app_client, monkeypatch
+):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#invitee"
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#invitee", "session"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#invitee@org"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.shared_conversation_service.get_accepted_invite_for_user_session",
+        lambda **_kwargs: {
+            "conversation_owner_user_id": "#V#owner",
+            "organisation_concept_id": "#V#org",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_session_focus",
+        lambda **_kwargs: {"focal_concept_ids": ["#V#task"]},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_history_session_summary",
+        lambda **_kwargs: {"session_name": "Owner discussion"},
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        lambda *_args, **_kwargs: [
+            {
+                "concept_id": "#V#task",
+                "name": "Task",
+                "relationships": {"is_an_instance_of": ["#V#task"]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.conversation_concept_service.get_or_create_conversation_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("shared viewer must not materialise owner's concept")
+        ),
+    )
+
+    response = client.get(
+        "/von/api/session/chat_session_focus?session_id=shared-session"
+    )
+
+    assert response.status_code == 200, response.get_json()
+    card = response.get_json()["conversation_projection"]
+    assert card["access_mode"] == "shared"
+    assert card["conversation_concept_id"] is None
+    assert card["projection_status"] == "source_backed"
+    assert card["open_action"] == {
+        "kind": "open_conversation",
+        "session_id": "shared-session",
+    }
+    assert "#V#owner" not in response.get_data(as_text=True)
+
+
+def test_unrelated_actor_cannot_discover_owner_session_or_focus(app_client, monkeypatch):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#unrelated"
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#unrelated", "session"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#unrelated@org"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.shared_conversation_service.get_accepted_invite_for_user_session",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: False,
+    )
+
+    response = client.get(
+        "/von/api/session/chat_session_focus?session_id=owner-secret-session"
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Session not found"}
+    assert "owner-secret-session" not in response.get_data(as_text=True)
+
+
+def test_revoked_shared_invite_has_no_point_or_catalogue_projection(
+    app_client, monkeypatch
+):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#former_invitee"
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#former_invitee", "session"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#former_invitee@org"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.shared_conversation_service.get_accepted_invite_for_user_session",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: False,
+    )
+
+    point = client.get(
+        "/von/api/session/chat_session_focus?session_id=formerly-shared"
+    )
+
+    assert point.status_code == 404
+    assert point.get_json() == {"error": "Session not found"}
+    assert "formerly-shared" not in point.get_data(as_text=True)
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        lambda *_args, **_kwargs: [
+            {
+                "concept_id": "#V#task",
+                "name": "Task",
+                "relationships": {"is_an_instance_of": ["#V#task"]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.list_chat_sessions_for_focal_concept",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.shared_conversation_service.list_accepted_invites_for_user",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_history_session_summaries_for_owner_sessions",
+        lambda *_args, **_kwargs: {},
+    )
+
+    catalogue = client.get(
+        "/von/api/session/chat_session_focus?focal_concept_id=%23V%23task"
+    )
+
+    assert catalogue.status_code == 200
+    assert catalogue.get_json()["sessions"] == []
+    assert catalogue.get_json()["conversation_backlinks"]["items"] == []
+    serialised_catalogue = catalogue.get_data(as_text=True)
+    for hidden_value in (
+        "formerly-shared",
+        "#V#owner",
+        "#V#owner@org",
+        "#V#private_task",
+    ):
+        assert hidden_value not in serialised_catalogue
+
+
+def test_shared_focus_access_loss_does_not_reveal_stale_focal_id(
+    app_client, monkeypatch
+):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#invitee"
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#invitee", "session"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#invitee@org"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.shared_conversation_service.get_accepted_invite_for_user_session",
+        lambda **_kwargs: {"conversation_owner_user_id": "#V#owner"},
+    )
+    monkeypatch.setattr(
+        "src.backend.services.chat_history_service.get_chat_session_focus",
+        lambda **_kwargs: {"focal_concept_ids": ["#V#private_task"]},
+    )
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        lambda *_args, **_kwargs: [],
+    )
+
+    response = client.get(
+        "/von/api/session/chat_session_focus?session_id=shared-session"
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {"error": "focused_conversation_access_changed"}
+    assert "#V#private_task" not in response.get_data(as_text=True)
+
+
+def test_catalogue_uses_one_batched_focal_read_and_one_shared_history_read(
+    monkeypatch,
+):
+    from src.backend.services import conversation_projection_service as service
+
+    concept_queries = []
+
+    def _find(query, *_args, **_kwargs):  # noqa: ANN001
+        concept_queries.append(query)
+        requested = query["concept_id"]["$in"]
+        return [
+            {
+                "concept_id": concept_id,
+                "name": concept_id,
+                "relationships": {"is_an_instance_of": ["#V#thing"]},
+            }
+            for concept_id in requested
+            if concept_id.startswith("#V#task")
+        ]
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find",
+        _find,
+    )
+    monkeypatch.setattr(
+        service.chat_history_service,
+        "list_chat_sessions_for_focal_concept",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        service.shared_conversation_service,
+        "list_accepted_invites_for_user",
+        lambda **_kwargs: [
+            {"session_id": f"shared-{index}", "conversation_owner_user_id": "#V#owner"}
+            for index in range(10)
+        ],
+    )
+    history_calls = []
+
+    def _batch(pairs, **_kwargs):  # noqa: ANN001
+        history_calls.append(list(pairs))
+        return {
+            ("#V#owner", f"shared-{index}"): {
+                "session_id": f"shared-{index}",
+                "session_name": f"Shared {index}",
+                "last_message_at": f"2026-08-22T12:{index:02d}:00+00:00",
+                "focal_concept_ids": ["#V#task", f"#V#task_{index}"],
+            }
+            for index in range(10)
+        }
+
+    monkeypatch.setattr(
+        service.chat_history_service,
+        "get_chat_history_session_summaries_for_owner_sessions",
+        _batch,
+    )
+    monkeypatch.setattr(
+        service.chat_history_service,
+        "get_chat_session_focus",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("no per-invite focus read")),
+    )
+
+    result = service.list_focal_conversation_backlinks(
+        actor_user_id="#V#actor",
+        focal_concept_id="#V#task",
+        actor_namespace="#V#actor",
+    )
+
+    assert len(history_calls) == 1
+    assert len(history_calls[0]) == 10
+    focal_queries = [
+        query
+        for query in concept_queries
+        if any(concept_id.startswith("#V#task_") for concept_id in query["concept_id"]["$in"])
+    ]
+    assert len(focal_queries) == 1
+    assert len(result["conversation_backlinks"]["items"]) == 10
 
 
 def test_focused_session_creation_returns_receipt_when_projection_is_pending(

--- a/tests/backend/test_conversation_concept_service.py
+++ b/tests/backend/test_conversation_concept_service.py
@@ -221,6 +221,7 @@ def test_created_conversation_projection_is_restricted_to_transcript_owner(
     monkeypatch,
 ) -> None:
     inserted: list[dict[str, Any]] = []
+    text_writes: list[dict[str, Any]] = []
 
     monkeypatch.setattr(
         service, "get_conversation_concept_by_session_id", lambda _session_id: None
@@ -230,10 +231,10 @@ def test_created_conversation_projection_is_restricted_to_transcript_owner(
         "insert_one",
         lambda doc: inserted.append(dict(doc)),
     )
-    monkeypatch.setattr(service, "upsert_text_for_concept", lambda **_kwargs: None)
     monkeypatch.setattr(
-        "src.backend.services.chat_history_service.get_chat_history_session_summary",
-        lambda **_kwargs: None,
+        service,
+        "upsert_text_for_concept",
+        lambda **kwargs: text_writes.append(kwargs),
     )
 
     conversation_id = service.get_or_create_conversation_concept(
@@ -249,3 +250,88 @@ def test_created_conversation_projection_is_restricted_to_transcript_owner(
     relationships = inserted[0]["relationships"]
     assert relationships[service.PREDICATE_HAS_OWNER] == ["#V#owner"]
     assert get_specific_to_user_values(relationships) == ["#V#owner"]
+    assert service.PREDICATE_HAS_NAME not in {
+        write["predicate"] for write in text_writes
+    }
+
+
+def test_source_backed_conversation_card_is_deterministic_and_minimal(
+    monkeypatch,
+) -> None:
+    session_id = "source-backed-session"
+    expected_conversation_id = service._generate_conversation_concept_id(session_id)
+    materialise = []
+
+    def _materialise(**kwargs):  # noqa: ANN003
+        materialise.append(kwargs)
+        return expected_conversation_id
+
+    monkeypatch.setattr(service, "get_or_create_conversation_concept", _materialise)
+
+    card = service.build_source_backed_conversation_projection(
+        session_id=session_id,
+        owner_concept_id="#V#owner",
+        authorised_focal_concepts=[
+            {"concept_id": "#V#task", "name": "Task", "type_ids": ["#V#task"]}
+        ],
+        access_mode="owner",
+        session_name="Current session title",
+        last_activity_at="2026-08-22T12:00:00+00:00",
+        materialise_owner_projection=True,
+    )
+
+    assert materialise[0]["session_id"] == session_id
+    assert card == {
+        "schema_version": "conversation_projection.v1",
+        "conversation_concept_id": expected_conversation_id,
+        "title": "Current session title",
+        "last_activity_at": "2026-08-22T12:00:00+00:00",
+        "access_mode": "owner",
+        "focal_concepts": [
+            {
+                "concept_id": "#V#task",
+                "display_name": "Task",
+                "type_ids": ["#V#task"],
+            }
+        ],
+        "projection_status": "materialised",
+        "open_action": {"kind": "open_conversation", "session_id": session_id},
+    }
+    assert "owner_concept_id" not in card
+    assert "history" not in card
+
+
+def test_shared_source_backed_card_does_not_materialise_owner_projection(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_or_create_conversation_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must not materialise")),
+    )
+
+    card = service.build_source_backed_conversation_projection(
+        session_id="shared-session",
+        owner_concept_id="#V#owner",
+        authorised_focal_concepts=[],
+        access_mode="shared",
+    )
+
+    assert card["conversation_concept_id"] is None
+    assert card["projection_status"] == "source_backed"
+    assert card["title"] == "Conversation"
+
+
+def test_focal_conversation_backlinks_are_bounded_and_source_scoped() -> None:
+    card = {"schema_version": "conversation_projection.v1", "title": "One"}
+
+    backlinks = service.build_focal_conversation_backlinks(
+        source_concept_id="#V#task",
+        items=[card] * 30,
+        more_count=5,
+    )
+
+    assert backlinks["schema_version"] == "conversation_backlinks.v1"
+    assert backlinks["source_concept_id"] == "#V#task"
+    assert len(backlinks["items"]) == 25
+    assert backlinks["more_count"] == 5

--- a/tests/backend/test_virtual_concept_providers.py
+++ b/tests/backend/test_virtual_concept_providers.py
@@ -75,6 +75,12 @@ def test_provider_must_declare_a_source_id():
         vcp.register_provider(_StubProvider(source_id="  "))
 
 
+def test_private_conversation_ids_are_not_claimed_by_public_virtual_registry():
+    """Conversation projections must retain ordinary actor-filtered access."""
+
+    assert vcp.owning_provider("#V#conversation_0123456789ab") is None
+
+
 def test_duplicate_source_ids_are_refused(stub_registered):
     with pytest.raises(ValueError, match="Duplicate"):
         vcp.register_provider(_StubProvider(source_id=stub_registered.source_id))


### PR DESCRIPTION
## Outcome

Adds actor-scoped, source-backed conversation cards and focal-object backlinks while keeping chat history authoritative for transcript, title, focus, recency, situation, and lifecycle.

## Boundary

- Owner reads lazily resolve the deterministic private conversation concept.
- Accepted shared readers receive a source-backed card without widening the owner-private concept.
- Focal concepts are freshly actor-authorised; revoked or inaccessible sources are non-revealing.
- The legacy launcher payload is restricted to session ID, display name, and activity time.
- Catalogue reads are bounded and batched; no per-invite focus/summary fan-out.
- No public virtual-concept provider is registered. Stage 2B is unnecessary for this capability and remains out of scope.

## Evidence

- 112 focused Stage 1+2 backend tests pass.
- Explicit owner, accepted-shared, unrelated actor, revoked invite, focal access-loss, redaction, deterministic identity, bounded-read and public-provider-negative coverage.
- Changed conversation services: Pyright 0 errors/warnings.
- Changed Python syntax and diff checks pass.

## Non-goals

- No transcript duplication in Vontology.
- No generic actor-scoped virtual-provider redesign.
- No deployment or running-system activation.