### PR TITLE
JVNAUTOSCI-2670: represent public papers at global scope

### DIFF
--- a/docs/engineering/ontology_publication_authority.md
+++ b/docs/engineering/ontology_publication_authority.md
@@ -7,7 +7,7 @@
 - **Authority scope:** Canonical Vontology publication, retraction, identity
   consolidation, and publication-scope change
 - **Owner:** Von maintainers
-- **Last reviewed:** 22 August 2026
+- **Last reviewed:** 23 August 2026
 - **Review trigger:** Merge, deployment, a role-lifecycle change, or a new
   canonical ontology mutation entry point
 - **Live authority or implementation evidence:** Initial activation completed
@@ -88,21 +88,16 @@ visibility merely from an opaque grant.
 
 An actor-bound workflow effect executed within the same trusted server does not
 become a separate authority handoff merely because an agent selected or
-composed it. After the resolved write passes the workflow mutation ceiling, an
-exact actor-private effect may retain the authenticated actor's direct
-authority. When an executing agent needs a separate capability, including for
-an ordinary-turn organisation or global creation, the server may issue one
-exact same-turn delegation only after resolving the final intent and checking
-the actor's corresponding live semantic role. This issuance is part of
-executing the authorised turn; it does not introduce an extra human
-confirmation or let the model enlarge its scope. The governed MCP path retains
-agent provenance, a durable effect receipt, and canonical read-back. Existing
-custom scholarly handlers do not yet share that receipt path; their bounded
-exception preflights every existing mutation target as the exact actor's
-private concept and requires global schema support to be preprovisioned.
-Historical/mixed, other-user, reserved-governance, sessionless, or separately
-delegated effects do not inherit this actor-bound path merely because the model
-requested them.
+composed it. After the resolved write passes the workflow mutation ceiling, the
+ordinary authority resolver evaluates the final exact user, organisation, or
+global intent against the authenticated actor's live authority. The workflow
+marker grants no authority of its own; a missing or mismatched semantic role,
+other-user target, historical or mixed context, or reserved governance
+predicate still fails closed. Minting and immediately consuming a delegation
+for that same trusted effect would only relabel the live authority decision.
+Use exact delegation when authority is handed to a separately acting principal
+or crosses an untrusted or sessionless boundary. The governed MCP path retains
+agent provenance, a durable effect receipt, and canonical read-back.
 
 ## 4. Governed effects and scope transition
 
@@ -171,6 +166,20 @@ scoped assertion carrier. Entity profiles may appear as context hints for an
 assertion decision, but they never select the assertion scope and there is no
 cross-plane "tightest wins" rule. Thus a person and paper may remain global
 while a particular `has_read` fact remains user-scoped.
+
+`JVNAUTOSCI-2670` applies this separation to scholarly representation. A
+scientific paper, its public bibliographic metadata, and an author occurrence
+derived from a public paper are globally published when the actor has live
+global semantic authority. DOI, source URI, publication date, topic-label, and
+authorship predicate profiles independently select the global canonical
+carrier. A file copy on one user's machine remains user-scoped through
+`#V#local_file_copy`; the workflow must not add a canonical file relationship
+to the public paper. A name-only author is a source-bounded occurrence for that
+paper rather than an identity merge across papers, while a supported public
+identifier such as ORCID may supply stable cross-paper identity. The
+publication-profile bundle is bootstrapped before the dependent paper workflow
+family, so a missing default cannot cause private paper creation followed by a
+backfill.
 
 The non-mutating `resolve_publication_scope_profile` tool is available to
 ordinary turns and durable workflows. Its evidence includes matched and
@@ -286,11 +295,11 @@ global authority; operational-admin non-equivalence; expiry, revocation,
 tampering, and cross-audience delegation denial; alternate entry-point
 enforcement; private-context non-leakage; retry/concurrency behaviour; and
 receipt-backed canonical read-back of successful and partial effects.
-Where a supported workflow route uses direct actor-private authority or
-same-turn exact delegation, the positive evidence must exercise its normal
-production actor and current-organisation binding, live role resolution,
-delegation issuance where applicable, and write ceiling rather than a manually
-injected delegation value. Creation evidence must cover private defaulting,
+Where a supported workflow route uses direct actor-bound authority or exact
+delegation, the positive evidence must exercise its normal production actor
+and current-organisation binding, live role resolution, delegation issuance
+where applicable, and write ceiling rather than a manually injected delegation
+value. Creation evidence must cover private defaulting,
 explicit organisation and global selection, spoofed-identity containment,
 authority denial without downgrade or mutation, and exact canonical read-back.
 Scope-edit evidence must cover every add/remove state transition across global,

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -3,7 +3,7 @@
 - **Kind:** Security guidance with dated deployment-posture observations
 - **Lifecycle:** Active
 - **Authority:** Canonical security guidance routed by [`AGENTS.md`](../../AGENTS.md)
-- **Last reviewed:** 22 August 2026
+- **Last reviewed:** 23 August 2026
 - **Evidence boundary:** Statements about current users, deployments, and
   implemented controls are dated observations and must be revalidated; the
   security requirements do not expire merely because implementation evidence
@@ -238,9 +238,11 @@ aperture. The `JVNAUTOSCI-2632` candidate separates organisation/global
 semantic roles from Von operational administration and requires an exact,
 server-issued, short-lived, non-recursive delegation when authority for a
 covered ontology effect is handed to a separately acting agent. A workflow
-effect that stays inside one trusted authenticated actor's exact private scope
-may retain that actor's direct authority after the workflow write ceiling and
-the final intent are checked; that is not a semantic delegation. The current
+effect that stays inside one trusted authenticated actor-bound execution may
+evaluate the final exact intent against that actor's live user, organisation,
+or global semantic authority after the workflow write ceiling is checked; that
+is not a semantic delegation. The marker grants no authority and missing or
+mismatched roles still fail closed. The current
 design/implementation boundary is
 [Ontology publication authority](ontology_publication_authority.md). This is a
 candidate branch reference, not evidence that a deployment has represented
@@ -260,9 +262,10 @@ mutation instead of being silently ignored. Optional organisation context does
 not disable an otherwise actor-authorised user-scoped assertion capability:
 payload organisation claims are hidden and cleared, then any current
 organisation is recovered only from the already trusted ambient actor context.
-Where an executing agent needs a separate capability, the server issues an
-exact same-turn delegation only after resolving the effect and rechecking that
-live authority; no additional human confirmation is required.
+Where authority is handed to a separately acting principal or crosses an
+untrusted or sessionless boundary, the server issues an exact delegation only
+after resolving the effect and rechecking that live authority; no additional
+human confirmation is required.
 Post-creation publication-scope changes use the governed preview-and-execute
 path: user and organisation restrictions are independently added or removed,
 and an exact one-user-plus-one-organisation composite requires authority over

--- a/src/backend/services/minimal_imposition_runtime_profile_vontology_service.py
+++ b/src/backend/services/minimal_imposition_runtime_profile_vontology_service.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping, Sequence
 
+from ..workflows.definitions import WRITE_TOOL_POLICY_WORKFLOW_ID
 from . import concept_service
 from .concept_service import ConceptNotFoundError, get_concept_by_concept_id
 from .text_value_service import get_texts_for_concept, upsert_singleton_text_relation
-from ..workflows.definitions import WRITE_TOOL_POLICY_WORKFLOW_ID
 
 DEFAULT_MINIMAL_IMPOSITION_RUNTIME_PROFILE_PREDICATE = (
     "#V#has_minimal_imposition_runtime_profile_json"
@@ -128,6 +128,7 @@ _DEFAULT_TOOL_RISK_CLASSES: dict[str, str] = {
     "update_task_status": "mutative_non_destructive",
     "update_text_relation": "mutative_non_destructive",
     "upsert_renderer_profile": "additive_low_risk",
+    "upsert_scoped_assertion": "additive_low_risk",
     "upsert_singleton_text_relation": "additive_low_risk",
     "upsert_text_relation": "additive_low_risk",
     "workflow_bind_event": "additive_low_risk",
@@ -634,6 +635,6 @@ __all__ = [
     "canonical_minimal_imposition_runtime_tool_risk_classes",
     "ensure_canonical_minimal_imposition_runtime_profiles",
     "load_minimal_imposition_runtime_profile",
-    "resolve_runtime_profile_write_tool_risk_class",
     "resolve_minimal_imposition_runtime_profile_concept_id",
+    "resolve_runtime_profile_write_tool_risk_class",
 ]

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -249,16 +249,18 @@ def publication_context_from_mapping(value: Mapping[str, Any]) -> PublicationCon
     source = _clean_text(value.get("source")) or "resolved"
     if kind == PublicationContextKind.COMPOSITE:
         raw_components = value.get("components")
-        if not isinstance(raw_components, Sequence) or isinstance(
-            raw_components,
-            (str, bytes, bytearray),
-        ) or len(raw_components) != 2 or any(
-            not isinstance(item, Mapping) for item in raw_components
+        if (
+            not isinstance(raw_components, Sequence)
+            or isinstance(
+                raw_components,
+                (str, bytes, bytearray),
+            )
+            or len(raw_components) != 2
+            or any(not isinstance(item, Mapping) for item in raw_components)
         ):
             raise ValueError("Composite publication context requires components")
         components = tuple(
-            publication_context_from_mapping(item)
-            for item in raw_components
+            publication_context_from_mapping(item) for item in raw_components
         )
         context = PublicationContext(
             kind=kind,
@@ -861,27 +863,23 @@ def _actor_bound_workflow_direct_authority_eligible(
 
     The marker is bound by workflow support code only after the resolved MCP
     write has passed the workflow mutation ceiling.  This exception therefore
-    carries no authority of its own: it merely permits the existing exact live
-    authority decision for an effect whose complete publication boundary stays
-    inside the authenticated actor's private context.
+    carries no authority of its own: it permits the existing exact live
+    authority decision for this one actor-bound effect.  The ordinary authority
+    resolver still requires the actor's matching user, organisation, or global
+    semantic role and still rejects cross-actor and reserved-governance writes.
+    Minting and immediately consuming a delegation for the same trusted effect
+    would only relabel that live authority; delegation remains required when a
+    separately acting principal or an untrusted/sessionless boundary is used.
     """
 
     actor_id = _normalise_concept_id(actor_concept_id)
-    if (
+    return not (
         invocation is None
         or invocation.actor_bound_workflow_effect is not True
         or invocation.surface != "workflow"
         or invocation.audience != "workflow"
         or trust_source != "preexisting_authenticated_or_workflow_context"
         or actor_id is None
-    ):
-        return False
-
-    return all(
-        context.kind == PublicationContextKind.USER and context.concept_id == actor_id
-        for context in expand_publication_contexts(
-            (*intent.source_contexts, intent.publication_context)
-        )
     )
 
 
@@ -1707,9 +1705,7 @@ def ontology_authority_denial_payload(
     authority_kind = {
         "authenticated_actor_context_required": "trusted_actor_context",
         "explicit_scope_adoption_required": "explicit_publication_scope_adoption",
-        "global_ontology_admin_authority_required": (
-            "global_ontology_administrator"
-        ),
+        "global_ontology_admin_authority_required": ("global_ontology_administrator"),
         "organisation_ontology_admin_authority_required": (
             "organisation_ontology_administrator"
         ),
@@ -2069,9 +2065,7 @@ def reconcile_indeterminate_mutation_receipt(
         },
         return_document=ReturnDocument.AFTER,
     )
-    return (
-        _receipt_public_projection(updated) if isinstance(updated, Mapping) else None
-    )
+    return _receipt_public_projection(updated) if isinstance(updated, Mapping) else None
 
 
 def get_mutation_receipt_for_actor(

--- a/src/backend/services/paper_representation_workflow_vontology_service.py
+++ b/src/backend/services/paper_representation_workflow_vontology_service.py
@@ -12,6 +12,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ..workflows.workflow_repo_seed_export_service import (
+    diff_repo_seed_workflow_bundle_from_authority,
+    write_repo_seed_workflow_bundle_from_authority,
+)
+from .publication_scope_profile_vontology_service import (
+    bootstrap_canonical_publication_scope_profiles,
+)
 from .text_value_service import upsert_singleton_text_relation
 from .workflow_prompt_authority_service import (
     DEFAULT_PROMPT_TYPE_ID,
@@ -22,15 +29,16 @@ from .workflow_prompt_authority_service import (
 from .workflow_repo_seed_bootstrap import (
     bootstrap_repo_seed_workflow_bundle,
 )
-from ..workflows.workflow_repo_seed_export_service import (
-    diff_repo_seed_workflow_bundle_from_authority,
-    write_repo_seed_workflow_bundle_from_authority,
-)
 
 SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID = (
     "#V#scholarly_article_metadata_representation_workflow"
 )
-SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID = "#V#scholarly_paper_representation_workflow"
+SCHOLARLY_PUBLIC_AUTHOR_REPRESENTATION_WORKFLOW_ID = (
+    "#V#scholarly_public_author_representation_workflow"
+)
+SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID = (
+    "#V#scholarly_paper_representation_workflow"
+)
 ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID = "#V#arxiv_paper_representation_workflow"
 SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID = (
     "#V#source_neutral_paper_reference_ingestion_workflow"
@@ -168,6 +176,7 @@ def bootstrap_canonical_paper_representation_workflows(
 ) -> dict[str, Any]:
     """Publish or repair the canonical scholarly-paper workflow family at startup."""
 
+    publication_scope_profiles = bootstrap_canonical_publication_scope_profiles()
     prompt_support = _ensure_paper_workflow_prompt_support(
         force_prompt_seed=bool(force_republish)
     )
@@ -178,10 +187,13 @@ def bootstrap_canonical_paper_representation_workflows(
         )
     )
     publication_counts = dict((report.get("publication") or {}).get("counts") or {})
+    report["publication_scope_profiles"] = publication_scope_profiles
     report["prompt_support"] = prompt_support
-    report["success"] = bool(prompt_support.get("success")) and int(
-        publication_counts.get("errors") or 0
-    ) == 0
+    report["success"] = (
+        bool(publication_scope_profiles.get("success"))
+        and bool(prompt_support.get("success"))
+        and int(publication_counts.get("errors") or 0) == 0
+    )
     return report
 
 
@@ -211,6 +223,7 @@ __all__ = [
     "ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID",
     "SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID",
     "SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID",
+    "SCHOLARLY_PUBLIC_AUTHOR_REPRESENTATION_WORKFLOW_ID",
     "SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID",
     "SOURCE_NEUTRAL_PAPER_REFERENCE_ITEM_INGESTION_WORKFLOW_ID",
     "bootstrap_canonical_paper_representation_workflows",

--- a/src/backend/vontology/seed_bundles/publication_scope_profiles_seed_bundle.json
+++ b/src/backend/vontology/seed_bundles/publication_scope_profiles_seed_bundle.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "publication_scope_profile_seed_bundle.v1",
-  "seed_version": "1",
-  "source_tag": "JVNAUTOSCI-2671",
+  "seed_version": "2",
+  "source_tag": "JVNAUTOSCI-2670",
   "managed_by": "publication_scope_profile_vontology_service",
   "concepts": [
     {"concept_id": "#V#thing", "name": "Thing", "parent_concept_ids": [], "create_as_instance": false},
@@ -37,6 +37,10 @@
 
     {"concept_id": "#V#authored_by", "name": "authored by", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
     {"concept_id": "#V#has_doi", "name": "has DOI", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
+    {"concept_id": "#V#has_source_uri", "name": "has source URI", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
+    {"concept_id": "#V#has_publication_date", "name": "has publication date", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
+    {"concept_id": "#V#has_topic_labels", "name": "has topic labels", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
+    {"concept_id": "#V#paper_on_arxiv", "name": "paper on arXiv", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
     {"concept_id": "#V#published_in", "name": "published in", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
     {"concept_id": "#V#public_affiliation", "name": "public affiliation", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
     {"concept_id": "#V#has_read", "name": "has read", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true},
@@ -135,8 +139,8 @@
     {
       "profile_concept_id": "#V#publication_profile_public_bibliographic_assertion_global",
       "name": "Public bibliographic assertion global profile",
-      "bound_subject_concept_ids": ["#V#authored_by", "#V#has_doi", "#V#published_in", "#V#public_affiliation"],
-      "payload": {"schema_version": "publication_scope_profile.v1", "profile_id": "public_bibliographic_assertion_global", "version": "1", "status": "active", "plane": "assertion", "recommended_scope_mode": "global_general", "applicability": {"source_kinds": ["public_record", "public_scholarly_metadata"]}, "source": "JVNAUTOSCI-2671"}
+      "bound_subject_concept_ids": ["#V#authored_by", "#V#has_doi", "#V#has_source_uri", "#V#has_publication_date", "#V#has_topic_labels", "#V#paper_on_arxiv", "#V#published_in", "#V#public_affiliation"],
+      "payload": {"schema_version": "publication_scope_profile.v1", "profile_id": "public_bibliographic_assertion_global", "version": "2", "status": "active", "plane": "assertion", "recommended_scope_mode": "global_general", "applicability": {"source_kinds": ["public_record", "public_scholarly_metadata"]}, "source": "JVNAUTOSCI-2670"}
     },
     {
       "profile_concept_id": "#V#publication_profile_private_context_assertion_user",

--- a/src/backend/workflows/durable/paper_representation_workflow.py
+++ b/src/backend/workflows/durable/paper_representation_workflow.py
@@ -21,17 +21,22 @@ from ...services.arxiv_paper_link_service import (
     materialise_scholarly_representation_for_file_copy,
     predict_scholarly_author_concept_id,
     predict_scholarly_topic_concept_id,
-    resolve_or_create_scholarly_author_concept_id,
 )
 from ...services.ontology_publication_authority_service import (
     PublicationContext,
     PublicationContextKind,
     concept_publication_context,
 )
+from ...services.publication_scope_profile_service import (
+    resolve_publication_scope_profile,
+)
 from ...services.relationship_write_service import (
-    add_relationship,
     add_structural_relationship,
     validate_predicate_concept,
+)
+from ...services.scoped_assertion_service import (
+    list_visible_scoped_assertions,
+    upsert_scoped_assertion,
 )
 from ...services.text_value_service import (
     get_texts_for_concept,
@@ -47,6 +52,7 @@ from ..execution_contracts import build_arxiv_ingestion_completion_report
 
 logger = logging.getLogger(__name__)
 _PUBLICATION_DATE_PREDICATE_ID = "#V#has_publication_date"
+_LOCAL_FILE_COPY_PREDICATE_ID = "#V#local_file_copy"
 _MAX_TOPIC_RELATIONS = 3
 
 SCHOLARLY_PAPER_NORMALISE_INPUTS_ACTION_ID = "scholarly_paper.normalise_inputs"
@@ -60,7 +66,9 @@ SCHOLARLY_PAPER_MATERIALISE_ACTION_ID = "scholarly_paper.materialise_from_file_c
 SCHOLARLY_PAPER_ENRICH_ACTION_ID = "scholarly_paper.enrich_from_metadata"
 SCHOLARLY_PAPER_RESOLVE_AUTHORS_ACTION_ID = "scholarly_paper.resolve_authors"
 SCHOLARLY_PAPER_RESOLVE_TOPICS_ACTION_ID = "scholarly_paper.resolve_topics"
-SCHOLARLY_PAPER_ASSERT_SOURCE_IDENTITY_ACTION_ID = "scholarly_paper.assert_source_identity"
+SCHOLARLY_PAPER_ASSERT_SOURCE_IDENTITY_ACTION_ID = (
+    "scholarly_paper.assert_source_identity"
+)
 SCHOLARLY_PAPER_VERIFY_ACTION_ID = "scholarly_paper.verify_representation"
 
 ARXIV_NORMALISE_SOURCE_ACTION_ID = "arxiv.normalise_source"
@@ -183,7 +191,9 @@ def _extract_doi_candidates(value: Any) -> list[str]:
     return candidates
 
 
-def _normalise_source_context(value: Any, *, provenance_required: bool = True) -> dict[str, Any]:
+def _normalise_source_context(
+    value: Any, *, provenance_required: bool = True
+) -> dict[str, Any]:
     source_context = _coerce_mapping(value)
     if "provenance_required" not in source_context:
         source_context["provenance_required"] = provenance_required
@@ -231,13 +241,16 @@ def _extend_reference_items_from_value(
 
 
 def _paper_reference_source_uri_from_item(item: Mapping[str, Any]) -> str:
-    return _first_non_empty_text(
-        item.get("source_uri"),
-        item.get("source_url"),
-        item.get("url"),
-        item.get("uri"),
-        item.get("href"),
-    ) or ""
+    return (
+        _first_non_empty_text(
+            item.get("source_uri"),
+            item.get("source_url"),
+            item.get("url"),
+            item.get("uri"),
+            item.get("href"),
+        )
+        or ""
+    )
 
 
 def _paper_reference_metadata_from_item(item: Mapping[str, Any]) -> dict[str, Any]:
@@ -360,7 +373,9 @@ def _normalise_paper_reference_item(
     return normalised
 
 
-def _build_reference_item_candidates(request: WorkflowActionRequest) -> list[dict[str, Any]]:
+def _build_reference_item_candidates(
+    request: WorkflowActionRequest,
+) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
     for source in (
         request.inputs.get("paper_reference_set"),
@@ -414,7 +429,9 @@ def _build_reference_item_candidates(request: WorkflowActionRequest) -> list[dic
     if metadata:
         candidates.append({"reference_kind": "metadata", "paper_metadata": metadata})
 
-    prompt = _first_non_empty_text(request.inputs.get("prompt"), request.data.get("prompt"))
+    prompt = _first_non_empty_text(
+        request.inputs.get("prompt"), request.data.get("prompt")
+    )
     if prompt:
         for arxiv_candidate in extract_arxiv_id_candidates(prompt):
             candidates.append({"reference_kind": "arxiv", "arxiv_id": arxiv_candidate})
@@ -436,7 +453,10 @@ def _dedupe_reference_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]
             item.get("title"),
             item.get("prompt"),
         )
-        key = (_normalise_reference_kind(item.get("reference_kind")), identity or str(item))
+        key = (
+            _normalise_reference_kind(item.get("reference_kind")),
+            identity or str(item),
+        )
         lowered_key = (key[0], key[1].casefold())
         if lowered_key in seen:
             continue
@@ -446,11 +466,11 @@ def _dedupe_reference_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]
     return deduped
 
 
-def _relationship_targets(concept_doc: Mapping[str, Any] | None, predicate: str) -> list[str]:
+def _relationship_targets(
+    concept_doc: Mapping[str, Any] | None, predicate: str
+) -> list[str]:
     relationships = (
-        concept_doc.get("relationships")
-        if isinstance(concept_doc, Mapping)
-        else None
+        concept_doc.get("relationships") if isinstance(concept_doc, Mapping) else None
     )
     if not isinstance(relationships, Mapping):
         return []
@@ -468,7 +488,9 @@ def _relation_contains_target(
     target: str,
 ) -> bool:
     target_clean = _clean_text(target)
-    return bool(target_clean) and target_clean in _relationship_targets(concept_doc, predicate)
+    return bool(target_clean) and target_clean in _relationship_targets(
+        concept_doc, predicate
+    )
 
 
 def _get_concept(concept_id: str) -> dict[str, Any] | None:
@@ -505,7 +527,8 @@ def _resolve_user_concept_id(request: WorkflowActionRequest) -> str | None:
     )
     resolved_user, _resolved_org = resolve_event_actor_context(
         user_id=explicit_user,
-        namespace=_clean_text(getattr(request.environment, "user_namespace", None)) or None,
+        namespace=_clean_text(getattr(request.environment, "user_namespace", None))
+        or None,
     )
     return _clean_text(resolved_user) or None
 
@@ -557,6 +580,68 @@ def _require_actor_private_targets(
                 error="scholarly_paper_actor_private_target_required",
             )
     return None
+
+
+def _require_global_targets(
+    concept_ids: Sequence[str],
+    *,
+    error_code: str,
+) -> WorkflowActionResult | None:
+    """Require exact global publication for canonical public mutations."""
+
+    checked: set[str] = set()
+    for raw_concept_id in concept_ids:
+        concept_id = _clean_text(raw_concept_id)
+        if not concept_id or concept_id in checked:
+            continue
+        checked.add(concept_id)
+        try:
+            target_context = concept_publication_context(concept_id)
+        except (LookupError, ValueError):
+            return WorkflowActionResult(
+                status="failed",
+                outputs={"mutation_target_concept_id": concept_id},
+                error="scholarly_paper_mutation_target_missing",
+            )
+        if target_context.kind != PublicationContextKind.GLOBAL:
+            return WorkflowActionResult(
+                status="failed",
+                outputs={
+                    "mutation_target_concept_id": concept_id,
+                    "mutation_target_publication_context": (
+                        target_context.to_mapping()
+                    ),
+                },
+                error=error_code,
+            )
+    return None
+
+
+def _paper_scope_mode_from_request(request: WorkflowActionRequest) -> str | None:
+    return _first_non_empty_text(
+        request.inputs.get("paper_instance_scope_mode"),
+        request.data.get("paper_instance_scope_mode"),
+    )
+
+
+def _visible_local_file_copy_assertions(
+    request: WorkflowActionRequest,
+    *,
+    paper_concept_id: str,
+) -> list[dict[str, Any]]:
+    actor_concept_id = _trusted_actor_concept_id(request)
+    if not actor_concept_id:
+        return []
+    return list_visible_scoped_assertions(
+        subject_concept_ids=[paper_concept_id],
+        predicates=[_LOCAL_FILE_COPY_PREDICATE_ID],
+        object_kind="concept",
+        limit=50,
+        user_concept_id=actor_concept_id,
+        organisation_concept_id=(
+            _clean_text(getattr(request.environment, "org_concept_id", None)) or None
+        ),
+    )
 
 
 def _require_preprovisioned_schema_support(
@@ -678,6 +763,168 @@ def _extract_author_names_from_request(request: WorkflowActionRequest) -> list[s
     return extract_scholarly_author_names(_extract_metadata_from_context(request))
 
 
+_PUBLIC_AUTHOR_IDENTIFIER_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("orcid", ("orcid", "orcid_id")),
+    ("openalex", ("openalex", "openalex_id")),
+    ("researcherid", ("researcherid", "researcher_id")),
+    ("scopus", ("scopus", "scopus_id", "scopus_author_id")),
+)
+
+
+def _normalise_public_author_identifier(scheme: str, value: Any) -> str:
+    cleaned = _clean_text(value)
+    if not cleaned:
+        return ""
+    lowered = cleaned.casefold()
+    prefixes = {
+        "orcid": ("https://orcid.org/", "http://orcid.org/", "orcid:"),
+        "openalex": ("https://openalex.org/", "http://openalex.org/"),
+    }
+    for prefix in prefixes.get(scheme, ()):
+        if lowered.startswith(prefix):
+            cleaned = cleaned[len(prefix) :].strip()
+            break
+    return cleaned.casefold()
+
+
+def _author_record_candidates(request: WorkflowActionRequest) -> list[dict[str, Any]]:
+    metadata = _extract_metadata_from_context(request)
+    raw_authors: Any = None
+    for candidate in (
+        request.inputs.get("author_records"),
+        request.data.get("author_records"),
+        metadata.get("authors"),
+        request.inputs.get("author_names"),
+        request.data.get("author_names"),
+    ):
+        if candidate not in (None, "", [], {}):
+            raw_authors = candidate
+            break
+
+    if isinstance(raw_authors, str):
+        raw_items: list[Any] = [
+            item for item in re.split(r"[;\n]+", raw_authors) if item.strip()
+        ]
+    elif isinstance(raw_authors, Sequence) and not isinstance(
+        raw_authors, (str, bytes, bytearray)
+    ):
+        raw_items = list(raw_authors)
+    else:
+        raw_items = []
+
+    records: list[dict[str, Any]] = []
+    for item in raw_items:
+        if isinstance(item, Mapping):
+            name = _first_non_empty_text(
+                item.get("name"),
+                item.get("full_name"),
+                item.get("display_name"),
+                item.get("author"),
+            )
+            public_identifier: dict[str, str] | None = None
+            nested_identifiers = item.get("external_identifiers")
+            identifier_sources = [item]
+            if isinstance(nested_identifiers, Mapping):
+                identifier_sources.insert(0, nested_identifiers)
+            for scheme, field_names in _PUBLIC_AUTHOR_IDENTIFIER_FIELDS:
+                raw_value = None
+                for source in identifier_sources:
+                    raw_value = next(
+                        (
+                            source.get(field_name)
+                            for field_name in field_names
+                            if source.get(field_name) not in (None, "")
+                        ),
+                        None,
+                    )
+                    if raw_value is not None:
+                        break
+                value = _normalise_public_author_identifier(scheme, raw_value)
+                if value:
+                    public_identifier = {"scheme": scheme, "value": value}
+                    break
+        else:
+            name = _clean_text(item)
+            public_identifier = None
+        if name:
+            records.append(
+                {
+                    "name": " ".join(name.split()),
+                    "public_identifier": public_identifier,
+                }
+            )
+    return records
+
+
+def _public_author_records_for_paper(
+    request: WorkflowActionRequest,
+    *,
+    paper_concept_id: str,
+) -> list[dict[str, Any]]:
+    from ...services.concept_external_identity_service import (
+        ExternalIdentifier,
+        canonical_concept_id_for_external_identifiers,
+    )
+
+    records: list[dict[str, Any]] = []
+    for position, candidate in enumerate(_author_record_candidates(request)):
+        name = _clean_text(candidate.get("name"))
+        public_identifier = candidate.get("public_identifier")
+        if isinstance(public_identifier, Mapping):
+            scheme = _clean_text(public_identifier.get("scheme")).casefold()
+            value = _clean_text(public_identifier.get("value"))
+            identity_kind = "public_identifier"
+        else:
+            scheme = "scholarly-author-occurrence"
+            occurrence_material = json.dumps(
+                {
+                    "author_name": " ".join(name.split()).casefold(),
+                    "author_position": position,
+                    "paper_concept_id": paper_concept_id,
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            value = f"sha256:{hashlib.sha256(occurrence_material.encode('utf-8')).hexdigest()}"
+            identity_kind = "source_bounded_candidate"
+        identifier = ExternalIdentifier(
+            scheme=scheme,
+            value=value,
+            source="public_scholarly_metadata",
+        )
+        concept_id = canonical_concept_id_for_external_identifiers(
+            (identifier,),
+            kind="instance",
+            parent_id="#V#person",
+            scope_mode="global_general",
+        )
+        if not concept_id:
+            raise ValueError("scholarly_author_external_identity_invalid")
+        records.append(
+            {
+                "name": name,
+                "concept_id": concept_id,
+                "external_identifiers": [identifier.to_dict()],
+                "identity_kind": identity_kind,
+                "identity_scheme": scheme,
+                "identity_stable": True,
+                "source_kind": "public_scholarly_metadata",
+                "source_paper_concept_id": paper_concept_id,
+                "source_author_position": position,
+                "description": (
+                    "Public scholarly author identity from stable public metadata."
+                    if identity_kind == "public_identifier"
+                    else (
+                        "Public scholarly author candidate bounded to one paper and "
+                        "author position; it is not a name-only cross-paper identity merge."
+                    )
+                ),
+            }
+        )
+    return records
+
+
 def _extract_topic_labels_from_request(request: WorkflowActionRequest) -> list[str]:
     for raw in (
         request.inputs.get("topic_labels"),
@@ -797,6 +1044,50 @@ def _build_normalise_inputs_handler():
 
 def _build_normalise_external_identity_handler():
     def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
+        paper_scope_mode = _paper_scope_mode_from_request(request)
+        if paper_scope_mode != "global_general":
+            return WorkflowActionResult(
+                status="failed",
+                outputs={"paper_instance_scope_mode": paper_scope_mode},
+                error="scholarly_paper_global_scope_profile_required",
+            )
+
+        supplied_paper_concept_id = _first_non_empty_text(
+            request.inputs.get("paper_concept_id"),
+            request.data.get("paper_concept_id"),
+        )
+        if supplied_paper_concept_id:
+            target_preflight = _require_global_targets(
+                (supplied_paper_concept_id,),
+                error_code="scholarly_paper_global_target_required",
+            )
+            if target_preflight is not None:
+                return target_preflight
+            supplied_doc = _get_concept(supplied_paper_concept_id)
+            if not _relation_contains_target(
+                supplied_doc,
+                "is_an_instance_of",
+                "#V#scholarly_article",
+            ):
+                return WorkflowActionResult(
+                    status="failed",
+                    outputs={"paper_concept_id": supplied_paper_concept_id},
+                    error="scholarly_paper_supplied_target_type_invalid",
+                )
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "arxiv_id": _extract_arxiv_id_from_request(request),
+                    "paper_instance_scope_mode": paper_scope_mode,
+                    "paper_external_identity_present": False,
+                    "paper_external_identity_scheme": None,
+                    "paper_external_identity_value": None,
+                    "paper_external_identity_concept_id": None,
+                    "paper_external_identity_resolution_status": "supplied",
+                    "paper_concept_id": supplied_paper_concept_id,
+                },
+            )
+
         metadata = _extract_metadata_from_context(request)
         source_uri = _first_non_empty_text(
             request.inputs.get("source_uri"),
@@ -860,12 +1151,6 @@ def _build_normalise_external_identity_handler():
         identity_resolution_status = "not_applicable"
         resolved_paper_concept_id: str | None = None
         if identity_scheme and identity_value:
-            actor_concept_id = _trusted_actor_concept_id(request)
-            if not actor_concept_id:
-                return WorkflowActionResult(
-                    status="failed",
-                    error="scholarly_paper_actor_user_missing",
-                )
             from ...services.concept_external_identity_service import (
                 ExternalIdentifier,
                 canonical_concept_id_for_external_identifiers,
@@ -880,8 +1165,8 @@ def _build_normalise_external_identity_handler():
                 ],
                 kind="instance",
                 parent_id="#V#scholarly_article",
-                scope_mode="user_only_default",
-                actor_user_id=actor_concept_id,
+                scope_mode=paper_scope_mode,
+                actor_user_id=_trusted_actor_concept_id(request),
                 actor_org_id=_clean_text(
                     getattr(request.environment, "org_concept_id", None)
                 )
@@ -896,9 +1181,9 @@ def _build_normalise_external_identity_handler():
             if existing_doc is None:
                 identity_resolution_status = "not_found"
             else:
-                target_preflight = _require_actor_private_targets(
-                    request,
+                target_preflight = _require_global_targets(
                     (identity_concept_id,),
+                    error_code="scholarly_paper_global_target_required",
                 )
                 if target_preflight is not None:
                     return target_preflight
@@ -921,6 +1206,7 @@ def _build_normalise_external_identity_handler():
             status="success",
             outputs={
                 "arxiv_id": arxiv_id,
+                "paper_instance_scope_mode": paper_scope_mode,
                 "paper_external_identity_present": bool(identity_value),
                 "paper_external_identity_scheme": identity_scheme,
                 "paper_external_identity_value": identity_value,
@@ -1078,9 +1364,9 @@ def _build_enrich_from_metadata_handler():
                 status="failed",
                 error="scholarly_paper_paper_concept_id_missing",
             )
-        target_preflight = _require_actor_private_targets(
-            request,
+        target_preflight = _require_global_targets(
             (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
@@ -1142,14 +1428,20 @@ def _build_enrich_from_metadata_handler():
                 predicate="hasName",
                 text=arxiv_id,
                 lang="en-NZ",
-                context={"name_type": "CODE", "source": "scholarly_workflow_enrichment"},
+                context={
+                    "name_type": "CODE",
+                    "source": "scholarly_workflow_enrichment",
+                },
             )
             upsert_text_for_concept(
                 subject_concept_id=paper_concept_id,
                 predicate="hasName",
                 text=f"https://arxiv.org/abs/{arxiv_id}",
                 lang="en-NZ",
-                context={"name_type": "CODE", "source": "scholarly_workflow_enrichment"},
+                context={
+                    "name_type": "CODE",
+                    "source": "scholarly_workflow_enrichment",
+                },
             )
             applied = True
 
@@ -1159,7 +1451,10 @@ def _build_enrich_from_metadata_handler():
                 predicate="hasName",
                 text=source_uri,
                 lang="en-NZ",
-                context={"name_type": "CODE", "source": "scholarly_workflow_enrichment"},
+                context={
+                    "name_type": "CODE",
+                    "source": "scholarly_workflow_enrichment",
+                },
             )
             applied = True
 
@@ -1190,84 +1485,81 @@ def _build_resolve_authors_handler():
                 error="scholarly_paper_paper_concept_id_missing",
             )
 
-        paper_doc = _get_concept(paper_concept_id)
-        existing_author_concept_ids = _relationship_targets(paper_doc, "#V#authored_by")
-        author_names = _extract_author_names_from_request(request)
-        if not author_names:
-            return WorkflowActionResult(
-                status="success",
-                outputs={
-                    "paper_concept_id": paper_concept_id,
-                    "author_names": [],
-                    "author_concept_ids": existing_author_concept_ids,
-                    "author_resolution_completed": True,
-                },
-            )
-
-        user_concept_id = _trusted_actor_concept_id(request)
-        if not user_concept_id:
-            return WorkflowActionResult(
-                status="failed",
-                error="scholarly_author_actor_user_missing",
-            )
-
         schema_preflight = _require_preprovisioned_schema_support(
             type_concept_ids=("#V#person",),
             predicate_concept_ids=("#V#authored_by",),
         )
-        predicted_author_concept_ids = [
-            predict_scholarly_author_concept_id(
-                user_concept_id=user_concept_id,
-                author_name=author_name,
-            )
-            for author_name in author_names
-        ]
-        target_preflight = _require_actor_private_targets(
-            request,
-            (
-                paper_concept_id,
-                *(
-                    concept_id
-                    for concept_id in predicted_author_concept_ids
-                    if _concept_exists(concept_id)
-                ),
-            ),
+        if schema_preflight is not None:
+            return schema_preflight
+        target_preflight = _require_global_targets(
+            (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
-        if schema_preflight is not None:
-            return schema_preflight
 
-        resolved_author_concept_ids: list[str] = []
-        for author_name in author_names:
-            author_concept_id = resolve_or_create_scholarly_author_concept_id(
-                user_concept_id=user_concept_id,
-                author_name=author_name,
-                logger=logger,
+        instance_profile = resolve_publication_scope_profile(
+            plane="instance",
+            type_concept_ids=["#V#person"],
+            source_kind="public_scholarly_metadata",
+            stable_identity_present=True,
+            producer="#V#scholarly_article_metadata_representation_workflow",
+        )
+        assertion_profile = resolve_publication_scope_profile(
+            plane="assertion",
+            predicate_concept_id="#V#authored_by",
+            subject_type_concept_ids=["#V#scholarly_article"],
+            object_type_concept_ids=["#V#person"],
+            source_kind="public_scholarly_metadata",
+            stable_identity_present=True,
+            producer="#V#scholarly_article_metadata_representation_workflow",
+        )
+        if (
+            not instance_profile.get("success")
+            or instance_profile.get("selected_scope_mode") != "global_general"
+            or not assertion_profile.get("success")
+            or assertion_profile.get("selected_scope_mode") != "global_general"
+        ):
+            return WorkflowActionResult(
+                status="failed",
+                outputs={
+                    "author_instance_publication_profile": instance_profile,
+                    "authorship_assertion_publication_profile": assertion_profile,
+                },
+                error="scholarly_author_global_scope_profile_required",
             )
-            resolved_author_concept_ids.append(author_concept_id)
-            add_relationship(
-                source_id=paper_concept_id,
-                predicate="#V#authored_by",
-                target=author_concept_id,
+
+        try:
+            author_records = _public_author_records_for_paper(
+                request,
+                paper_concept_id=paper_concept_id,
             )
+        except ValueError as exc:
+            return WorkflowActionResult(status="failed", error=str(exc))
 
         return WorkflowActionResult(
             status="success",
             outputs={
                 "paper_concept_id": paper_concept_id,
-                "author_names": author_names,
-                "author_concept_ids": list(
-                    dict.fromkeys([*existing_author_concept_ids, *resolved_author_concept_ids])
+                "author_names": [record["name"] for record in author_records],
+                "public_author_records": author_records,
+                "public_author_count": len(author_records),
+                "author_instance_scope_mode": instance_profile.get(
+                    "selected_scope_mode"
                 ),
-                "author_resolution_completed": True,
+                "authorship_assertion_scope_mode": assertion_profile.get(
+                    "selected_scope_mode"
+                ),
+                "author_scope_profiles_resolved": True,
             },
         )
 
     return _handle
 
 
-def _has_non_code_title(name_rows: list[Mapping[str, Any]], *, arxiv_id: str | None) -> bool:
+def _has_non_code_title(
+    name_rows: list[Mapping[str, Any]], *, arxiv_id: str | None
+) -> bool:
     arxiv_id_clean = _clean_text(arxiv_id).casefold()
     disallowed: set[str] = set()
     if arxiv_id_clean:
@@ -1305,6 +1597,15 @@ def _build_verify_representation_handler():
         paper_doc = _get_concept(paper_concept_id or "")
         if not paper_doc:
             verification_failures.append("paper_concept_missing")
+        paper_publication_context: dict[str, Any] | None = None
+        if paper_concept_id and paper_doc:
+            try:
+                paper_context = concept_publication_context(paper_concept_id)
+                paper_publication_context = paper_context.to_mapping()
+                if paper_context.kind != PublicationContextKind.GLOBAL:
+                    verification_failures.append("paper_not_global")
+            except (LookupError, ValueError):
+                verification_failures.append("paper_publication_context_missing")
 
         if require_file_copy and not file_copy_concept_id:
             verification_failures.append("file_copy_concept_missing")
@@ -1346,20 +1647,53 @@ def _build_verify_representation_handler():
             verification_failures.append("type_missing")
 
         file_link_verified = False
+        file_link_assertion_id: str | None = None
+        canonical_file_link_present = False
         if file_copy_concept_id:
-            file_link_verified = _relation_contains_target(
+            canonical_file_link_present = _relation_contains_target(
                 paper_doc,
                 "#V#propositional_information_thing_has_computer_file",
                 file_copy_concept_id,
             )
+            scoped_file_links = _visible_local_file_copy_assertions(
+                request,
+                paper_concept_id=paper_concept_id or "",
+            )
+            matching_file_links = [
+                assertion
+                for assertion in scoped_file_links
+                if _clean_text(assertion.get("object_concept_id"))
+                == file_copy_concept_id
+                and assertion.get("canonical_publication") is False
+            ]
+            file_link_verified = bool(matching_file_links)
+            if matching_file_links:
+                file_link_assertion_id = (
+                    _clean_text(matching_file_links[0].get("assertion_id")) or None
+                )
+            if canonical_file_link_present:
+                verification_failures.append("file_link_scope_leak")
         if file_copy_concept_id and not file_link_verified:
             verification_failures.append("file_link_missing")
 
-        has_name_signal = bool(name_rows) or bool(_clean_text((paper_doc or {}).get("name")))
+        has_name_signal = bool(name_rows) or bool(
+            _clean_text((paper_doc or {}).get("name"))
+        )
         if not has_name_signal:
             verification_failures.append("title_or_name_missing")
 
         author_concept_ids = _relationship_targets(paper_doc, "#V#authored_by")
+        non_global_author_concept_ids: list[str] = []
+        for author_concept_id in author_concept_ids:
+            try:
+                author_context = concept_publication_context(author_concept_id)
+            except (LookupError, ValueError):
+                non_global_author_concept_ids.append(author_concept_id)
+                continue
+            if author_context.kind != PublicationContextKind.GLOBAL:
+                non_global_author_concept_ids.append(author_concept_id)
+        if non_global_author_concept_ids:
+            verification_failures.append("authors_not_global")
         topic_concept_ids = _relationship_targets(paper_doc, "#V#about")
         topic_label_rows = (
             get_texts_for_concept(
@@ -1373,9 +1707,7 @@ def _build_verify_representation_handler():
 
         if verification_profile == "arxiv":
             paper_attributes = (
-                paper_doc.get("attributes")
-                if isinstance(paper_doc, Mapping)
-                else None
+                paper_doc.get("attributes") if isinstance(paper_doc, Mapping) else None
             )
             stored_arxiv_id = _clean_text(
                 (paper_attributes or {}).get("arxiv_id")
@@ -1444,11 +1776,17 @@ def _build_verify_representation_handler():
                 "topic_concept_ids": topic_concept_ids,
                 "publication_date": (
                     _clean_text(publication_date_rows[0].get("text"))
-                    if publication_date_rows and isinstance(publication_date_rows[0], Mapping)
+                    if publication_date_rows
+                    and isinstance(publication_date_rows[0], Mapping)
                     else None
                 ),
                 "type_asserted": type_asserted,
                 "file_link_verified": file_link_verified,
+                "file_link_assertion_id": file_link_assertion_id,
+                "file_link_canonical_publication": False,
+                "canonical_file_link_present": canonical_file_link_present,
+                "paper_publication_context": paper_publication_context,
+                "non_global_author_concept_ids": non_global_author_concept_ids,
             },
         )
 
@@ -1573,8 +1911,6 @@ def _build_scholarly_paper_ensure_paper_concept_handler():
 
 def _build_scholarly_paper_link_file_copy_handler():
     def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
-        from ...services.arxiv_paper_link_service import _link_file_copy_to_paper_concept
-
         paper_concept_id = _first_non_empty_text(
             request.inputs.get("paper_concept_id"),
             request.data.get("paper_concept_id"),
@@ -1589,17 +1925,71 @@ def _build_scholarly_paper_link_file_copy_handler():
                 status="failed",
                 error="scholarly_paper_link_missing_ids",
             )
-        target_preflight = _require_actor_private_targets(
-            request,
-            (paper_concept_id, file_copy_concept_id),
+        target_preflight = _require_global_targets(
+            (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
-
-        changed = _link_file_copy_to_paper_concept(
-            file_copy_concept_id=file_copy_concept_id,
-            paper_concept_id=paper_concept_id,
+        actor_concept_id = _trusted_actor_concept_id(request)
+        if not actor_concept_id:
+            return WorkflowActionResult(
+                status="failed",
+                error="scholarly_paper_actor_user_missing",
+            )
+        scope_profile = resolve_publication_scope_profile(
+            plane="assertion",
+            predicate_concept_id=_LOCAL_FILE_COPY_PREDICATE_ID,
+            subject_type_concept_ids=["#V#scholarly_article"],
+            object_type_concept_ids=["#V#computer_file_copy"],
+            source_kind="private_email",
+            producer="#V#scholarly_article_metadata_representation_workflow",
         )
+        carrier = scope_profile.get("carrier")
+        carrier_scope_mode = (
+            _clean_text(carrier.get("scope_mode"))
+            if isinstance(carrier, Mapping)
+            else ""
+        )
+        if (
+            not scope_profile.get("success")
+            or scope_profile.get("selected_scope_mode") != "user_only_default"
+            or carrier_scope_mode != "user"
+        ):
+            return WorkflowActionResult(
+                status="failed",
+                outputs={"file_link_publication_profile": scope_profile},
+                error="scholarly_paper_file_link_scoped_profile_required",
+            )
+        try:
+            receipt = upsert_scoped_assertion(
+                subject_concept_id=paper_concept_id,
+                predicate=_LOCAL_FILE_COPY_PREDICATE_ID,
+                target_concept_id=file_copy_concept_id,
+                scope_mode=carrier_scope_mode,
+                acting_user_concept_id=actor_concept_id,
+                organisation_concept_id=(
+                    _clean_text(getattr(request.environment, "org_concept_id", None))
+                    or None
+                ),
+                namespace=(
+                    _clean_text(getattr(request.environment, "user_namespace", None))
+                    or None
+                ),
+                evidence={
+                    "source_kind": "private_email",
+                    "workflow_id": (
+                        request.workflow_id
+                        or "#V#scholarly_article_metadata_representation_workflow"
+                    ),
+                },
+                canonical_publication=False,
+            )
+        except (PermissionError, RuntimeError, ValueError) as exc:
+            return WorkflowActionResult(
+                status="failed",
+                error=f"scholarly_paper_file_link_assertion_failed:{exc}",
+            )
 
         return WorkflowActionResult(
             status="success",
@@ -1607,7 +1997,11 @@ def _build_scholarly_paper_link_file_copy_handler():
                 "paper_concept_id": paper_concept_id,
                 "file_copy_concept_id": file_copy_concept_id,
                 "file_link_written": True,
-                "file_link_changed": bool(changed),
+                "file_link_changed": bool(receipt.get("changed")),
+                "file_link_assertion_id": receipt.get("assertion_id"),
+                "file_link_scope_mode": carrier_scope_mode,
+                "file_link_canonical_publication": False,
+                "file_link_canonical_read_back": receipt.get("canonical_read_back"),
             },
         )
 
@@ -1626,9 +2020,9 @@ def _build_scholarly_paper_attach_metadata_handler():
                 error="scholarly_paper_paper_concept_id_missing",
             )
 
-        target_preflight = _require_actor_private_targets(
-            request,
+        target_preflight = _require_global_targets(
             (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
@@ -1684,10 +2078,6 @@ def _build_scholarly_paper_attach_metadata_handler():
 
 def _build_scholarly_paper_resolve_topics_handler():
     def _handle(request: WorkflowActionRequest) -> WorkflowActionResult:
-        from ...services.arxiv_paper_link_service import (
-            _resolve_or_create_topic_concept_id,
-        )
-
         paper_concept_id = _first_non_empty_text(
             request.inputs.get("paper_concept_id"),
             request.data.get("paper_concept_id"),
@@ -1699,94 +2089,21 @@ def _build_scholarly_paper_resolve_topics_handler():
             )
 
         topic_labels = _extract_topic_labels_from_request(request)
-        if not topic_labels:
-            return WorkflowActionResult(
-                status="success",
-                outputs={
-                    "paper_concept_id": paper_concept_id,
-                    "topic_concept_ids": [],
-                    "topic_resolution_completed": True,
-                },
-            )
-
-        user_concept_id = _trusted_actor_concept_id(request)
-        if not user_concept_id:
-            return WorkflowActionResult(
-                status="failed",
-                error="scholarly_topic_actor_user_missing",
-            )
-
-        schema_preflight = _require_preprovisioned_schema_support(
-            type_concept_ids=("#V#research_topic",),
-            predicate_concept_ids=("#V#about",),
-        )
-        predicted_topic_concept_ids = [
-            predict_scholarly_topic_concept_id(
-                user_concept_id=user_concept_id,
-                topic_label=topic_label,
-            )
-            for topic_label in topic_labels[:_MAX_TOPIC_RELATIONS]
-        ]
-        target_preflight = _require_actor_private_targets(
-            request,
-            (
-                paper_concept_id,
-                *(
-                    concept_id
-                    for concept_id in predicted_topic_concept_ids
-                    if _concept_exists(concept_id)
-                ),
-            ),
+        target_preflight = _require_global_targets(
+            (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
-        if schema_preflight is not None:
-            return schema_preflight
-
-        topic_concept_ids: list[str] = []
-        for label in topic_labels[:_MAX_TOPIC_RELATIONS]:
-            topic_concept_id = _resolve_or_create_topic_concept_id(
-                user_concept_id=user_concept_id,
-                topic_label=label,
-                logger=logger,
-            )
-            topic_concept_ids.append(topic_concept_id)
-            relationship_result = add_relationship(
-                source_id=paper_concept_id,
-                predicate="#V#about",
-                target=topic_concept_id,
-            )
-            if not bool(relationship_result.get("success")):
-                return WorkflowActionResult(
-                    status="failed",
-                    error=(
-                        "scholarly_topic_relationship_write_failed:"
-                        f"{relationship_result.get('error') or 'unknown_error'}"
-                    ),
-                    outputs={
-                        "paper_concept_id": paper_concept_id,
-                        "topic_labels": topic_labels,
-                        "topic_concept_ids": topic_concept_ids,
-                        "relationship_write_result": relationship_result,
-                    },
-                )
-
-        if topic_labels:
-            upsert_text_for_concept(
-                subject_concept_id=paper_concept_id,
-                predicate="#V#has_topic_labels",
-                text=", ".join(topic_labels),
-                lang="en-NZ",
-                context={"source": "scholarly_topic_attach"},
-            )
 
         return WorkflowActionResult(
             status="success",
             outputs={
                 "paper_concept_id": paper_concept_id,
                 "topic_labels": topic_labels,
-                "topic_concept_ids": topic_concept_ids,
-                "topic_resolution_completed": True,
+                "topic_labels_text": ", ".join(topic_labels),
+                "topic_labels_present": bool(topic_labels),
+                "topic_normalisation_completed": True,
             },
         )
 
@@ -1804,9 +2121,9 @@ def _build_scholarly_paper_assert_source_identity_handler():
                 status="failed",
                 error="scholarly_paper_paper_concept_id_missing",
             )
-        target_preflight = _require_actor_private_targets(
-            request,
+        target_preflight = _require_global_targets(
             (paper_concept_id,),
+            error_code="scholarly_paper_global_target_required",
         )
         if target_preflight is not None:
             return target_preflight
@@ -1994,33 +2311,38 @@ def _build_arxiv_inspect_existing_state_handler():
                 error="arxiv_identifier_missing",
             )
 
-        actor_concept_id = _trusted_actor_concept_id(request)
-        if not actor_concept_id:
-            return WorkflowActionResult(
-                status="failed",
-                error="scholarly_paper_actor_user_missing",
-            )
-
-        # JVNAUTOSCI-1768: Proper search over actor-scoped ontology identity.
-        from ...services.arxiv_paper_link_service import (
-            resolve_actor_private_arxiv_paper_concept_id,
+        from ...services.concept_external_identity_service import (
+            ExternalIdentifier,
+            canonical_concept_id_for_external_identifiers,
         )
 
-        predicted_cid = resolve_actor_private_arxiv_paper_concept_id(
-            user_concept_id=actor_concept_id,
-            arxiv_id=arxiv_id,
+        predicted_cid = canonical_concept_id_for_external_identifiers(
+            (
+                ExternalIdentifier(
+                    scheme="arxiv",
+                    value=arxiv_id,
+                    source="public_scholarly_metadata",
+                ),
+            ),
+            kind="instance",
+            parent_id="#V#scholarly_article",
+            scope_mode="global_general",
         )
 
         paper_concept_id = None
-        if _concept_exists(predicted_cid):
+        if predicted_cid and _concept_exists(predicted_cid):
             paper_concept_id = predicted_cid
 
         file_copy_concept_id = None
         if paper_concept_id:
-            paper_doc = _get_concept(paper_concept_id)
-            targets = _relationship_targets(
-                paper_doc, "#V#propositional_information_thing_has_computer_file"
-            )
+            targets = [
+                _clean_text(assertion.get("object_concept_id"))
+                for assertion in _visible_local_file_copy_assertions(
+                    request,
+                    paper_concept_id=paper_concept_id,
+                )
+            ]
+            targets = [target for target in targets if target]
             if targets:
                 file_copy_concept_id = targets[0]
 
@@ -2119,16 +2441,20 @@ def _build_arxiv_build_completion_report_handler():
                 request.data.get("source_uri"),
             ),
             arxiv_id=arxiv_id,
-            metadata_status="fetched" if _extract_metadata_from_context(request) else "missing",
+            metadata_status="fetched"
+            if _extract_metadata_from_context(request)
+            else "missing",
             acquisition_mode=_first_non_empty_text(
                 request.inputs.get("acquisition_mode"),
                 request.data.get("acquisition_mode"),
             ),
             download_attempted=bool(
-                request.inputs.get("download_attempted") or request.data.get("download_attempted")
+                request.inputs.get("download_attempted")
+                or request.data.get("download_attempted")
             ),
             download_succeeded=bool(
-                request.inputs.get("download_succeeded") or request.data.get("download_succeeded")
+                request.inputs.get("download_succeeded")
+                or request.data.get("download_succeeded")
             ),
             used_existing_file_copy=bool(
                 request.inputs.get("used_existing_file_copy")
@@ -2141,12 +2467,18 @@ def _build_arxiv_build_completion_report_handler():
             file_copy_concept_id=file_copy_concept_id,
             paper_concept_id=paper_concept_id,
             author_concept_ids=_coerce_string_list(
-                request.inputs.get("author_concept_ids") or request.data.get("author_concept_ids")
+                request.inputs.get("author_concept_ids")
+                or request.data.get("author_concept_ids")
             ),
             topic_concept_ids=_coerce_string_list(
-                request.inputs.get("topic_concept_ids") or request.data.get("topic_concept_ids")
+                request.inputs.get("topic_concept_ids")
+                or request.data.get("topic_concept_ids")
             ),
-            verification_status="verified" if verified else "failed" if verification_failures else "unknown",
+            verification_status="verified"
+            if verified
+            else "failed"
+            if verification_failures
+            else "unknown",
             verification_failures=verification_failures,
             user_safe_operational_summary=f"Processed arXiv paper {arxiv_id}.",
         )
@@ -2191,7 +2523,10 @@ def register_paper_representation_actions(registry: ActionRegistry) -> None:
         ActionSpec(
             action_id=SCHOLARLY_PAPER_LINK_FILE_COPY_ACTION_ID,
             handler=_build_scholarly_paper_link_file_copy_handler(),
-            description="Link a paper concept to its computer file copy.",
+            description=(
+                "Link a public paper to a local file copy through an actor-scoped "
+                "assertion."
+            ),
         )
     )
     registry.register_if_absent(
@@ -2219,14 +2554,20 @@ def register_paper_representation_actions(registry: ActionRegistry) -> None:
         ActionSpec(
             action_id=SCHOLARLY_PAPER_RESOLVE_AUTHORS_ACTION_ID,
             handler=_build_resolve_authors_handler(),
-            description="Resolve or create author concepts for a scholarly paper.",
+            description=(
+                "Prepare source-bounded or publicly identified author records "
+                "without mutating concepts."
+            ),
         )
     )
     registry.register_if_absent(
         ActionSpec(
             action_id=SCHOLARLY_PAPER_RESOLVE_TOPICS_ACTION_ID,
             handler=_build_scholarly_paper_resolve_topics_handler(),
-            description="Resolve or create topic concepts for a scholarly paper.",
+            description=(
+                "Normalise public topic labels without minting name-only topic "
+                "concepts."
+            ),
         )
     )
     registry.register_if_absent(

--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "26",
+  "seed_version": "27",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
@@ -32,7 +32,7 @@
       ]
     }
   },
-  "source_tag": "JVNAUTOSCI-2434",
+  "source_tag": "JVNAUTOSCI-2670",
   "supported_action_ids": [
     "scholarly_paper.normalise_inputs",
     "scholarly_paper.normalise_external_identity",
@@ -46,23 +46,21 @@
     "get_paper_metadata",
     "import_url_file_copy",
     "workflow_invoke_subworkflow",
-    "scholarly_paper.enrich_from_metadata",
-    "scholarly_paper.materialise_from_file_copy",
     "workflow_control.context_set",
     "workflow_control.context_template",
     "workflow_control.for_each",
     "paper_reference.normalise_reference_set",
     "paper_reference.fail_item",
     "resolve_concept_by_name",
+    "resolve_publication_scope_profile",
     "create_concepts",
+    "add_relationship",
+    "upsert_scoped_assertion",
     "upsert_text_relation",
     "fetch_concept_content",
     "get_text_relations_summary",
-    "scholarly_paper.ensure_paper_concept",
-    "scholarly_paper.link_file_copy",
-    "scholarly_paper.attach_metadata",
     "scholarly_paper.resolve_topics",
-    "scholarly_paper.assert_source_identity"
+    "llm.action"
   ],
   "workflows": [
     {
@@ -502,27 +500,49 @@
                 ]
               }
             ],
-            "next_state": "normalise_external_identity",
-            "conditional_transitions": [
+            "next_state": "resolve_paper_instance_scope"
+          },
+          {
+            "state_id": "resolve_paper_instance_scope",
+            "action_id": "resolve_publication_scope_profile",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
               {
-                "to_state": "attach_metadata",
-                "reason": "existing_article_concept_supplied",
-                "condition_spec": {
-                  "kind": "all",
-                  "conditions": [
-                    {
-                      "kind": "context_exists",
-                      "key": "paper_concept_id",
-                      "expected": true
-                    },
-                    {
-                      "kind": "context_is_null",
-                      "key": "paper_concept_id",
-                      "expected": false
-                    }
-                  ]
-                }
+                "key": "plane",
+                "value": "instance"
+              },
+              {
+                "key": "type_concept_ids",
+                "value": [
+                  "#V#scholarly_article"
+                ]
+              },
+              {
+                "key": "source_kind",
+                "value": "public_scholarly_metadata"
+              },
+              {
+                "key": "producer",
+                "value": "#V#scholarly_article_metadata_representation_workflow"
               }
+            ],
+            "next_state": "normalise_external_identity",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_paper_scope_selected_to_paper_instance_scope_mode",
+                "context_key": "paper_instance_scope_mode",
+                "tool_output_field": "selected_scope_mode"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_paper_scope_evidence_to_paper_scope_decision_evidence",
+                "context_key": "paper_scope_decision_evidence",
+                "tool_output_field": "decision_evidence"
+              }
+            ],
+            "writes_context_keys": [
+              "paper_instance_scope_mode",
+              "paper_scope_decision_evidence"
             ]
           },
           {
@@ -553,17 +573,38 @@
                 "context_key": "paper_metadata",
                 "required": false,
                 "tool_param": "paper_metadata"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_normalise_external_identity_paper_scope_to_paper_instance_scope_mode_parameter",
+                "context_key": "paper_instance_scope_mode",
+                "required": true,
+                "tool_param": "paper_instance_scope_mode"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_normalise_external_identity_paper_concept_id_to_paper_concept_id_parameter",
+                "context_key": "paper_concept_id",
+                "required": false,
+                "tool_param": "paper_concept_id"
               }
             ],
             "next_state": "resolve_existing_article",
             "conditional_transitions": [
               {
                 "to_state": "attach_metadata",
-                "reason": "actor_private_external_identity_resolved",
+                "reason": "global_external_identity_resolved",
                 "condition_spec": {
                   "kind": "context_value_equals",
                   "key": "paper_external_identity_resolution_status",
                   "value": "resolved"
+                }
+              },
+              {
+                "to_state": "attach_metadata",
+                "reason": "supplied_global_article_validated",
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "paper_external_identity_resolution_status",
+                  "value": "supplied"
                 }
               },
               {
@@ -639,7 +680,7 @@
               },
               {
                 "key": "require_actor_private",
-                "value": true
+                "value": false
               },
               {
                 "key": "max_results",
@@ -725,7 +766,7 @@
               },
               {
                 "key": "error_message",
-                "value": "An actor-private scholarly article has the same title, but no stable identity or sufficient bibliographic fingerprint proves that it is the same paper. No mutation was attempted."
+                "value": "A visible scholarly article has the same title, but no stable identity or sufficient bibliographic fingerprint proves that it is the same paper. No mutation was attempted."
               }
             ],
             "on_failure_state": "failed"
@@ -771,7 +812,9 @@
               },
               {
                 "key": "scope_mode",
-                "value": "user_only_default"
+                "value": {
+                  "$context_key": "paper_instance_scope_mode"
+                }
               }
             ],
             "next_state": "capture_article_concept",
@@ -818,6 +861,12 @@
               {
                 "key": "allow_duplicate_instances",
                 "value": false
+              },
+              {
+                "key": "scope_mode",
+                "value": {
+                  "$context_key": "paper_instance_scope_mode"
+                }
               }
             ],
             "next_state": "capture_article_concept",
@@ -862,58 +911,202 @@
           },
           {
             "state_id": "attach_metadata",
-            "action_id": "scholarly_paper.attach_metadata",
+            "action_id": "workflow_control.context_set",
             "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "assignments",
+                "value": [
+                  {
+                    "key": "metadata_attach_gate",
+                    "value": "public_scholarly_metadata"
+                  }
+                ]
+              }
+            ],
+            "next_state": "decide_summary_metadata",
+            "conditional_transitions": [
+              {
+                "to_state": "attach_title_metadata",
+                "reason": "public_title_present",
+                "condition_spec": {
+                  "kind": "context_exists",
+                  "key": "title",
+                  "expected": true
+                }
+              }
+            ]
+          },
+          {
+            "state_id": "attach_title_metadata",
+            "action_id": "upsert_text_relation",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_metadata_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "hasName"
+              },
+              {
+                "key": "context",
+                "value": {
+                  "name_type": "NL",
+                  "source": "public_scholarly_metadata"
+                }
+              }
+            ],
             "context_input_mapping_specs": [
               {
-                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_metadata_paper_concept_id_to_paper_concept_id_parameter",
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_title_paper_to_concept_id_parameter",
                 "context_key": "paper_concept_id",
                 "required": true,
-                "tool_param": "paper_concept_id"
+                "tool_param": "concept_id"
               },
               {
-                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_metadata_paper_metadata_to_paper_metadata_parameter",
-                "context_key": "paper_metadata",
-                "required": false,
-                "tool_param": "paper_metadata"
-              },
-              {
-                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_metadata_title_to_title_parameter",
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_title_text_to_text_parameter",
                 "context_key": "title",
-                "required": false,
-                "tool_param": "title"
+                "required": true,
+                "tool_param": "text"
+              }
+            ],
+            "next_state": "decide_summary_metadata",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "decide_summary_metadata",
+            "action_id": "workflow_control.context_set",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "assignments",
+                "value": [
+                  {
+                    "key": "summary_attach_gate",
+                    "value": "optional"
+                  }
+                ]
+              }
+            ],
+            "next_state": "decide_publication_date_metadata",
+            "conditional_transitions": [
+              {
+                "to_state": "attach_summary_metadata",
+                "reason": "public_summary_present",
+                "condition_spec": {
+                  "kind": "context_exists",
+                  "key": "summary",
+                  "expected": true
+                }
+              }
+            ]
+          },
+          {
+            "state_id": "attach_summary_metadata",
+            "action_id": "upsert_text_relation",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_metadata_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "hasDescription"
               },
               {
-                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_metadata_summary_to_summary_parameter",
+                "key": "context",
+                "value": {
+                  "source": "public_scholarly_metadata"
+                }
+              }
+            ],
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_summary_paper_to_concept_id_parameter",
+                "context_key": "paper_concept_id",
+                "required": true,
+                "tool_param": "concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_summary_text_to_text_parameter",
                 "context_key": "summary",
-                "required": false,
-                "tool_param": "summary"
-              },
+                "required": true,
+                "tool_param": "text"
+              }
+            ],
+            "next_state": "decide_publication_date_metadata",
+            "on_failure_state": "failed"
+          },
+          {
+            "state_id": "decide_publication_date_metadata",
+            "action_id": "workflow_control.context_set",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
               {
-                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_metadata_publication_date_to_publication_date_parameter",
-                "context_key": "publication_date",
-                "required": false,
-                "tool_param": "publication_date"
+                "key": "assignments",
+                "value": [
+                  {
+                    "key": "publication_date_attach_gate",
+                    "value": "optional"
+                  }
+                ]
               }
             ],
             "next_state": "resolve_authors",
-            "on_failure_state": "failed",
-            "tool_output_mapping_specs": [
+            "conditional_transitions": [
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_attach_metadata_paper_concept_id_to_paper_concept_id",
-                "context_key": "paper_concept_id",
-                "tool_output_field": "paper_concept_id"
+                "to_state": "attach_publication_date_metadata",
+                "reason": "public_publication_date_present",
+                "condition_spec": {
+                  "kind": "context_exists",
+                  "key": "publication_date",
+                  "expected": true
+                }
+              }
+            ]
+          },
+          {
+            "state_id": "attach_publication_date_metadata",
+            "action_id": "upsert_text_relation",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_metadata_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "#V#has_publication_date"
               },
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_attach_metadata_metadata_attached_to_metadata_attached",
-                "context_key": "metadata_attached",
-                "tool_output_field": "metadata_attached"
+                "key": "context",
+                "value": {
+                  "source": "public_scholarly_metadata"
+                }
               }
             ],
-            "writes_context_keys": [
-              "paper_concept_id",
-              "metadata_attached"
-            ]
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_date_paper_to_concept_id_parameter",
+                "context_key": "paper_concept_id",
+                "required": true,
+                "tool_param": "concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_date_text_to_text_parameter",
+                "context_key": "publication_date",
+                "required": true,
+                "tool_param": "text"
+              }
+            ],
+            "next_state": "resolve_authors",
+            "on_failure_state": "failed"
           },
           {
             "state_id": "resolve_authors",
@@ -934,16 +1127,91 @@
               }
             ],
             "next_state": "resolve_topics",
+            "conditional_transitions": [
+              {
+                "to_state": "dispatch_public_authors",
+                "reason": "public_author_records_present",
+                "condition_spec": {
+                  "kind": "context_compare",
+                  "key": "public_author_count",
+                  "operator": "gt",
+                  "value": 0
+                }
+              }
+            ],
             "on_failure_state": "failed",
             "tool_output_mapping_specs": [
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_authors_author_concept_ids_to_author_concept_ids",
-                "context_key": "author_concept_ids",
-                "tool_output_field": "author_concept_ids"
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_authors_records_to_public_author_records",
+                "context_key": "public_author_records",
+                "tool_output_field": "public_author_records"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_authors_count_to_public_author_count",
+                "context_key": "public_author_count",
+                "tool_output_field": "public_author_count"
               }
             ],
             "writes_context_keys": [
-              "author_concept_ids"
+              "public_author_records",
+              "public_author_count"
+            ]
+          },
+          {
+            "state_id": "dispatch_public_authors",
+            "action_id": "workflow_control.for_each",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              [
+                "workflow_id",
+                "#V#scholarly_public_author_representation_workflow"
+              ],
+              [
+                "items_context_key",
+                "public_author_records"
+              ],
+              [
+                "item_context_key",
+                "current_public_author"
+              ],
+              [
+                "index_context_key",
+                "public_author_index"
+              ],
+              [
+                "success_policy",
+                "all_must_succeed"
+              ],
+              [
+                "max_items",
+                200
+              ],
+              [
+                "max_concurrency",
+                1
+              ],
+              [
+                "max_transitions",
+                30
+              ]
+            ],
+            "next_state": "resolve_topics",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_dispatch_authors_results_to_public_author_iteration_results",
+                "context_key": "public_author_iteration_results",
+                "tool_output_field": "iteration_results"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_dispatch_authors_success_count_to_public_author_success_count",
+                "context_key": "public_author_success_count",
+                "tool_output_field": "for_each_success_count"
+              }
+            ],
+            "writes_context_keys": [
+              "public_author_iteration_results",
+              "public_author_success_count"
             ]
           },
           {
@@ -965,16 +1233,81 @@
               }
             ],
             "next_state": "decide_arxiv_identity",
+            "conditional_transitions": [
+              {
+                "to_state": "attach_topic_labels",
+                "reason": "public_topic_labels_present",
+                "condition_spec": {
+                  "kind": "context_flag",
+                  "key": "topic_labels_present",
+                  "expected": true
+                }
+              }
+            ],
             "on_failure_state": "failed",
             "tool_output_mapping_specs": [
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_topics_topic_concept_ids_to_topic_concept_ids",
-                "context_key": "topic_concept_ids",
-                "tool_output_field": "topic_concept_ids"
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_topics_labels_text_to_topic_labels_text",
+                "context_key": "topic_labels_text",
+                "tool_output_field": "topic_labels_text"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_topics_present_to_topic_labels_present",
+                "context_key": "topic_labels_present",
+                "tool_output_field": "topic_labels_present"
               }
             ],
             "writes_context_keys": [
-              "topic_concept_ids"
+              "topic_labels_text",
+              "topic_labels_present"
+            ]
+          },
+          {
+            "state_id": "attach_topic_labels",
+            "action_id": "upsert_text_relation",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_metadata_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "#V#has_topic_labels"
+              },
+              {
+                "key": "context",
+                "value": {
+                  "source": "public_scholarly_metadata"
+                }
+              }
+            ],
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_topics_paper_to_concept_id_parameter",
+                "context_key": "paper_concept_id",
+                "required": true,
+                "tool_param": "concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_attach_topics_text_to_text_parameter",
+                "context_key": "topic_labels_text",
+                "required": true,
+                "tool_param": "text"
+              }
+            ],
+            "next_state": "decide_arxiv_identity",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_attach_topics_result_to_topic_labels_write_result",
+                "context_key": "topic_labels_write_result",
+                "tool_output_field": "result"
+              }
+            ],
+            "writes_context_keys": [
+              "topic_labels_write_result"
             ]
           },
           {
@@ -1259,7 +1592,7 @@
             "next_state": "read_back_article",
             "conditional_transitions": [
               {
-                "to_state": "link_optional_file_copy",
+                "to_state": "resolve_file_link_scope",
                 "reason": "file_copy_present",
                 "condition_spec": {
                   "kind": "context_exists",
@@ -1270,34 +1603,117 @@
             ]
           },
           {
-            "state_id": "link_optional_file_copy",
-            "action_id": "scholarly_paper.link_file_copy",
+            "state_id": "resolve_file_link_scope",
+            "action_id": "resolve_publication_scope_profile",
             "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "plane",
+                "value": "assertion"
+              },
+              {
+                "key": "predicate_concept_id",
+                "value": "#V#local_file_copy"
+              },
+              {
+                "key": "subject_type_concept_ids",
+                "value": [
+                  "#V#scholarly_article"
+                ]
+              },
+              {
+                "key": "object_type_concept_ids",
+                "value": [
+                  "#V#computer_file_copy"
+                ]
+              },
+              {
+                "key": "source_kind",
+                "value": "private_email"
+              },
+              {
+                "key": "producer",
+                "value": "#V#scholarly_article_metadata_representation_workflow"
+              }
+            ],
+            "next_state": "link_optional_file_copy",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_file_scope_carrier_to_file_link_scope_mode",
+                "context_key": "file_link_scope_mode",
+                "tool_output_field": "carrier.scope_mode"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_resolve_file_scope_evidence_to_file_link_scope_evidence",
+                "context_key": "file_link_scope_evidence",
+                "tool_output_field": "decision_evidence"
+              }
+            ],
+            "writes_context_keys": [
+              "file_link_scope_mode",
+              "file_link_scope_evidence"
+            ]
+          },
+          {
+            "state_id": "link_optional_file_copy",
+            "action_id": "upsert_scoped_assertion",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "private_file_link_scoped_assertion"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "#V#local_file_copy"
+              },
+              {
+                "key": "evidence",
+                "value": {
+                  "source_kind": "private_email",
+                  "workflow_id": "#V#scholarly_article_metadata_representation_workflow"
+                }
+              }
+            ],
             "context_input_mapping_specs": [
               {
                 "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_link_optional_file_copy_paper_concept_id_to_paper_concept_id_parameter",
                 "context_key": "paper_concept_id",
                 "required": true,
-                "tool_param": "paper_concept_id"
+                "tool_param": "subject_concept_id"
               },
               {
                 "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_link_optional_file_copy_file_copy_concept_id_to_file_copy_concept_id_parameter",
                 "context_key": "file_copy_concept_id",
                 "required": true,
-                "tool_param": "file_copy_concept_id"
+                "tool_param": "target_concept_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_article_metadata_representation_workflow_link_optional_file_copy_scope_to_scope_mode_parameter",
+                "context_key": "file_link_scope_mode",
+                "required": true,
+                "tool_param": "scope_mode"
               }
             ],
             "next_state": "read_back_article",
             "on_failure_state": "failed",
             "tool_output_mapping_specs": [
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_link_optional_file_copy_file_link_written_to_file_link_written",
-                "context_key": "file_link_written",
-                "tool_output_field": "file_link_written"
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_link_optional_file_copy_assertion_id_to_file_link_assertion_id",
+                "context_key": "file_link_assertion_id",
+                "tool_output_field": "assertion_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_article_metadata_representation_workflow_link_optional_file_copy_readback_to_file_link_canonical_read_back",
+                "context_key": "file_link_canonical_read_back",
+                "tool_output_field": "canonical_read_back"
               }
             ],
             "writes_context_keys": [
-              "file_link_written"
+              "file_link_assertion_id",
+              "file_link_canonical_read_back"
             ]
           },
           {
@@ -1342,7 +1758,9 @@
                   "hasName",
                   "hasDescription",
                   "#V#has_doi",
-                  "#V#has_source_uri"
+                  "#V#has_source_uri",
+                  "#V#has_publication_date",
+                  "#V#has_topic_labels"
                 ]
               },
               {
@@ -1480,6 +1898,255 @@
               "observations",
               "metadata_verification",
               "verification_passed"
+            ]
+          },
+          {
+            "state_id": "completed"
+          },
+          {
+            "state_id": "failed"
+          }
+        ]
+      }
+    },
+    {
+      "workflow_id": "#V#scholarly_public_author_representation_workflow",
+      "display_name": "Scholarly Public Author Representation Workflow",
+      "description": "Represent one public scholarly author through stable public identity evidence or a paper-source-bounded candidate, then add globally published authorship without name-only merging.",
+      "content": "Resolve the represented person instance scope, create or reuse the exact public author identity selected by the parent scholarly workflow, resolve the authored-by predicate scope, add the canonical public authorship relation, and preserve source-bounded candidate identity when no cross-paper identifier is available.",
+      "text_relations": [
+        {
+          "predicate": "#V#hasWorkflowLifecycleJson",
+          "text": "{\"phase\": \"published\", \"published\": true, \"schema_version\": \"workflow_publication_lifecycle.v1\"}",
+          "lang": "en-NZ"
+        },
+        {
+          "predicate": "#V#hasWorkflowTerminalSuccessContractJson",
+          "text": "{\"schema_version\":\"workflow_terminal_success_contract.v1\",\"success_statuses\":[\"completed\"],\"required_summary_fields\":[\"workflow_id\",\"terminal_status\",\"final_state\",\"completed\"],\"require_terminal_status\":true,\"require_final_state\":true,\"require_completed_true\":true,\"require_completion_gate_safe_to_claim_completion\":false}",
+          "lang": "en-NZ"
+        }
+      ],
+      "publication_spec": {
+        "initial_state": "resolve_author_instance_scope",
+        "steps": [
+          {
+            "state_id": "resolve_author_instance_scope",
+            "action_id": "resolve_publication_scope_profile",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "plane",
+                "value": "instance"
+              },
+              {
+                "key": "type_concept_ids",
+                "value": [
+                  "#V#person"
+                ]
+              },
+              {
+                "key": "source_kind",
+                "value": "public_scholarly_metadata"
+              },
+              {
+                "key": "stable_identity_present",
+                "value": true
+              },
+              {
+                "key": "producer",
+                "value": "#V#scholarly_public_author_representation_workflow"
+              }
+            ],
+            "next_state": "create_public_author",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_public_author_representation_workflow_resolve_scope_selected_to_author_instance_scope_mode",
+                "context_key": "author_instance_scope_mode",
+                "tool_output_field": "selected_scope_mode"
+              }
+            ],
+            "writes_context_keys": [
+              "author_instance_scope_mode"
+            ]
+          },
+          {
+            "state_id": "create_public_author",
+            "action_id": "create_concepts",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_author_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "parent_id",
+                "value": "#V#person"
+              },
+              {
+                "key": "concepts",
+                "value": [
+                  {
+                    "name": {
+                      "$context_key": "current_public_author.name"
+                    },
+                    "kind": "instance",
+                    "description": {
+                      "$context_key": "current_public_author.description"
+                    },
+                    "concept_id": {
+                      "$context_key": "current_public_author.concept_id"
+                    }
+                  }
+                ]
+              },
+              {
+                "key": "allow_duplicate_instances",
+                "value": false
+              },
+              {
+                "key": "duplicate_resolution_mode",
+                "value": "canonical_id_only"
+              },
+              {
+                "key": "scope_mode",
+                "value": {
+                  "$context_key": "author_instance_scope_mode"
+                }
+              }
+            ],
+            "next_state": "capture_public_author",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_public_author_representation_workflow_create_result_to_public_author_create_result",
+                "context_key": "public_author_create_result",
+                "tool_output_field": "result"
+              }
+            ],
+            "writes_context_keys": [
+              "public_author_create_result"
+            ]
+          },
+          {
+            "state_id": "capture_public_author",
+            "action_id": "workflow_control.context_set",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "assignments",
+                "value": [
+                  {
+                    "key": "author_concept_id",
+                    "value_from_context": "public_author_create_result.results.0.concept_id"
+                  }
+                ]
+              }
+            ],
+            "next_state": "resolve_authorship_assertion_scope",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_public_author_representation_workflow_capture_author_id_to_author_concept_id",
+                "context_key": "author_concept_id",
+                "tool_output_field": "author_concept_id"
+              }
+            ],
+            "writes_context_keys": [
+              "author_concept_id"
+            ]
+          },
+          {
+            "state_id": "resolve_authorship_assertion_scope",
+            "action_id": "resolve_publication_scope_profile",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              {
+                "key": "plane",
+                "value": "assertion"
+              },
+              {
+                "key": "predicate_concept_id",
+                "value": "#V#authored_by"
+              },
+              {
+                "key": "subject_type_concept_ids",
+                "value": [
+                  "#V#scholarly_article"
+                ]
+              },
+              {
+                "key": "object_type_concept_ids",
+                "value": [
+                  "#V#person"
+                ]
+              },
+              {
+                "key": "source_kind",
+                "value": "public_scholarly_metadata"
+              },
+              {
+                "key": "stable_identity_present",
+                "value": true
+              },
+              {
+                "key": "producer",
+                "value": "#V#scholarly_public_author_representation_workflow"
+              }
+            ],
+            "next_state": "add_public_authorship",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_public_author_representation_workflow_resolve_authorship_scope_selected_to_authorship_scope_mode",
+                "context_key": "authorship_scope_mode",
+                "tool_output_field": "selected_scope_mode"
+              }
+            ],
+            "writes_context_keys": [
+              "authorship_scope_mode"
+            ]
+          },
+          {
+            "state_id": "add_public_authorship",
+            "action_id": "add_relationship",
+            "execution_mode": "deterministic",
+            "mutation_authority": {
+              "schema_version": "workflow_step_mutation_authority.v1",
+              "maximum_level": "additive_vontology",
+              "reason_code": "public_scholarly_authorship_additive_writes"
+            },
+            "static_input_bindings": [
+              {
+                "key": "predicate",
+                "value": "#V#authored_by"
+              }
+            ],
+            "context_input_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_public_author_representation_workflow_add_authorship_paper_to_source_id_parameter",
+                "context_key": "paper_concept_id",
+                "required": true,
+                "tool_param": "source_id"
+              },
+              {
+                "concept_id": "#V#workflow_mapping_scholarly_public_author_representation_workflow_add_authorship_author_to_target_parameter",
+                "context_key": "author_concept_id",
+                "required": true,
+                "tool_param": "target"
+              }
+            ],
+            "next_state": "completed",
+            "on_failure_state": "failed",
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_scholarly_public_author_representation_workflow_add_authorship_result_to_authorship_write_result",
+                "context_key": "authorship_write_result",
+                "tool_output_field": "result"
+              }
+            ],
+            "writes_context_keys": [
+              "authorship_write_result"
             ]
           },
           {
@@ -1738,16 +2405,6 @@
                 "tool_output_field": "result.paper_concept_id"
               },
               {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_paper_representation_workflow_delegate_to_metadata_workflow_result_author_concept_ids_to_author_concept_ids",
-                "context_key": "author_concept_ids",
-                "tool_output_field": "result.author_concept_ids"
-              },
-              {
-                "concept_id": "#V#workflow_mapping_tool_field_scholarly_paper_representation_workflow_delegate_to_metadata_workflow_result_topic_concept_ids_to_topic_concept_ids",
-                "context_key": "topic_concept_ids",
-                "tool_output_field": "result.topic_concept_ids"
-              },
-              {
                 "concept_id": "#V#workflow_mapping_tool_field_scholarly_paper_representation_workflow_delegate_to_metadata_workflow_result_article_readback_to_article_readback",
                 "context_key": "article_readback",
                 "tool_output_field": "result.article_readback"
@@ -1755,8 +2412,6 @@
             ],
             "writes_context_keys": [
               "paper_concept_id",
-              "author_concept_ids",
-              "topic_concept_ids",
               "article_readback"
             ]
           },
@@ -2821,16 +3476,6 @@
                 "tool_output_field": "result.paper_concept_id"
               },
               {
-                "concept_id": "#V#workflow_mapping_tool_field_arxiv_paper_representation_workflow_delegate_to_general_paper_workflow_result_author_concept_ids_to_author_concept_ids",
-                "context_key": "author_concept_ids",
-                "tool_output_field": "result.author_concept_ids"
-              },
-              {
-                "concept_id": "#V#workflow_mapping_tool_field_arxiv_paper_representation_workflow_delegate_to_general_paper_workflow_result_topic_concept_ids_to_topic_concept_ids",
-                "context_key": "topic_concept_ids",
-                "tool_output_field": "result.topic_concept_ids"
-              },
-              {
                 "concept_id": "#V#workflow_mapping_tool_field_arxiv_paper_representation_workflow_delegate_to_general_paper_workflow_result_article_readback_to_article_readback",
                 "context_key": "article_readback",
                 "tool_output_field": "result.article_readback"
@@ -2838,8 +3483,6 @@
             ],
             "writes_context_keys": [
               "paper_concept_id",
-              "author_concept_ids",
-              "topic_concept_ids",
               "article_readback"
             ]
           },
@@ -3986,7 +4629,40 @@
         "#V#predicate"
       ],
       "create_as_instance": true,
+      "preserve_existing_authority": true,
       "description": "Predicate for a source URI text relation that records the authoritative external source URL used to represent a scholarly work or other sourced artefact.",
+      "system_tags": [
+        "ontology",
+        "predicate",
+        "scholarly_metadata",
+        "workflow-support"
+      ]
+    },
+    {
+      "concept_id": "#V#has_publication_date",
+      "name": "Has publication date",
+      "parent_concept_ids": [
+        "#V#predicate"
+      ],
+      "create_as_instance": true,
+      "preserve_existing_authority": true,
+      "description": "Predicate for the public scholarly publication date supplied by a bibliographic source.",
+      "system_tags": [
+        "ontology",
+        "predicate",
+        "scholarly_metadata",
+        "workflow-support"
+      ]
+    },
+    {
+      "concept_id": "#V#has_topic_labels",
+      "name": "Has topic labels",
+      "parent_concept_ids": [
+        "#V#predicate"
+      ],
+      "create_as_instance": true,
+      "preserve_existing_authority": true,
+      "description": "Predicate for public source-supplied scholarly topic or category labels without minting topic identities from labels alone.",
       "system_tags": [
         "ontology",
         "predicate",

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -10,9 +10,7 @@ import pytest
 def test_json_safe_treats_naive_pymongo_datetimes_as_utc() -> None:
     from src.backend.services import ontology_publication_authority_service as service
 
-    stored = datetime(2026, 8, 13, 17, 5, 57, 150000, tzinfo=UTC).replace(
-        tzinfo=None
-    )
+    stored = datetime(2026, 8, 13, 17, 5, 57, 150000, tzinfo=UTC).replace(tzinfo=None)
 
     assert service._json_safe(stored) == "2026-08-13T17:05:57.150000+00:00"
 
@@ -734,20 +732,33 @@ def test_admitted_actor_bound_workflow_retains_exact_private_authority(
 
 
 @pytest.mark.parametrize(
-    "publication_context,source_contexts",
+    "publication_context,source_contexts,expected_reason_code",
     (
-        ("other_user", ()),
-        ("organisation", ()),
-        ("global", ()),
-        ("historical", ()),
-        ("private", ("other_user",)),
+        (
+            "other_user",
+            (),
+            "private_scope_canonical_publication_not_delegated",
+        ),
+        (
+            "organisation",
+            (),
+            "organisation_ontology_admin_authority_required",
+        ),
+        ("global", (), "global_ontology_admin_authority_required"),
+        ("historical", (), "explicit_scope_adoption_required"),
+        (
+            "private",
+            ("other_user",),
+            "private_scope_canonical_publication_not_delegated",
+        ),
     ),
 )
-def test_actor_bound_workflow_cannot_cross_private_context_boundary(
+def test_actor_bound_workflow_rechecks_each_requested_context_live(
     authority_stores,
     monkeypatch,
     publication_context,
     source_contexts,
+    expected_reason_code,
 ):
     service, _delegations, _receipts = authority_stores
     monkeypatch.setattr(
@@ -789,7 +800,65 @@ def test_actor_bound_workflow_cannot_cross_private_context_boundary(
         decision = service.authorise_ontology_mutation(intent)
 
     assert decision.allowed is False
-    assert decision.reason_code == "ontology_agent_delegation_required"
+    assert decision.reason_code == expected_reason_code
+
+
+@pytest.mark.parametrize("scope_kind", ("organisation", "global"))
+def test_actor_bound_workflow_may_exercise_matching_live_semantic_role(
+    authority_stores,
+    monkeypatch,
+    scope_kind,
+):
+    service, _delegations, _receipts = authority_stores
+    monkeypatch.setattr(
+        service,
+        "_gateway_actor_trust_source",
+        lambda: "preexisting_authenticated_or_workflow_context",
+    )
+    if scope_kind == "organisation":
+        context = service.PublicationContext.organisation("#V#organisation")
+        role = _evidence(
+            service,
+            actor="#V#actor",
+            role=service.ORGANISATION_ONTOLOGY_ADMINISTRATOR_ROLE,
+            organisation="#V#organisation",
+        )
+    else:
+        context = service.PublicationContext.global_context()
+        role = _evidence(
+            service,
+            actor="#V#actor",
+            role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        )
+    monkeypatch.setattr(
+        service,
+        "resolve_live_semantic_roles",
+        lambda actor: (role,) if actor == "#V#actor" else (),
+    )
+    intent = service.OntologyMutationIntent(
+        operation="concept.create",
+        publication_context=context,
+        target_concept_ids=("#V#paper",),
+        tool_name="create_concepts",
+        delta={"names": ["A paper"]},
+    )
+
+    with (
+        service.override_current_actor("#V#actor", "#V#organisation"),
+        service.bind_ontology_invocation(
+            surface="workflow",
+            executing_agent_concept_id="#V#von_system",
+            audience="workflow",
+            effect_id=f"workflow:paper:create:{scope_kind}",
+            workflow_id="#V#paper_workflow",
+            actor_bound_workflow_effect=True,
+        ),
+    ):
+        decision = service.authorise_ontology_mutation(intent)
+
+    assert decision.allowed is True
+    assert decision.reason_code == "semantic_ontology_authority_verified"
+    assert decision.role_evidence == (role,)
 
 
 def test_actor_bound_workflow_marker_requires_workflow_and_gateway_trust(

--- a/tests/backend/test_paper_representation_workflow.py
+++ b/tests/backend/test_paper_representation_workflow.py
@@ -7,11 +7,11 @@ from src.backend.services.ontology_publication_authority_service import (
 )
 from src.backend.workflows.action_registry import ActionRegistry, WorkflowEnvironment
 from src.backend.workflows.durable.paper_representation_workflow import (
-    ARXIV_DECIDE_ACQUISITION_MODE_ACTION_ID,
     ARXIV_ACQUISITION_MODE_DOWNLOAD_FROM_SOURCE,
     ARXIV_ACQUISITION_MODE_EXISTING_FILE_COPY,
     ARXIV_ACQUISITION_MODE_FINALISE_CACHED_PDF,
     ARXIV_ACQUISITION_MODE_REACQUIRE_PARTIAL_CACHE,
+    ARXIV_DECIDE_ACQUISITION_MODE_ACTION_ID,
     ARXIV_NORMALISE_SOURCE_ACTION_ID,
     SCHOLARLY_PAPER_ENRICH_ACTION_ID,
     SCHOLARLY_PAPER_ENSURE_PAPER_CONCEPT_ACTION_ID,
@@ -22,7 +22,6 @@ from src.backend.workflows.durable.paper_representation_workflow import (
     SCHOLARLY_PAPER_VERIFY_ACTION_ID,
     register_paper_representation_actions,
 )
-
 
 _ACTOR_CONCEPT_ID = "#V#paper_workflow_actor"
 
@@ -71,9 +70,11 @@ def test_ensure_arxiv_paper_rejects_existing_shared_target_before_mutation(
     monkeypatch.setattr(
         mod,
         "concept_publication_context",
-        lambda concept_id: paper_context
-        if concept_id == predicted_paper_id
-        else PublicationContext.global_context(),
+        lambda concept_id: (
+            paper_context
+            if concept_id == predicted_paper_id
+            else PublicationContext.global_context()
+        ),
     )
     monkeypatch.setattr(
         arxiv_paper_link_service,
@@ -107,7 +108,7 @@ def test_ensure_arxiv_paper_rejects_existing_shared_target_before_mutation(
     assert mutation_calls == []
 
 
-def test_link_file_copy_rejects_shared_file_before_mutating_either_record(
+def test_link_file_copy_rejects_non_global_paper_before_writing_scoped_assertion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from src.backend.services import arxiv_paper_link_service
@@ -145,8 +146,8 @@ def test_link_file_copy_rejects_shared_file_before_mutating_either_record(
     )
 
     assert result.status == "failed"
-    assert result.error == "scholarly_paper_actor_private_target_required"
-    assert result.outputs["mutation_target_concept_id"] == file_copy_concept_id
+    assert result.error == "scholarly_paper_global_target_required"
+    assert result.outputs["mutation_target_concept_id"] == paper_concept_id
     assert link_calls == []
 
 
@@ -174,7 +175,7 @@ def test_sessionless_custom_mutation_ignores_payload_actor_and_writes_nothing(
     )
 
     assert result.status == "failed"
-    assert result.error == "scholarly_paper_actor_private_target_required"
+    assert result.error == "scholarly_paper_mutation_target_missing"
     assert text_writes == []
 
 
@@ -224,9 +225,7 @@ def test_missing_schema_support_fails_without_on_demand_global_creation(
 
     assert result.status == "failed"
     assert result.error == "scholarly_paper_schema_support_missing"
-    assert result.outputs["missing_schema_concept_ids"] == [
-        "#V#scholarly_article"
-    ]
+    assert result.outputs["missing_schema_concept_ids"] == ["#V#scholarly_article"]
     assert mutation_calls == []
 
 
@@ -248,7 +247,9 @@ def test_guarded_materialisation_skips_inner_on_demand_schema_ensure(
     }
     materialisation_calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(mod, "_concept_exists", lambda concept_id: concept_id in schema_ids)
+    monkeypatch.setattr(
+        mod, "_concept_exists", lambda concept_id: concept_id in schema_ids
+    )
     monkeypatch.setattr(
         mod,
         "validate_predicate_concept",
@@ -257,9 +258,11 @@ def test_guarded_materialisation_skips_inner_on_demand_schema_ensure(
     monkeypatch.setattr(
         mod,
         "concept_publication_context",
-        lambda concept_id: PublicationContext.user(_ACTOR_CONCEPT_ID)
-        if concept_id == file_copy_concept_id
-        else PublicationContext.global_context(),
+        lambda concept_id: (
+            PublicationContext.user(_ACTOR_CONCEPT_ID)
+            if concept_id == file_copy_concept_id
+            else PublicationContext.global_context()
+        ),
     )
     monkeypatch.setattr(
         arxiv_paper_link_service,
@@ -298,70 +301,37 @@ def test_guarded_materialisation_skips_inner_on_demand_schema_ensure(
     assert materialisation_calls[0]["schema_support_preprovisioned"] is True
 
 
-def test_actor_bound_schema_preflight_uses_hard_predicate_authority_view(
+def test_resolve_authors_uses_scope_profiles_without_mutating_concepts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from src.backend.security import access_control
     from src.backend.workflows.durable import paper_representation_workflow as mod
 
-    paper_concept_id = "#V#actor_private_schema_preflight_paper"
-    author_concept_id = "#V#actor_private_schema_preflight_author"
-    relationship_calls: list[tuple[str, str, str]] = []
+    paper_concept_id = "#V#global_scope_profile_paper"
 
     monkeypatch.setattr(
         mod,
-        "_concept_exists",
-        lambda concept_id: concept_id in {"#V#person", "#V#authored_by"},
+        "_require_preprovisioned_schema_support",
+        lambda **_kwargs: None,
     )
     monkeypatch.setattr(
         mod,
-        "_get_concept",
-        lambda concept_id: {
-            "concept_id": concept_id,
-            "relationships": {},
+        "_require_global_targets",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        mod,
+        "resolve_publication_scope_profile",
+        lambda **kwargs: {
+            "success": True,
+            "plane": kwargs["plane"],
+            "selected_scope_mode": "global_general",
         },
     )
-    monkeypatch.setattr(
-        mod,
-        "concept_publication_context",
-        lambda _concept_id: PublicationContext.user(_ACTOR_CONCEPT_ID),
-    )
-    monkeypatch.setattr(
-        mod,
-        "predict_scholarly_author_concept_id",
-        lambda **_kwargs: author_concept_id,
-    )
-    monkeypatch.setattr(
-        mod,
-        "resolve_or_create_scholarly_author_concept_id",
-        lambda **_kwargs: author_concept_id,
-    )
-    monkeypatch.setattr(
-        mod,
-        "add_relationship",
-        lambda **kwargs: relationship_calls.append(
-            (kwargs["source_id"], kwargs["predicate"], kwargs["target"])
-        ),
-    )
-
-    def _find_predicate(filter_doc: dict[str, object], projection=None):
-        del projection
-        assert access_control._BYPASS.get() is True
-        return {
-            "concept_id": filter_doc["concept_id"],
-            "relationships": {"is_an_instance_of": ["#V#predicate"]},
-        }
-
-    monkeypatch.setattr(
-        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
-        _find_predicate,
-    )
-
     result = _paper_registry().execute(
         SCHOLARLY_PAPER_RESOLVE_AUTHORS_ACTION_ID,
         inputs={
             "paper_concept_id": paper_concept_id,
-            "author_names": ["Private Author"],
+            "author_names": ["Public Author"],
         },
         context={},
         env=WorkflowEnvironment(
@@ -371,9 +341,73 @@ def test_actor_bound_schema_preflight_uses_hard_predicate_authority_view(
     )
 
     assert result.status == "success"
-    assert relationship_calls == [
-        (paper_concept_id, "#V#authored_by", author_concept_id)
-    ]
+    assert result.outputs["author_instance_scope_mode"] == "global_general"
+    assert result.outputs["authorship_assertion_scope_mode"] == "global_general"
+    assert result.outputs["public_author_count"] == 1
+    author_record = result.outputs["public_author_records"][0]
+    assert author_record["name"] == "Public Author"
+    assert author_record["identity_scheme"] == "scholarly-author-occurrence"
+    assert author_record["concept_id"].startswith(
+        "#V#external_identity_scholarly_author_occurrence_"
+    )
+
+
+def test_resolve_authors_reuses_a_public_identifier_across_papers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.workflows.durable import paper_representation_workflow as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_require_preprovisioned_schema_support",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_require_global_targets",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        mod,
+        "resolve_publication_scope_profile",
+        lambda **kwargs: {
+            "success": True,
+            "plane": kwargs["plane"],
+            "selected_scope_mode": "global_general",
+        },
+    )
+    registry = _paper_registry()
+    author = {
+        "name": "Publicly Identified Author",
+        "orcid": "https://orcid.org/0000-0002-1825-0097",
+    }
+
+    first = registry.execute(
+        SCHOLARLY_PAPER_RESOLVE_AUTHORS_ACTION_ID,
+        inputs={
+            "paper_concept_id": "#V#public_paper_one",
+            "author_records": [author],
+        },
+        context={},
+        env=WorkflowEnvironment(llm_client=None),
+    )
+    second = registry.execute(
+        SCHOLARLY_PAPER_RESOLVE_AUTHORS_ACTION_ID,
+        inputs={
+            "paper_concept_id": "#V#public_paper_two",
+            "author_records": [author],
+        },
+        context={},
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert first.status == "success"
+    assert second.status == "success"
+    first_record = first.outputs["public_author_records"][0]
+    second_record = second.outputs["public_author_records"][0]
+    assert first_record["identity_kind"] == "public_identifier"
+    assert first_record["identity_scheme"] == "orcid"
+    assert first_record["concept_id"] == second_record["concept_id"]
 
 
 def test_normalise_inputs_extracts_arxiv_id_from_prompt_context() -> None:
@@ -424,7 +458,9 @@ def test_arxiv_decide_acquisition_mode_prefers_existing_file_copy(monkeypatch) -
     registry = ActionRegistry()
     register_paper_representation_actions(registry)
 
-    monkeypatch.setattr(mod, "_resolve_user_concept_id", lambda _request: "#V#user_test")
+    monkeypatch.setattr(
+        mod, "_resolve_user_concept_id", lambda _request: "#V#user_test"
+    )
     monkeypatch.setattr(
         "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.inspect_cached_arxiv_artifacts",
         lambda *, arxiv_id, storage_path=None: {
@@ -453,7 +489,9 @@ def test_arxiv_decide_acquisition_mode_prefers_existing_file_copy(monkeypatch) -
     assert result.status == "success"
     assert result.outputs["result"] is False
     assert result.outputs["acquisition_required"] is False
-    assert result.outputs["acquisition_mode"] == ARXIV_ACQUISITION_MODE_EXISTING_FILE_COPY
+    assert (
+        result.outputs["acquisition_mode"] == ARXIV_ACQUISITION_MODE_EXISTING_FILE_COPY
+    )
 
 
 def test_arxiv_decide_acquisition_mode_prefers_finalise_for_cached_pdf(
@@ -464,7 +502,9 @@ def test_arxiv_decide_acquisition_mode_prefers_finalise_for_cached_pdf(
     registry = ActionRegistry()
     register_paper_representation_actions(registry)
 
-    monkeypatch.setattr(mod, "_resolve_user_concept_id", lambda _request: "#V#user_test")
+    monkeypatch.setattr(
+        mod, "_resolve_user_concept_id", lambda _request: "#V#user_test"
+    )
     monkeypatch.setattr(
         "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.inspect_cached_arxiv_artifacts",
         lambda *, arxiv_id, storage_path=None: {
@@ -491,7 +531,9 @@ def test_arxiv_decide_acquisition_mode_prefers_finalise_for_cached_pdf(
     assert result.status == "success"
     assert result.outputs["result"] is True
     assert result.outputs["acquisition_required"] is True
-    assert result.outputs["acquisition_mode"] == ARXIV_ACQUISITION_MODE_FINALISE_CACHED_PDF
+    assert (
+        result.outputs["acquisition_mode"] == ARXIV_ACQUISITION_MODE_FINALISE_CACHED_PDF
+    )
     assert result.outputs["cache_state"] == "cached_pdf_available"
     assert result.outputs["cached_pdf_path"] == "C:/tmp/arxiv_cache/2603.14482.pdf"
     assert result.outputs["partial_cache_without_pdf"] is False
@@ -505,7 +547,9 @@ def test_arxiv_decide_acquisition_mode_marks_partial_cache_for_reacquisition(
     registry = ActionRegistry()
     register_paper_representation_actions(registry)
 
-    monkeypatch.setattr(mod, "_resolve_user_concept_id", lambda _request: "#V#user_test")
+    monkeypatch.setattr(
+        mod, "_resolve_user_concept_id", lambda _request: "#V#user_test"
+    )
     monkeypatch.setattr(
         "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.inspect_cached_arxiv_artifacts",
         lambda *, arxiv_id, storage_path=None: {
@@ -549,7 +593,9 @@ def test_arxiv_decide_acquisition_mode_falls_back_to_download_without_cache(
     registry = ActionRegistry()
     register_paper_representation_actions(registry)
 
-    monkeypatch.setattr(mod, "_resolve_user_concept_id", lambda _request: "#V#user_test")
+    monkeypatch.setattr(
+        mod, "_resolve_user_concept_id", lambda _request: "#V#user_test"
+    )
     monkeypatch.setattr(
         "src.backend.integrations.internal_mcp.arxiv_proxy_mcp.inspect_cached_arxiv_artifacts",
         lambda *, arxiv_id, storage_path=None: {
@@ -574,7 +620,10 @@ def test_arxiv_decide_acquisition_mode_falls_back_to_download_without_cache(
     )
 
     assert result.status == "success"
-    assert result.outputs["acquisition_mode"] == ARXIV_ACQUISITION_MODE_DOWNLOAD_FROM_SOURCE
+    assert (
+        result.outputs["acquisition_mode"]
+        == ARXIV_ACQUISITION_MODE_DOWNLOAD_FROM_SOURCE
+    )
     assert result.outputs["partial_cache_without_pdf"] is False
 
 
@@ -600,6 +649,11 @@ def test_verify_representation_requires_publication_date_for_arxiv_profile(
             },
             "attributes": {"arxiv_id": "2603.21702"},
         },
+    )
+    monkeypatch.setattr(
+        mod,
+        "concept_publication_context",
+        lambda _concept_id: mod.PublicationContext.global_context(),
     )
 
     def _fake_get_texts_for_concept(*, predicate: str, **_kwargs):
@@ -658,6 +712,11 @@ def test_verify_representation_allows_missing_file_copy_when_not_required(
             "attributes": {"arxiv_id": "2505.17801"},
             "name": "Integrating Counterfactual Simulations",
         },
+    )
+    monkeypatch.setattr(
+        mod,
+        "concept_publication_context",
+        lambda _concept_id: mod.PublicationContext.global_context(),
     )
 
     def _fake_get_texts_for_concept(*, predicate: str, **_kwargs):

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -17,19 +17,23 @@ from src.backend.services.paper_representation_workflow_vontology_service import
     ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID,
     SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
     SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID,
+    SCHOLARLY_PUBLIC_AUTHOR_REPRESENTATION_WORKFLOW_ID,
     SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID,
     SOURCE_NEUTRAL_PAPER_REFERENCE_ITEM_INGESTION_WORKFLOW_ID,
     bootstrap_canonical_paper_representation_workflows,
     diff_canonical_paper_representation_workflow_repo_seed_bundle,
     export_canonical_paper_representation_workflow_repo_seed_bundle,
 )
-from src.backend.services.workflow_discovery_service import (
-    invalidate_workflow_discovery_executability_caches,
-)
 from src.backend.services.text_value_service import (
     delete_text_relation,
     get_texts_for_concept,
     upsert_singleton_text_relation,
+)
+from src.backend.services.workflow_discovery_service import (
+    invalidate_workflow_discovery_executability_caches,
+)
+from src.backend.workflows import (
+    workflow_concept_authority_service as authority_service,
 )
 from src.backend.workflows.action_registry import (
     ActionRegistry,
@@ -38,9 +42,7 @@ from src.backend.workflows.action_registry import (
     WorkflowActionResult,
     WorkflowEnvironment,
 )
-from src.backend.workflows import (
-    workflow_concept_authority_service as authority_service,
-)
+from src.backend.workflows.durable import registry_factory
 from src.backend.workflows.durable.control_flow_actions import (
     register_control_flow_actions,
 )
@@ -50,7 +52,6 @@ from src.backend.workflows.durable.paper_representation_workflow import (
 from src.backend.workflows.durable.subworkflow_actions import (
     register_subworkflow_actions,
 )
-from src.backend.workflows.durable import registry_factory
 from src.backend.workflows.engine import (
     WorkflowActionInvocation,
     WorkflowDefinition,
@@ -159,7 +160,9 @@ def _delete_workflow_text_relations(
         delete_text_relation(workflow_id, relation_id, garbage_collect=True)
 
 
-def _snapshot_concept_text_relations(concept_id: str) -> list[tuple[str, str, str, str]]:
+def _snapshot_concept_text_relations(
+    concept_id: str,
+) -> list[tuple[str, str, str, str]]:
     return sorted(
         (
             str(row.get("predicate") or ""),
@@ -398,11 +401,39 @@ def _reset_mock_db(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")
     authority_service.clear_workflow_type_resolution_cache()
 
+    from src.backend.services import ontology_publication_authority_service
+
+    monkeypatch.setattr(
+        ontology_publication_authority_service,
+        "resolve_live_semantic_roles",
+        lambda actor_id: (
+            (
+                ontology_publication_authority_service.AuthorityRoleEvidence(
+                    role=(
+                        ontology_publication_authority_service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+                    ),
+                    actor_concept_id=_LIVE_ARXIV_ACCEPTANCE_USER_ID,
+                    organisation_concept_id=None,
+                    relation_id="test:paper-workflow-global-authority",
+                    revision="test-revision-1",
+                ),
+            )
+            if actor_id == _LIVE_ARXIV_ACCEPTANCE_USER_ID
+            else ()
+        ),
+    )
+
     from src.backend.db.mongo_client import get_db
 
     db = get_db()
     if db is not None:
-        for collection_name in ("concepts", "text_relations", "text_values"):
+        for collection_name in (
+            "concepts",
+            "text_relations",
+            "text_values",
+            "scoped_knowledge_assertions",
+            "ontology_mutation_receipts",
+        ):
             try:
                 db.drop_collection(collection_name)
             except Exception:
@@ -420,11 +451,18 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
 
     publication = report.get("publication") or {}
     counts = publication.get("counts") or {}
-    assert counts.get("workflows_published") == 5
+    assert counts.get("workflows_published") == 6, json.dumps(
+        report, sort_keys=True, default=str
+    )
     assert counts.get("errors") == 0
     support_concepts = report.get("support_concepts") or {}
     assert support_concepts.get("errors") == []
-    created_support_ids = support_concepts.get("created_concept_ids") or []
+    publication_scope_profiles = report.get("publication_scope_profiles") or {}
+    assert publication_scope_profiles.get("success") is True
+    created_support_ids = {
+        *(support_concepts.get("created_concept_ids") or []),
+        *(publication_scope_profiles.get("created_concept_ids") or []),
+    }
     assert "#V#scholarly_article" in created_support_ids
     assert "#V#person" in created_support_ids
     assert "#V#research_topic" in created_support_ids
@@ -463,6 +501,11 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
     )
     assert metadata_definition is not None
+
+    public_author_definition = load_workflow_definition_from_vontology(
+        SCHOLARLY_PUBLIC_AUTHOR_REPRESENTATION_WORKFLOW_ID
+    )
+    assert public_author_definition is not None
 
     scholarly_definition = load_workflow_definition_from_vontology(
         SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID
@@ -528,9 +571,12 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         workflow_id=SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID,
         state_id="failed",
     )
-    assert source_neutral_definition.metadata["terminal_success_contract"][
-        "failed_terminal_error_code"
-    ] == "paper_reference_ingestion_no_items_succeeded"
+    assert (
+        source_neutral_definition.metadata["terminal_success_contract"][
+            "failed_terminal_error_code"
+        ]
+        == "paper_reference_ingestion_no_items_succeeded"
+    )
     source_required_effects = source_neutral_definition.metadata.get(
         "required_effects_contract"
     )
@@ -580,16 +626,22 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         workflow_id=SOURCE_NEUTRAL_PAPER_REFERENCE_ITEM_INGESTION_WORKFLOW_ID,
         state_id="ingest_metadata_reference",
     )
-    assert item_definition.states[ingest_metadata_state_id].metadata[
-        "subworkflow_contract"
-    ]["workflow_id"] == SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    assert (
+        item_definition.states[ingest_metadata_state_id].metadata[
+            "subworkflow_contract"
+        ]["workflow_id"]
+        == SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    )
     ingest_file_state_id = authority_service._step_concept_id(
         workflow_id=SOURCE_NEUTRAL_PAPER_REFERENCE_ITEM_INGESTION_WORKFLOW_ID,
         state_id="ingest_file_copy_reference",
     )
-    assert item_definition.states[ingest_file_state_id].metadata[
-        "subworkflow_contract"
-    ]["workflow_id"] == SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID
+    assert (
+        item_definition.states[ingest_file_state_id].metadata["subworkflow_contract"][
+            "workflow_id"
+        ]
+        == SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID
+    )
     route_arxiv_targets_state_id = authority_service._step_concept_id(
         workflow_id=ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID,
         state_id="route_arxiv_targets",
@@ -674,7 +726,6 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         == extract_metadata_state_id
     )
 
-
     extract_metadata_action = metadata_definition.states[
         extract_metadata_state_id
     ].actions[0]
@@ -712,29 +763,25 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         and "source_uri" in item.get("value_from_context_options", [])
         for item in assignments
     )
-    normalise_metadata_transitions = {
-        transition.reason: transition
-        for transition in metadata_definition.states[
-            normalise_metadata_state_id
-        ].transitions
-    }
-    assert normalise_metadata_transitions[
-        "existing_article_concept_supplied"
-    ].condition_spec == {
-        "kind": "all",
-        "conditions": [
-            {
-                "kind": "context_exists",
-                "key": "paper_concept_id",
-                "expected": True,
-            },
-            {
-                "kind": "context_is_null",
-                "key": "paper_concept_id",
-                "expected": False,
-            },
-        ],
-    }
+    resolve_paper_scope_state_id = authority_service._step_concept_id(
+        workflow_id=SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
+        state_id="resolve_paper_instance_scope",
+    )
+    assert (
+        metadata_definition.states[normalise_metadata_state_id].transitions[0].to_state
+        == resolve_paper_scope_state_id
+    )
+    resolve_paper_scope_action = metadata_definition.states[
+        resolve_paper_scope_state_id
+    ].actions[0]
+    assert resolve_paper_scope_action.action_id == "resolve_publication_scope_profile"
+    assert resolve_paper_scope_action.inputs.get("plane") == "instance"
+    assert resolve_paper_scope_action.inputs.get("type_concept_ids") == [
+        "#V#scholarly_article"
+    ]
+    assert resolve_paper_scope_action.inputs.get("source_kind") == (
+        "public_scholarly_metadata"
+    )
     normalise_external_identity_state_id = authority_service._step_concept_id(
         workflow_id=SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
         state_id="normalise_external_identity",
@@ -742,7 +789,7 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
     assert any(
         transition.to_state == normalise_external_identity_state_id
         for transition in metadata_definition.states[
-            normalise_metadata_state_id
+            resolve_paper_scope_state_id
         ].transitions
     )
     normalise_external_identity_state = metadata_definition.states[
@@ -759,23 +806,30 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         workflow_id=SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
         state_id="create_article_by_external_identity",
     )
-    assert external_identity_transitions[
-        "canonical_external_identity_available"
-    ].to_state == create_external_identity_state_id
+    assert (
+        external_identity_transitions["canonical_external_identity_available"].to_state
+        == create_external_identity_state_id
+    )
     attach_metadata_state_id = authority_service._step_concept_id(
         workflow_id=SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
         state_id="attach_metadata",
     )
-    assert external_identity_transitions[
-        "actor_private_external_identity_resolved"
-    ].to_state == attach_metadata_state_id
+    assert (
+        external_identity_transitions["global_external_identity_resolved"].to_state
+        == attach_metadata_state_id
+    )
+    assert (
+        external_identity_transitions["supplied_global_article_validated"].to_state
+        == attach_metadata_state_id
+    )
     create_external_identity_state = metadata_definition.states[
         create_external_identity_state_id
     ]
     create_external_identity_action = create_external_identity_state.actions[0]
     assert create_external_identity_action.action_id == "create_concepts"
-    assert create_external_identity_action.inputs.get("scope_mode") == (
-        "user_only_default"
+    assert (
+        create_external_identity_action.inputs.get("scope_mode", {}).get("$context_key")
+        == "paper_instance_scope_mode"
     )
     assert create_external_identity_action.inputs.get("duplicate_resolution_mode") == (
         "canonical_id_only"
@@ -783,8 +837,9 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
     assert create_external_identity_action.inputs["concepts"][0]["concept_id"] == {
         "$context_key": "paper_external_identity_concept_id"
     }
-    assert "external_identifiers" not in (
-        create_external_identity_action.inputs["concepts"][0]
+    assert (
+        "external_identifiers"
+        not in (create_external_identity_action.inputs["concepts"][0])
     )
     assert create_external_identity_state.metadata.get("mutation_authority") == {
         "maximum_level": "additive_vontology",
@@ -805,9 +860,12 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
             resolve_existing_article_state_id
         ].transitions
     }
-    assert resolve_existing_article_transitions[
-        "title_match_without_stable_identity_requires_review"
-    ].to_state == reject_title_reuse_state_id
+    assert (
+        resolve_existing_article_transitions[
+            "title_match_without_stable_identity_requires_review"
+        ].to_state
+        == reject_title_reuse_state_id
+    )
     resolve_topics_state_id = authority_service._step_concept_id(
         workflow_id=SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
         state_id="resolve_topics",
@@ -920,6 +978,8 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         "hasDescription",
         "#V#has_doi",
         "#V#has_source_uri",
+        "#V#has_publication_date",
+        "#V#has_topic_labels",
     ]
     read_back_text_relations_transitions = {
         transition.reason: transition
@@ -928,8 +988,7 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         ].transitions
     }
     assert (
-        read_back_text_relations_transitions["next_step"].to_state
-        == completed_state_id
+        read_back_text_relations_transitions["next_step"].to_state == completed_state_id
     )
     summary_transition = read_back_text_relations_transitions[
         "representation_evidence_summary_required"
@@ -1165,7 +1224,9 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
     assert "author_names" in contract["provided_inputs"]
     assert "topic_labels" in contract["provided_inputs"]
     delegate_action = delegate_state.actions[0]
-    assert delegate_action.inputs.get("require_representation_evidence_summary") is False
+    assert (
+        delegate_action.inputs.get("require_representation_evidence_summary") is False
+    )
     assert delegate_action.inputs.get("paper_concept_id") == {
         "$context_key": "paper_concept_id",
         "$mapping_concept_id": "#V#workflow_mapping_arxiv_paper_representation_workflow_delegate_to_general_paper_workflow_paper_concept_id_to_paper_concept_id_parameter",
@@ -1284,9 +1345,10 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         ],
         "kind": "all",
     }
-    assert "finalise_cached_pdf" not in recovery_transition.condition_spec[
-        "conditions"
-    ][1]["values"]
+    assert (
+        "finalise_cached_pdf"
+        not in recovery_transition.condition_spec["conditions"][1]["values"]
+    )
     build_pdf_import_action = arxiv_definition.states[
         build_pdf_import_state_id
     ].actions[0]
@@ -1345,9 +1407,7 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
     optional_pdf_diagnostics = record_pdf_import_skipped_action.inputs.get(
         "assignments"
     )[3:]
-    assert {
-        assignment["key"] for assignment in optional_pdf_diagnostics
-    } == {
+    assert {assignment["key"] for assignment in optional_pdf_diagnostics} == {
         "arxiv_pdf_import_error",
         "arxiv_pdf_import_message",
         "arxiv_pdf_import_status_code",
@@ -1556,7 +1616,9 @@ def _build_source_neutral_execution_registry(
             definition=definition,
             registration_source="vontology" if definition is not None else "unknown",
             known_workflow_ids=(),
-            error_code=None if definition is not None else "workflow_concept_not_accessible",
+            error_code=None
+            if definition is not None
+            else "workflow_concept_not_accessible",
             diagnostics={
                 "actor_scoped_authority_required": True,
                 "shared_registry_definition_trusted": False,
@@ -1621,7 +1683,9 @@ def _build_source_neutral_execution_registry(
     return registry, calls
 
 
-def _load_source_neutral_test_definitions() -> tuple[WorkflowDefinition, WorkflowDefinition]:
+def _load_source_neutral_test_definitions() -> tuple[
+    WorkflowDefinition, WorkflowDefinition
+]:
     parent_definition = load_workflow_definition_from_vontology(
         SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID
     )
@@ -1691,7 +1755,15 @@ def test_source_neutral_paper_reference_workflow_fans_out_mixed_references_with_
         },
     )
 
-    assert result.completed is True
+    assert result.completed is True, json.dumps(
+        {
+            key: value
+            for key, value in result.data.items()
+            if key.startswith("last_") or "scope" in key or "error" in key
+        },
+        sort_keys=True,
+        default=str,
+    )
     assert result.final_state.endswith("_completed")
     assert result.data["paper_reference_item_count"] == 5
     assert result.data["for_each_success_count"] == 4
@@ -1895,7 +1967,7 @@ def test_bootstrap_skips_republication_when_workflow_family_is_current(
 ) -> None:
     first_report = bootstrap_canonical_paper_representation_workflows()
     first_counts = (first_report.get("publication") or {}).get("counts") or {}
-    assert first_counts.get("workflows_published") == 5
+    assert first_counts.get("workflows_published") == 6
 
     second_report = bootstrap_canonical_paper_representation_workflows()
     second_authority = second_report.get("authority_contract") or {}
@@ -2052,7 +2124,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "26" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "27" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID
@@ -2071,8 +2143,9 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
     ]
     assert required_effect["required_payload_fields"] == ["paper_concept_id"]
     assert required_effect["targets_extractor"] == "arxiv_id_list"
-    assert "workflow_discovery_result.discovery_query_input" in (
-        required_effect["targets_source_expressions"]
+    assert (
+        "workflow_discovery_result.discovery_query_input"
+        in (required_effect["targets_source_expressions"])
     )
 
 
@@ -2534,7 +2607,15 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
         },
     )
 
-    assert result.completed is True
+    assert result.completed is True, json.dumps(
+        {
+            key: value
+            for key, value in result.data.items()
+            if key.startswith("last_") or "scope" in key or "error" in key
+        },
+        sort_keys=True,
+        default=str,
+    )
     assert result.final_state.endswith("_completed"), result.data.get(
         "last_action_outputs"
     )
@@ -2550,8 +2631,24 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
     assert paper_doc is not None
     relationships = paper_doc.get("relationships") or {}
     assert "#V#scholarly_article" in (relationships.get("is_an_instance_of") or [])
-    assert relationships.get("#V#authored_by")
-    assert relationships.get("#V#about")
+    author_concept_ids = relationships.get("#V#authored_by") or []
+    assert author_concept_ids
+    from src.backend.services import ontology_publication_authority_service
+
+    assert (
+        ontology_publication_authority_service.concept_publication_context(
+            paper_concept_id
+        ).kind
+        == ontology_publication_authority_service.PublicationContextKind.GLOBAL
+    )
+    assert all(
+        ontology_publication_authority_service.concept_publication_context(
+            author_concept_id
+        ).kind
+        == ontology_publication_authority_service.PublicationContextKind.GLOBAL
+        for author_concept_id in author_concept_ids
+    )
+    assert relationships.get("#V#about") is None
 
     names = [
         row.get("text")
@@ -2580,6 +2677,15 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
         )
     ]
     assert "https://dl.acm.org/doi/full/10.1145/3743093.3770985" in (source_uri_values)
+    topic_label_values = [
+        row.get("text")
+        for row in get_texts_for_concept(
+            paper_concept_id,
+            predicate="#V#has_topic_labels",
+            limit=5,
+        )
+    ]
+    assert "computer vision, story illustration" in topic_label_values
     text_relation_summary = result.data.get("article_text_relations_summary")
     assert isinstance(text_relation_summary, dict)
     summary_predicates = {
@@ -2589,6 +2695,8 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
     }
     assert "#V#has_doi" in summary_predicates
     assert "#V#has_source_uri" in summary_predicates
+    assert "#V#has_publication_date" in summary_predicates
+    assert "#V#has_topic_labels" in summary_predicates
 
     descriptions = [
         row.get("text")
@@ -2599,6 +2707,249 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
         )
     ]
     assert "A paper about composable identity control." in descriptions
+
+
+def test_metadata_workflow_reuses_global_papers_across_authorised_actors_but_not_name_only_people(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import ontology_publication_authority_service
+
+    bootstrap_canonical_paper_representation_workflows()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+    definition = load_workflow_definition_from_vontology(
+        SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    )
+    assert definition is not None
+
+    second_actor_id = "#V#second_public_paper_actor"
+    authorised_actor_ids = {
+        _LIVE_ARXIV_ACCEPTANCE_USER_ID,
+        second_actor_id,
+    }
+
+    def _roles(actor_id: str):
+        if actor_id not in authorised_actor_ids:
+            return ()
+        return (
+            ontology_publication_authority_service.AuthorityRoleEvidence(
+                role=(
+                    ontology_publication_authority_service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+                ),
+                actor_concept_id=actor_id,
+                organisation_concept_id=None,
+                relation_id=f"test:global-paper-role:{actor_id}",
+                revision="test-revision-cross-actor-1",
+            ),
+        )
+
+    monkeypatch.setattr(
+        ontology_publication_authority_service,
+        "resolve_live_semantic_roles",
+        _roles,
+    )
+    executor = WorkflowExecutor(
+        registry=registry_factory.build_durable_action_registry(),
+        max_transitions=40,
+    )
+    first_environment = WorkflowEnvironment(
+        llm_client=None,
+        user_namespace=_LIVE_ARXIV_ACCEPTANCE_NAMESPACE,
+        user_concept_id=_LIVE_ARXIV_ACCEPTANCE_USER_ID,
+        org_concept_id=_LIVE_ARXIV_ACCEPTANCE_ORG_ID,
+    )
+    second_environment = WorkflowEnvironment(
+        llm_client=None,
+        user_namespace=(
+            f"{second_actor_id}@{_LIVE_ARXIV_ACCEPTANCE_ORG_ID.removeprefix('#V#')}"
+        ),
+        user_concept_id=second_actor_id,
+        org_concept_id=_LIVE_ARXIV_ACCEPTANCE_ORG_ID,
+    )
+
+    first = executor.run(
+        definition,
+        environment=first_environment,
+        data={
+            "paper_metadata": {
+                "title": "Cross-actor Public Paper",
+                "doi": "10.5555/cross-actor-public-paper",
+                "authors": ["Alex Kim"],
+            },
+            "require_representation_evidence_summary": False,
+        },
+    )
+    same_paper = executor.run(
+        definition,
+        environment=second_environment,
+        data={
+            "paper_metadata": {
+                "title": "Cross-actor Public Paper, Corrected Title",
+                "doi": "https://doi.org/10.5555/cross-actor-public-paper",
+                "authors": ["Alex Kim"],
+            },
+            "require_representation_evidence_summary": False,
+        },
+    )
+    second_paper = executor.run(
+        definition,
+        environment=second_environment,
+        data={
+            "paper_metadata": {
+                "title": "A Distinct Paper with a Namesake Author",
+                "doi": "10.5555/namesake-author-paper",
+                "authors": ["Alex Kim"],
+            },
+            "require_representation_evidence_summary": False,
+        },
+    )
+
+    assert first.completed is True, first.error
+    assert same_paper.completed is True, same_paper.error
+    assert second_paper.completed is True, second_paper.error
+    first_paper_id = first.data.get("paper_concept_id")
+    assert same_paper.data.get("paper_concept_id") == first_paper_id
+    assert second_paper.data.get("paper_concept_id") != first_paper_id
+
+    first_author_ids = set(
+        (concept_service.get_concept_by_concept_id(first_paper_id) or {})
+        .get("relationships", {})
+        .get("#V#authored_by", [])
+    )
+    second_author_ids = set(
+        (
+            concept_service.get_concept_by_concept_id(
+                second_paper.data.get("paper_concept_id")
+            )
+            or {}
+        )
+        .get("relationships", {})
+        .get("#V#authored_by", [])
+    )
+    assert len(first_author_ids) == 1
+    assert len(second_author_ids) == 1
+    assert first_author_ids.isdisjoint(second_author_ids)
+
+
+def test_metadata_workflow_rejects_global_representation_without_live_role(
+    _reset_mock_db: Any,
+) -> None:
+    bootstrap_canonical_paper_representation_workflows()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+    definition = load_workflow_definition_from_vontology(
+        SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    )
+    assert definition is not None
+
+    result = WorkflowExecutor(
+        registry=registry_factory.build_durable_action_registry(),
+        max_transitions=40,
+    ).run(
+        definition,
+        environment=WorkflowEnvironment(
+            llm_client=None,
+            user_namespace="#V#unauthorised_paper_actor",
+            user_concept_id="#V#unauthorised_paper_actor",
+            org_concept_id=None,
+        ),
+        data={
+            "paper_metadata": {
+                "title": "Unauthorised Global Paper Attempt",
+                "doi": "10.5555/unauthorised-global-paper",
+            },
+            "require_representation_evidence_summary": False,
+        },
+    )
+
+    assert result.completed is False
+    assert result.data.get("last_action_error") == (
+        "global_ontology_admin_authority_required"
+    )
+    predicted_paper_id = result.data.get("paper_external_identity_concept_id")
+    assert isinstance(predicted_paper_id, str)
+    with pytest.raises(concept_service.ConceptNotFoundError):
+        concept_service.get_concept_by_concept_id(predicted_paper_id)
+
+
+def test_metadata_workflow_keeps_local_file_copy_link_user_scoped(
+    _reset_mock_db: Any,
+) -> None:
+    bootstrap_canonical_paper_representation_workflows()
+    registry_factory._resolve_subworkflow_definition.cache_clear()
+    file_copy_concept_id = "#V#private_local_copy_of_public_paper"
+    concept_service.create_concept(
+        name="Local copy of public paper",
+        concept_id=file_copy_concept_id,
+        parent_concept_ids=["#V#computer_file"],
+        create_as_instance=True,
+        created_by_concept_id=_LIVE_ARXIV_ACCEPTANCE_USER_ID,
+        organisation_concept_id=_LIVE_ARXIV_ACCEPTANCE_ORG_ID,
+        visibility_scope_mode="user_only_default",
+        maintain_relationship_inverses=False,
+    )
+    definition = load_workflow_definition_from_vontology(
+        SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    )
+    assert definition is not None
+
+    result = WorkflowExecutor(
+        registry=registry_factory.build_durable_action_registry(),
+        max_transitions=40,
+    ).run(
+        definition,
+        environment=WorkflowEnvironment(
+            llm_client=None,
+            user_namespace=_LIVE_ARXIV_ACCEPTANCE_NAMESPACE,
+            user_concept_id=_LIVE_ARXIV_ACCEPTANCE_USER_ID,
+            org_concept_id=_LIVE_ARXIV_ACCEPTANCE_ORG_ID,
+        ),
+        data={
+            "file_copy_concept_id": file_copy_concept_id,
+            "paper_metadata": {
+                "title": "Public Paper with a Private Local Copy",
+                "doi": "10.5555/public-paper-private-copy",
+                "authors": ["Ada Lovelace"],
+            },
+            "require_representation_evidence_summary": False,
+        },
+    )
+
+    assert result.completed is True, json.dumps(
+        {
+            key: value
+            for key, value in result.data.items()
+            if key.startswith("last_") or "scope" in key or "file" in key
+        },
+        sort_keys=True,
+        default=str,
+    )
+    paper_concept_id = result.data.get("paper_concept_id")
+    assert isinstance(paper_concept_id, str)
+    paper_doc = concept_service.get_concept_by_concept_id(paper_concept_id) or {}
+    assert not (
+        (paper_doc.get("relationships") or {}).get(
+            "#V#propositional_information_thing_has_computer_file"
+        )
+        or []
+    )
+
+    from src.backend.db.mongo_client import (
+        get_scoped_knowledge_assertions_collection,
+    )
+
+    assertion = get_scoped_knowledge_assertions_collection().find_one(
+        {
+            "subject_concept_id": paper_concept_id,
+            "predicate": "#V#local_file_copy",
+            "object_concept_id": file_copy_concept_id,
+        }
+    )
+    assert assertion is not None
+    assert assertion.get("canonical_publication") is False
+    assert (assertion.get("scope") or {}).get("mode") == "user"
+    assert (assertion.get("scope") or {}).get("user_concept_id") == (
+        _LIVE_ARXIV_ACCEPTANCE_USER_ID
+    )
 
 
 def test_metadata_workflow_reuses_existing_article_on_identical_retry(
@@ -2899,7 +3250,7 @@ def test_metadata_workflow_rejects_title_only_reuse_before_mutation(
     "scope_mode",
     ["organisation_general", "global_general"],
 )
-def test_metadata_workflow_does_not_reuse_shared_article_by_title(
+def test_metadata_workflow_does_not_mutate_shared_article_by_title_alone(
     _reset_mock_db: Any,
     scope_mode: str,
 ) -> None:
@@ -2945,9 +3296,10 @@ def test_metadata_workflow_does_not_reuse_shared_article_by_title(
     )
 
     assert result.completed is False
-    assert result.data.get("article_resolution_status") == "not_found"
+    assert result.data.get("article_resolution_status") == "resolved"
+    assert result.data.get("paper_concept_id") == shared_concept_id
     assert result.data.get("last_action_error") == (
-        "ontology_create_concept_id_conflict"
+        "scholarly_paper_title_only_reuse_unverified"
     )
     descriptions = [
         row.get("text")
@@ -2964,7 +3316,7 @@ def test_metadata_workflow_does_not_reuse_shared_article_by_title(
     "scope_mode",
     ["organisation_general", "global_general"],
 )
-def test_metadata_workflow_rejects_supplied_shared_article_before_text_mutation(
+def test_metadata_workflow_validates_supplied_article_scope_before_text_mutation(
     _reset_mock_db: Any,
     scope_mode: str,
 ) -> None:
@@ -3010,11 +3362,25 @@ def test_metadata_workflow_rejects_supplied_shared_article_before_text_mutation(
         },
     )
 
-    assert result.completed is False
-    assert result.data.get("last_action_error") == (
-        "scholarly_paper_actor_private_target_required"
-    )
-    assert _snapshot_concept_text_relations(paper_concept_id) == before_text
+    if scope_mode == "organisation_general":
+        assert result.completed is False
+        assert result.data.get("last_action_error") == (
+            "scholarly_paper_global_target_required"
+        )
+        assert _snapshot_concept_text_relations(paper_concept_id) == before_text
+    else:
+        assert result.completed is True, result.error
+        assert result.data.get("paper_external_identity_resolution_status") == (
+            "supplied"
+        )
+        assert "Attempted Shared Article Rewrite" in {
+            row.get("text")
+            for row in get_texts_for_concept(
+                paper_concept_id,
+                predicate="hasName",
+                limit=10,
+            )
+        }
 
 
 def test_metadata_workflow_rejects_supplied_private_article_without_trusted_actor(
@@ -3063,12 +3429,12 @@ def test_metadata_workflow_rejects_supplied_private_article_without_trusted_acto
 
     assert result.completed is False
     assert result.data.get("last_action_error") == (
-        "scholarly_paper_actor_private_target_required"
+        "scholarly_paper_global_target_required"
     )
     assert _snapshot_concept_text_relations(paper_concept_id) == before_text
 
 
-def test_metadata_workflow_accepts_supplied_actor_private_article(
+def test_metadata_workflow_rejects_supplied_actor_private_article(
     _reset_mock_db: Any,
 ) -> None:
     bootstrap_canonical_paper_representation_workflows()
@@ -3111,8 +3477,10 @@ def test_metadata_workflow_accepts_supplied_actor_private_article(
         },
     )
 
-    assert result.completed is True, result.error
-    assert result.data.get("paper_concept_id") == paper_concept_id
+    assert result.completed is False
+    assert result.data.get("last_action_error") == (
+        "scholarly_paper_global_target_required"
+    )
     descriptions = [
         row.get("text")
         for row in get_texts_for_concept(
@@ -3121,7 +3489,7 @@ def test_metadata_workflow_accepts_supplied_actor_private_article(
             limit=10,
         )
     ]
-    assert "The trusted actor may extend their private article." in descriptions
+    assert "The trusted actor may extend their private article." not in descriptions
 
 
 def test_metadata_workflow_represents_sparse_source_uri_without_title(
@@ -3348,15 +3716,13 @@ def test_bootstrap_preserves_authoritative_state_when_repo_seed_snapshot_is_stal
     assert repair_publication.get("bundle_snapshot_issue_codes") == []
     assert repair_counts.get("workflows_published") == 0
     assert repair_counts.get("errors") == 1
-    authority_blockers = (
-        (repair_report.get("repo_seed_version_gate") or {}).get(
-            "authority_blockers_by_workflow"
-        )
-        or {}
+    authority_blockers = (repair_report.get("repo_seed_version_gate") or {}).get(
+        "authority_blockers_by_workflow"
+    ) or {}
+    assert (
+        authority_blockers[ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID]["error_code"]
+        == "live_authority_requires_explicit_migration"
     )
-    assert authority_blockers[ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID][
-        "error_code"
-    ] == "live_authority_requires_explicit_migration"
 
     repaired_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID
@@ -3609,6 +3975,7 @@ def test_export_refreshes_paper_repo_seed_bundle_from_authority(
     assert export_report.get("asset_path") == str(tmp_asset_path.resolve())
     assert export_report.get("workflow_ids") == [
         SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
+        SCHOLARLY_PUBLIC_AUTHOR_REPRESENTATION_WORKFLOW_ID,
         SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID,
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID,
         SOURCE_NEUTRAL_PAPER_REFERENCE_INGESTION_WORKFLOW_ID,

--- a/tests/backend/test_scholarly_metadata_workflow_durable_authority.py
+++ b/tests/backend/test_scholarly_metadata_workflow_durable_authority.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from src.backend.services import concept_service
+from src.backend.services import concept_service, ontology_publication_authority_service
 from src.backend.services.paper_representation_workflow_vontology_service import (
     SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID,
     bootstrap_canonical_paper_representation_workflows,
@@ -55,11 +55,26 @@ def _reset_durable_paper_state(monkeypatch: pytest.MonkeyPatch) -> Any:
     workflow_concept_authority_service.clear_workflow_type_resolution_cache()
 
 
-def test_durable_submitted_metadata_workflow_uses_bound_private_actor_authority(
+def test_durable_submitted_metadata_workflow_uses_bound_live_global_authority(
     _reset_durable_paper_state: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prove the normal persisted workflow route, without an injected grant."""
+    """Prove the persisted actor-bound route uses the actor's live global role."""
+
+    global_role = ontology_publication_authority_service.AuthorityRoleEvidence(
+        role=(
+            ontology_publication_authority_service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE
+        ),
+        actor_concept_id=_ACTOR_ID,
+        organisation_concept_id=None,
+        relation_id="role-relation:durable-paper-global-admin",
+        revision="role-revision-1",
+    )
+    monkeypatch.setattr(
+        ontology_publication_authority_service,
+        "resolve_live_semantic_roles",
+        lambda actor_id: (global_role,) if actor_id == _ACTOR_ID else (),
+    )
 
     bootstrap = bootstrap_canonical_paper_representation_workflows()
     assert (bootstrap.get("publication") or {}).get("counts", {}).get("errors") == 0
@@ -79,10 +94,10 @@ def test_durable_submitted_metadata_workflow_uses_bound_private_actor_authority(
         namespace=_NAMESPACE,
         inputs={
             "paper_metadata": {
-                "title": "Durably Bound Private Workflow Authority",
+                "title": "Durably Bound Global Workflow Authority",
                 "abstract": (
-                    "The canonical durable route should complete this private "
-                    "additive representation without delegation ceremony."
+                    "The canonical durable route should complete this global "
+                    "paper representation through the actor's live role."
                 ),
             },
             "require_representation_evidence_summary": False,
@@ -144,8 +159,8 @@ def test_durable_submitted_metadata_workflow_uses_bound_private_actor_authority(
         )
     }
     assert (
-        "The canonical durable route should complete this private additive "
-        "representation without delegation ceremony."
+        "The canonical durable route should complete this global paper "
+        "representation through the actor's live role."
     ) in descriptions
     terminal = manager.get_instance(submission.instance_id)
     assert terminal is not None

--- a/tests/backend/test_write_tool_policy.py
+++ b/tests/backend/test_write_tool_policy.py
@@ -32,6 +32,10 @@ def test_classify_write_tool_risk_covers_policy_classes():
 
     assert classify_write_tool_risk("add_relationship") == WRITE_RISK_ADDITIVE_LOW_RISK
     assert (
+        classify_write_tool_risk("upsert_scoped_assertion")
+        == WRITE_RISK_ADDITIVE_LOW_RISK
+    )
+    assert (
         classify_write_tool_risk("update_concept")
         == WRITE_RISK_MUTATIVE_NON_DESTRUCTIVE
     )
@@ -319,9 +323,7 @@ def test_explicit_request_evidence_allows_workflow_execute_external_write():
         request_evidence=_request_evidence(
             "workflow_execute",
             request_state="explicit_request",
-            rationale=(
-                "represented expected-outcome contract requires this workflow"
-            ),
+            rationale=("represented expected-outcome contract requires this workflow"),
         ),
         recent_user_prompts=[],
     )


### PR DESCRIPTION
## Outcome

Make public scholarly papers, their public bibliographic metadata, and public-source author occurrences globally represented when the actor has live global ontology authority, while keeping contextual facts such as local file copies scoped to the actor.

## Changes

- consume represented type- and predicate-level publication-scope profiles before paper mutations
- publish papers, DOI/source/date/topic metadata, authors and authorship through governed generic workflow writes
- use source-bounded author occurrences to avoid name-only person merges; reuse supported public identifiers such as ORCID
- store local file-copy links as user-scoped assertions without canonical leakage
- recheck live organisation/global authority directly for exact trusted actor-bound workflow effects; retain delegation for separate or untrusted principals
- bootstrap scope profiles before the dependent paper workflow family
- classify scoped-assertion upserts as bounded additive Vontology writes

## Validation

- `66 passed` across paper action, ontology-authority, durable-authority, write-policy and runtime-profile suites
- `38 passed, 2 skipped` in the represented paper-workflow suite; the skipped cases require explicitly enabled live arXiv access
- targeted bootstrap/read-back, cross-actor reuse, name-only non-merge, unauthorised denial, user-scoped file assertion and canonical non-leak checks
- JSON parse, compile, focused Ruff checks and `git diff --check`

## Boundary

This publishes repository changes only. It does not deploy or activate a running environment. The broader conversation/country/iwi/hapu context model remains non-blocking follow-up JVNAUTOSCI-2672. The repeated email-to-paper reliability campaign remains blocked on this merge as JVNAUTOSCI-2244.
