### PR TITLE
JVNAUTOSCI-2677 Render conversations as concept summaries

### DIFF
--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -312,7 +312,15 @@ def get_concept_summary_renderer(concept_id: str) -> ResponseReturnValue:
     """Return the concept-page summary renderer payload for one concept."""
 
     try:
-        payload = load_concept_summary_renderer(concept_id)
+        actor_user_id = _get_current_user_concept_id()
+        payload = load_concept_summary_renderer(
+            concept_id,
+            actor_user_id=actor_user_id,
+            actor_namespace=_get_request_namespace() if actor_user_id else None,
+            organisation_concept_id=(
+                _get_current_org_concept_id() if actor_user_id else None
+            ),
+        )
         return jsonify(payload), 200
     except ConceptNotFoundError:
         return jsonify({"error": "Concept not found"}), 404

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -2547,6 +2547,66 @@ def search_concepts():
             use_two_pass=fallback_substring,
         )
 
+        # Built-in code concepts are valid public virtual concepts even before
+        # their first materialisation. The repository-backed search service
+        # cannot discover an absent row, so merge the cheap in-memory code
+        # registry here. Persisted results retain identity precedence, and we
+        # deliberately do not enumerate the heavier MCP-tool provider.
+        from ...vontology.code_concepts_registry import iter_code_concepts
+
+        merged_results = list(search_result.get("results") or [])
+        seen_result_ids = {
+            result.get("concept_id")
+            for result in merged_results
+            if isinstance(result, dict)
+        }
+        query_lower = q.lower()
+        for code_concept in iter_code_concepts():
+            if code_concept.concept_id in seen_result_ids:
+                continue
+            result_kind = (
+                code_concept.kind
+                if code_concept.kind in {"type", "predicate", "individual"}
+                else "individual"
+            )
+            if filter_kind and result_kind not in filter_kind:
+                continue
+            candidate_scores = []
+            for candidate in (
+                code_concept.display_name,
+                code_concept.concept_id,
+            ):
+                candidate_lower = candidate.lower()
+                if candidate_lower == query_lower:
+                    candidate_scores.append(100.0)
+                elif candidate_lower.startswith(query_lower):
+                    candidate_scores.append(
+                        90.0 + (len(query_lower) / len(candidate_lower) * 5.0)
+                    )
+                elif query_lower in candidate_lower:
+                    candidate_scores.append(
+                        70.0 + (len(query_lower) / len(candidate_lower) * 15.0)
+                    )
+            if not candidate_scores:
+                continue
+            merged_results.append(
+                {
+                    "concept_id": code_concept.concept_id,
+                    "name": code_concept.display_name,
+                    "kind": result_kind,
+                    "relevance_score": max(candidate_scores),
+                }
+            )
+            seen_result_ids.add(code_concept.concept_id)
+
+        merged_results.sort(
+            key=lambda result: (
+                -float(result.get("relevance_score") or 0.0),
+                str(result.get("name") or "").lower(),
+            )
+        )
+        search_result["results"] = merged_results[:limit]
+
         # Transform results to match expected frontend format
         # Frontend expects: [{"id": concept_id, "name": display_name, "kind": kind}, ...]
         # Service returns: [{"concept_id": ..., "name": ..., "kind": ..., "relevance_score": ...}, ...]
@@ -2578,6 +2638,26 @@ def search_concepts():
                         predicate_text_map[cid] = (
                             "#V#binary_text_predicate" in instance_of
                         )
+                    missing_predicate_ids = set(predicate_ids) - set(
+                        predicate_text_map
+                    )
+                    if missing_predicate_ids:
+                        from ...vontology.code_concepts_registry import (
+                            build_virtual_concept_doc,
+                        )
+
+                        for cid in missing_predicate_ids:
+                            virtual_doc = build_virtual_concept_doc(cid)
+                            if not virtual_doc:
+                                continue
+                            instance_of = virtual_doc.get("relationships", {}).get(
+                                "is_an_instance_of", []
+                            )
+                            if isinstance(instance_of, str):
+                                instance_of = [instance_of]
+                            predicate_text_map[cid] = (
+                                "#V#binary_text_predicate" in instance_of
+                            )
             except Exception:
                 predicate_text_map = {}
 

--- a/src/backend/services/code_predicate_sync_service.py
+++ b/src/backend/services/code_predicate_sync_service.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass
 from typing import Iterable, List, Dict, Any
 
 from ..services import concept_service
-from ..vontology.code_concepts_registry import list_code_predicate_ids
+from ..vontology.code_concepts_registry import (
+    get_code_predicate_instance_type_ids,
+    list_code_predicate_ids,
+)
 from ..vontology.utils_vontology import is_predicate
 
 
@@ -37,14 +40,22 @@ def _unique(values: Iterable[str]) -> List[str]:
     return ordered
 
 
-def _resolve_parent_ids() -> List[str]:
+def _resolve_parent_ids(
+    predicate_id: str, availability_cache: Dict[str, bool]
+) -> List[str]:
     parents: List[str] = []
-    for candidate in (PREDICATE_TYPE_ID, MENTIONED_IN_CODE_ID):
-        try:
-            exists = concept_service.get_concept_by_concept_id(candidate)
-        except Exception:
-            exists = None
-        if exists:
+    expected_ids = get_code_predicate_instance_type_ids(predicate_id) or [
+        PREDICATE_TYPE_ID,
+        MENTIONED_IN_CODE_ID,
+    ]
+    for candidate in expected_ids:
+        if candidate not in availability_cache:
+            try:
+                exists = concept_service.get_concept_by_concept_id(candidate)
+            except Exception:
+                exists = None
+            availability_cache[candidate] = bool(exists)
+        if availability_cache[candidate]:
             parents.append(candidate)
     return parents or [PREDICATE_TYPE_ID]
 
@@ -81,10 +92,11 @@ def sync_code_predicate_concepts(
     skipped: List[str] = []
     warnings: List[str] = []
 
-    parent_ids = _resolve_parent_ids()
     predicate_ids = _unique(list_code_predicate_ids())
+    parent_availability: Dict[str, bool] = {}
 
     for predicate_id in predicate_ids:
+        parent_ids = _resolve_parent_ids(predicate_id, parent_availability)
         name = predicate_id.replace("#V#", "")
         concept = None
         try:

--- a/src/backend/services/concept_summary_renderer_service.py
+++ b/src/backend/services/concept_summary_renderer_service.py
@@ -8,29 +8,44 @@ for the concept tab's top summary panel.
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping, cast
+from collections.abc import Mapping
+from typing import Any, cast
 
+from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
+from .chat_history_service import ChatHistoryServiceError
 from .concept_predicate_metadata_service import get_relationship_kinds_set
-from .concept_summary_field_resolver import get_concept_summary_field_resolver
 from .concept_service import (
     ConceptNotFoundError,
     enrich_concept_with_text_relations,
     get_concept_by_concept_id,
+)
+from .concept_summary_field_resolver import get_concept_summary_field_resolver
+from .conversation_projection_service import (
+    ConversationProjectionAccessChangedError,
+    ConversationProjectionNotFoundError,
+    get_conversation_projection_for_session,
+    list_focal_conversation_backlinks,
 )
 from .renderer_applicability_service import resolve_renderer_applicability_from_metadata
 from .renderer_applicability_vontology_service import (
     load_renderer_definitions_from_concept_ids,
 )
 from .text_value_service import get_texts_for_concept
-from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
 
 CONCEPT_PAGE_RENDERER_CONCEPT_IDS: tuple[str, ...] = (
+    "#V#concept_page_conversation_renderer",
     "#V#concept_page_identity_renderer",
     "#V#concept_page_document_renderer",
     "#V#concept_page_task_renderer",
     "#V#concept_page_event_renderer",
     "#V#concept_page_location_renderer",
     "#V#concept_page_text_summary_renderer",
+)
+
+_CONVERSATION_RENDERER_ID = "#V#concept_page_conversation_renderer"
+_CONVERSATION_TYPE_ID = "#V#conversation"
+_CONVERSATION_SESSION_ID_PREDICATES = frozenset(
+    {"#V#hasSessionId", "hasSessionId"}
 )
 
 _GENERIC_TYPE_EXCLUSIONS: frozenset[str] = frozenset(
@@ -329,6 +344,156 @@ def _facts(*items: tuple[str, str | None]) -> list[dict[str, str]]:
             continue
         rows.append({"label": label, "value": text})
     return rows
+
+
+def _conversation_session_id(
+    concept: Mapping[str, Any], text_rows: list[dict[str, Any]]
+) -> str | None:
+    """Read the source locator without exposing the concept's stored metadata."""
+
+    metadata = concept.get("metadata")
+    raw_session_id = metadata.get("session_id") if isinstance(metadata, Mapping) else None
+    if isinstance(raw_session_id, str) and raw_session_id.strip():
+        return raw_session_id.strip()
+    for row in text_rows:
+        if row.get("predicate") not in _CONVERSATION_SESSION_ID_PREDICATES:
+            continue
+        text = row.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return None
+
+
+def _project_focal_concepts(raw: Any) -> list[dict[str, Any]]:
+    """Copy only renderer-safe fields from already actor-authorised focus cards."""
+
+    if not isinstance(raw, list):
+        return []
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in raw[:4]:
+        if not isinstance(item, Mapping):
+            continue
+        concept_id = item.get("concept_id")
+        if (
+            not isinstance(concept_id, str)
+            or not concept_id.strip().startswith("#V#")
+            or concept_id.strip() in seen
+        ):
+            continue
+        concept_id = concept_id.strip()
+        seen.add(concept_id)
+        display_name = item.get("display_name")
+        type_ids = item.get("type_ids")
+        result.append(
+            {
+                "concept_id": concept_id,
+                "display_name": (
+                    display_name.strip()
+                    if isinstance(display_name, str) and display_name.strip()
+                    else concept_id
+                ),
+                "type_ids": [
+                    type_id.strip()
+                    for type_id in type_ids[:12]
+                    if isinstance(type_id, str) and type_id.strip().startswith("#V#")
+                ]
+                if isinstance(type_ids, list)
+                else [],
+            }
+        )
+    return result
+
+
+def _project_open_conversation_action(raw: Any) -> dict[str, str] | None:
+    if not isinstance(raw, Mapping) or raw.get("kind") != "open_conversation":
+        return None
+    session_id = raw.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+    return {"kind": "open_conversation", "session_id": session_id.strip()}
+
+
+def _project_conversation_card(raw: Any) -> dict[str, Any] | None:
+    """Map a Stage 2 card to the renderer contract through an explicit allow-list."""
+
+    if not isinstance(raw, Mapping):
+        return None
+    action = _project_open_conversation_action(raw.get("open_action"))
+    title = raw.get("title")
+    if action is None or not isinstance(title, str) or not title.strip():
+        return None
+    concept_id = raw.get("conversation_concept_id")
+    if not isinstance(concept_id, str) or not concept_id.strip().startswith("#V#"):
+        concept_id = None
+    last_activity_at = raw.get("last_activity_at")
+    access_mode = raw.get("access_mode")
+    projection_status = raw.get("projection_status")
+    return {
+        "schema_version": "conversation_projection.v1",
+        "conversation_concept_id": concept_id.strip() if concept_id else None,
+        "title": title.strip(),
+        "last_activity_at": (
+            last_activity_at.strip()
+            if isinstance(last_activity_at, str) and last_activity_at.strip()
+            else None
+        ),
+        "access_mode": access_mode if access_mode in {"owner", "shared"} else None,
+        "focal_concepts": _project_focal_concepts(raw.get("focal_concepts")),
+        "projection_status": (
+            projection_status
+            if projection_status in {"materialised", "source_backed", "pending"}
+            else None
+        ),
+        "open_action": action,
+    }
+
+
+def _project_conversation_backlinks(
+    raw: Any, *, source_concept_id: str
+) -> dict[str, Any]:
+    """Copy a bounded backlink projection without legacy or source-store fields."""
+
+    raw_mapping = raw if isinstance(raw, Mapping) else {}
+    cards: list[dict[str, Any]] = []
+    raw_items = raw_mapping.get("items")
+    if isinstance(raw_items, list):
+        for item in raw_items[:25]:
+            card = _project_conversation_card(item)
+            if card is not None:
+                cards.append(card)
+    more_count = raw_mapping.get("more_count")
+    return {
+        "schema_version": "conversation_backlinks.v1",
+        "source_concept_id": source_concept_id,
+        "items": cards,
+        "more_count": (
+            max(more_count, 0)
+            if isinstance(more_count, int) and not isinstance(more_count, bool)
+            else 0
+        ),
+    }
+
+
+def _build_conversation_panel(card: Mapping[str, Any]) -> dict[str, Any]:
+    last_activity_at = card.get("last_activity_at")
+    return {
+        "variant": "conversation",
+        "eyebrow": "Conversation",
+        "title": str(card.get("title") or "Conversation").strip() or "Conversation",
+        "subtitle": "Focused discussion" if card.get("focal_concepts") else "Discussion",
+        "badges": [],
+        "summary": "",
+        "facts": _facts(
+            (
+                "Last activity",
+                last_activity_at if isinstance(last_activity_at, str) else None,
+            )
+        ),
+        "expanded_sections": [],
+        "focal_concepts": list(card.get("focal_concepts") or []),
+        "open_action": card.get("open_action"),
+    }
 
 
 def _build_person_panel(
@@ -658,7 +823,13 @@ def _build_panel_for_renderer(
     )
 
 
-def load_concept_summary_renderer(concept_id: str) -> dict[str, Any]:
+def load_concept_summary_renderer(
+    concept_id: str,
+    *,
+    actor_user_id: str | None = None,
+    actor_namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+) -> dict[str, Any]:
     """Resolve a concept-page summary renderer and build its payload."""
 
     concept = get_concept_by_concept_id(concept_id)
@@ -698,18 +869,53 @@ def load_concept_summary_renderer(concept_id: str) -> dict[str, Any]:
     selected = resolution.selected_renderers[0] if resolution.selected_renderers else None
     preview_cache: dict[str, str] = {}
     indexed_text_rows = _index_text_rows(text_rows)
-    panel = _build_panel_for_renderer(
-        renderer_id=selected.renderer_id if selected else None,
-        concept=concept,
-        relationships=relationships,
-        indexed_text_rows=indexed_text_rows,
-        direct_type_ids=direct_type_ids,
-        resolved_type_ids=resolved_type_ids,
-        preview_cache=preview_cache,
-        summary_field_keys=summary_field_keys,
-    )
+    selected_renderer_id = selected.renderer_id if selected else None
+    is_conversation = _CONVERSATION_TYPE_ID in resolved_type_ids
+    conversation_card: dict[str, Any] | None = None
+    if is_conversation:
+        session_id = _conversation_session_id(concept, text_rows)
+        if not actor_user_id or not session_id:
+            raise ConceptNotFoundError(f"Concept not found: {concept_id}")
+        try:
+            projection_result = get_conversation_projection_for_session(
+                actor_user_id=actor_user_id,
+                session_id=session_id,
+                actor_namespace=actor_namespace,
+                organisation_concept_id=organisation_concept_id,
+            )
+        except (
+            ConversationProjectionAccessChangedError,
+            ConversationProjectionNotFoundError,
+        ) as exc:
+            raise ConceptNotFoundError(f"Concept not found: {concept_id}") from exc
+        conversation_card = _project_conversation_card(
+            projection_result.get("conversation_projection")
+            if isinstance(projection_result, Mapping)
+            else None
+        )
+        if (
+            conversation_card is None
+            or conversation_card.get("access_mode") != "owner"
+            or conversation_card.get("conversation_concept_id") != concept_id
+        ):
+            raise ConceptNotFoundError(f"Concept not found: {concept_id}")
+    if selected_renderer_id == _CONVERSATION_RENDERER_ID:
+        if conversation_card is None:
+            raise ConceptNotFoundError(f"Concept not found: {concept_id}")
+        panel = _build_conversation_panel(conversation_card)
+    else:
+        panel = _build_panel_for_renderer(
+            renderer_id=selected_renderer_id,
+            concept=concept,
+            relationships=relationships,
+            indexed_text_rows=indexed_text_rows,
+            direct_type_ids=direct_type_ids,
+            resolved_type_ids=resolved_type_ids,
+            preview_cache=preview_cache,
+            summary_field_keys=summary_field_keys,
+        )
 
-    return {
+    payload = {
         "success": True,
         "concept_id": concept_id,
         "display_name": _display_name(concept),
@@ -723,3 +929,18 @@ def load_concept_summary_renderer(concept_id: str) -> dict[str, Any]:
             "renderer_resolution": resolution.to_dict(),
         },
     }
+    if actor_user_id and not is_conversation:
+        try:
+            backlink_result = list_focal_conversation_backlinks(
+                actor_user_id=actor_user_id,
+                focal_concept_id=concept_id,
+                actor_namespace=actor_namespace,
+            )
+        except (ConversationProjectionNotFoundError, ChatHistoryServiceError):
+            backlink_result = None
+        if isinstance(backlink_result, Mapping):
+            payload["conversation_backlinks"] = _project_conversation_backlinks(
+                backlink_result.get("conversation_backlinks"),
+                source_concept_id=concept_id,
+            )
+    return payload

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -17,6 +17,7 @@ from ..models.text_value_models import RelationPredicate
 MENTIONED_IN_VON_CODE_ID = "#V#mentioned_in_von_code"
 MENTIONED_IN_VON_TEST_ID = "#V#mentioned_in_von_test"
 PREDICATE_TYPE_ID = "#V#predicate"
+BINARY_TEXT_PREDICATE_TYPE_ID = "#V#binary_text_predicate"
 
 
 @dataclass(frozen=True)
@@ -54,6 +55,7 @@ _TEXT_PREDICATE_IDS = [
     f"#V#{RelationPredicate.HAS_NOTE}",
     f"#V#{RelationPredicate.HAS_INTERACTION}",
     "#V#hasDefinition",
+    "#V#has_renderer_profile_json",
 ]
 
 _FILE_METADATA_PREDICATE_IDS = [
@@ -390,6 +392,17 @@ def list_code_predicate_ids() -> list[str]:
     return list(_CODE_PREDICATE_IDS)
 
 
+def get_code_predicate_instance_type_ids(concept_id: str) -> list[str]:
+    """Return the represented types expected for a built-in predicate."""
+
+    if concept_id not in _CODE_PREDICATE_CONCEPTS:
+        return []
+    instance_type_ids = [PREDICATE_TYPE_ID, MENTIONED_IN_VON_CODE_ID]
+    if concept_id in _TEXT_PREDICATE_IDS:
+        instance_type_ids.append(BINARY_TEXT_PREDICATE_TYPE_ID)
+    return instance_type_ids
+
+
 def is_code_concept_id(concept_id: str) -> bool:
     return concept_id in _CODE_CONCEPTS
 
@@ -424,7 +437,7 @@ def build_code_concept_doc(concept_id: str) -> Optional[dict]:
         return None
 
     if cc.kind == "predicate":
-        instance_of = [PREDICATE_TYPE_ID, MENTIONED_IN_VON_CODE_ID]
+        instance_of = get_code_predicate_instance_type_ids(cc.concept_id)
         type_of = []
     else:
         instance_of = [MENTIONED_IN_VON_CODE_ID]

--- a/src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js
@@ -1,4 +1,15 @@
 import { getJsonDetailed } from '../apiService.js';
+import { activateTab } from '../tabNavigation.js';
+
+const PANEL_VARIANTS = new Set([
+  'identity',
+  'document',
+  'task',
+  'event',
+  'location',
+  'conversation',
+  'generic',
+]);
 
 function getMountElement(stepContainer, suffix) {
   return (
@@ -15,110 +26,263 @@ function createPanelElement(suffix) {
   return panel;
 }
 
-function renderBadgeRow(badges = []) {
-  if (!Array.isArray(badges) || badges.length === 0) return '';
-  return `
-    <div class="concept-summary-badges">
-      ${badges
-        .filter((badge) => typeof badge === 'string' && badge.trim())
-        .map((badge) => `<span class="concept-summary-badge">${badge}</span>`)
-        .join('')}
-    </div>
-  `;
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
 }
 
-function renderFacts(facts = []) {
-  if (!Array.isArray(facts) || facts.length === 0) return '';
-  return `
-    <dl class="concept-summary-facts">
-      ${facts
-        .filter((item) => item && typeof item.label === 'string' && typeof item.value === 'string')
-        .map(
-          (item) => `
-            <div class="concept-summary-fact">
-              <dt>${item.label}</dt>
-              <dd>${item.value}</dd>
-            </div>
-          `,
-        )
-        .join('')}
-    </dl>
-  `;
+function appendTextElement(parent, tagName, className, text) {
+  const value = cleanText(text);
+  if (!value) return null;
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = value;
+  parent.appendChild(element);
+  return element;
 }
 
-function renderExpandedSections(expandedSections = []) {
+function createBadgeRow(badges = []) {
+  const values = Array.isArray(badges)
+    ? badges.map(cleanText).filter(Boolean)
+    : [];
+  if (values.length === 0) return null;
+  const row = document.createElement('div');
+  row.className = 'concept-summary-badges';
+  values.forEach((value) => {
+    appendTextElement(row, 'span', 'concept-summary-badge', value);
+  });
+  return row;
+}
+
+function createFacts(facts = []) {
+  const values = Array.isArray(facts)
+    ? facts.filter(
+        (item) => item && cleanText(item.label) && cleanText(item.value),
+      )
+    : [];
+  if (values.length === 0) return null;
+  const list = document.createElement('dl');
+  list.className = 'concept-summary-facts';
+  values.forEach((item) => {
+    const fact = document.createElement('div');
+    fact.className = 'concept-summary-fact';
+    appendTextElement(fact, 'dt', '', item.label);
+    appendTextElement(fact, 'dd', '', item.value);
+    list.appendChild(fact);
+  });
+  return list;
+}
+
+function createExpandedSections(expandedSections = []) {
   const sections = Array.isArray(expandedSections)
     ? expandedSections.filter(
         (section) =>
           section &&
-          typeof section.title === 'string' &&
+          cleanText(section.title) &&
           Array.isArray(section.items) &&
-          section.items.some((item) => typeof item === 'string' && item.trim()),
+          section.items.some((item) => cleanText(item)),
       )
     : [];
-  if (sections.length === 0) return '';
-  return `
-    <div class="concept-summary-expanded hidden">
-      ${sections
-        .map(
-          (section) => `
-            <section class="concept-summary-expanded-section">
-              <h4>${section.title}</h4>
-              <ul>
-                ${section.items
-                  .filter((item) => typeof item === 'string' && item.trim())
-                  .map((item) => `<li>${item}</li>`)
-                  .join('')}
-              </ul>
-            </section>
-          `,
-        )
-        .join('')}
-    </div>
-  `;
+  if (sections.length === 0) return null;
+  const expanded = document.createElement('div');
+  expanded.className = 'concept-summary-expanded hidden';
+  sections.forEach((sectionData) => {
+    const section = document.createElement('section');
+    section.className = 'concept-summary-expanded-section';
+    appendTextElement(section, 'h4', '', sectionData.title);
+    const list = document.createElement('ul');
+    sectionData.items.map(cleanText).filter(Boolean).forEach((item) => {
+      appendTextElement(list, 'li', '', item);
+    });
+    section.appendChild(list);
+    expanded.appendChild(section);
+  });
+  return expanded;
+}
+
+function normaliseFocalConcepts(raw) {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set();
+  return raw.slice(0, 4).flatMap((item) => {
+    const conceptId = cleanText(item?.concept_id);
+    if (!conceptId.startsWith('#V#') || seen.has(conceptId)) return [];
+    seen.add(conceptId);
+    return [{
+      conceptId,
+      displayName: cleanText(item?.display_name) || conceptId,
+    }];
+  });
+}
+
+function createFocalConcepts(raw, { label = 'Discussing' } = {}) {
+  const focalConcepts = normaliseFocalConcepts(raw);
+  if (focalConcepts.length === 0) return null;
+  const container = document.createElement('div');
+  container.className = 'concept-summary-focus';
+  appendTextElement(container, 'span', 'concept-summary-focus-label', label);
+  const links = document.createElement('div');
+  links.className = 'concept-summary-focus-links';
+  focalConcepts.forEach(({ conceptId, displayName }) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'concept-summary-focus-link';
+    button.textContent = displayName;
+    button.addEventListener('click', () => {
+      document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+        detail: {
+          conceptId,
+          createConceptTab: true,
+          promoteExistingTab: true,
+          modifierKeys: { shiftKey: true },
+        },
+      }));
+    });
+    links.appendChild(button);
+  });
+  container.appendChild(links);
+  return container;
+}
+
+function normaliseOpenConversationAction(raw) {
+  if (!raw || raw.kind !== 'open_conversation') return null;
+  const sessionId = cleanText(raw.session_id);
+  if (!sessionId || sessionId.length > 512) return null;
+  return { kind: 'open_conversation', sessionId };
+}
+
+function createActionStatus() {
+  const status = document.createElement('span');
+  status.className = 'concept-summary-action-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  return status;
+}
+
+function createOpenConversationButton(rawAction, { label = 'Open conversation' } = {}) {
+  const action = normaliseOpenConversationAction(rawAction);
+  if (!action) return null;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'concept-summary-action';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'concept-summary-open-conversation';
+  button.textContent = label;
+  const status = createActionStatus();
+  button.addEventListener('click', async () => {
+    if (button.disabled) return;
+    button.disabled = true;
+    button.textContent = 'Opening…';
+    status.textContent = '';
+    try {
+      const { switchToChatSession } = await import('../chatTab.js');
+      const result = await switchToChatSession(action.sessionId);
+      if (!result || result.ok !== true) {
+        throw new Error(cleanText(result?.error) || 'Conversation unavailable');
+      }
+      button.disabled = false;
+      button.textContent = label;
+      activateTab('chatTab');
+    } catch (error) {
+      console.warn('[conceptSummaryRendererPanel] Failed to open conversation', error);
+      button.disabled = false;
+      button.textContent = label;
+      status.textContent = 'Could not open this conversation. Please try again.';
+    }
+  });
+  wrapper.append(button, status);
+  return wrapper;
+}
+
+function createConversationBacklinks(raw) {
+  const items = Array.isArray(raw?.items) ? raw.items.slice(0, 25) : [];
+  const cards = items.filter((item) => cleanText(item?.title));
+  if (cards.length === 0) return null;
+  const section = document.createElement('section');
+  section.className = 'concept-summary-conversations';
+  appendTextElement(
+    section,
+    'h4',
+    'concept-summary-conversations-title',
+    'Conversations about this concept',
+  );
+  const list = document.createElement('div');
+  list.className = 'concept-summary-conversation-list';
+  cards.forEach((card) => {
+    const item = document.createElement('article');
+    item.className = 'concept-summary-conversation-card';
+    appendTextElement(item, 'h5', 'concept-summary-conversation-title', card.title);
+    appendTextElement(item, 'p', 'concept-summary-conversation-activity', card.last_activity_at);
+    const focus = createFocalConcepts(card.focal_concepts, { label: 'Focus' });
+    if (focus) item.appendChild(focus);
+    const action = createOpenConversationButton(card.open_action, { label: 'Continue' });
+    if (action) item.appendChild(action);
+    list.appendChild(item);
+  });
+  section.appendChild(list);
+  const moreCount = Number.isInteger(raw?.more_count) && raw.more_count > 0
+    ? raw.more_count
+    : 0;
+  if (moreCount > 0) {
+    appendTextElement(
+      section,
+      'p',
+      'concept-summary-conversations-more',
+      `${moreCount} more in Conversations`,
+    );
+  }
+  return section;
 }
 
 function applyPanelPayload(panel, payload) {
   const panelData = payload?.panel || {};
-  const title = typeof panelData.title === 'string' ? panelData.title.trim() : '';
-  const subtitle = typeof panelData.subtitle === 'string' ? panelData.subtitle.trim() : '';
-  const summary = typeof panelData.summary === 'string' ? panelData.summary.trim() : '';
-  const eyebrow = typeof panelData.eyebrow === 'string' ? panelData.eyebrow.trim() : 'Concept';
-  const variant = typeof panelData.variant === 'string' ? panelData.variant.trim() : 'generic';
-  const hasExpandedSections =
-    Array.isArray(panelData.expanded_sections) &&
-    panelData.expanded_sections.some(
-      (section) => Array.isArray(section?.items) && section.items.some((item) => typeof item === 'string' && item.trim()),
-    );
+  const variantCandidate = cleanText(panelData.variant);
+  const variant = PANEL_VARIANTS.has(variantCandidate) ? variantCandidate : 'generic';
+  const expanded = createExpandedSections(panelData.expanded_sections);
 
   panel.className = `concept-summary-card concept-summary-card-${variant}`;
-  panel.innerHTML = `
-    <div class="concept-summary-header">
-      <div class="concept-summary-eyebrow">${eyebrow}</div>
-      ${
-        hasExpandedSections
-          ? `<button type="button" class="concept-summary-toggle" aria-expanded="false">Show more</button>`
-          : ''
-      }
-    </div>
-    <h3 class="concept-summary-title">${title}</h3>
-    ${subtitle ? `<p class="concept-summary-subtitle">${subtitle}</p>` : ''}
-    ${renderBadgeRow(panelData.badges)}
-    ${renderFacts(panelData.facts)}
-    ${summary ? `<p class="concept-summary-text">${summary}</p>` : ''}
-    ${renderExpandedSections(panelData.expanded_sections)}
-  `;
+  panel.replaceChildren();
 
-  const toggle = panel.querySelector('.concept-summary-toggle');
-  const expanded = panel.querySelector('.concept-summary-expanded');
-  if (toggle && expanded) {
+  const header = document.createElement('div');
+  header.className = 'concept-summary-header';
+  appendTextElement(
+    header,
+    'div',
+    'concept-summary-eyebrow',
+    cleanText(panelData.eyebrow) || 'Concept',
+  );
+  if (expanded) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'concept-summary-toggle';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.textContent = 'Show more';
     toggle.addEventListener('click', () => {
       const isExpanded = !expanded.classList.contains('hidden');
       expanded.classList.toggle('hidden', isExpanded);
       toggle.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
       toggle.textContent = isExpanded ? 'Show more' : 'Show less';
     });
+    header.appendChild(toggle);
   }
+  panel.appendChild(header);
+  appendTextElement(panel, 'h3', 'concept-summary-title', panelData.title);
+  appendTextElement(panel, 'p', 'concept-summary-subtitle', panelData.subtitle);
+  const badges = createBadgeRow(panelData.badges);
+  if (badges) panel.appendChild(badges);
+  const facts = createFacts(panelData.facts);
+  if (facts) panel.appendChild(facts);
+  appendTextElement(panel, 'p', 'concept-summary-text', panelData.summary);
+  const focus = createFocalConcepts(panelData.focal_concepts);
+  if (focus) panel.appendChild(focus);
+  const primaryAction = createOpenConversationButton(panelData.open_action);
+  if (primaryAction) panel.appendChild(primaryAction);
+  if (expanded) panel.appendChild(expanded);
+  const backlinks = createConversationBacklinks(payload?.conversation_backlinks);
+  if (backlinks) panel.appendChild(backlinks);
+}
+
+function clearPanel(panel) {
+  panel.className = 'concept-summary-card hidden';
+  panel.replaceChildren();
 }
 
 export async function ensureConceptSummaryRendererPanelForConceptTab({
@@ -144,16 +308,14 @@ export async function ensureConceptSummaryRendererPanelForConceptTab({
       { cache: 'no-store' },
     );
     if (!data || !data.panel) {
-      panel.className = 'concept-summary-card hidden';
-      panel.innerHTML = '';
+      clearPanel(panel);
       return false;
     }
     applyPanelPayload(panel, data);
     return true;
   } catch (error) {
     console.warn('[conceptSummaryRendererPanel] Failed to load concept summary renderer', error);
-    panel.className = 'concept-summary-card hidden';
-    panel.innerHTML = '';
+    clearPanel(panel);
     return false;
   }
 }

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -59,12 +59,24 @@ export function discussCurrentlySelectedConcept(suffix = '') {
   }
   const containerId = suffix ? `conceptTab_${suffix}` : 'conceptTab';
   const container = document.getElementById(containerId);
-  const conceptName = String(
-    container?.dataset?.conceptName
-    || (suffix ? document.getElementById(`conceptFormTitleText_${suffix}`)?.textContent : elements?.conceptFormTitleText?.textContent)
-    || elements?.conceptTypeDisplayNamePluralElement?.textContent
-    || conceptId
-  ).trim();
+  const tabButton = Array.from(document.querySelectorAll('.tab-button[data-concept-id]'))
+    .find((button) => button.dataset.conceptId === conceptId);
+  const visibleTabName = tabButton?.querySelector('.tab-button-label')?.textContent;
+  const formTitle = suffix
+    ? document.getElementById(`conceptFormTitleText_${suffix}`)?.textContent
+    : elements?.conceptFormTitleText?.textContent;
+  const placeholderNames = new Set(['select or create concept', 'concept details']);
+  const conceptName = [
+    container?.dataset?.conceptName,
+    visibleTabName,
+    tabButton?.title,
+    tabButton?.dataset?.conceptName,
+    formTitle,
+    elements?.conceptTypeDisplayNamePluralElement?.textContent,
+    conceptId,
+  ]
+    .map((value) => String(value || '').trim())
+    .find((value) => value && !placeholderNames.has(value.toLowerCase())) || conceptId;
   document.dispatchEvent(new CustomEvent('von:discussConcept', {
     detail: {
       conceptId,

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -11358,6 +11358,100 @@ button.prompt-vontology-cartouche {
     margin: 0 0 4px;
 }
 
+.concept-summary-focus,
+.concept-summary-action {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.concept-summary-focus-label {
+    color: #64748b;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.concept-summary-focus-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.concept-summary-focus-link,
+.concept-summary-open-conversation {
+    border: 1px solid #99d5cc;
+    border-radius: 999px;
+    background: #f0fdfa;
+    color: #115e59;
+    cursor: pointer;
+    font-size: 0.84rem;
+    font-weight: 650;
+    padding: 6px 11px;
+}
+
+.concept-summary-focus-link:hover,
+.concept-summary-open-conversation:hover {
+    background: #ccfbf1;
+}
+
+.concept-summary-open-conversation:disabled {
+    cursor: wait;
+    opacity: 0.68;
+}
+
+.concept-summary-action-status {
+    color: #b42318;
+    font-size: 0.84rem;
+}
+
+.concept-summary-conversations {
+    display: grid;
+    gap: 8px;
+    border-top: 1px solid #d9e1ec;
+    padding-top: 10px;
+}
+
+.concept-summary-conversations-title,
+.concept-summary-conversation-title,
+.concept-summary-conversation-activity,
+.concept-summary-conversations-more {
+    margin: 0;
+}
+
+.concept-summary-conversations-title {
+    color: #0f172a;
+    font-size: 0.94rem;
+}
+
+.concept-summary-conversation-list {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.concept-summary-conversation-card {
+    display: grid;
+    gap: 7px;
+    border: 1px solid #d9e1ec;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.78);
+    padding: 10px;
+}
+
+.concept-summary-conversation-title {
+    color: #0f172a;
+    font-size: 0.92rem;
+}
+
+.concept-summary-conversation-activity,
+.concept-summary-conversations-more {
+    color: #64748b;
+    font-size: 0.8rem;
+}
+
 .concept-summary-card-identity {
     background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.98)),
@@ -11386,6 +11480,12 @@ button.prompt-vontology-cartouche {
     background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 253, 245, 0.98)),
         linear-gradient(135deg, rgba(22, 163, 74, 0.08), rgba(13, 148, 136, 0.05));
+}
+
+.concept-summary-card-conversation {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(240, 253, 250, 0.98)),
+        linear-gradient(135deg, rgba(13, 148, 136, 0.09), rgba(59, 130, 246, 0.05));
 }
 
 @media (max-width: 768px) {

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from src.backend.vontology.code_concepts_registry import (
-    PREDICATE_TYPE_ID,
+    BINARY_TEXT_PREDICATE_TYPE_ID,
     MENTIONED_IN_VON_CODE_ID,
+    PREDICATE_TYPE_ID,
     build_virtual_concept_doc,
     list_code_predicate_ids,
 )
@@ -49,6 +50,20 @@ def test_background_launch_policy_virtual_doc_is_predicate_instance():
         else []
     )
     assert PREDICATE_TYPE_ID in inst_of
+    assert MENTIONED_IN_VON_CODE_ID in inst_of
+
+
+def test_renderer_profile_predicate_is_registered_as_binary_text():
+    ids = set(list_code_predicate_ids())
+
+    assert "#V#has_renderer_profile_json" in ids
+
+    doc = build_virtual_concept_doc("#V#has_renderer_profile_json")
+
+    assert doc is not None
+    inst_of = doc.get("relationships", {}).get("is_an_instance_of", [])
+    assert PREDICATE_TYPE_ID in inst_of
+    assert BINARY_TEXT_PREDICATE_TYPE_ID in inst_of
     assert MENTIONED_IN_VON_CODE_ID in inst_of
 
 

--- a/tests/backend/test_code_predicate_sync_service.py
+++ b/tests/backend/test_code_predicate_sync_service.py
@@ -14,6 +14,7 @@ def test_sync_code_predicate_creates_missing_concepts(monkeypatch):
         if concept_id in {
             sync_service.PREDICATE_TYPE_ID,
             sync_service.MENTIONED_IN_CODE_ID,
+            "#V#binary_text_predicate",
         }:
             return {"concept_id": concept_id, "relationships": {}}
         return None
@@ -40,6 +41,7 @@ def test_sync_code_predicate_creates_missing_concepts(monkeypatch):
     assert created[0]["parent_concept_ids"] == [
         sync_service.PREDICATE_TYPE_ID,
         sync_service.MENTIONED_IN_CODE_ID,
+        "#V#binary_text_predicate",
     ]
 
 
@@ -52,6 +54,7 @@ def test_sync_code_predicate_updates_instance_of(monkeypatch):
         if concept_id in {
             sync_service.PREDICATE_TYPE_ID,
             sync_service.MENTIONED_IN_CODE_ID,
+            "#V#binary_text_predicate",
         }:
             return {"concept_id": concept_id, "relationships": {}}
         if concept_id == "#V#hasContent":
@@ -82,6 +85,7 @@ def test_sync_code_predicate_updates_instance_of(monkeypatch):
     assert updates
     updated_inst_of = updates[0]["payload"]["relationships"]["is_an_instance_of"]
     assert sync_service.MENTIONED_IN_CODE_ID in updated_inst_of
+    assert "#V#binary_text_predicate" in updated_inst_of
 
 
 def test_sync_code_predicate_retags_non_predicate(monkeypatch):
@@ -93,6 +97,7 @@ def test_sync_code_predicate_retags_non_predicate(monkeypatch):
         if concept_id in {
             sync_service.PREDICATE_TYPE_ID,
             sync_service.MENTIONED_IN_CODE_ID,
+            "#V#binary_text_predicate",
         }:
             return {"concept_id": concept_id, "relationships": {}}
         if concept_id == "#V#has_blob_uri":
@@ -131,6 +136,7 @@ def test_sync_code_predicate_creates_for_virtual_concept(monkeypatch):
         if concept_id in {
             sync_service.PREDICATE_TYPE_ID,
             sync_service.MENTIONED_IN_CODE_ID,
+            "#V#binary_text_predicate",
         }:
             return {"concept_id": concept_id, "relationships": {}}
         if concept_id == "#V#hasContent":
@@ -156,3 +162,95 @@ def test_sync_code_predicate_creates_for_virtual_concept(monkeypatch):
 
     assert result.created == ["#V#hasContent"]
     assert created
+
+
+def test_sync_code_predicate_repairs_renderer_profile_text_type_additively(
+    monkeypatch,
+):
+    from src.backend.services import code_predicate_sync_service as sync_service
+
+    updates: List[Dict[str, Any]] = []
+
+    def _fake_get(concept_id: str):
+        if concept_id in {
+            sync_service.PREDICATE_TYPE_ID,
+            sync_service.MENTIONED_IN_CODE_ID,
+            "#V#binary_text_predicate",
+        }:
+            return {"concept_id": concept_id, "relationships": {}}
+        if concept_id == "#V#has_renderer_profile_json":
+            return {
+                "concept_id": concept_id,
+                "relationships": {
+                    "is_an_instance_of": [sync_service.PREDICATE_TYPE_ID],
+                    "related_to": ["#V#preserved_relationship"],
+                },
+            }
+        return None
+
+    def _fake_update(concept_id: str, payload: Dict[str, Any]):
+        updates.append({"concept_id": concept_id, "payload": payload})
+        return {"concept_id": concept_id}
+
+    monkeypatch.setattr(
+        sync_service.concept_service,
+        "get_concept_by_concept_id",
+        _fake_get,
+    )
+    monkeypatch.setattr(sync_service.concept_service, "update_concept", _fake_update)
+    monkeypatch.setattr(
+        sync_service,
+        "list_code_predicate_ids",
+        lambda: ["#V#has_renderer_profile_json"],
+    )
+
+    result = sync_service.sync_code_predicate_concepts()
+
+    assert result.updated == ["#V#has_renderer_profile_json"]
+    relationships = updates[0]["payload"]["relationships"]
+    assert relationships["related_to"] == ["#V#preserved_relationship"]
+    assert relationships["is_an_instance_of"] == [
+        sync_service.PREDICATE_TYPE_ID,
+        sync_service.MENTIONED_IN_CODE_ID,
+        "#V#binary_text_predicate",
+    ]
+
+
+def test_sync_resolves_each_shared_parent_at_most_once(monkeypatch):
+    from src.backend.services import code_predicate_sync_service as sync_service
+
+    looked_up: List[str] = []
+    parent_ids = {
+        sync_service.PREDICATE_TYPE_ID,
+        sync_service.MENTIONED_IN_CODE_ID,
+        "#V#binary_text_predicate",
+    }
+
+    def _fake_get(concept_id: str):
+        looked_up.append(concept_id)
+        if concept_id in parent_ids:
+            return {"concept_id": concept_id, "relationships": {}}
+        return None
+
+    monkeypatch.setattr(
+        sync_service.concept_service,
+        "get_concept_by_concept_id",
+        _fake_get,
+    )
+    monkeypatch.setattr(
+        sync_service.concept_service,
+        "create_concept",
+        lambda **kwargs: {"concept_id": kwargs["concept_id"]},
+    )
+    monkeypatch.setattr(sync_service.concept_service, "update_concept", lambda *a, **k: {})
+    monkeypatch.setattr(
+        sync_service,
+        "list_code_predicate_ids",
+        lambda: ["#V#hasContent", "#V#has_blob_uri"],
+    )
+
+    result = sync_service.sync_code_predicate_concepts()
+
+    assert result.created == ["#V#hasContent", "#V#has_blob_uri"]
+    for parent_id in parent_ids:
+        assert looked_up.count(parent_id) == 1

--- a/tests/backend/test_concept_summary_renderer_routes.py
+++ b/tests/backend/test_concept_summary_renderer_routes.py
@@ -18,7 +18,7 @@ def test_get_concept_summary_renderer_returns_payload(monkeypatch) -> None:
     app = _make_concept_app()
     monkeypatch.setattr(
         "src.backend.server.routes.concept_routes.load_concept_summary_renderer",
-        lambda concept_id: {
+        lambda concept_id, **_kwargs: {
             "success": True,
             "concept_id": concept_id,
             "selected_renderer": {"renderer_id": "#V#concept_page_document_renderer"},
@@ -39,7 +39,9 @@ def test_get_concept_summary_renderer_returns_404_for_missing_concept(monkeypatc
     app = _make_concept_app()
     monkeypatch.setattr(
         "src.backend.server.routes.concept_routes.load_concept_summary_renderer",
-        lambda _concept_id: (_ for _ in ()).throw(ConceptNotFoundError("missing")),
+        lambda _concept_id, **_kwargs: (_ for _ in ()).throw(
+            ConceptNotFoundError("missing")
+        ),
     )
 
     with app.test_client() as client:
@@ -47,3 +49,90 @@ def test_get_concept_summary_renderer_returns_404_for_missing_concept(monkeypatc
 
     assert resp.status_code == 404
     assert resp.get_json() == {"error": "Concept not found"}
+
+
+def test_get_concept_summary_renderer_passes_trusted_actor_context(monkeypatch) -> None:
+    app = _make_concept_app()
+    captured = {}
+
+    def _load(concept_id, **kwargs):
+        captured.update({"concept_id": concept_id, **kwargs})
+        return {
+            "success": True,
+            "concept_id": concept_id,
+            "panel": {"variant": "generic", "title": "Visible concept"},
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_concept_summary_renderer",
+        _load,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: "#V#actor",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_request_namespace",
+        lambda: "#V#actor@lab",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_org_concept_id",
+        lambda: "#V#lab",
+    )
+
+    with app.test_client() as client:
+        resp = client.get("/api/concepts/%23V%23visible/summary_renderer")
+
+    assert resp.status_code == 200
+    assert captured == {
+        "concept_id": "#V#visible",
+        "actor_user_id": "#V#actor",
+        "actor_namespace": "#V#actor@lab",
+        "organisation_concept_id": "#V#lab",
+    }
+
+
+def test_get_concept_summary_renderer_passes_no_private_scope_for_anonymous_request(
+    monkeypatch,
+) -> None:
+    app = _make_concept_app()
+    captured = {}
+
+    def _load(concept_id, **kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "concept_id": concept_id,
+            "panel": {"variant": "generic", "title": "Public concept"},
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_concept_summary_renderer",
+        _load,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_request_namespace",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("anonymous renderer must not resolve a private namespace")
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_org_concept_id",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("anonymous renderer must not resolve an organisation")
+        ),
+    )
+
+    with app.test_client() as client:
+        resp = client.get("/api/concepts/%23V%23public/summary_renderer")
+
+    assert resp.status_code == 200
+    assert captured == {
+        "actor_user_id": None,
+        "actor_namespace": None,
+        "organisation_concept_id": None,
+    }

--- a/tests/backend/test_concept_summary_renderer_service.py
+++ b/tests/backend/test_concept_summary_renderer_service.py
@@ -272,3 +272,438 @@ def test_load_concept_summary_renderer_falls_back_to_generic_text_summary(
     assert payload["selected_renderer"]["renderer_id"] == "#V#concept_page_text_summary_renderer"
     assert payload["panel"]["variant"] == "generic"
     assert payload["panel"]["summary"] == "Fallback summary content."
+
+
+def _install_conversation_concept(monkeypatch, *, concept_id="#V#conversation_abc"):
+    _install_summary_field_resolver(monkeypatch)
+    concept_docs = {
+        concept_id: {
+            "concept_id": concept_id,
+            "relationships": {"is_an_instance_of": ["#V#conversation"]},
+            "metadata": {
+                "session_id": "session-abc",
+                "organisation_concept_id": "#V#hidden_org",
+            },
+        },
+        "#V#conversation": {
+            "concept_id": "#V#conversation",
+            "name": "Conversation",
+            "relationships": {"is_a_type_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "name": "Thing",
+            "relationships": {"is_a_type_of": []},
+        },
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda requested_id: concept_docs[requested_id],
+    )
+    monkeypatch.setattr(service, "enrich_concept_with_text_relations", lambda concept: concept)
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concept",
+        lambda subject_concept_id, limit=250: [],
+    )
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [
+                {
+                    "renderer_id": "#V#concept_page_conversation_renderer",
+                    "renderer_type": "concept_page_conversation",
+                    "modalities": ["visual"],
+                    "applies_to_object_kinds": ["concept"],
+                    "applies_to_concept_type_ids": ["#V#conversation"],
+                    "required_context_tags": ["concept_page_summary"],
+                    "priority": 95,
+                },
+                {
+                    "renderer_id": "#V#concept_page_text_summary_renderer",
+                    "renderer_type": "text_summary",
+                    "modalities": ["textual"],
+                    "applies_to_object_kinds": ["concept"],
+                    "required_context_tags": ["concept_page_summary"],
+                    "priority": 10,
+                },
+            ],
+            {"loaded_definition_count": 2, "requested_concept_ids": list(concept_ids)},
+        ),
+    )
+    return concept_id
+
+
+def test_conversation_renderer_is_a_vontology_loaded_profile_candidate() -> None:
+    assert (
+        "#V#concept_page_conversation_renderer"
+        in service.CONCEPT_PAGE_RENDERER_CONCEPT_IDS
+    )
+
+
+def test_load_conversation_renderer_uses_fresh_actor_projection_and_safe_shape(
+    monkeypatch,
+) -> None:
+    concept_id = _install_conversation_concept(monkeypatch)
+    captured = {}
+
+    def _projection(**kwargs):
+        captured.update(kwargs)
+        return {
+            "session_id": "session-abc",
+            "owner_concept_id": "#V#must_not_escape",
+            "namespace": "#V#must_not_escape@org",
+            "conversation_projection": {
+                "schema_version": "conversation_projection.v1",
+                "conversation_concept_id": concept_id,
+                "title": "Current conversation title",
+                "last_activity_at": "2026-08-22T11:30:00Z",
+                "access_mode": "owner",
+                "focal_concepts": [
+                    {
+                        "concept_id": "#V#visible_focus",
+                        "display_name": "Visible focus",
+                        "type_ids": ["#V#project"],
+                        "private_note": "must not escape",
+                    }
+                ],
+                "projection_status": "materialised",
+                "open_action": {
+                    "kind": "open_conversation",
+                    "session_id": "session-abc",
+                },
+                "transcript": "must not escape",
+            },
+        }
+
+    monkeypatch.setattr(service, "get_conversation_projection_for_session", _projection)
+
+    payload = service.load_concept_summary_renderer(
+        concept_id,
+        actor_user_id="#V#actor",
+        actor_namespace="#V#actor@lab",
+        organisation_concept_id="#V#lab",
+    )
+
+    assert captured == {
+        "actor_user_id": "#V#actor",
+        "session_id": "session-abc",
+        "actor_namespace": "#V#actor@lab",
+        "organisation_concept_id": "#V#lab",
+    }
+    assert payload["selected_renderer"]["renderer_id"] == (
+        "#V#concept_page_conversation_renderer"
+    )
+    assert payload["panel"] == {
+        "variant": "conversation",
+        "eyebrow": "Conversation",
+        "title": "Current conversation title",
+        "subtitle": "Focused discussion",
+        "badges": [],
+        "summary": "",
+        "facts": [
+            {"label": "Last activity", "value": "2026-08-22T11:30:00Z"}
+        ],
+        "expanded_sections": [],
+        "focal_concepts": [
+            {
+                "concept_id": "#V#visible_focus",
+                "display_name": "Visible focus",
+                "type_ids": ["#V#project"],
+            }
+        ],
+        "open_action": {"kind": "open_conversation", "session_id": "session-abc"},
+    }
+    rendered = repr(payload)
+    assert "must_not_escape" not in rendered
+    assert "transcript" not in rendered
+    assert "namespace" not in rendered
+    assert "owner_concept_id" not in rendered
+
+
+def test_load_conversation_renderer_fails_closed_for_projection_identity_mismatch(
+    monkeypatch,
+) -> None:
+    concept_id = _install_conversation_concept(monkeypatch)
+    monkeypatch.setattr(
+        service,
+        "get_conversation_projection_for_session",
+        lambda **_kwargs: {
+            "conversation_projection": {
+                "conversation_concept_id": "#V#conversation_other",
+                "title": "Other conversation",
+                "access_mode": "owner",
+                "focal_concepts": [],
+                "projection_status": "materialised",
+                "open_action": {
+                    "kind": "open_conversation",
+                    "session_id": "session-abc",
+                },
+            }
+        },
+    )
+
+    try:
+        service.load_concept_summary_renderer(
+            concept_id,
+            actor_user_id="#V#actor",
+            actor_namespace="#V#actor",
+        )
+    except service.ConceptNotFoundError:
+        pass
+    else:
+        raise AssertionError("projection identity mismatch must fail closed")
+
+
+def test_load_conversation_renderer_requires_authenticated_actor(monkeypatch) -> None:
+    concept_id = _install_conversation_concept(monkeypatch)
+    monkeypatch.setattr(
+        service,
+        "get_conversation_projection_for_session",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("anonymous renderer must not query a conversation source")
+        ),
+    )
+
+    try:
+        service.load_concept_summary_renderer(concept_id)
+    except service.ConceptNotFoundError:
+        pass
+    else:
+        raise AssertionError("anonymous conversation renderer must fail closed")
+
+
+def test_anonymous_conversation_fails_closed_when_renderer_profile_is_missing(
+    monkeypatch,
+) -> None:
+    concept_id = _install_conversation_concept(monkeypatch)
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [],
+            {"loaded_definition_count": 0, "requested_concept_ids": list(concept_ids)},
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "get_conversation_projection_for_session",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("anonymous fallback must not query a conversation source")
+        ),
+    )
+
+    try:
+        service.load_concept_summary_renderer(concept_id)
+    except service.ConceptNotFoundError:
+        pass
+    else:
+        raise AssertionError("missing profile must not expose a generic conversation panel")
+
+
+def test_authenticated_ordinary_concept_gets_safe_conversation_backlinks(
+    monkeypatch,
+) -> None:
+    _install_summary_field_resolver(monkeypatch)
+    concept_docs = {
+        "#V#project": {
+            "concept_id": "#V#project",
+            "name": "Project",
+            "relationships": {"is_an_instance_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "name": "Thing",
+            "relationships": {"is_a_type_of": []},
+        },
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda requested_id: concept_docs[requested_id],
+    )
+    monkeypatch.setattr(service, "enrich_concept_with_text_relations", lambda concept: concept)
+    monkeypatch.setattr(service, "get_texts_for_concept", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [
+                {
+                    "renderer_id": "#V#concept_page_text_summary_renderer",
+                    "renderer_type": "text_summary",
+                    "modalities": ["textual"],
+                    "applies_to_object_kinds": ["concept"],
+                    "required_context_tags": ["concept_page_summary"],
+                    "priority": 10,
+                }
+            ],
+            {"loaded_definition_count": 1, "requested_concept_ids": list(concept_ids)},
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "list_focal_conversation_backlinks",
+        lambda **_kwargs: {
+            "owner_concept_id": "#V#must_not_escape",
+            "sessions": [{"session_id": "legacy-must-not-escape"}],
+            "conversation_backlinks": {
+                "schema_version": "conversation_backlinks.v1",
+                "source_concept_id": "#V#project",
+                "items": [
+                    {
+                        "conversation_concept_id": None,
+                        "title": "Shared discussion",
+                        "last_activity_at": "2026-08-22T10:00:00Z",
+                        "access_mode": "shared",
+                        "focal_concepts": [
+                            {
+                                "concept_id": "#V#project",
+                                "display_name": "Project",
+                                "type_ids": ["#V#thing"],
+                            }
+                        ],
+                        "projection_status": "source_backed",
+                        "open_action": {
+                            "kind": "open_conversation",
+                            "session_id": "shared-session",
+                        },
+                        "namespace": "#V#must_not_escape",
+                    }
+                ],
+                "more_count": 2,
+            },
+        },
+    )
+
+    payload = service.load_concept_summary_renderer(
+        "#V#project",
+        actor_user_id="#V#actor",
+        actor_namespace="#V#actor",
+    )
+
+    assert payload["conversation_backlinks"] == {
+        "schema_version": "conversation_backlinks.v1",
+        "source_concept_id": "#V#project",
+        "items": [
+            {
+                "schema_version": "conversation_projection.v1",
+                "conversation_concept_id": None,
+                "title": "Shared discussion",
+                "last_activity_at": "2026-08-22T10:00:00Z",
+                "access_mode": "shared",
+                "focal_concepts": [
+                    {
+                        "concept_id": "#V#project",
+                        "display_name": "Project",
+                        "type_ids": ["#V#thing"],
+                    }
+                ],
+                "projection_status": "source_backed",
+                "open_action": {
+                    "kind": "open_conversation",
+                    "session_id": "shared-session",
+                },
+            }
+        ],
+        "more_count": 2,
+    }
+    assert "must_not_escape" not in repr(payload)
+    assert "legacy-must-not-escape" not in repr(payload)
+
+
+def test_anonymous_ordinary_concept_does_not_query_or_return_backlinks(
+    monkeypatch,
+) -> None:
+    _install_summary_field_resolver(monkeypatch)
+    concept_docs = {
+        "#V#public": {
+            "concept_id": "#V#public",
+            "name": "Public",
+            "relationships": {"is_an_instance_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "name": "Thing",
+            "relationships": {"is_a_type_of": []},
+        },
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda requested_id: concept_docs[requested_id],
+    )
+    monkeypatch.setattr(service, "enrich_concept_with_text_relations", lambda concept: concept)
+    monkeypatch.setattr(service, "get_texts_for_concept", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [],
+            {"loaded_definition_count": 0, "requested_concept_ids": list(concept_ids)},
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "list_focal_conversation_backlinks",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("anonymous renderer must not query private backlinks")
+        ),
+    )
+
+    payload = service.load_concept_summary_renderer("#V#public")
+
+    assert payload["panel"]["variant"] == "generic"
+    assert "conversation_backlinks" not in payload
+
+
+def test_ordinary_summary_survives_typed_chat_history_backlink_failure(
+    monkeypatch,
+) -> None:
+    _install_summary_field_resolver(monkeypatch)
+    concept_docs = {
+        "#V#project": {
+            "concept_id": "#V#project",
+            "name": "Project",
+            "relationships": {"is_an_instance_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "name": "Thing",
+            "relationships": {"is_a_type_of": []},
+        },
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda requested_id: concept_docs[requested_id],
+    )
+    monkeypatch.setattr(service, "enrich_concept_with_text_relations", lambda concept: concept)
+    monkeypatch.setattr(service, "get_texts_for_concept", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [],
+            {"loaded_definition_count": 0, "requested_concept_ids": list(concept_ids)},
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "list_focal_conversation_backlinks",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            service.ChatHistoryServiceError("chat history unavailable")
+        ),
+    )
+
+    payload = service.load_concept_summary_renderer(
+        "#V#project",
+        actor_user_id="#V#actor",
+        actor_namespace="#V#actor",
+    )
+
+    assert payload["panel"]["variant"] == "generic"
+    assert payload["panel"]["title"] == "Project"
+    assert "conversation_backlinks" not in payload

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -222,6 +222,42 @@ def test_relationships_route_allows_virtual_code_predicate(app_client, monkeypat
     assert payload.get("concept_id") == "#V#hasContent"
 
 
+def test_search_marks_virtual_renderer_profile_predicate_as_text(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.ConceptsRepository.find",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.TextRelationsRepository.find",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.services.concept_search_service.TextValuesRepository.find",
+        lambda *a, **k: [],
+    )
+
+    resp = client.get(
+        "/vontology/api/vontology/search"
+        "?q=renderer&filter_kind=predicate&include_predicate_metadata=true"
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["results"] == [
+        {
+            "id": "#V#has_renderer_profile_json",
+            "name": "has_renderer_profile_json",
+            "kind": "predicate",
+            "relevance_score": 74.8,
+            "is_text_predicate": True,
+        }
+    ]
+
+
 def test_relationships_route_normalises_has_subtypes_alias(app_client, monkeypatch):
     _, client = app_client
 

--- a/tests/frontend/conceptSummaryRendererPanel.test.js
+++ b/tests/frontend/conceptSummaryRendererPanel.test.js
@@ -4,6 +4,18 @@ jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => 
     getJsonDetailed: jest.fn(),
 }));
 
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/chatTab.js', () => ({
+    switchToChatSession: jest.fn(),
+}));
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('concept summary renderer panel', () => {
     let warnSpy;
 
@@ -84,5 +96,176 @@ describe('concept summary renderer panel', () => {
         expect(rendered).toBe(false);
         const panel = document.getElementById('conceptSummaryRendererPanel_test');
         expect(panel.classList.contains('hidden')).toBe(true);
+    });
+
+    test('renders server text as text rather than executable markup', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                panel: {
+                    variant: 'identity',
+                    eyebrow: '<img src=x onerror="window.__summaryXss = true">',
+                    title: '<script>window.__summaryXss = true</script>',
+                    badges: ['<img src=x onerror="window.__summaryXss = true">'],
+                    facts: [{ label: '<b>Email</b>', value: '<svg onload="window.__summaryXss = true">' }],
+                    summary: '<a href="javascript:window.__summaryXss = true">unsafe link</a>',
+                    expanded_sections: [{ title: '<i>Details</i>', items: ['<iframe srcdoc="x"></iframe>'] }],
+                },
+            },
+        });
+
+        const {
+            ensureConceptSummaryRendererPanelForConceptTab,
+        } = require('../../src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js');
+
+        await ensureConceptSummaryRendererPanelForConceptTab({
+            conceptId: '#V#markup',
+            suffix: 'test',
+        });
+
+        const panel = document.getElementById('conceptSummaryRendererPanel_test');
+        expect(panel.querySelector('script, img, svg, a, iframe')).toBeNull();
+        expect(panel.querySelector('.concept-summary-title').textContent).toBe(
+            '<script>window.__summaryXss = true</script>',
+        );
+        expect(panel.textContent).toContain('<a href="javascript:window.__summaryXss = true">unsafe link</a>');
+        expect(window.__summaryXss).toBeUndefined();
+    });
+
+    test('opens an allow-listed conversation and focal concept through reauthorising controllers', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const chatTab = require('../../src/frontend/web/von_interface/static/js/chatTab.js');
+        const tabNavigation = require('../../src/frontend/web/von_interface/static/js/tabNavigation.js');
+        chatTab.switchToChatSession.mockResolvedValue({ ok: true });
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                panel: {
+                    variant: 'conversation',
+                    eyebrow: 'Conversation',
+                    title: 'Current discussion',
+                    focal_concepts: [{
+                        concept_id: '#V#focus',
+                        display_name: 'Visible focus',
+                    }],
+                    open_action: {
+                        kind: 'open_conversation',
+                        session_id: 'session-123',
+                    },
+                },
+            },
+        });
+        const seen = [];
+        const handler = (event) => seen.push(event.detail);
+        document.addEventListener('von:selectConceptById', handler);
+
+        const {
+            ensureConceptSummaryRendererPanelForConceptTab,
+        } = require('../../src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js');
+        await ensureConceptSummaryRendererPanelForConceptTab({
+            conceptId: '#V#conversation_123',
+            suffix: 'test',
+        });
+
+        document.querySelector('.concept-summary-focus-link').click();
+        document.querySelector('.concept-summary-open-conversation').click();
+        await flushMicrotasks();
+
+        expect(seen).toEqual([{
+            conceptId: '#V#focus',
+            createConceptTab: true,
+            promoteExistingTab: true,
+            modifierKeys: { shiftKey: true },
+        }]);
+        expect(chatTab.switchToChatSession).toHaveBeenCalledWith('session-123');
+        expect(tabNavigation.activateTab).toHaveBeenCalledWith('chatTab');
+        expect(document.querySelector('.concept-summary-open-conversation').disabled).toBe(false);
+        document.removeEventListener('von:selectConceptById', handler);
+    });
+
+    test('renders backlink cards but omits unsupported or malformed actions', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                panel: {
+                    variant: 'generic',
+                    title: 'Project',
+                    open_action: { kind: 'delete_conversation', session_id: 'unsafe' },
+                },
+                conversation_backlinks: {
+                    items: [
+                        {
+                            title: 'Useful discussion',
+                            open_action: { kind: 'open_conversation', session_id: 'shared-1' },
+                            focal_concepts: [],
+                        },
+                        {
+                            title: 'Malformed action',
+                            open_action: { kind: 'open_conversation', session_id: '' },
+                        },
+                        {
+                            title: 'Unsupported action',
+                            open_action: { kind: 'external_url', href: 'javascript:alert(1)' },
+                        },
+                    ],
+                    more_count: 2,
+                },
+            },
+        });
+
+        const {
+            ensureConceptSummaryRendererPanelForConceptTab,
+        } = require('../../src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js');
+        await ensureConceptSummaryRendererPanelForConceptTab({
+            conceptId: '#V#project',
+            suffix: 'test',
+        });
+
+        expect(document.querySelectorAll('.concept-summary-conversation-card')).toHaveLength(3);
+        expect(Array.from(document.querySelectorAll('.concept-summary-conversation-title')).map(
+            (title) => title.textContent,
+        )).toEqual(['Useful discussion', 'Malformed action', 'Unsupported action']);
+        expect(document.querySelectorAll('.concept-summary-open-conversation')).toHaveLength(1);
+        expect(document.querySelector('.concept-summary-conversations-more').textContent).toBe(
+            '2 more in Conversations',
+        );
+        expect(document.querySelector('a')).toBeNull();
+    });
+
+    test('reports a failed conversation switch and re-enables the action', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const chatTab = require('../../src/frontend/web/von_interface/static/js/chatTab.js');
+        const tabNavigation = require('../../src/frontend/web/von_interface/static/js/tabNavigation.js');
+        chatTab.switchToChatSession.mockResolvedValue({ ok: false, error: 'revoked' });
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                panel: {
+                    variant: 'conversation',
+                    title: 'Revoked conversation',
+                    open_action: {
+                        kind: 'open_conversation',
+                        session_id: 'session-revoked',
+                    },
+                },
+            },
+        });
+
+        const {
+            ensureConceptSummaryRendererPanelForConceptTab,
+        } = require('../../src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js');
+        await ensureConceptSummaryRendererPanelForConceptTab({
+            conceptId: '#V#conversation_revoked',
+            suffix: 'test',
+        });
+
+        const button = document.querySelector('.concept-summary-open-conversation');
+        button.click();
+        await flushMicrotasks();
+
+        expect(button.disabled).toBe(false);
+        expect(button.textContent).toBe('Open conversation');
+        expect(document.querySelector('.concept-summary-action-status').textContent).toBe(
+            'Could not open this conversation. Please try again.',
+        );
+        expect(tabNavigation.activateTab).not.toHaveBeenCalled();
     });
 });

--- a/tests/frontend/interactionSessionRecovery.test.js
+++ b/tests/frontend/interactionSessionRecovery.test.js
@@ -147,4 +147,31 @@ describe("Concept interaction session recovery", () => {
         }]);
         document.removeEventListener("von:discussConcept", handler);
     });
+
+    it("uses the dynamic tab label while the concept form is still hydrating", () => {
+        document.body.innerHTML = `
+          <div class="tab-button" data-concept-id="#V#concept_loading" data-concept-name="Concept_loading">
+            <span class="tab-button-label">Loading concept</span>
+          </div>
+          <div class="tab-content active" id="conceptTab_loading" data-concept-id="#V#concept_loading">
+            <span id="conceptFormTitleText_loading">Select or Create Concept</span>
+            <button id="discussConceptButton_loading"></button>
+          </div>
+        `;
+        setCurrentlySelectedConceptId("#V#another_concept");
+        setupConceptTabEventListenersWithSuffix("loading");
+
+        const seen = [];
+        const handler = (event) => seen.push(event.detail);
+        document.addEventListener("von:discussConcept", handler);
+
+        document.getElementById("discussConceptButton_loading").click();
+
+        expect(seen).toEqual([{
+            conceptId: "#V#concept_loading",
+            conceptName: "Loading concept",
+            source: "concept",
+        }]);
+        document.removeEventListener("von:discussConcept", handler);
+    });
 });


### PR DESCRIPTION
## Outcome

Completes Stage 3 of the concept-like conversations plan.

- Renders an actor-authorised conversation projection as a concept-page summary.
- Shows safe focal-object backlinks and a reauthorised Open conversation action.
- Reuses the existing concept-tab and Conversations-tab navigation rather than adding a second strip.
- Publishes and resolves the governed Vontology renderer profile for #V#conversation.
- Makes #V#has_renderer_profile_json discoverable and correctly typed as a virtual binary-text predicate on a fresh installation.
- Fixes the loading-state Discuss label race without changing conversation anchoring.

## Authority and privacy

- Conversation rendering always requires a fresh owner projection; a missing or unselected profile does not weaken that requirement.
- Shared or anonymous access to an unavailable owner projection returns not found.
- Renderer payloads expose only safe summary fields, focal backlinks, and the open action; no transcript, owner, namespace, or hidden metadata is copied into the concept page.
- Open conversation reauthorises the session before activating Chat.
- Materialised concepts and predicate typing retain precedence over virtual fallbacks.

## Validation

- 32 focused backend tests passed.
- 104 Jest suites / 832 tests passed.
- Changed Python sources passed Pyright with 0 errors; the large Vontology route retains exactly the same two pre-existing findings as origin/main.
- Python compilation and diff checks passed.
- Isolated AgentTest browser replay proved focal Discuss, return navigation, conversation-concept rendering, focal backlinks, and reauthorised Open conversation with zero model calls.
- A production-shaped loading-state replay showed Discuss Concept Page Conversation Renderer and no placeholder title.
- Independent read-only review found no remaining candidate-caused merge blocker.

The three unrelated failures in the broader legacy virtual-concept module reproduce on origin/main and are not changed by this candidate.

Jira: JVNAUTOSCI-2677
