### PR TITLE
Fix paper fallback identity and batch output

### DIFF
--- a/src/backend/workflows/durable/paper_representation_workflow.py
+++ b/src/backend/workflows/durable/paper_representation_workflow.py
@@ -2247,21 +2247,53 @@ def _build_prepare_public_title_search_handler():
             metadata.get("source_uri"),
             metadata.get("source_url"),
         )
-        if doi_candidates or stable_source_uri:
-            return WorkflowActionResult(
-                status="failed",
-                outputs={"paper_metadata": metadata or None},
-                error="public_paper_title_resolution_not_required",
-            )
         title = _first_non_empty_text(
             request.inputs.get("title"),
             request.data.get("title"),
             metadata.get("title"),
             metadata.get("paper_title"),
         )
+        publication_date = _first_non_empty_text(
+            request.inputs.get("publication_date"),
+            request.data.get("publication_date"),
+            metadata.get("publication_date"),
+            metadata.get("published"),
+        )
+        author_names = _coerce_string_list(
+            request.inputs.get("author_names")
+            or request.data.get("author_names")
+            or metadata.get("authors")
+        )
+
+        bibliographic_fallback_basis: str | None = None
+        if doi_candidates:
+            bibliographic_fallback_basis = "doi"
+        elif stable_source_uri:
+            bibliographic_fallback_basis = "source_uri"
+        elif title and publication_date and author_names:
+            bibliographic_fallback_basis = "title_publication_date_authors"
+
+        if doi_candidates or stable_source_uri:
+            return WorkflowActionResult(
+                status="success",
+                outputs={
+                    "paper_metadata": metadata or None,
+                    "public_paper_title": title,
+                    "public_paper_title_query": title,
+                    "public_paper_title_search_required": False,
+                    "bibliographic_fallback_sufficient": True,
+                    "bibliographic_fallback_basis": bibliographic_fallback_basis,
+                },
+            )
         if not title:
             return WorkflowActionResult(
                 status="failed",
+                outputs={
+                    "paper_metadata": metadata or None,
+                    "public_paper_title_search_required": False,
+                    "bibliographic_fallback_sufficient": False,
+                    "bibliographic_fallback_basis": "insufficient",
+                },
                 error="public_paper_title_missing",
             )
         return WorkflowActionResult(
@@ -2270,6 +2302,11 @@ def _build_prepare_public_title_search_handler():
                 "public_paper_title": title,
                 "public_paper_title_query": title,
                 "paper_metadata": metadata or {"title": title},
+                "public_paper_title_search_required": True,
+                "bibliographic_fallback_sufficient": bool(bibliographic_fallback_basis),
+                "bibliographic_fallback_basis": (
+                    bibliographic_fallback_basis or "insufficient"
+                ),
             },
         )
 

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "19",
+  "seed_version": "20",
   "source_tag": "JVNAUTOSCI-2244",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",
@@ -556,75 +556,61 @@
               [
                 "field_sources",
                 {
-                  "schema_version": "gmail_arxiv_batch_result.v1",
-                  "source_system": "gmail",
-                  "source_profile": {
-                    "$context_key": "gmail_profile"
-                  },
-                  "effective_query": {
-                    "$context_key": "effective_gmail_query"
-                  },
-                  "requested_max_items": {
-                    "$context_key": "gmail_max_results"
-                  },
-                  "result_size_estimate": {
-                    "$context_key": "gmail_result_size_estimate"
-                  },
-                  "page_token_used": {
-                    "$context_key": "gmail_page_token"
-                  },
-                  "next_page_token": {
-                    "$context_key": "gmail_next_page_token"
-                  },
-                  "discovered_message_count": {
-                    "$context_key": "message_item_count"
-                  },
-                  "selected_message_count": {
-                    "$context_key": "message_selected_item_count"
-                  },
-                  "unattempted_message_count": {
-                    "$context_key": "message_unattempted_count"
-                  },
-                  "successful_message_count": {
-                    "$context_key": "message_success_count"
-                  },
-                  "failed_message_count": {
-                    "$context_key": "message_error_count"
-                  },
-                  "partial_success": {
-                    "$context_key": "message_partial_success"
-                  },
-                  "final_state_counts": {
-                    "$context_key": "message_final_state_counts"
-                  },
-                  "items": {
-                    "$context_key": "message_iteration_results"
-                  },
-                  "failures": {
-                    "$context_key": "message_iteration_errors"
+                  "batch_result": {
+                    "schema_version": "gmail_arxiv_batch_result.v1",
+                    "source_system": "gmail",
+                    "source_profile": {
+                      "$context_key": "gmail_profile"
+                    },
+                    "effective_query": {
+                      "$context_key": "effective_gmail_query"
+                    },
+                    "requested_max_items": {
+                      "$context_key": "gmail_max_results"
+                    },
+                    "result_size_estimate": {
+                      "$context_key": "gmail_result_size_estimate"
+                    },
+                    "page_token_used": {
+                      "$context_key": "gmail_page_token"
+                    },
+                    "next_page_token": {
+                      "$context_key": "gmail_next_page_token"
+                    },
+                    "discovered_message_count": {
+                      "$context_key": "message_item_count"
+                    },
+                    "selected_message_count": {
+                      "$context_key": "message_selected_item_count"
+                    },
+                    "unattempted_message_count": {
+                      "$context_key": "message_unattempted_count"
+                    },
+                    "successful_message_count": {
+                      "$context_key": "message_success_count"
+                    },
+                    "failed_message_count": {
+                      "$context_key": "message_error_count"
+                    },
+                    "partial_success": {
+                      "$context_key": "message_partial_success"
+                    },
+                    "final_state_counts": {
+                      "$context_key": "message_final_state_counts"
+                    },
+                    "items": {
+                      "$context_key": "message_iteration_results"
+                    },
+                    "failures": {
+                      "$context_key": "message_iteration_errors"
+                    }
                   }
                 }
               ],
               [
                 "required_fields",
                 [
-                  "schema_version",
-                  "source_system",
-                  "source_profile",
-                  "effective_query",
-                  "requested_max_items",
-                  "result_size_estimate",
-                  "page_token_used",
-                  "next_page_token",
-                  "discovered_message_count",
-                  "selected_message_count",
-                  "unattempted_message_count",
-                  "successful_message_count",
-                  "failed_message_count",
-                  "partial_success",
-                  "final_state_counts",
-                  "items",
-                  "failures"
+                  "batch_result"
                 ]
               ],
               [
@@ -641,10 +627,18 @@
               ],
               [
                 "target_key",
-                "batch_result"
+                "workflow_return_payload"
               ]
             ],
+            "tool_output_mapping_specs": [
+              {
+                "concept_id": "#V#workflow_mapping_tool_field_zhan_gmail_arxiv_ingestion_workflow_project_batch_result_workflow_return_payload_batch_result_to_batch_result",
+                "context_key": "batch_result",
+                "tool_output_field": "workflow_return_payload.batch_result"
+              }
+            ],
             "writes_context_keys": [
+              "workflow_return_payload",
               "batch_result"
             ]
           },

--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "29",
+  "seed_version": "30",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
@@ -4531,7 +4531,18 @@
             "action_id": "paper_reference.prepare_public_title_search",
             "execution_mode": "deterministic",
             "next_state": "search_public_arxiv",
-            "on_failure_state": "ingest_metadata_fallback",
+            "on_failure_state": "decide_metadata_fallback",
+            "conditional_transitions": [
+              {
+                "to_state": "decide_metadata_fallback",
+                "reason": "stable_bibliographic_identity_already_available",
+                "condition_spec": {
+                  "kind": "context_flag",
+                  "key": "public_paper_title_search_required",
+                  "expected": false
+                }
+              }
+            ],
             "tool_output_mapping_specs": [
               {
                 "context_key": "public_paper_title",
@@ -4547,12 +4558,30 @@
                 "context_key": "paper_metadata",
                 "tool_output_field": "paper_metadata",
                 "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_paper_metadata_to_paper_metadata"
+              },
+              {
+                "context_key": "public_paper_title_search_required",
+                "tool_output_field": "public_paper_title_search_required",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_public_paper_title_search_required_to_public_paper_title_search_required"
+              },
+              {
+                "context_key": "bibliographic_fallback_sufficient",
+                "tool_output_field": "bibliographic_fallback_sufficient",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_bibliographic_fallback_sufficient_to_bibliographic_fallback_sufficient"
+              },
+              {
+                "context_key": "bibliographic_fallback_basis",
+                "tool_output_field": "bibliographic_fallback_basis",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_bibliographic_fallback_basis_to_bibliographic_fallback_basis"
               }
             ],
             "writes_context_keys": [
               "public_paper_title",
               "public_paper_title_query",
-              "paper_metadata"
+              "paper_metadata",
+              "public_paper_title_search_required",
+              "bibliographic_fallback_sufficient",
+              "bibliographic_fallback_basis"
             ]
           },
           {
@@ -4560,7 +4589,7 @@
             "action_id": "workflow_mcp.invoke_tool",
             "execution_mode": "deterministic",
             "next_state": "select_exact_title_match",
-            "on_failure_state": "ingest_metadata_fallback",
+            "on_failure_state": "decide_metadata_fallback",
             "static_input_bindings": [
               [
                 "tool_arguments",
@@ -4593,7 +4622,7 @@
             "action_id": "paper_reference.select_arxiv_title_match",
             "execution_mode": "deterministic",
             "next_state": "ingest_resolved_arxiv",
-            "on_failure_state": "ingest_metadata_fallback",
+            "on_failure_state": "decide_metadata_fallback",
             "context_input_mapping_specs": [
               {
                 "tool_param": "search_payload",
@@ -4707,6 +4736,78 @@
               "paper_concept_id",
               "file_copy_concept_id",
               "article_readback"
+            ]
+          },
+          {
+            "state_id": "decide_metadata_fallback",
+            "action_id": "workflow_control.context_set",
+            "execution_mode": "deterministic",
+            "next_state": "reject_insufficient_bibliographic_identity",
+            "conditional_transitions": [
+              {
+                "to_state": "ingest_metadata_fallback",
+                "reason": "sufficient_bibliographic_identity_available",
+                "condition_spec": {
+                  "kind": "context_flag",
+                  "key": "bibliographic_fallback_sufficient",
+                  "expected": true
+                }
+              }
+            ],
+            "static_input_bindings": [
+              [
+                "assignments",
+                [
+                  {
+                    "key": "public_paper_fallback_decision",
+                    "value": "stable_bibliographic_identity_gate"
+                  }
+                ]
+              ]
+            ],
+            "writes_context_keys": [
+              "public_paper_fallback_decision"
+            ]
+          },
+          {
+            "state_id": "reject_insufficient_bibliographic_identity",
+            "action_id": "paper_reference.fail_item",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              [
+                "error_code",
+                "public_paper_stable_identity_not_resolved"
+              ],
+              [
+                "error_message",
+                "Public lookup did not resolve one stable paper identity, and the supplied metadata lacks DOI, source URI, or title plus publication date and authors."
+              ],
+              [
+                "reference_kind",
+                "metadata"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "context_key": "paper_reference_item_status",
+                "tool_output_field": "paper_reference_item_status",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_insufficient_bibliographic_identity_paper_reference_item_status_to_paper_reference_item_status"
+              },
+              {
+                "context_key": "paper_reference_error_code",
+                "tool_output_field": "paper_reference_error_code",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_insufficient_bibliographic_identity_paper_reference_error_code_to_paper_reference_error_code"
+              },
+              {
+                "context_key": "paper_reference_error_message",
+                "tool_output_field": "paper_reference_error_message",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_insufficient_bibliographic_identity_paper_reference_error_message_to_paper_reference_error_message"
+              }
+            ],
+            "writes_context_keys": [
+              "paper_reference_item_status",
+              "paper_reference_error_code",
+              "paper_reference_error_message"
             ]
           },
           {

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -15,6 +15,9 @@ from src.backend.workflows.action_registry import (
 from src.backend.workflows.durable.control_flow_actions import (
     register_control_flow_actions,
 )
+from src.backend.workflows.durable.failed_output_diagnostics import (
+    build_completed_workflow_outputs,
+)
 from src.backend.workflows.durable.models import WorkflowSchedule
 from src.backend.workflows.engine import WorkflowExecutor
 from src.backend.workflows.workflow_launch_input_contracts import (
@@ -753,6 +756,25 @@ def test_parent_batch_preserves_all_22_item_results_and_one_retryable_failure() 
     assert batch_result["partial_success"] is True
     assert batch_result["items"] == iteration_results
     assert batch_result["failures"] == iteration_errors
+    assert result.data["workflow_return_payload"] == {"batch_result": batch_result}
+    terminal_outputs = build_completed_workflow_outputs(
+        result.data,
+        result_envelope=result.result_envelope,
+        final_state=result.final_state,
+    )
+    assert terminal_outputs["terminal_output_source"] == "declared_output_payload"
+    terminal_batch = terminal_outputs["batch_result"]
+    assert terminal_batch["schema_version"] == "gmail_arxiv_batch_result.v1"
+    assert terminal_batch["successful_message_count"] == 21
+    assert terminal_batch["failed_message_count"] == 1
+    assert terminal_batch["selected_message_count"] == 22
+    assert terminal_batch["page_token_used"] == "[redacted]"
+    assert terminal_batch["items"][-1] == {
+        "truncated": True,
+        "reason": "max_items",
+        "omitted_item_count": 14,
+    }
+    assert "result" not in terminal_outputs
     represented_ids = {
         arxiv_id
         for item in batch_result["items"]

--- a/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
+++ b/tests/backend/test_jvnautosci_2272_zhan_gmail_arxiv_workflow_repair.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from scripts.repair_jvnautosci_2272_zhan_gmail_arxiv_ingestion_workflow import (
     ALLOW_PARTIAL_SUCCESS_POLICY,
     CHILD_EXTRACT_RESOURCES_STEP_ID,
@@ -232,11 +234,18 @@ def test_launch_contracts_are_valid_and_mapping_backed() -> None:
 
 
 def test_legacy_repair_entry_point_delegates_to_current_canonical_seed() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as service,
+    )
+
     report = publish_jvnautosci_2272_repair(dry_run=True)
+    canonical_payload = json.loads(
+        service._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8")
+    )
 
     assert report["success"] is True
     assert report["deprecated_entry_point"] is True
-    assert report["seed_version"] == "13"
+    assert report["seed_version"] == canonical_payload["seed_version"]
     assert report["delegates_to"] == (
         "bootstrap_canonical_email_source_representation_convergence_workflows"
     )

--- a/tests/backend/test_paper_representation_workflow.py
+++ b/tests/backend/test_paper_representation_workflow.py
@@ -130,6 +130,61 @@ def test_public_title_resolution_selects_one_exact_arxiv_match() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("paper_metadata", "expected_sufficient", "expected_basis"),
+    (
+        (
+            {"title": "A Bare Paper Title"},
+            False,
+            "insufficient",
+        ),
+        (
+            {
+                "title": "A Bibliographically Identified Paper",
+                "authors": ["Ada Lovelace"],
+                "publication_date": "1843",
+            },
+            True,
+            "title_publication_date_authors",
+        ),
+        (
+            {
+                "title": "A DOI Identified Paper",
+                "doi": "10.1000/example",
+            },
+            True,
+            "doi",
+        ),
+        (
+            {
+                "title": "A Source Identified Paper",
+                "source_url": "https://example.org/papers/identified",
+            },
+            True,
+            "source_uri",
+        ),
+    ),
+)
+def test_prepare_public_title_search_reports_bibliographic_fallback_evidence(
+    paper_metadata: dict[str, object],
+    expected_sufficient: bool,
+    expected_basis: str,
+) -> None:
+    prepared = _paper_registry().execute(
+        PAPER_REFERENCE_PREPARE_PUBLIC_TITLE_SEARCH_ACTION_ID,
+        inputs={"paper_metadata": paper_metadata},
+        context={},
+        env=WorkflowEnvironment(llm_client=None),
+    )
+
+    assert prepared.status == "success"
+    assert prepared.outputs["bibliographic_fallback_sufficient"] is expected_sufficient
+    assert prepared.outputs["bibliographic_fallback_basis"] == expected_basis
+    assert prepared.outputs["public_paper_title_search_required"] is (
+        expected_basis not in {"doi", "source_uri"}
+    )
+
+
 def test_public_title_resolution_fails_closed_on_ambiguous_exact_matches() -> None:
     selected = _paper_registry().execute(
         PAPER_REFERENCE_SELECT_ARXIV_TITLE_MATCH_ACTION_ID,
@@ -218,6 +273,109 @@ def test_public_title_resolution_workflow_searches_then_represents_exact_match()
     assert result.data["public_paper_resolution_status"] == (
         "exact_public_title_match"
     )
+
+
+def test_public_title_resolution_workflow_rejects_title_only_after_public_miss() -> (
+    None
+):
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[_REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID],
+    )[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID]
+    registry = _paper_registry()
+    register_control_flow_actions(registry)
+    registry.register(
+        ActionSpec(
+            action_id="workflow_mcp.invoke_tool",
+            handler=lambda _request: WorkflowActionResult(
+                status="success",
+                outputs={"result": {"results": []}},
+            ),
+        )
+    )
+    registry.register(
+        ActionSpec(
+            action_id="workflow_invoke_subworkflow",
+            handler=lambda _request: pytest.fail(
+                "title-only evidence must not reach a mutating fallback"
+            ),
+        )
+    )
+
+    result = WorkflowExecutor(registry=registry, max_transitions=12).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={"paper_metadata": {"title": "A Bare Paper Title"}},
+    )
+
+    assert result.completed is False
+    assert result.error == "public_paper_stable_identity_not_resolved"
+    assert result.data["last_action_outputs"]["paper_reference_item_status"] == (
+        "failed"
+    )
+    assert result.data["last_action_outputs"]["paper_reference_error_code"] == (
+        "public_paper_stable_identity_not_resolved"
+    )
+
+
+def test_public_title_resolution_workflow_uses_sufficient_bibliographic_fallback() -> (
+    None
+):
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[_REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID],
+    )[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID]
+    calls: list[str] = []
+
+    def invoke_tool(_request):
+        calls.append("search_arxiv")
+        return WorkflowActionResult(
+            status="success",
+            outputs={"result": {"results": []}},
+        )
+
+    def invoke_metadata(request):
+        calls.append(str(request.workflow_state_id))
+        assert request.inputs["paper_metadata"]["authors"] == ["Ada Lovelace"]
+        assert request.inputs["paper_metadata"]["publication_date"] == "1843"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "paper_concept_id": "#V#public_bibliographic_example",
+                    "article_readback": {
+                        "concept_id": "#V#public_bibliographic_example"
+                    },
+                }
+            },
+        )
+
+    registry = _paper_registry()
+    register_control_flow_actions(registry)
+    registry.register(
+        ActionSpec(action_id="workflow_mcp.invoke_tool", handler=invoke_tool)
+    )
+    registry.register(
+        ActionSpec(action_id="workflow_invoke_subworkflow", handler=invoke_metadata)
+    )
+    result = WorkflowExecutor(registry=registry, max_transitions=12).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={
+            "paper_metadata": {
+                "title": "A Bibliographically Identified Paper",
+                "authors": ["Ada Lovelace"],
+                "publication_date": "1843",
+            }
+        },
+    )
+
+    assert result.completed is True
+    assert calls == ["search_arxiv", "ingest_metadata_fallback"]
+    assert result.data["bibliographic_fallback_basis"] == (
+        "title_publication_date_authors"
+    )
+    assert result.data["paper_concept_id"] == "#V#public_bibliographic_example"
 
 
 def test_public_title_resolution_workflow_preserves_stronger_doi_identity() -> None:

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -647,6 +647,66 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         ]
         == SCHOLARLY_PAPER_REPRESENTATION_WORKFLOW_ID
     )
+    public_title_prepare_state_id = authority_service._step_concept_id(
+        workflow_id=PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID,
+        state_id="prepare_title_search",
+    )
+    public_title_decide_fallback_state_id = authority_service._step_concept_id(
+        workflow_id=PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID,
+        state_id="decide_metadata_fallback",
+    )
+    public_title_reject_fallback_state_id = authority_service._step_concept_id(
+        workflow_id=PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID,
+        state_id="reject_insufficient_bibliographic_identity",
+    )
+    public_title_ingest_fallback_state_id = authority_service._step_concept_id(
+        workflow_id=PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID,
+        state_id="ingest_metadata_fallback",
+    )
+    public_title_prepare_state = public_title_definition.states[
+        public_title_prepare_state_id
+    ]
+    assert {
+        mapping.get("context_key")
+        for mapping in public_title_prepare_state.metadata.get(
+            "tool_output_context_mappings", []
+        )
+    }.issuperset(
+        {
+            "public_paper_title_search_required",
+            "bibliographic_fallback_sufficient",
+            "bibliographic_fallback_basis",
+        }
+    )
+    assert any(
+        transition.to_state == public_title_decide_fallback_state_id
+        and transition.reason == "stable_bibliographic_identity_already_available"
+        for transition in public_title_prepare_state.transitions
+    )
+    public_title_decide_state = public_title_definition.states[
+        public_title_decide_fallback_state_id
+    ]
+    assert any(
+        transition.to_state == public_title_ingest_fallback_state_id
+        and transition.reason == "sufficient_bibliographic_identity_available"
+        and transition.condition_spec
+        == {
+            "kind": "context_flag",
+            "key": "bibliographic_fallback_sufficient",
+            "expected": True,
+        }
+        for transition in public_title_decide_state.transitions
+    )
+    assert any(
+        transition.to_state == public_title_reject_fallback_state_id
+        for transition in public_title_decide_state.transitions
+    )
+    assert (
+        public_title_definition.states[public_title_reject_fallback_state_id]
+        .actions[0]
+        .action_id
+        == "paper_reference.fail_item"
+    )
     route_arxiv_targets_state_id = authority_service._step_concept_id(
         workflow_id=ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID,
         state_id="route_arxiv_targets",
@@ -2158,7 +2218,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "29" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "30" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID


### PR DESCRIPTION
## Outcome

Makes Gmail paper convergence return its declared batch result and prevents a public-title lookup miss from globally publishing a new paper from title-only evidence.

## Behaviour

- exact public arXiv title matches still proceed to full representation
- DOI, stable source URL, or title plus publication date and authors may use the bibliographic fallback
- title-only misses return typed non-success without invoking the mutating fallback
- terminal Gmail output exposes the bounded gmail_arxiv_batch_result.v1 instead of the stale list payload

## Validation

- 27 paper action and workflow tests passed
- 30 email convergence bootstrap tests passed
- 39 canonical paper Vontology service tests passed, 2 skipped
- 95 repo-seed invariant and legacy Gmail repair tests passed
- JSON validation, diff check, and targeted lint passed

Jira: JVNAUTOSCI-2244