### PR TITLE
JVNAUTOSCI-2244: allow registered nested worktrees during deploy

### DIFF
--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import subprocess
@@ -64,10 +65,56 @@ def _git(root: Path, *args: str, check: bool = True) -> str:
     return _run(["git", "-C", root, *args], check=check).stdout.strip()
 
 
+def _registered_nested_worktree_roots(root: Path) -> frozenset[Path]:
+    roots: set[Path] = set()
+    payload = _git(root, "worktree", "list", "--porcelain")
+    for line in payload.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        path_text = line.removeprefix("worktree ").strip()
+        if not path_text:
+            continue
+        candidate = Path(os.path.abspath(path_text))
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            continue
+        if candidate != root:
+            roots.add(candidate)
+    return frozenset(roots)
+
+
+def _porcelain_status_path(line: str) -> str | None:
+    if len(line) < 4:
+        return None
+    raw_path = line[3:]
+    if not raw_path:
+        return None
+    if raw_path.startswith('"'):
+        try:
+            decoded = ast.literal_eval(raw_path)
+        except (SyntaxError, ValueError):
+            return None
+        return decoded if isinstance(decoded, str) and decoded else None
+    return raw_path
+
+
 def _require_clean(root: Path, label: str) -> None:
     status = _git(root, "status", "--porcelain=v1", "--untracked-files=all")
-    if status:
-        first_entries = ", ".join(status.splitlines()[:5])
+    nested_worktree_roots = _registered_nested_worktree_roots(root)
+    blocking_entries: list[str] = []
+    for line in status.splitlines():
+        if line.startswith("?? "):
+            relative_path = _porcelain_status_path(line)
+            if relative_path:
+                candidate = Path(
+                    os.path.abspath(root / relative_path.rstrip("/"))
+                )
+                if candidate in nested_worktree_roots:
+                    continue
+        blocking_entries.append(line)
+    if blocking_entries:
+        first_entries = ", ".join(blocking_entries[:5])
         raise DeploymentError(
             f"Refusing to deploy: {label} worktree is not clean ({first_entries})"
         )

--- a/tests/test_deploy_local_main.py
+++ b/tests/test_deploy_local_main.py
@@ -90,6 +90,51 @@ def test_prepare_refuses_primary_that_is_not_main(tmp_path: Path) -> None:
         _prepare_primary(primary.resolve(), remote="origin", branch="main")
 
 
+def test_prepare_allows_registered_nested_worktree(tmp_path: Path) -> None:
+    _, _, primary, _ = _setup_repositories(tmp_path)
+    nested_worktree = primary / ".worktrees" / "feature"
+    _git(
+        primary,
+        "worktree",
+        "add",
+        "-b",
+        "feature/nested",
+        str(nested_worktree),
+        "HEAD",
+    )
+    (nested_worktree / "tracked.txt").write_text(
+        "uncommitted feature work\n",
+        encoding="utf-8",
+    )
+
+    prepared = _prepare_primary(primary.resolve(), remote="origin", branch="main")
+
+    assert prepared == _git(primary, "rev-parse", "HEAD")
+    assert (nested_worktree / "tracked.txt").read_text(encoding="utf-8") == (
+        "uncommitted feature work\n"
+    )
+
+
+def test_prepare_still_refuses_other_untracked_files_beside_nested_worktree(
+    tmp_path: Path,
+) -> None:
+    _, _, primary, _ = _setup_repositories(tmp_path)
+    nested_worktree = primary / ".worktrees" / "feature"
+    _git(
+        primary,
+        "worktree",
+        "add",
+        "-b",
+        "feature/nested",
+        str(nested_worktree),
+        "HEAD",
+    )
+    (primary / "ordinary-untracked.txt").write_text("do not ignore me\n")
+
+    with pytest.raises(DeploymentError, match="ordinary-untracked.txt"):
+        _prepare_primary(primary.resolve(), remote="origin", branch="main")
+
+
 def test_health_verification_requires_exact_clean_durable_build() -> None:
     commit = "a" * 40
     payload = {


### PR DESCRIPTION
Outcome
- deploy-main now excludes only exact Git-registered worktree roots nested beneath the primary checkout from its primary cleanliness failure.
- Ordinary tracked changes, untracked files, and unregistered directories remain blocking.
- Dirty work inside the separate registered worktree is preserved and does not affect deployment of main.

Evidence
- 10 deploy workflow tests passed, including registered nested worktree acceptance and ordinary untracked-file rejection.
- Diff check passed.
- Existing Ruff findings in these files are unchanged pre-existing style findings.

Delivery decision
- Merge decision does not change: this is required to run the canonical deployment without deleting, moving, staging, or hiding unrelated registered work.
- Stop ship if the filter ignores anything other than an exact registered nested worktree root, or if it modifies the nested worktree.

Jira: JVNAUTOSCI-2244