### PR TITLE
JVNAUTOSCI-2244: make deploy-main predecessor handoff exact

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1826,11 +1826,13 @@ start_server() {
 stop_server() {
     local pid=""
     local graceful=0
+    local exact_pid_stop=0
     # Match run.ps1: stop supports extra args like: stop <pid> | stop force | stop force-any
     if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
         local arg="${EXTRA_ARGS[0]}"
         if printf '%s' "$arg" | grep -qE '^[0-9]+$'; then
             pid="$arg"
+            exact_pid_stop=1
             log "Stopping specific PID=$pid (direct)"
         elif [ "$(printf '%s' "$arg" | tr '[:upper:]' '[:lower:]')" = "force" ]; then
             pid="$(get_listening_pid_by_port "$PORT" || true)"
@@ -1942,6 +1944,14 @@ stop_server() {
     remove_pidfile
     if [ "$AGENT_TEST_INSTANCE" -eq 1 ]; then
         log "Agent test mode: preserving other Von server processes and shared RAG/concept-index workers."
+    elif [ "$exact_pid_stop" -eq 1 ]; then
+        # A deploy handoff names and verifies the one predecessor that owns the
+        # target port.  Do not let that exact stop sweep another Von server
+        # (notably the isolated AgentTest instance) merely because it runs the
+        # same script from this checkout.
+        log "Exact PID stop: preserving other Von server processes."
+        stop_rag_worker || true
+        stop_concept_index_worker || true
     else
         stop_python_processes_by_script "src/workflows/von/main.py" "Von Server" "$pid"
         stop_rag_worker || true

--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -10,10 +10,13 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
+
+import psutil
 
 
 class DeploymentError(RuntimeError):
@@ -169,6 +172,109 @@ def _read_health(url: str) -> dict[str, Any]:
     return payload
 
 
+def _matching_von_process_root(
+    *,
+    pid: int,
+    expected_port: int,
+    allowed_roots: Sequence[Path],
+) -> Path:
+    """Return the allowed checkout that owns one exact Von listener process."""
+
+    try:
+        process = psutil.Process(pid)
+        command = [str(part) for part in process.cmdline()]
+        process_cwd = Path(process.cwd()).resolve()
+    except (psutil.Error, OSError) as exc:
+        raise DeploymentError(
+            f"Cannot inspect existing health PID {pid}: {exc}"
+        ) from exc
+
+    port_matches = any(
+        part == "--port"
+        and index + 1 < len(command)
+        and command[index + 1] == str(expected_port)
+        for index, part in enumerate(command)
+    )
+    if not port_matches:
+        raise DeploymentError(
+            f"Refusing to stop health PID {pid}: command does not select "
+            f"port {expected_port}"
+        )
+
+    candidates: list[Path] = []
+    for part in command:
+        normalised = part.replace("\\", "/")
+        if not normalised.endswith("src/workflows/von/main.py"):
+            continue
+        path = Path(part)
+        candidates.append(
+            (path if path.is_absolute() else process_cwd / path).resolve()
+        )
+
+    for root in allowed_roots:
+        resolved_root = root.resolve()
+        expected_script = (
+            resolved_root / "src" / "workflows" / "von" / "main.py"
+        ).resolve()
+        if expected_script in candidates:
+            return resolved_root
+
+    rendered = " ".join(command) or "<empty>"
+    raise DeploymentError(
+        f"Refusing to stop health PID {pid}: it is not the Von server from an "
+        f"allowed deployment checkout ({rendered})"
+    )
+
+
+def _stop_verified_predecessor(
+    *,
+    primary_root: Path,
+    runtime_root: Path,
+    current_launcher: Path,
+    health_url: str,
+) -> int | None:
+    """Stop only a verified Von process already serving the deployment port."""
+
+    try:
+        health = _read_health(health_url)
+    except DeploymentError:
+        return None
+
+    pid = health.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        raise DeploymentError(
+            f"Existing health response has invalid server PID: {pid!r}"
+        )
+    parsed_url = urllib.parse.urlparse(health_url)
+    try:
+        expected_port = parsed_url.port
+    except ValueError as exc:
+        raise DeploymentError(f"Invalid health URL port: {health_url}") from exc
+    if expected_port is None:
+        expected_port = 443 if parsed_url.scheme == "https" else 80
+
+    predecessor_root = _matching_von_process_root(
+        pid=pid,
+        expected_port=expected_port,
+        allowed_roots=(primary_root, runtime_root),
+    )
+    stop_environment = os.environ.copy()
+    stop_environment["VON_LAUNCHER_ROOT"] = str(predecessor_root)
+    _run(
+        ["bash", current_launcher, "stop", str(pid), "-NoBrowser"],
+        cwd=predecessor_root,
+        capture_output=False,
+        env=stop_environment,
+    )
+    try:
+        psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return pid
+    raise DeploymentError(
+        f"Verified predecessor PID {pid} remained alive after exact stop"
+    )
+
+
 def _health_error(payload: dict[str, Any], target_commit: str) -> str | None:
     if payload.get("status") != "healthy":
         return f"status={payload.get('status')!r}"
@@ -276,6 +382,12 @@ def deploy(
 
     # Validate before stopping, then change code only while the server is down.
     _validate_runtime(primary_root, runtime_root)
+    _stop_verified_predecessor(
+        primary_root=primary_root,
+        runtime_root=runtime_root,
+        current_launcher=current_launcher,
+        health_url=health_url,
+    )
     stop_environment = os.environ.copy()
     stop_environment["VON_LAUNCHER_ROOT"] = str(runtime_root)
     _run(

--- a/tests/test_deploy_local_main.py
+++ b/tests/test_deploy_local_main.py
@@ -10,8 +10,10 @@ import pytest
 from scripts.deploy_local_main import (
     DeploymentError,
     _health_error,
+    _matching_von_process_root,
     _prepare_primary,
     _prepare_runtime,
+    _stop_verified_predecessor,
 )
 
 
@@ -118,6 +120,128 @@ def test_health_verification_requires_exact_clean_durable_build() -> None:
     assert _health_error(no_scheduler, commit) == (
         "durable workflow readiness false: scheduler_running"
     )
+
+
+def test_matching_von_process_root_accepts_only_exact_checkout_and_port(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    primary = (tmp_path / "Von").resolve()
+    runtime = (tmp_path / "Von-runtime-main").resolve()
+
+    class _Process:
+        def __init__(self, _pid: int) -> None:
+            pass
+
+        def cmdline(self) -> list[str]:
+            return [
+                "/usr/bin/python3",
+                "-u",
+                str(primary / "src/workflows/von/main.py"),
+                "--port",
+                "5001",
+            ]
+
+        def cwd(self) -> str:
+            return str(primary)
+
+    monkeypatch.setattr("scripts.deploy_local_main.psutil.Process", _Process)
+
+    assert _matching_von_process_root(
+        pid=4242,
+        expected_port=5001,
+        allowed_roots=(primary, runtime),
+    ) == primary
+
+    with pytest.raises(DeploymentError, match="does not select port 5010"):
+        _matching_von_process_root(
+            pid=4242,
+            expected_port=5010,
+            allowed_roots=(primary, runtime),
+        )
+
+
+def test_matching_von_process_root_rejects_foreign_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    primary = (tmp_path / "Von").resolve()
+    runtime = (tmp_path / "Von-runtime-main").resolve()
+    foreign = (tmp_path / "Foreign-Von").resolve()
+
+    class _Process:
+        def __init__(self, _pid: int) -> None:
+            pass
+
+        def cmdline(self) -> list[str]:
+            return [
+                "/usr/bin/python3",
+                str(foreign / "src/workflows/von/main.py"),
+                "--port",
+                "5001",
+            ]
+
+        def cwd(self) -> str:
+            return str(foreign)
+
+    monkeypatch.setattr("scripts.deploy_local_main.psutil.Process", _Process)
+
+    with pytest.raises(DeploymentError, match="allowed deployment checkout"):
+        _matching_von_process_root(
+            pid=4343,
+            expected_port=5001,
+            allowed_roots=(primary, runtime),
+        )
+
+
+def test_stop_verified_predecessor_uses_exact_matching_root_and_pid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    primary = (tmp_path / "Von").resolve()
+    runtime = (tmp_path / "Von-runtime-main").resolve()
+    launcher = primary / "run.sh"
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._read_health",
+        lambda _url: {"status": "healthy", "pid": 4444},
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._matching_von_process_root",
+        lambda **_kwargs: primary,
+    )
+
+    def _record_run(args, **kwargs):
+        calls.append({"args": list(args), **kwargs})
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr("scripts.deploy_local_main._run", _record_run)
+
+    def _missing_process(pid: int):
+        raise __import__("psutil").NoSuchProcess(pid)
+
+    monkeypatch.setattr(
+        "scripts.deploy_local_main.psutil.Process",
+        _missing_process,
+    )
+
+    assert _stop_verified_predecessor(
+        primary_root=primary,
+        runtime_root=runtime,
+        current_launcher=launcher,
+        health_url="http://127.0.0.1:5001/health",
+    ) == 4444
+    assert calls[0]["args"] == [
+        "bash",
+        launcher,
+        "stop",
+        "4444",
+        "-NoBrowser",
+    ]
+    assert calls[0]["cwd"] == primary
+    assert calls[0]["capture_output"] is False
+    assert calls[0]["env"]["VON_LAUNCHER_ROOT"] == str(primary)
 
 
 def test_run_sh_detached_worker_helper_starts_a_new_session(tmp_path: Path) -> None:

--- a/tests/test_run_sh_start_behaviour.py
+++ b/tests/test_run_sh_start_behaviour.py
@@ -1052,6 +1052,47 @@ PY
     assert "browser opened" not in payload["logs"]
 
 
+def test_run_sh_exact_pid_stop_preserves_other_von_servers() -> None:
+    payload = _run_bash_probe(
+        r"""
+logs=()
+stopped_workers=()
+process_exists_calls=0
+log() { logs+=("$*"); }
+process_exists() {
+    process_exists_calls=$((process_exists_calls + 1))
+    [ "$process_exists_calls" -eq 1 ]
+}
+is_von_main_process() { return 0; }
+remove_pidfile() { :; }
+stop_python_processes_by_script() { logs+=("broad sweep:$*"); }
+stop_rag_worker() { stopped_workers+=("rag"); }
+stop_concept_index_worker() { stopped_workers+=("concept"); }
+
+TOKEN_FILE="/definitely/not/a/token/file"
+EXTRA_ARGS=("4242")
+stop_server
+
+LOGS="$(printf '%s\n' "${logs[@]}")" \
+STOPPED_WORKERS="$(printf '%s\n' "${stopped_workers[@]}")" \
+python3 - <<PY
+import json
+import os
+print(json.dumps({
+    "logs": [line for line in os.environ.get("LOGS", "").splitlines() if line],
+    "stopped_workers": [
+        line for line in os.environ.get("STOPPED_WORKERS", "").splitlines() if line
+    ],
+}))
+PY
+"""
+    )
+
+    assert "Exact PID stop: preserving other Von server processes." in payload["logs"]
+    assert not any(line.startswith("broad sweep:") for line in payload["logs"])
+    assert payload["stopped_workers"] == ["rag", "concept"]
+
+
 def test_stale_server_cleanup_does_not_match_deploy_local_main_by_basename(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Outcome

Make canonical local deployment replace an older Von listener from either the primary or runtime checkout without sweeping AgentTest or unrelated processes.

## Changes

- inspect the current target health PID before deployment
- require the exact configured port and exact Von script under an allowed deployment checkout
- stop only that verified predecessor PID
- preserve other Von servers during numeric-PID stop while stopping that checkout worker pair
- retain fail-safe behaviour for foreign roots, wrong ports and unverifiable PIDs

## Evidence

- 45 launcher/deployment tests pass
- exact root/port, foreign checkout, exact-stop command and AgentTest-preservation cases added
- shell syntax, Python compilation, fatal Ruff and diff checks pass

## Live acceptance after merge

Run deploy-main while production and AgentTest are both alive; verify the exact deployed commit, durable readiness, RAG and concept-index workers, and the original AgentTest PID survives.