### PR TITLE
JVNAUTOSCI-530: Make concept tabs fast and actor-effectively complete

### DIFF
--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -38,6 +38,10 @@ from ...services.paper_recommendation_workflow_vontology_service import (
 from ...services.concept_summary_renderer_service import (
     load_concept_summary_renderer,
 )
+from ...services.concept_effective_assertion_service import (
+    DEFAULT_PAGE_LIMIT as DEFAULT_EFFECTIVE_ASSERTION_PAGE_LIMIT,
+    load_concept_effective_assertions,
+)
 from ...vontology.utils_vontology import (
     get_concept_notes,
 )  # Added getter import
@@ -332,6 +336,76 @@ def get_concept_summary_renderer(concept_id: str) -> ResponseReturnValue:
             exc_info=True,
         )
         return jsonify({"error": "Failed to load concept summary renderer"}), 500
+
+
+@concept_bp.route("/<string:concept_id>/effective_assertions", methods=["GET"])
+def get_concept_effective_assertions(concept_id: str) -> ResponseReturnValue:
+    """Return one bounded actor-effective assertion page for a concept.
+
+    The request cannot nominate a user, organisation, namespace, or scope. The
+    scoped-assertion service derives visibility only from trusted ambient
+    request context. Anonymous callers receive the base-only empty projection,
+    without learning whether private assertions exist.
+    """
+
+    current_user_id = _get_current_user_concept_id()
+    if not current_user_id:
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "concept_id": concept_id,
+                    "context_view": "base_publication",
+                    "items": [],
+                    "returned": 0,
+                    "offset": 0,
+                    "limit": DEFAULT_EFFECTIVE_ASSERTION_PAGE_LIMIT,
+                    "has_more": False,
+                    "next_offset": None,
+                    "truncated": False,
+                    "counts_are_lower_bounds": False,
+                }
+            ),
+            200,
+        )
+
+    try:
+        payload = load_concept_effective_assertions(
+            concept_id=concept_id,
+            limit=request.args.get(
+                "limit",
+                DEFAULT_EFFECTIVE_ASSERTION_PAGE_LIMIT,
+            ),
+            offset=request.args.get("offset", 0),
+        )
+        return jsonify(payload), 200
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except RuntimeError as exc:
+        current_app.logger.warning(
+            "Actor-effective assertions unavailable for %s: %s",
+            concept_id,
+            exc,
+            exc_info=True,
+        )
+        return (
+            jsonify(
+                {
+                    "error": "Actor-effective assertions are temporarily unavailable",
+                    "error_code": "actor_effective_assertions_unavailable",
+                    "retryable": True,
+                }
+            ),
+            503,
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to load actor-effective assertions for %s: %s",
+            concept_id,
+            exc,
+            exc_info=True,
+        )
+        return jsonify({"error": "Failed to load actor-effective assertions"}), 500
 
 
 @concept_bp.route("/", methods=["GET"])

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -57,6 +57,7 @@ from ...services.relationship_extent_index_service import (
     incoming_dynamic_extent_rows_page_for_target,
     incoming_dynamic_extent_rows_for_target,
     relationship_extent_index_ready,
+    relationship_extent_index_readiness_snapshot,
 )
 from ...services.concept_search_service import (
     search_concepts as search_concepts_service,
@@ -3769,6 +3770,8 @@ def get_relationships_extent_route():
         str(request.args.get("include_uncertain") or "").strip().lower()
     )
     include_uncertain = include_uncertain_raw in {"1", "true", "yes", "on"}
+    bounded_only_raw = str(request.args.get("bounded_only") or "").strip().lower()
+    bounded_only = bounded_only_raw in {"1", "true", "yes", "on"}
     uncertainty_statuses: list[str] = []
     for raw in request.args.getlist("uncertainty_status"):
         token = str(raw or "").strip().lower()
@@ -3788,6 +3791,26 @@ def get_relationships_extent_route():
     incoming_index_ready = (
         wants_arg2 and wants_structured and relationship_extent_index_ready()
     )
+    if bounded_only and wants_arg2 and wants_structured and not incoming_index_ready:
+        readiness_snapshot = relationship_extent_index_readiness_snapshot()
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Relationship extent index is not ready.",
+                    "error_code": "relationship_extent_index_not_ready",
+                    "retryable": True,
+                    "extent_index": {
+                        "ready": False,
+                        "used_extent_index": False,
+                        "fallback_used": False,
+                        "reason": "relationship_extent_index_not_ready",
+                        "index_state": readiness_snapshot,
+                    },
+                }
+            ),
+            503,
+        )
     wants_uncertain_payload = wants_uncertain and (
         include_uncertain or bool(uncertainty_mode) or bool(uncertainty_statuses)
     )
@@ -3980,6 +4003,9 @@ def get_relationships_extent_route():
             has_more = True
             total = max(exact_total, offset + len(paged_rows) + 1)
         if incoming_extent_index_diagnostics:
+            incoming_extent_index_diagnostics["index_state"] = (
+                relationship_extent_index_readiness_snapshot()
+            )
             incoming_extent_index_diagnostics["rows_returned"] = len(paged_rows)
             current_app.logger.info(
                 "[relationship_extent] concept=%s role=%s source=%s "
@@ -3995,6 +4021,68 @@ def get_relationships_extent_route():
                 incoming_extent_index_diagnostics.get("complete"),
                 incoming_extent_index_diagnostics.get("bounded"),
             )
+
+        metadata_ids: list[str] = []
+        seen_metadata_ids: set[str] = set()
+        for row in paged_rows:
+            for raw_id in (
+                row.get("predicate_id"),
+                row.get("arg1_value"),
+                row.get("arg2_value"),
+            ):
+                candidate = str(raw_id or "").strip()
+                if not candidate.startswith("#V#") or candidate in seen_metadata_ids:
+                    continue
+                seen_metadata_ids.add(candidate)
+                metadata_ids.append(candidate)
+        metadata_docs = (
+            list(
+                ConceptsRepository.find(
+                    {"concept_id": {"$in": metadata_ids}},
+                    {
+                        "concept_id": 1,
+                        "name": 1,
+                        "names": 1,
+                        "kind": 1,
+                        "metadata.concept_type": 1,
+                        "relationships.is_a_type_of": 1,
+                        "relationships.is_an_instance_of": 1,
+                    },
+                    limit=len(metadata_ids),
+                )
+            )
+            if metadata_ids
+            else []
+        )
+        metadata_names = resolve_concept_display_names(metadata_docs)
+        display_metadata: dict[str, dict[str, str]] = {}
+        for doc in metadata_docs:
+            metadata_concept_id = str(doc.get("concept_id") or "").strip()
+            if not metadata_concept_id:
+                continue
+            metadata = doc.get("metadata")
+            stored_kind = str(doc.get("kind") or "").strip().lower()
+            metadata_kind = (
+                str(metadata.get("concept_type") or "").strip().lower()
+                if isinstance(metadata, Mapping)
+                else ""
+            )
+            relationships = doc.get("relationships")
+            relation_payload = relationships if isinstance(relationships, Mapping) else {}
+            if stored_kind in {"type", "predicate", "individual"}:
+                display_kind = stored_kind
+            elif metadata_kind == "predicate":
+                display_kind = "predicate"
+            elif relation_payload.get("is_a_type_of"):
+                display_kind = "type"
+            else:
+                display_kind = "individual"
+            display_metadata[metadata_concept_id] = {
+                "name": metadata_names.get(metadata_concept_id)
+                or get_concept_display_name_with_names_fallback(doc)
+                or metadata_concept_id,
+                "kind": display_kind,
+            }
         return (
             jsonify(
                 {
@@ -4003,10 +4091,12 @@ def get_relationships_extent_route():
                     "total": total,
                     "total_is_complete": total_is_complete,
                     "has_more": has_more,
+                    "next_offset": offset + limit if has_more else None,
                     "limit": limit,
                     "offset": offset,
                     "rows": paged_rows,
                     "extent_index": incoming_extent_index_diagnostics,
+                    "display_metadata": display_metadata,
                 }
             ),
             200,

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -1413,6 +1413,7 @@ def create_flask_app(
     _configure_internal_mcp_orchestrator_startup(app, gateway_instance)
     _ensure_db_monitor_started(app)
     _maybe_start_startup_rag_requeue(app)
+    _maybe_start_relationship_extent_index_reconciliation(app)
     _bootstrap_concept_summary_fields_for_startup(app)
     _bootstrap_publication_scope_profiles_for_startup(app)
     _configure_durable_workflow_startup(app)
@@ -2541,6 +2542,60 @@ def _maybe_start_startup_rag_requeue(app: Flask) -> None:
             app.logger.warning("[startup] Failed to start requeue thread: %s", exc)
         except Exception:
             pass
+
+
+def _maybe_start_relationship_extent_index_reconciliation(app: Flask) -> None:
+    """Repair a missing/degraded relationship index without delaying startup."""
+
+    if _is_running_under_pytest() or _is_agent_test_instance():
+        return
+    if not _env_bool("VON_RELATIONSHIP_EXTENT_STARTUP_RECONCILE", True):
+        return
+
+    app.config["RELATIONSHIP_EXTENT_INDEX_RECONCILIATION"] = {
+        "status": "queued",
+        "success": None,
+    }
+
+    def _run() -> None:
+        try:
+            from ..services.relationship_extent_index_service import (
+                reconcile_relationship_extent_index_if_needed,
+            )
+
+            result = reconcile_relationship_extent_index_if_needed(
+                reason="server_startup_reconciliation"
+            )
+            app.config["RELATIONSHIP_EXTENT_INDEX_RECONCILIATION"] = result
+            log = app.logger.info if result.get("success") else app.logger.warning
+            log("[relationship_extent_index] startup reconciliation: %s", result)
+        except Exception as exc:  # pragma: no cover - defensive startup boundary
+            app.config["RELATIONSHIP_EXTENT_INDEX_RECONCILIATION"] = {
+                "success": False,
+                "status": "failed",
+                "error_type": type(exc).__name__,
+            }
+            app.logger.warning(
+                "[relationship_extent_index] startup reconciliation failed: %s",
+                exc,
+            )
+
+    try:
+        threading.Thread(
+            target=_run,
+            daemon=True,
+            name="relationship_extent_index_startup_reconciliation",
+        ).start()
+    except Exception as exc:  # pragma: no cover - thread start boundary
+        app.config["RELATIONSHIP_EXTENT_INDEX_RECONCILIATION"] = {
+            "success": False,
+            "status": "failed",
+            "error_type": type(exc).__name__,
+        }
+        app.logger.warning(
+            "[relationship_extent_index] failed to start reconciliation: %s",
+            exc,
+        )
 
 
 def _bootstrap_concept_summary_fields_for_startup(app: Flask) -> None:

--- a/src/backend/services/concept_effective_assertion_service.py
+++ b/src/backend/services/concept_effective_assertion_service.py
@@ -1,0 +1,222 @@
+"""Bounded actor-effective assertion projection for concept pages.
+
+The scoped-assertion store remains authoritative for scope, provenance, and
+lifecycle.  This module adds only a presentation-oriented read projection:
+it obtains the already authority-filtered page and resolves the small set of
+predicate, object, and organisation labels in one concept batch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from .concept_service import resolve_concept_display_names
+from .scoped_assertion_service import (
+    MAX_PAGE_LIMIT,
+    list_visible_scoped_assertions_page,
+)
+
+DEFAULT_PAGE_LIMIT = 25
+MAX_CONCEPT_PAGE_LIMIT = min(100, MAX_PAGE_LIMIT)
+
+
+def _normalise_page_value(
+    value: Any,
+    *,
+    field_name: str,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer")
+    try:
+        resolved = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if resolved < minimum or resolved > maximum:
+        raise ValueError(f"{field_name} must be between {minimum} and {maximum}")
+    return resolved
+
+
+def _humanise_identifier(value: Any, *, fallback: str) -> str:
+    token = str(value or "").strip()
+    if not token:
+        return fallback
+    if token.startswith("#V#"):
+        token = token[3:]
+    return " ".join(token.replace("_", " ").split()) or fallback
+
+
+def _referenced_concept_ids(items: list[Mapping[str, Any]]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        scope = item.get("scope")
+        candidates = [
+            item.get("predicate"),
+            item.get("object_concept_id"),
+            (
+                scope.get("organisation_concept_id")
+                if isinstance(scope, Mapping)
+                else None
+            ),
+        ]
+        for candidate in candidates:
+            if not isinstance(candidate, str) or not candidate.startswith("#V#"):
+                continue
+            if candidate not in seen:
+                seen.add(candidate)
+                ordered.append(candidate)
+    return ordered
+
+
+def _display_names_for_ids(concept_ids: list[str]) -> dict[str, str]:
+    if not concept_ids:
+        return {}
+    concept_docs = list(
+        ConceptsRepository.find(
+            {"concept_id": {"$in": concept_ids}},
+            {"concept_id": 1, "name": 1, "names": 1},
+            limit=len(concept_ids),
+        )
+    )
+    return resolve_concept_display_names(concept_docs)
+
+
+def _project_item(
+    item: Mapping[str, Any],
+    *,
+    display_names: Mapping[str, str],
+) -> dict[str, Any]:
+    predicate_id = str(item.get("predicate") or "").strip()
+    predicate_label = display_names.get(predicate_id) or _humanise_identifier(
+        predicate_id,
+        fallback="Assertion",
+    )
+
+    object_kind = str(item.get("object_kind") or "").strip()
+    if object_kind == "concept":
+        object_concept_id = str(item.get("object_concept_id") or "").strip()
+        object_payload: dict[str, Any] = {
+            "kind": "concept",
+            "concept_id": object_concept_id,
+            "display_name": display_names.get(object_concept_id)
+            or _humanise_identifier(object_concept_id, fallback="Concept"),
+        }
+    else:
+        object_text = item.get("object_text")
+        text_payload = object_text if isinstance(object_text, Mapping) else {}
+        object_payload = {
+            "kind": "text",
+            "text": str(text_payload.get("text") or ""),
+            "language": str(text_payload.get("language") or "") or None,
+        }
+
+    scope = item.get("scope")
+    scope_payload = scope if isinstance(scope, Mapping) else {}
+    scope_mode = str(scope_payload.get("mode") or "").strip()
+    organisation_id = str(scope_payload.get("organisation_concept_id") or "").strip()
+    if scope_mode == "organisation":
+        organisation_name = display_names.get(organisation_id)
+        source_context = {
+            "kind": "organisation",
+            "label": (
+                f"Organisation — {organisation_name}"
+                if organisation_name
+                else "Organisation"
+            ),
+            "organisation_concept_id": organisation_id or None,
+            "organisation_display_name": organisation_name,
+        }
+    else:
+        source_context = {
+            "kind": "personal",
+            "label": "Personal — visible only to you",
+            "organisation_concept_id": None,
+            "organisation_display_name": None,
+        }
+
+    return {
+        "assertion_id": item.get("assertion_id"),
+        "assertion_revision": item.get("assertion_revision"),
+        "subject_concept_id": item.get("subject_concept_id"),
+        "predicate": {
+            "concept_id": predicate_id if predicate_id.startswith("#V#") else None,
+            "storage_id": predicate_id,
+            "display_name": predicate_label,
+        },
+        "object": object_payload,
+        "source_context": source_context,
+        "status": item.get("status"),
+        "canonical_publication": False,
+        "assertion_context": item.get("assertion_context"),
+        "provenance": item.get("provenance"),
+        "created_at": item.get("created_at"),
+        "updated_at": item.get("updated_at"),
+    }
+
+
+def load_concept_effective_assertions(
+    *,
+    concept_id: str,
+    limit: Any = DEFAULT_PAGE_LIMIT,
+    offset: Any = 0,
+) -> dict[str, Any]:
+    """Return one actor-filtered, presentation-ready assertion page.
+
+    Identity and organisation scope are deliberately absent from this API.
+    ``list_visible_scoped_assertions_page`` resolves the trusted ambient actor
+    and fails closed when no authorised audience exists.
+    """
+
+    subject_id = str(concept_id or "").strip()
+    if not subject_id.startswith("#V#"):
+        raise ValueError("concept_id must be an exact #V# concept ID")
+    page_limit = _normalise_page_value(
+        limit,
+        field_name="limit",
+        default=DEFAULT_PAGE_LIMIT,
+        minimum=1,
+        maximum=MAX_CONCEPT_PAGE_LIMIT,
+    )
+    page_offset = _normalise_page_value(
+        offset,
+        field_name="offset",
+        default=0,
+        minimum=0,
+        maximum=2_147_483_647,
+    )
+
+    page = list_visible_scoped_assertions_page(
+        subject_concept_ids=[subject_id],
+        limit=page_limit,
+        offset=page_offset,
+        limit_per_subject=page_limit,
+    )
+    raw_items = [item for item in page.get("items") or [] if isinstance(item, Mapping)]
+    display_names = _display_names_for_ids(_referenced_concept_ids(raw_items))
+    items = [_project_item(item, display_names=display_names) for item in raw_items]
+    return {
+        "success": True,
+        "concept_id": subject_id,
+        "context_view": "actor_effective",
+        "items": items,
+        "returned": len(items),
+        "offset": page_offset,
+        "limit": page_limit,
+        "has_more": bool(page.get("has_more")),
+        "next_offset": page.get("next_offset"),
+        "truncated": bool(page.get("truncated")),
+        "counts_are_lower_bounds": bool(page.get("counts_are_lower_bounds")),
+    }
+
+
+__all__ = [
+    "DEFAULT_PAGE_LIMIT",
+    "MAX_CONCEPT_PAGE_LIMIT",
+    "load_concept_effective_assertions",
+]

--- a/src/backend/services/concept_summary_field_resolver.py
+++ b/src/backend/services/concept_summary_field_resolver.py
@@ -13,8 +13,9 @@ import logging
 import time
 from typing import Any, Mapping, Sequence
 
+from ..db.repositories.concepts_repository import ConceptsRepository
 from .concept_service import get_concept_by_concept_id
-from .text_value_service import get_texts_for_concept
+from .text_value_service import get_texts_for_concept, get_texts_for_concepts
 
 _logger = logging.getLogger(__name__)
 
@@ -138,9 +139,12 @@ class ConceptSummaryFieldResolver:
 
     def get_summary_fields_for_types(self, type_ids: Sequence[str]) -> tuple[str, ...]:
         self._ensure_cache()
-        for type_id in _normalise_strings(type_ids):
-            fields = self.get_summary_fields_for_type(type_id)
+        ordered_type_ids = _normalise_strings(type_ids)
+        self._load_type_bindings(ordered_type_ids)
+        for type_id in ordered_type_ids:
+            fields = self._summary_fields_by_type.get(type_id, ())
             if fields:
+                self._load_field_metadata_for_fields(fields)
                 return fields
         return ()
 
@@ -198,6 +202,105 @@ class ConceptSummaryFieldResolver:
             if field_keys:
                 break
         self._summary_fields_by_type[type_id] = _dedupe_preserve_order(field_keys)
+
+    def _load_type_bindings(self, type_ids: Sequence[str]) -> None:
+        missing = [
+            type_id
+            for type_id in _normalise_strings(type_ids)
+            if type_id not in self._summary_fields_by_type
+        ]
+        if not missing:
+            return
+        try:
+            docs = list(
+                ConceptsRepository.find(
+                    {"concept_id": {"$in": missing}},
+                    {"concept_id": 1, "relationships": 1},
+                    limit=len(missing),
+                )
+            )
+        except Exception as exc:
+            _logger.debug(
+                "[summary_field_resolver] Failed to batch-load type bindings: %s",
+                exc,
+            )
+            docs = []
+        docs_by_id = {
+            str(doc.get("concept_id") or "").strip(): doc
+            for doc in docs
+            if isinstance(doc, Mapping)
+        }
+        for type_id in missing:
+            concept = docs_by_id.get(type_id)
+            relationships = (
+                concept.get("relationships")
+                if isinstance(concept, Mapping)
+                else None
+            )
+            if not isinstance(relationships, Mapping):
+                self._summary_fields_by_type[type_id] = ()
+                continue
+            field_keys: list[str] = []
+            for predicate in _TYPE_FIELD_RELATIONSHIP_ALIASES:
+                for field_concept_id in _normalise_strings(
+                    relationships.get(predicate)
+                ):
+                    field_key = _field_key_from_concept_id(field_concept_id)
+                    if field_key:
+                        field_keys.append(field_key)
+                if field_keys:
+                    break
+            self._summary_fields_by_type[type_id] = _dedupe_preserve_order(
+                field_keys
+            )
+
+    def _load_field_metadata_for_fields(self, field_keys: Sequence[str]) -> None:
+        ordered_field_keys = _normalise_strings(field_keys)
+        missing_field_keys = [
+            field_key
+            for field_key in ordered_field_keys
+            if field_key not in self._text_predicates_by_field
+            or field_key not in self._relationship_predicates_by_field
+        ]
+        if not missing_field_keys:
+            return
+        concept_ids = [_field_concept_id(key) for key in missing_field_keys]
+        predicates = _dedupe_preserve_order(
+            [*_TEXT_PREDICATE_CONFIG_ALIASES, *_RELATIONSHIP_PREDICATE_CONFIG_ALIASES]
+        )
+        try:
+            rows_by_concept = get_texts_for_concepts(
+                concept_ids,
+                predicates=predicates,
+                limit_per_concept=10,
+            )
+        except Exception as exc:
+            _logger.debug(
+                "[summary_field_resolver] Failed to batch-load field metadata: %s",
+                exc,
+            )
+            rows_by_concept = {}
+
+        for field_key, concept_id in zip(missing_field_keys, concept_ids):
+            rows = rows_by_concept.get(concept_id, [])
+            text_predicates: tuple[str, ...] = ()
+            relationship_predicates: tuple[str, ...] = ()
+            for predicate in _TEXT_PREDICATE_CONFIG_ALIASES:
+                text_predicates = self._first_config_value(
+                    [row for row in rows if row.get("predicate") == predicate]
+                )
+                if text_predicates:
+                    break
+            for predicate in _RELATIONSHIP_PREDICATE_CONFIG_ALIASES:
+                relationship_predicates = self._first_config_value(
+                    [row for row in rows if row.get("predicate") == predicate]
+                )
+                if relationship_predicates:
+                    break
+            self._text_predicates_by_field[field_key] = text_predicates
+            self._relationship_predicates_by_field[field_key] = (
+                relationship_predicates
+            )
 
     @staticmethod
     def _load_first_predicate_config(

--- a/src/backend/services/concept_summary_renderer_service.py
+++ b/src/backend/services/concept_summary_renderer_service.py
@@ -11,6 +11,7 @@ import re
 from collections.abc import Mapping
 from typing import Any, cast
 
+from ..db.repositories.concepts_repository import ConceptsRepository
 from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
 from .chat_history_service import ChatHistoryServiceError
 from .concept_predicate_metadata_service import get_relationship_kinds_set
@@ -18,8 +19,10 @@ from .concept_service import (
     ConceptNotFoundError,
     enrich_concept_with_text_relations,
     get_concept_by_concept_id,
+    resolve_concept_display_names,
 )
 from .concept_summary_field_resolver import get_concept_summary_field_resolver
+from .concept_type_closure_service import load_type_closure
 from .conversation_projection_service import (
     ConversationProjectionAccessChangedError,
     ConversationProjectionNotFoundError,
@@ -160,26 +163,64 @@ def _concept_preview(concept_id: str, cache: dict[str, str]) -> str:
 
 
 def _collect_ancestor_type_ids(type_ids: list[str]) -> list[str]:
-    queue = list(type_ids)
-    visited: set[str] = set()
-    ordered: list[str] = []
-    while queue:
-        current = queue.pop(0)
-        if current in visited:
-            continue
-        visited.add(current)
-        try:
-            concept = get_concept_by_concept_id(current)
-        except Exception:
-            continue
-        if not isinstance(concept, Mapping):
-            continue
-        parents = _normalise_strings((concept.get("relationships") or {}).get("is_a_type_of"))
-        for parent_id in parents:
-            if parent_id not in visited and parent_id not in queue:
-                queue.append(parent_id)
-                ordered.append(parent_id)
-    return _dedupe_preserve_order(ordered)
+    return list(load_type_closure(type_ids).get("ancestor_type_ids") or [])
+
+
+def _apply_relation_backed_names(
+    concept: Mapping[str, Any],
+    text_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    projected = dict(concept)
+    relation_names = [
+        {
+            "name": str(row.get("text") or ""),
+            "language": str(row.get("lang") or "en-NZ"),
+            "type": str((row.get("context") or {}).get("name_type") or "NL"),
+        }
+        for row in text_rows
+        if row.get("predicate") == "hasName" and str(row.get("text") or "").strip()
+    ]
+    if relation_names:
+        projected["names"] = relation_names
+    return projected
+
+
+def _prime_preview_cache(
+    *,
+    concept: Mapping[str, Any],
+    resolved_type_ids: list[str],
+    type_documents: Mapping[str, Mapping[str, Any]],
+) -> dict[str, str]:
+    candidate_ids = list(resolved_type_ids)
+    relationships = concept.get("relationships")
+    if isinstance(relationships, Mapping):
+        for raw in relationships.values():
+            candidate_ids.extend(
+                value for value in _normalise_strings(raw) if value.startswith("#V#")
+            )
+    candidate_ids = _dedupe_preserve_order(candidate_ids)
+    docs_by_id: dict[str, dict[str, Any]] = {
+        concept_id: dict(doc)
+        for concept_id, doc in type_documents.items()
+        if isinstance(doc, Mapping)
+    }
+    missing_ids = [item for item in candidate_ids if item not in docs_by_id]
+    if missing_ids:
+        for doc in ConceptsRepository.find(
+            {"concept_id": {"$in": missing_ids}},
+            {"concept_id": 1, "name": 1, "names": 1},
+            limit=len(missing_ids),
+        ):
+            if not isinstance(doc, Mapping):
+                continue
+            doc_id = str(doc.get("concept_id") or "").strip()
+            if doc_id:
+                docs_by_id[doc_id] = dict(doc)
+    display_names = resolve_concept_display_names(docs_by_id.values())
+    return {
+        concept_id: display_names.get(concept_id) or _display_name(doc) or concept_id
+        for concept_id, doc in docs_by_id.items()
+    }
 
 
 def _collect_present_predicates(
@@ -835,15 +876,16 @@ def load_concept_summary_renderer(
     concept = get_concept_by_concept_id(concept_id)
     if not isinstance(concept, Mapping):
         raise ConceptNotFoundError(f"Concept not found: {concept_id}")
-    concept = enrich_concept_with_text_relations(dict(concept))
+    text_rows = get_texts_for_concept(subject_concept_id=concept_id, limit=250)
+    concept = _apply_relation_backed_names(concept, text_rows)
     relationships = concept.get("relationships")
     if not isinstance(relationships, Mapping):
         relationships = {}
-
-    text_rows = get_texts_for_concept(subject_concept_id=concept_id, limit=250)
     direct_type_ids = _normalise_strings(relationships.get("is_an_instance_of"))
-    ancestor_type_ids = _collect_ancestor_type_ids(direct_type_ids)
-    resolved_type_ids = _dedupe_preserve_order(direct_type_ids + ancestor_type_ids)
+    type_closure = load_type_closure(direct_type_ids)
+    resolved_type_ids = _dedupe_preserve_order(
+        list(type_closure.get("ordered_type_ids") or direct_type_ids)
+    )
     present_predicates = _collect_present_predicates(relationships, text_rows)
     field_resolver = get_concept_summary_field_resolver()
     summary_field_keys = frozenset(
@@ -867,7 +909,11 @@ def load_concept_summary_renderer(
     )
 
     selected = resolution.selected_renderers[0] if resolution.selected_renderers else None
-    preview_cache: dict[str, str] = {}
+    preview_cache = _prime_preview_cache(
+        concept=concept,
+        resolved_type_ids=resolved_type_ids,
+        type_documents=type_closure.get("documents_by_id") or {},
+    )
     indexed_text_rows = _index_text_rows(text_rows)
     selected_renderer_id = selected.renderer_id if selected else None
     is_conversation = _CONVERSATION_TYPE_ID in resolved_type_ids

--- a/src/backend/services/concept_type_closure_service.py
+++ b/src/backend/services/concept_type_closure_service.py
@@ -1,0 +1,95 @@
+"""Bounded, actor-visible type-closure reads for concept presentation paths."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+
+DEFAULT_MAX_DEPTH = 16
+DEFAULT_MAX_NODES = 250
+
+
+def _normalise_ids(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        return []
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        concept_id = str(item or "").strip()
+        if not concept_id or concept_id in seen:
+            continue
+        seen.add(concept_id)
+        ordered.append(concept_id)
+    return ordered
+
+
+def load_type_closure(
+    direct_type_ids: Sequence[str] | None,
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict[str, Any]:
+    """Return direct types plus ancestors using one access-filtered query per depth.
+
+    The limits protect concept-page latency from malformed cycles or unexpectedly
+    broad hierarchies. The repository applies the trusted actor visibility filter.
+    """
+
+    direct = _normalise_ids(direct_type_ids)
+    ordered = list(direct)
+    seen = set(direct)
+    frontier = list(direct)
+    docs_by_id: dict[str, dict[str, Any]] = {}
+    depth = 0
+    truncated = False
+
+    while frontier and depth < max_depth and len(seen) <= max_nodes:
+        docs = list(
+            ConceptsRepository.find(
+                {"concept_id": {"$in": frontier}},
+                {"concept_id": 1, "name": 1, "names": 1, "relationships": 1},
+                limit=min(len(frontier), max_nodes),
+            )
+        )
+        next_frontier: list[str] = []
+        for doc in docs:
+            if not isinstance(doc, Mapping):
+                continue
+            concept_id = str(doc.get("concept_id") or "").strip()
+            if not concept_id:
+                continue
+            docs_by_id[concept_id] = dict(doc)
+            relationships = doc.get("relationships")
+            parents = _normalise_ids(
+                relationships.get("is_a_type_of")
+                if isinstance(relationships, Mapping)
+                else None
+            )
+            for parent_id in parents:
+                if parent_id in seen:
+                    continue
+                if len(seen) >= max_nodes:
+                    truncated = True
+                    break
+                seen.add(parent_id)
+                ordered.append(parent_id)
+                next_frontier.append(parent_id)
+        frontier = next_frontier
+        depth += 1
+
+    if frontier:
+        truncated = True
+    return {
+        "ordered_type_ids": ordered,
+        "ancestor_type_ids": ordered[len(direct) :],
+        "documents_by_id": docs_by_id,
+        "depth": depth,
+        "truncated": truncated,
+    }
+
+
+__all__ = ["load_type_closure"]

--- a/src/backend/services/paper_recommendation_profile_vontology_service.py
+++ b/src/backend/services/paper_recommendation_profile_vontology_service.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping, Sequence
 
 from . import concept_service
 from .concept_service import ConceptNotFoundError, get_concept_by_concept_id
+from .concept_type_closure_service import load_type_closure
 from .paper_recommendation_policy_authority_service import (
     normalise_profile_fields,
     resolve_paper_recommendation_policy,
@@ -175,26 +176,12 @@ def _ensure_predicate_concept(*, concept_id: str, name: str, description: str) -
 
 
 def _collect_type_and_ancestor_type_ids(type_ids: Sequence[str] | None) -> list[str]:
-    queue: list[str] = _normalise_concept_id_list(type_ids)
-    visited: set[str] = set()
-    ordered: list[str] = []
-
-    while queue:
-        raw_type_id = queue.pop(0)
-        type_id = _normalise_concept_id(raw_type_id)
-        if not type_id or type_id in visited:
-            continue
-        visited.add(type_id)
-        ordered.append(type_id)
-
-        concept_doc = load_concept(type_id)
-        parent_type_ids = normalise_relationship_targets(
-            (concept_doc or {}).get("relationships", {}).get("is_a_type_of")
+    return list(
+        load_type_closure(_normalise_concept_id_list(type_ids)).get(
+            "ordered_type_ids"
         )
-        for parent_type_id in parent_type_ids:
-            if parent_type_id not in visited:
-                queue.append(parent_type_id)
-    return ordered
+        or []
+    )
 
 
 def _load_profile_type_salient_to_type_ids() -> list[str]:

--- a/src/backend/services/relationship_extent_index_service.py
+++ b/src/backend/services/relationship_extent_index_service.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Sequence
+from uuid import uuid4
 
 from pymongo import DeleteMany, ReplaceOne
 from pymongo.collection import Collection
@@ -33,7 +35,11 @@ logger = logging.getLogger(__name__)
 
 RELATIONSHIP_EXTENT_INDEX_STATE_SETTING = "relationship_extent_index_state"
 RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION = 1
-_READINESS_CACHE: dict[str, Any] = {"ready": None, "checked_at": 0.0}
+_READINESS_CACHE: dict[str, Any] = {
+    "ready": None,
+    "checked_at": 0.0,
+    "state": None,
+}
 _READINESS_CACHE_TTL_SECONDS = 10.0
 RELATIONSHIP_EXTENT_PAGE_BATCH_SIZE = int(
     os.environ.get("VON_RELATIONSHIP_EXTENT_PAGE_BATCH_SIZE", "128")
@@ -86,10 +92,31 @@ _DEFERRED_SYNC_SOURCE_IDS: ContextVar[set[str] | None] = ContextVar(
     "relationship_extent_deferred_sync_source_ids",
     default=None,
 )
+_REBUILD_LOCK = threading.Lock()
+_REBUILD_STATE_LEASE_SECONDS = max(
+    60.0,
+    float(os.environ.get("VON_RELATIONSHIP_EXTENT_REBUILD_LEASE_SECONDS", "1800")),
+)
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _rebuild_state_has_live_lease(state: Mapping[str, Any]) -> bool:
+    """Return whether a recorded rebuild is recent enough to still be active."""
+
+    started_at = state.get("started_at")
+    if not isinstance(started_at, str) or not started_at.strip():
+        return False
+    try:
+        parsed = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    age_seconds = (_utc_now() - parsed.astimezone(timezone.utc)).total_seconds()
+    return -60.0 <= age_seconds < _REBUILD_STATE_LEASE_SECONDS
 
 
 def _adaptive_advisory_seconds(operation: str, configured_seconds: float) -> float:
@@ -249,24 +276,24 @@ def _mark_relationship_extent_index_degraded(
     """Fail the derived index closed after an incomplete refresh."""
 
     now = _utc_now()
+    degraded_state = {
+        "status": "degraded",
+        "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
+        "reason": reason,
+        "degraded_at": now.isoformat(),
+        "source_count": max(0, int(source_count)),
+        "error_type": error_type,
+    }
     _READINESS_CACHE["ready"] = False
     _READINESS_CACHE["checked_at"] = time.monotonic()
+    _READINESS_CACHE["state"] = dict(degraded_state)
     advisory_seconds = _adaptive_advisory_seconds(
         "state_write",
         RELATIONSHIP_EXTENT_STATE_WRITE_ADVISORY_SECONDS,
     )
     started = time.perf_counter()
     try:
-        _record_rebuild_state(
-            {
-                "status": "degraded",
-                "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
-                "reason": reason,
-                "degraded_at": now.isoformat(),
-                "source_count": max(0, int(source_count)),
-                "error_type": error_type,
-            }
-        )
+        _record_rebuild_state(degraded_state)
         _record_successful_operation(
             "state_write",
             time.perf_counter() - started,
@@ -629,6 +656,7 @@ def relationship_extent_index_ready() -> bool:
         return cached_ready
 
     ready = False
+    readiness_state: dict[str, Any] | None = None
     operation = "readiness"
     advisory_seconds = _adaptive_advisory_seconds(
         operation,
@@ -644,6 +672,7 @@ def relationship_extent_index_ready() -> bool:
             )
             value = state.get("value") if isinstance(state, Mapping) else None
             if isinstance(value, Mapping):
+                readiness_state = dict(value)
                 state_is_current = (
                     value.get("schema_version")
                     == RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION
@@ -665,7 +694,93 @@ def relationship_extent_index_ready() -> bool:
 
     _READINESS_CACHE["ready"] = ready
     _READINESS_CACHE["checked_at"] = now_monotonic
+    _READINESS_CACHE["state"] = readiness_state
     return ready
+
+
+def relationship_extent_index_readiness_snapshot() -> dict[str, Any]:
+    """Return bounded readiness metadata from the same cached state read."""
+
+    relationship_extent_index_ready()
+    state = _READINESS_CACHE.get("state")
+    state_payload = dict(state) if isinstance(state, Mapping) else {}
+    return {
+        "ready": _READINESS_CACHE.get("ready") is True,
+        "status": state_payload.get("status") or "missing",
+        "schema_version": state_payload.get("schema_version"),
+        "revision": state_payload.get("rebuild_run_id"),
+        "watermark": state_payload.get("finished_at"),
+        "source_count": state_payload.get("source_count"),
+        "edge_count": state_payload.get("edge_count"),
+    }
+
+
+def relationship_extent_index_state() -> dict[str, Any]:
+    """Return the persisted derived-index state without exposing store details."""
+
+    try:
+        settings = get_application_settings_collection()
+        if settings is None:
+            return {"available": False, "status": "unavailable"}
+        state = settings.find_one(
+            {"setting_name": RELATIONSHIP_EXTENT_INDEX_STATE_SETTING},
+            {"value": 1},
+        )
+        value = state.get("value") if isinstance(state, Mapping) else None
+        if not isinstance(value, Mapping):
+            return {"available": True, "status": "missing"}
+        return {"available": True, **dict(value)}
+    except Exception as exc:
+        logger.warning(
+            "[relationship_extent_index] state_query_failed error_type=%s",
+            type(exc).__name__,
+        )
+        return {
+            "available": False,
+            "status": "unavailable",
+            "error_type": type(exc).__name__,
+        }
+
+
+def reconcile_relationship_extent_index_if_needed(
+    *,
+    reason: str = "startup_reconciliation",
+) -> dict[str, Any]:
+    """Repair missing/degraded index state once, outside latency-sensitive reads."""
+
+    if relationship_extent_index_ready():
+        return {"success": True, "status": "ready", "changed": False}
+    state = relationship_extent_index_state()
+    if state.get("available") is not True:
+        return {
+            "success": False,
+            "status": "unavailable",
+            "changed": False,
+            "reason": "state_store_unavailable",
+        }
+    if state.get("status") == "rebuilding" and _rebuild_state_has_live_lease(
+        state
+    ):
+        return {
+            "success": True,
+            "status": "rebuilding",
+            "changed": False,
+            "reason": "rebuild_already_recorded",
+        }
+    if not _REBUILD_LOCK.acquire(blocking=False):
+        return {
+            "success": True,
+            "status": "rebuilding",
+            "changed": False,
+            "reason": "rebuild_already_running",
+        }
+    try:
+        if relationship_extent_index_ready():
+            return {"success": True, "status": "ready", "changed": False}
+        result = rebuild_relationship_extent_index(reason=reason)
+        return {**result, "changed": result.get("success") is True}
+    finally:
+        _REBUILD_LOCK.release()
 
 
 def rebuild_relationship_extent_index(
@@ -680,19 +795,21 @@ def rebuild_relationship_extent_index(
         return {"success": False, "status": "unavailable"}
 
     started_at = _utc_now()
+    rebuilding_state = {
+        "status": "rebuilding",
+        "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
+        "reason": reason,
+        "started_at": started_at.isoformat(),
+    }
     _READINESS_CACHE["ready"] = False
     _READINESS_CACHE["checked_at"] = time.monotonic()
-    _record_rebuild_state(
-        {
-            "status": "rebuilding",
-            "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
-            "reason": reason,
-            "started_at": started_at.isoformat(),
-        }
-    )
+    _READINESS_CACHE["state"] = dict(rebuilding_state)
+    _record_rebuild_state(rebuilding_state)
 
+    rebuild_run_id = f"rei_{uuid4().hex}"
     total_sources = 0
     total_edges = 0
+
     def _flush_pending_docs(pending_docs: list[dict[str, Any]]) -> None:
         if not pending_docs:
             return
@@ -711,7 +828,6 @@ def rebuild_relationship_extent_index(
         coll.bulk_write(operations, ordered=False)
 
     try:
-        coll.delete_many({})
         with bypass_access_control():
             cursor = ConceptsRepository.find(
                 {"relationships": {"$type": "object"}},
@@ -733,6 +849,8 @@ def rebuild_relationship_extent_index(
                 seen_source_ids.add(source_id)
                 total_sources += 1
                 docs = _index_docs_for_concept(concept_doc)
+                for doc in docs:
+                    doc["rebuild_run_id"] = rebuild_run_id
                 total_edges += len(docs)
                 pending_docs.extend(docs)
                 while batch_size > 0 and len(pending_docs) >= batch_size:
@@ -746,6 +864,14 @@ def rebuild_relationship_extent_index(
             if pending_docs:
                 _flush_pending_docs(pending_docs)
 
+        # Only retire prior-generation rows after the complete canonical scan
+        # and all replacements have succeeded. A failed rebuild therefore
+        # leaves the prior derived data recoverable, while readiness remains
+        # degraded so interactive reads cannot mistake it for current state.
+        deleted = coll.delete_many(
+            {"rebuild_run_id": {"$ne": rebuild_run_id}}
+        ).deleted_count
+
         finished_at = _utc_now()
         state = {
             "status": "ready",
@@ -755,27 +881,30 @@ def rebuild_relationship_extent_index(
             "finished_at": finished_at.isoformat(),
             "source_count": total_sources,
             "edge_count": total_edges,
+            "retired_edge_count": deleted,
+            "rebuild_run_id": rebuild_run_id,
         }
         _record_rebuild_state(state)
         _READINESS_CACHE["ready"] = True
         _READINESS_CACHE["checked_at"] = time.monotonic()
+        _READINESS_CACHE["state"] = dict(state)
         return {"success": True, **state}
     except Exception as exc:
         logger.error(
             "Failed rebuilding relationship extent index: %s", exc, exc_info=True
         )
+        failed_state = {
+            "status": "failed",
+            "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
+            "reason": reason,
+            "started_at": started_at.isoformat(),
+            "failed_at": _utc_now().isoformat(),
+            "error_type": type(exc).__name__,
+        }
         _READINESS_CACHE["ready"] = False
         _READINESS_CACHE["checked_at"] = time.monotonic()
-        _record_rebuild_state(
-            {
-                "status": "failed",
-                "schema_version": RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
-                "reason": reason,
-                "started_at": started_at.isoformat(),
-                "failed_at": _utc_now().isoformat(),
-                "error_type": type(exc).__name__,
-            }
-        )
+        _READINESS_CACHE["state"] = dict(failed_state)
+        _record_rebuild_state(failed_state)
         return {"success": False, "status": "failed", "error_type": type(exc).__name__}
 
 

--- a/src/backend/services/renderer_applicability_vontology_service.py
+++ b/src/backend/services/renderer_applicability_vontology_service.py
@@ -10,9 +10,10 @@ import json
 import re
 from typing import Any, Mapping, Sequence
 
+from ..db.repositories.concepts_repository import ConceptsRepository
 from .concept_service import get_concept_by_concept_id
 from .renderer_applicability_service import RendererProfile
-from .text_value_service import get_texts_for_concept
+from .text_value_service import get_texts_for_concept, get_texts_for_concepts
 from .text_value_service import upsert_singleton_text_relation
 
 _DEFAULT_PROFILE_TEXT_PREDICATES: tuple[str, ...] = (
@@ -226,24 +227,40 @@ def load_renderer_definitions_from_concept_ids(
     malformed_profile_concept_ids: list[str] = []
     malformed_profile_entries: list[dict[str, Any]] = []
 
-    for concept_id in ordered_concept_ids:
-        try:
-            concept = get_concept_by_concept_id(concept_id)
-        except Exception:
-            concept = None
+    concept_docs = list(
+        ConceptsRepository.find(
+            {"concept_id": {"$in": list(ordered_concept_ids)}},
+            {"concept_id": 1},
+            limit=len(ordered_concept_ids),
+        )
+    ) if ordered_concept_ids else []
+    resolved_concept_ids = {
+        str(doc.get("concept_id") or "").strip()
+        for doc in concept_docs
+        if isinstance(doc, Mapping)
+    }
+    try:
+        text_rows_by_concept = get_texts_for_concepts(
+            list(ordered_concept_ids),
+            predicates=list(predicates),
+            limit_per_concept=20,
+        )
+    except Exception:
+        text_rows_by_concept = {}
 
-        if not isinstance(concept, Mapping):
+    for concept_id in ordered_concept_ids:
+        if concept_id not in resolved_concept_ids:
             unresolved_concept_ids.append(concept_id)
             continue
 
         concept_definitions: list[dict[str, Any]] = []
         concept_malformed_entries: list[dict[str, Any]] = []
         profile_rows_found = False
+        all_text_rows = text_rows_by_concept.get(concept_id, [])
         for predicate in predicates:
-            try:
-                text_rows = get_texts_for_concept(concept_id, predicate=predicate, limit=20)
-            except Exception:
-                text_rows = []
+            text_rows = [
+                row for row in all_text_rows if row.get("predicate") == predicate
+            ]
             if not text_rows:
                 continue
             profile_rows_found = True

--- a/src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js
@@ -1,0 +1,319 @@
+import { getJsonDetailed } from '../apiService.js';
+
+const DEFAULT_PAGE_LIMIT = 25;
+const ACTOR_CONTEXT_STATE_KEY = '__vonConceptEffectiveAssertionContextState';
+const actorContextState = globalThis[ACTOR_CONTEXT_STATE_KEY] || {
+  registrations: new Map(),
+  listenersBound: false,
+  reload: null,
+};
+globalThis[ACTOR_CONTEXT_STATE_KEY] = actorContextState;
+const panelRegistrations = actorContextState.registrations;
+
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function getMountElement(suffix) {
+  return (
+    document.getElementById(`conceptEffectiveAssertionsMount_${suffix}`) ||
+    document.getElementById('conceptEffectiveAssertionsMount') ||
+    null
+  );
+}
+
+function appendText(parent, tagName, className, text) {
+  const value = cleanText(text);
+  if (!value) return null;
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  element.textContent = value;
+  parent.appendChild(element);
+  return element;
+}
+
+function createPanel(mount, suffix) {
+  let panel = document.getElementById(`conceptEffectiveAssertionsPanel_${suffix}`);
+  if (panel) return panel;
+
+  panel = document.createElement('section');
+  panel.id = `conceptEffectiveAssertionsPanel_${suffix}`;
+  panel.className = 'concept-effective-assertions hidden';
+  panel.setAttribute('aria-labelledby', `conceptEffectiveAssertionsTitle_${suffix}`);
+
+  const header = document.createElement('div');
+  header.className = 'concept-effective-assertions-header';
+  const headingGroup = document.createElement('div');
+  const title = appendText(
+    headingGroup,
+    'h3',
+    'concept-effective-assertions-title',
+    'Knowledge visible to you',
+  );
+  if (title) title.id = `conceptEffectiveAssertionsTitle_${suffix}`;
+  appendText(
+    headingGroup,
+    'p',
+    'concept-effective-assertions-intro',
+    'Personal and organisation assertions are shown with their source context; they do not replace base publication facts.',
+  );
+  header.appendChild(headingGroup);
+
+  const status = document.createElement('span');
+  status.id = `conceptEffectiveAssertionsStatus_${suffix}`;
+  status.className = 'concept-effective-assertions-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  header.appendChild(status);
+  panel.appendChild(header);
+
+  const rows = document.createElement('div');
+  rows.id = `conceptEffectiveAssertionsRows_${suffix}`;
+  rows.className = 'concept-effective-assertions-rows';
+  panel.appendChild(rows);
+
+  const actions = document.createElement('div');
+  actions.className = 'concept-effective-assertions-actions';
+  const loadMore = document.createElement('button');
+  loadMore.id = `conceptEffectiveAssertionsLoadMore_${suffix}`;
+  loadMore.type = 'button';
+  loadMore.className = 'concept-effective-assertions-load-more hidden';
+  loadMore.textContent = 'Load more';
+  actions.appendChild(loadMore);
+  panel.appendChild(actions);
+
+  mount.appendChild(panel);
+  return panel;
+}
+
+function formatDate(value) {
+  const token = cleanText(value);
+  if (!token) return '';
+  const date = new Date(token);
+  return Number.isNaN(date.getTime()) ? token : date.toLocaleString();
+}
+
+function createDetailRow(list, label, value) {
+  const text = cleanText(value);
+  if (!text) return;
+  appendText(list, 'dt', '', label);
+  appendText(list, 'dd', '', text);
+}
+
+function createAssertionDetails(item) {
+  const details = document.createElement('details');
+  details.className = 'concept-effective-assertion-details';
+  appendText(details, 'summary', '', 'Details');
+  const list = document.createElement('dl');
+  createDetailRow(list, 'Assertion ID', item?.assertion_id);
+  createDetailRow(list, 'Status', item?.status);
+  createDetailRow(list, 'Updated', formatDate(item?.updated_at));
+  createDetailRow(
+    list,
+    'Recorded by',
+    item?.provenance?.asserted_by_user_concept_id,
+  );
+  createDetailRow(list, 'Source capability', item?.provenance?.capability_name);
+  const evidence = item?.provenance?.evidence;
+  if (evidence && typeof evidence === 'object' && Object.keys(evidence).length > 0) {
+    createDetailRow(list, 'Evidence', JSON.stringify(evidence));
+  }
+  details.appendChild(list);
+  return details;
+}
+
+function createAssertionRow(item) {
+  const predicate = cleanText(item?.predicate?.display_name) || 'Assertion';
+  const object = item?.object || {};
+  const value = object.kind === 'concept'
+    ? cleanText(object.display_name) || cleanText(object.concept_id)
+    : cleanText(object.text);
+  if (!value) return null;
+
+  const row = document.createElement('article');
+  row.className = 'concept-effective-assertion-row';
+  row.dataset.assertionId = cleanText(item?.assertion_id);
+
+  const statement = document.createElement('div');
+  statement.className = 'concept-effective-assertion-statement';
+  appendText(statement, 'span', 'concept-effective-assertion-predicate', predicate);
+  appendText(statement, 'span', 'concept-effective-assertion-value', value);
+  row.appendChild(statement);
+
+  const context = item?.source_context || {};
+  const contextKind = context.kind === 'organisation' ? 'organisation' : 'personal';
+  const badge = appendText(
+    row,
+    'span',
+    `concept-effective-assertion-scope concept-effective-assertion-scope-${contextKind}`,
+    context.label || (contextKind === 'organisation' ? 'Organisation' : 'Personal'),
+  );
+  if (badge) badge.setAttribute('aria-label', `Assertion context: ${badge.textContent}`);
+  row.appendChild(createAssertionDetails(item));
+  return row;
+}
+
+function appendAssertionToPredicateGroup(rows, item) {
+  const predicateId = cleanText(item?.predicate?.storage_id)
+    || cleanText(item?.predicate?.concept_id)
+    || cleanText(item?.predicate?.display_name)
+    || 'assertion';
+  let group = Array.from(rows.querySelectorAll('.concept-effective-assertion-group'))
+    .find((candidate) => candidate.dataset.predicateId === predicateId);
+  if (!group) {
+    group = document.createElement('section');
+    group.className = 'concept-effective-assertion-group';
+    group.dataset.predicateId = predicateId;
+    appendText(
+      group,
+      'h4',
+      'concept-effective-assertion-group-title',
+      item?.predicate?.display_name || 'Assertion',
+    );
+    const groupRows = document.createElement('div');
+    groupRows.className = 'concept-effective-assertion-group-rows';
+    group.appendChild(groupRows);
+    rows.appendChild(group);
+  }
+  const row = createAssertionRow(item);
+  if (row) {
+    group.querySelector('.concept-effective-assertion-group-rows')?.appendChild(row);
+  }
+  return row;
+}
+
+function setPanelStatus(panel, suffix, message, { error = false } = {}) {
+  const status = panel.querySelector(`#conceptEffectiveAssertionsStatus_${suffix}`);
+  if (!status) return;
+  status.textContent = message || '';
+  status.classList.toggle('error', error);
+}
+
+function setLoadMoreState(panel, suffix, payload, onLoadMore) {
+  const button = panel.querySelector(`#conceptEffectiveAssertionsLoadMore_${suffix}`);
+  if (!button) return;
+  const hasMore = payload?.has_more === true && Number.isInteger(payload?.next_offset);
+  button.classList.toggle('hidden', !hasMore);
+  button.disabled = false;
+  button.textContent = 'Load more';
+  button.onclick = hasMore ? onLoadMore : null;
+}
+
+async function loadPage({ conceptId, suffix, offset, append }) {
+  const mount = getMountElement(suffix);
+  if (!mount) return { rendered: false, contextView: null };
+  const panel = createPanel(mount, suffix);
+  const rows = panel.querySelector(`#conceptEffectiveAssertionsRows_${suffix}`);
+  const token = `${conceptId}:${offset}:${Date.now()}:${Math.random()}`;
+  panel.dataset.loadToken = token;
+  panel.dataset.conceptId = conceptId;
+  if (!append) {
+    panel.classList.add('hidden');
+    rows?.replaceChildren();
+  }
+
+  try {
+    const { data } = await getJsonDetailed(
+      `/api/concepts/${encodeURIComponent(conceptId)}/effective_assertions?limit=${DEFAULT_PAGE_LIMIT}&offset=${offset}`,
+      { cache: 'no-store' },
+    );
+    if (panel.dataset.loadToken !== token || panel.dataset.conceptId !== conceptId) {
+      return { rendered: false, contextView: null };
+    }
+
+    const contextView = cleanText(data?.context_view);
+    const items = Array.isArray(data?.items)
+      ? data.items.filter((item) => item?.status === 'asserted')
+      : [];
+    if (contextView !== 'actor_effective' || (items.length === 0 && !append)) {
+      panel.classList.add('hidden');
+      setPanelStatus(panel, suffix, '');
+      return { rendered: false, contextView };
+    }
+
+    panel.classList.remove('hidden');
+    for (const item of items) {
+      if (rows) appendAssertionToPredicateGroup(rows, item);
+    }
+    const assertionCount = rows?.querySelectorAll('.concept-effective-assertion-row').length || 0;
+    const lowerBound = data?.counts_are_lower_bounds === true;
+    setPanelStatus(
+      panel,
+      suffix,
+      data?.has_more === true || lowerBound
+        ? 'Showing a bounded page. More visible assertions are available.'
+        : `${assertionCount} visible assertion${assertionCount === 1 ? '' : 's'}.`,
+    );
+    setLoadMoreState(panel, suffix, data, async () => {
+      const button = panel.querySelector(`#conceptEffectiveAssertionsLoadMore_${suffix}`);
+      if (button) button.disabled = true;
+      await loadPage({
+        conceptId,
+        suffix,
+        offset: data.next_offset,
+        append: true,
+      });
+    });
+    return { rendered: true, contextView };
+  } catch (error) {
+    if (panel.dataset.loadToken !== token || panel.dataset.conceptId !== conceptId) {
+      return { rendered: false, contextView: null };
+    }
+    console.warn('[conceptEffectiveAssertionsPanel] Failed to load assertions', error);
+    panel.classList.remove('hidden');
+    setPanelStatus(
+      panel,
+      suffix,
+      'Knowledge visible to you is temporarily unavailable.',
+      { error: true },
+    );
+    const button = panel.querySelector(`#conceptEffectiveAssertionsLoadMore_${suffix}`);
+    if (button) {
+      button.classList.remove('hidden');
+      button.disabled = false;
+      button.textContent = 'Retry';
+      button.onclick = () => loadPage({ conceptId, suffix, offset: 0, append: false });
+    }
+    return { rendered: false, contextView: 'degraded' };
+  }
+}
+
+function clearAndReloadRegisteredPanels() {
+  for (const [suffix, registration] of panelRegistrations.entries()) {
+    const mount = getMountElement(suffix);
+    if (!mount?.isConnected) {
+      panelRegistrations.delete(suffix);
+      continue;
+    }
+    const panel = mount.querySelector(`#conceptEffectiveAssertionsPanel_${suffix}`);
+    panel?.classList.add('hidden');
+    panel?.querySelector(`#conceptEffectiveAssertionsRows_${suffix}`)?.replaceChildren();
+    void loadPage({
+      conceptId: registration.conceptId,
+      suffix,
+      offset: 0,
+      append: false,
+    });
+  }
+}
+
+function registerActorContextInvalidation(conceptId, suffix) {
+  panelRegistrations.set(suffix, { conceptId });
+  actorContextState.reload = clearAndReloadRegisteredPanels;
+  if (actorContextState.listenersBound) return;
+  actorContextState.listenersBound = true;
+  const reloadLatestProjection = () => actorContextState.reload?.();
+  document.addEventListener('orgSwitched', reloadLatestProjection);
+  document.addEventListener('authStatusChanged', reloadLatestProjection);
+}
+
+export async function ensureConceptEffectiveAssertionsPanel({ conceptId, suffix }) {
+  registerActorContextInvalidation(conceptId, suffix);
+  return loadPage({ conceptId, suffix, offset: 0, append: false });
+}
+
+export const _test = {
+  createAssertionRow,
+  appendAssertionToPredicateGroup,
+  formatDate,
+};

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -59,6 +59,29 @@ let suppressConceptTabPersistence = false;
 let dynamicConceptTabRecencyCounter = 0;
 let conceptTabLoadingSequence = 0;
 const expandedConceptTabBuckets = new Set();
+let conceptTabTemplatePromise = null;
+
+function loadConceptTabTemplate() {
+    if (!conceptTabTemplatePromise) {
+        if (typeof globalThis.fetch !== 'function') {
+            return Promise.reject(new Error('Fetch is unavailable for concept tab template loading'));
+        }
+        conceptTabTemplatePromise = globalThis.fetch('/concept_tab')
+            .then(async (response) => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                return response.text();
+            })
+            .catch((error) => {
+                // A transient preload failure must remain retryable on the next
+                // explicit concept open.
+                conceptTabTemplatePromise = null;
+                throw error;
+            });
+    }
+    return conceptTabTemplatePromise;
+}
 
 export function clampConceptPageWidthPx(requestedWidthPx, availableWidthPx) {
     const available = Number(availableWidthPx);
@@ -2185,13 +2208,9 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
     tabInfo.loadingPromise = (async () => {
     try {
         const initialBucketKind = getConceptTabBucketKind(tabInfo.kind);
-        // Fetch the concept tab template
-        const response = await fetch('/concept_tab');
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const html = await response.text();
+        // Reuse the application-start preload so a concept activation is not
+        // queued behind unrelated runtime requests just to obtain static HTML.
+        const html = await loadConceptTabTemplate();
 
         // Make IDs unique for this dynamic tab.
         // IMPORTANT: Do not rely solely on a non-alnum scrub of conceptId, as that can collide
@@ -2207,6 +2226,8 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
         tabInfo.content.innerHTML = modifiedHtml;
         initialiseConceptPageResizeUI(tabInfo.content);
 
+        let deferredHeaderNodeLoad = null;
+
         // Add a small kind badge and an ID copy chip to the header if available.
         // Fallback inference: if tabInfo.kind is absent (regression / legacy dispatch), infer from node content.
         let nodeJson = null; // Store for both badge and predicate detection
@@ -2214,11 +2235,20 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
             let { kind } = tabInfo;
             const headerSpan = document.getElementById(`conceptTypeDisplayNamePluralElement_${uniqueIdSuffix}`);
             const headerDiv = headerSpan ? headerSpan.closest('.concept-header') : null;
-            // Always attempt inference: even if an initial kind was provided it may be wrong.
-            try {
+            const loadNodeContent = async () => {
                 const nodeResp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(conceptId)}`);
-                if (nodeResp.ok) {
-                    nodeJson = await nodeResp.json();
+                return nodeResp.ok ? nodeResp.json() : null;
+            };
+            // Only an unknown-kind tab needs legacy node content before it can
+            // initialise. Search/tree callers already provide a bounded kind;
+            // hydrate node-dependent header controls after primary readiness.
+            if (normaliseConceptTabKind(kind) === 'unknown') {
+                try {
+                    nodeJson = await loadNodeContent();
+                } catch (inferErr) {
+                    console.warn('[dynamicTabs] Kind inference failed', inferErr);
+                }
+                if (nodeJson) {
                     // Prefer backend-provided computed_kind if available
                     if (nodeJson.computed_kind && nodeJson.computed_kind !== kind) {
                         kind = setDynamicConceptTabKind(conceptId, nodeJson.computed_kind, { rebuild: false }) || kind;
@@ -2235,8 +2265,29 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
                         kind = setDynamicConceptTabKind(conceptId, inferred, { rebuild: false }) || kind;
                     }
                 }
-            } catch (inferErr) {
-                console.warn('[dynamicTabs] Kind inference failed', inferErr);
+            } else if (headerDiv) {
+                deferredHeaderNodeLoad = async () => {
+                    try {
+                        const deferredNodeJson = await loadNodeContent();
+                        const deferredKind = deferredNodeJson?.computed_kind || deferredNodeJson?.kind || kind;
+                        if (deferredKind && deferredKind !== kind) {
+                            const previousBucket = getConceptTabBucketKind(kind);
+                            kind = setDynamicConceptTabKind(conceptId, deferredKind, { rebuild: false }) || kind;
+                            if (getConceptTabBucketKind(kind) !== previousBucket) {
+                                rebuildConceptTabBuckets();
+                            }
+                        }
+                        const deferredBadge = headerDiv.querySelector('.kind-badge');
+                        if (deferredBadge) {
+                            deferredBadge.className = `kind-badge ${kind}`;
+                            deferredBadge.textContent = kind === 'predicate' ? 'Predicate' : (kind === 'type' ? 'Type' : 'Individual');
+                        }
+                        attachAnalysisButtons(headerDiv, conceptId, kind, deferredNodeJson);
+                    } catch (headerNodeErr) {
+                        console.warn('[dynamicTabs] Deferred header node content failed', headerNodeErr);
+                        attachAnalysisButtons(headerDiv, conceptId, kind, null);
+                    }
+                };
             }
 
             if (headerDiv && (kind === 'type' || kind === 'individual' || kind === 'predicate') && !headerDiv.querySelector('.kind-badge')) {
@@ -2259,7 +2310,9 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
                 attachConceptIdCopyChip(headerDiv, conceptId, kind);
                 attachRawDataButton(headerDiv, conceptId, kind, tabInfo.content);
                 attachKeyConceptStarButton(headerDiv, conceptId);
-                attachAnalysisButtons(headerDiv, conceptId, kind, nodeJson);
+                if (nodeJson) {
+                    attachAnalysisButtons(headerDiv, conceptId, kind, nodeJson);
+                }
             }
         } catch (e) {
             console.warn('[dynamicTabs] Could not attach kind badge:', e);
@@ -2322,6 +2375,9 @@ export async function loadDynamicConceptTabContent(tabId, conceptId) {
         await Promise.resolve();
         console.log(`[dynamicTabs] Initializing concept tab functionality for ${conceptId}`);
         await initializeDynamicConceptTab(conceptId, uniqueIdSuffix);
+        if (deferredHeaderNodeLoad) {
+            void deferredHeaderNodeLoad();
+        }
         try { attachNamesObserver(conceptId, uniqueIdSuffix); } catch (_) { }
         try { backfillNoteGlyphs(tabInfo.content); } catch (e) { console.warn('[dynamicTabs] backfillNoteGlyphs post-init failed', e); }
 
@@ -2905,6 +2961,7 @@ async function initializeDynamicConceptTab(conceptId, uniqueIdSuffix) {
         }
 
         let tabKind = (dynamicConceptTabs.get(conceptId) || {}).kind;
+        let individualInitialisationLoad = null;
 
         // Toggle type-only sections visibility by tab kind
         try {
@@ -2952,47 +3009,63 @@ async function initializeDynamicConceptTab(conceptId, uniqueIdSuffix) {
 
             // For individuals: adapt UI to show summary/description and hide creation/list sections
             if (tabKind === 'individual') {
-                await adaptIndividualConceptTabUI(conceptId, uniqueIdSuffix);
+                individualInitialisationLoad = adaptIndividualConceptTabUI(conceptId, uniqueIdSuffix);
             }
         } catch (e) {
             console.warn('[dynamicTabs] Unable to toggle type sections for tab', conceptId, e);
         }
 
-        let namesOutcome = null;
-        try {
-            await initializeNamesForm(uniqueIdSuffix);
-            namesOutcome = await loadConceptNames(conceptId, uniqueIdSuffix);
-            // Load attributes (text relations excluding names)
-            await loadConceptAttributes(conceptId, uniqueIdSuffix);
-        } catch (e) {
-            console.warn('[dynamicTabs] Failed to initialize names form for tab', conceptId, e);
-        }
-
-        if (namesOutcome && namesOutcome.status === 'not_found') {
-            console.warn(`[dynamicTabs] Concept ${conceptId} is unavailable; skipping further initialisation.`);
-            return;
-        }
-
-        try {
-            await initializeRelationshipsUI(conceptId, uniqueIdSuffix, tabKind);
-        } catch (e) {
-            console.warn('[dynamicTabs] Failed to initialise relationships UI for tab', conceptId, e);
-        }
-
-        console.log(`[dynamicTabs] Dynamic concept tab initialization complete for ${conceptId}`);
-
-        // Initialize predicate view if this concept is a predicate
-        try {
-            // Fetch concept data to check if it's a predicate
-            const nodeResp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(conceptId)}`);
-            if (nodeResp.ok) {
-                const conceptData = await nodeResp.json();
-                if (conceptData.raw_doc) {
-                    await initializePredicateView(conceptId, uniqueIdSuffix, conceptData.raw_doc);
-                }
+        const initialiseSecondarySections = async () => {
+            let namesOutcome = null;
+            try {
+                await initializeNamesForm(uniqueIdSuffix);
+                namesOutcome = await loadConceptNames(conceptId, uniqueIdSuffix);
+                // Load attributes (text relations excluding names)
+                await loadConceptAttributes(conceptId, uniqueIdSuffix);
+            } catch (e) {
+                console.warn('[dynamicTabs] Failed to initialize names form for tab', conceptId, e);
             }
-        } catch (predicateErr) {
-            console.warn('[dynamicTabs] Failed to initialize predicate view', predicateErr);
+
+            if (namesOutcome && namesOutcome.status === 'not_found') {
+                console.warn(`[dynamicTabs] Concept ${conceptId} is unavailable; skipping further initialisation.`);
+                return;
+            }
+
+            try {
+                await initializeRelationshipsUI(conceptId, uniqueIdSuffix, tabKind);
+            } catch (e) {
+                console.warn('[dynamicTabs] Failed to initialise relationships UI for tab', conceptId, e);
+            }
+
+            // Predicate details are also panel-level enrichment.
+            try {
+                const nodeResp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(conceptId)}`);
+                if (nodeResp.ok) {
+                    const conceptData = await nodeResp.json();
+                    if (conceptData.raw_doc) {
+                        await initializePredicateView(conceptId, uniqueIdSuffix, conceptData.raw_doc);
+                    }
+                }
+            } catch (predicateErr) {
+                console.warn('[dynamicTabs] Failed to initialize predicate view', predicateErr);
+            }
+            console.log(`[dynamicTabs] Secondary concept panels complete for ${conceptId}`);
+        };
+
+        if (tabKind === 'individual') {
+            // The shell already carries the concept name, kind, identifier,
+            // core controls, and honestly loading content/assertion panels.
+            // Atlas-backed identity enrichment and secondary graph material
+            // continue independently without extending the global busy state.
+            void Promise.resolve(individualInitialisationLoad)
+                .then(() => initialiseSecondarySections())
+                .catch((error) => {
+                    console.warn('[dynamicTabs] Deferred individual initialisation failed', error);
+                });
+            console.log(`[dynamicTabs] Dynamic concept tab primary initialization complete for ${conceptId}`);
+        } else {
+            await initialiseSecondarySections();
+            console.log(`[dynamicTabs] Dynamic concept tab initialization complete for ${conceptId}`);
         }
 
         // Post-init verification: ensure description section actually materialized for type tabs
@@ -3021,6 +3094,12 @@ async function initializeDynamicConceptTab(conceptId, uniqueIdSuffix) {
  */
 export function initializeDynamicTabs() {
     console.log('[dynamicTabs] Initializing dynamic tabs functionality');
+
+    // Static concept-tab markup is needed on every concept open. Begin its
+    // retryable preload while the rest of the application initialises.
+    void loadConceptTabTemplate().catch((error) => {
+        console.warn('[dynamicTabs] Concept tab template preload failed', error);
+    });
 
     // Clear any existing dynamic tabs on initialization
     closeAllDynamicConceptTabs({ persist: false });
@@ -3341,15 +3420,44 @@ function attachNamesObserver(conceptId, suffix, attempt = 0) {
 async function adaptIndividualConceptTabUI(conceptId, suffix) {
     try {
         const encodedId = encodeURIComponent(conceptId);
-        // Fetch parents (types) and node content for description
-        const [parentsRes, nodeRes, conceptRes] = await Promise.all([
-            fetch(`/vontology/api/vontology/parents?identifier=${encodedId}`),
-            fetch(`/vontology/api/vontology/node_content?identifier=${encodedId}`),
-            fetch(`/api/concepts/${encodedId}`)
+        // Primary identity/type material is available from the bounded parents
+        // and direct concept reads. The legacy node-content projection scans a
+        // much broader text-relation surface and is only needed later by the
+        // independent predicate-detail panel.
+        const parentsDataPromise = fetch(`/vontology/api/vontology/parents?identifier=${encodedId}`)
+            .then(async (response) => response.ok ? response.json() : { parents: [] });
+        const conceptDataPromise = fetch(`/api/concepts/${encodedId}`)
+            .then(async (response) => response.ok ? response.json() : null);
+
+        // Mount every independently loading panel before waiting on Atlas.
+        // The tab shell can then become globally ready while each projection
+        // remains honest about its own loading, empty, or degraded state.
+        const effectiveAssertionsLoad = (async () => {
+            try {
+                const { ensureConceptEffectiveAssertionsPanel } = await import('./components/conceptEffectiveAssertionsPanel.js');
+                await ensureConceptEffectiveAssertionsPanel({ conceptId, suffix });
+            } catch (assertionErr) {
+                console.warn('[dynamicTabs] Unable to initialise actor-effective assertions panel', assertionErr);
+            }
+        })();
+        const descriptionLoad = ensureUnifiedDescriptionSection(conceptId, suffix, {
+            allowLegacyFallback: false,
+            fallbackDescriptionPromise: conceptDataPromise.then((conceptData) => (
+                typeof conceptData?.description === 'string' ? conceptData.description : null
+            )),
+        });
+        const textSectionsLoad = (async () => {
+            await Promise.allSettled([
+                populateNotesSection(conceptId, suffix),
+                populateContentSection(conceptId, suffix),
+            ]);
+        })();
+
+        const [parentsData, conceptData] = await Promise.all([
+            parentsDataPromise,
+            conceptDataPromise,
         ]);
-        const parentsData = parentsRes.ok ? await parentsRes.json() : { parents: [] };
-        const nodeData = nodeRes.ok ? await nodeRes.json() : {};
-        const conceptData = conceptRes && conceptRes.ok ? await conceptRes.json() : null;
+        const nodeData = {};
 
         // Sync concept selection state and original notes using the shared helper
         try {
@@ -3380,20 +3488,11 @@ async function adaptIndividualConceptTabUI(conceptId, suffix) {
             if (conceptName) nameInput.value = conceptName;
         }
 
-        // Prefer the dedicated concept summary renderer panel; fall back to the
-        // older type-summary line if the summary payload is unavailable.
+        // Render the small type summary immediately. The specialised summary
+        // renderer is useful enrichment, but it must not block description,
+        // notes, actor-effective knowledge, or the tab's primary readiness.
         const step1 = document.getElementById(`conceptStep1_${suffix}`) || document.getElementById('conceptStep1');
-        let renderedConceptSummary = false;
-        try {
-            const { ensureConceptSummaryRendererPanelForConceptTab } = await import('./components/conceptSummaryRendererPanel.js');
-            renderedConceptSummary = await ensureConceptSummaryRendererPanelForConceptTab({
-                conceptId,
-                suffix,
-            });
-        } catch (rendererErr) {
-            console.warn('[dynamicTabs] Unable to initialise concept summary renderer panel', rendererErr);
-        }
-        if (!renderedConceptSummary && step1 && !step1.querySelector('.concept-types-summary')) {
+        if (step1 && !step1.querySelector('.concept-types-summary')) {
             const summary = document.createElement('div');
             summary.className = 'concept-types-summary';
             summary.style.margin = '6px 0 10px 0';
@@ -3403,35 +3502,39 @@ async function adaptIndividualConceptTabUI(conceptId, suffix) {
             step1.insertBefore(summary, step1.querySelector('label'));
         }
 
-        // Ensure unified description UI (reuse type description section & logic for individuals)
-        const descriptionLoad = ensureUnifiedDescriptionSection(conceptId, suffix);
+        const summaryRendererLoad = (async () => {
+            try {
+                const { ensureConceptSummaryRendererPanelForConceptTab } = await import('./components/conceptSummaryRendererPanel.js');
+                const rendered = await ensureConceptSummaryRendererPanelForConceptTab({
+                    conceptId,
+                    suffix,
+                });
+                if (rendered && step1) {
+                    step1.querySelector('.concept-types-summary')?.remove();
+                }
+            } catch (rendererErr) {
+                console.warn('[dynamicTabs] Unable to initialise concept summary renderer panel', rendererErr);
+            }
+        })();
         const recommendationProfileLoad = (async () => {
-            const { ensureRecommendationProfilePanelForConceptTab } = await import('./components/paperRecommendationProfilePanel.js');
-            await ensureRecommendationProfilePanelForConceptTab({
-                conceptId,
-                suffix,
-            });
+            try {
+                const { ensureRecommendationProfilePanelForConceptTab } = await import('./components/paperRecommendationProfilePanel.js');
+                await ensureRecommendationProfilePanelForConceptTab({
+                    conceptId,
+                    suffix,
+                });
+            } catch (profileErr) {
+                console.warn('[dynamicTabs] Unable to initialise recommendation profile panel', profileErr);
+            }
         })();
-        const textSectionsLoad = (async () => {
-            // Keep content below notes without making both wait for description/profile panels.
-            await populateNotesSection(conceptId, suffix);
-            await populateContentSection(conceptId, suffix);
-        })();
-        const secondaryLoads = await Promise.allSettled([
-            descriptionLoad,
+        // Observe optional completion without extending the global loading state.
+        void Promise.allSettled([
+            summaryRendererLoad,
+            effectiveAssertionsLoad,
             recommendationProfileLoad,
-            textSectionsLoad
+            textSectionsLoad,
+            descriptionLoad,
         ]);
-        const [descriptionOutcome, profileOutcome, textSectionsOutcome] = secondaryLoads;
-        if (descriptionOutcome.status === 'rejected') {
-            console.warn('[dynamicTabs] Unable to initialise description section', descriptionOutcome.reason);
-        }
-        if (profileOutcome.status === 'rejected') {
-            console.warn('[dynamicTabs] Unable to initialise recommendation profile panel', profileOutcome.reason);
-        }
-        if (textSectionsOutcome.status === 'rejected') {
-            console.warn('[dynamicTabs] Unable to initialise note/content sections', textSectionsOutcome.reason);
-        }
 
         // If pure instance (no type-of parents), hide the concept list entirely
         const isPureInstance = !Array.isArray(parentsData.parents) || parentsData.parents.length === 0;
@@ -3491,7 +3594,7 @@ export async function updateConceptDescription(conceptId, description) {
     }
 }
 
-async function ensureUnifiedDescriptionSection(conceptId, suffix) {
+async function ensureUnifiedDescriptionSection(conceptId, suffix, options = {}) {
     try {
         let step1 = document.getElementById(`conceptStep1_${suffix}`) || document.getElementById('conceptStep1');
         if (!step1) {
@@ -3610,7 +3713,7 @@ async function ensureUnifiedDescriptionSection(conceptId, suffix) {
         // Inject SVG icons into any newly created or upgraded action buttons
         try { upgradeActionButtonIcons(descSection || step1); } catch (_) { }
         // Populate description then emit a deterministic readiness event for tests & other listeners
-        await populateTypeDescription(conceptId, suffix);
+        await populateTypeDescription(conceptId, suffix, options);
         try {
             const evt = new CustomEvent('description-populated', { detail: { conceptId, suffix } });
             document.dispatchEvent(evt);
@@ -4538,7 +4641,7 @@ export function buildDescriptionMetadataRows(record = {}) {
 }
 
 // Helper: show description for Type tabs and attach edit/save/cancel
-async function populateTypeDescription(conceptId, suffix) {
+async function populateTypeDescription(conceptId, suffix, options = {}) {
     try {
         const descSection = document.getElementById(`typeDescriptionSection_${suffix}`) || document.getElementById('typeDescriptionSection');
         const encodedId = encodeURIComponent(conceptId);
@@ -4679,7 +4782,7 @@ async function populateTypeDescription(conceptId, suffix) {
                 synthesized = true;
             }
             if (synthesized || isTestEnv) {
-                return populateTypeDescription(conceptId, suffix);
+                return populateTypeDescription(conceptId, suffix, options);
             }
             console.warn('[dynamicTabs] populateTypeDescription: missing essential elements – will retry shortly', { hasDisplay: !!display, hasEditActions: !!editActions, hasTextarea: !!textarea, hasEdit: !!editBtn, hasSave: !!saveBtn, hasCancel: !!cancelBtn, suffix, synthesized });
             // Light retry strategy (non-test only): attempt a few times with backoff; store attempt count on window-scoped map
@@ -4691,7 +4794,7 @@ async function populateTypeDescription(conceptId, suffix) {
                     rec.attempts += 1;
                     window.__descPopulateRetries.set(key, rec);
                     const delay = 80 * rec.attempts; // incremental backoff
-                    setTimeout(() => { try { populateTypeDescription(conceptId, suffix); } catch (_) { /* swallow */ } }, delay);
+                    setTimeout(() => { try { populateTypeDescription(conceptId, suffix, options); } catch (_) { /* swallow */ } }, delay);
                 } else {
                     console.warn('[dynamicTabs] populateTypeDescription: giving up after retries', { conceptId, suffix });
                 }
@@ -4746,6 +4849,24 @@ async function populateTypeDescription(conceptId, suffix) {
                 if (res.ok && dynamicConceptTabs.get(conceptId)?.newlyCreated) {
                     console.debug('[dynamicTabs] Newly-created concept has no hasDescription relation; skipping legacy description fallbacks', { conceptId });
                     setEmpty();
+                    return;
+                }
+                if (res.ok && options.allowLegacyFallback === false) {
+                    let fallbackDescription = options.fallbackDescription;
+                    if (typeof fallbackDescription !== 'string' && options.fallbackDescriptionPromise) {
+                        fallbackDescription = await Promise.resolve(options.fallbackDescriptionPromise)
+                            .catch(() => null);
+                    }
+                    if (typeof fallbackDescription === 'string') {
+                        applyRawDescription(fallbackDescription);
+                        textarea.value = fallbackDescription;
+                        relationId = null;
+                        renderDescriptionMetadata(null);
+                        console.debug('[dynamicTabs] Description loaded (bounded concept fallback)', { conceptId });
+                    } else {
+                        console.debug('[dynamicTabs] No bounded description found; legacy fallbacks disabled', { conceptId });
+                        setEmpty();
+                    }
                     return;
                 }
                 console.debug('[dynamicTabs] Primary description API returned no data – attempting legacy fallbacks', { status: res.status, bodyKeys: Object.keys(data || {}) });
@@ -7166,39 +7287,30 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
     }
 }
 
-// Metadata cache for concept kind and display names (relationships section)
-const relationshipsConceptMetadataCache = new Map();
-async function getConceptMetadata(conceptId) {
-    if (relationshipsConceptMetadataCache.has(conceptId)) {
-        return relationshipsConceptMetadataCache.get(conceptId);
-    }
-    try {
-        const resp = await fetch(`/api/concepts/${encodeURIComponent(conceptId)}`);
-        if (resp.ok) {
-            const data = await resp.json();
-            const metadata = {
-                kind: data.kind || 'individual',
-                name: data.display_name || conceptId
-            };
-            relationshipsConceptMetadataCache.set(conceptId, metadata);
-            return metadata;
-        }
-    } catch (err) {
-        console.warn('[dynamicTabs] Failed to fetch metadata for', conceptId, err);
-    }
-    return { kind: 'individual', name: conceptId };
+const relationshipExtentPageState = new Map();
+
+function relationshipExtentStateKey(conceptId, suffix) {
+    return `${conceptId}::${suffix}`;
 }
 
-async function renderRelationships(conceptId, suffix, kind) {
+async function renderRelationships(conceptId, suffix, kind, { offset = 0, append = false } = {}) {
     const content = document.getElementById(`relationshipsContent_${suffix}`) || document.getElementById('relationshipsContent');
     if (!content) return;
-    content.innerHTML = '<div>Loading relationships...</div>';
+    if (!append) {
+        content.replaceChildren();
+        const loading = document.createElement('div');
+        loading.textContent = 'Loading relationships...';
+        content.appendChild(loading);
+    }
+    content.dataset.panelState = 'loading';
     try {
         const uiState = getRelationshipExtentUiState(conceptId, suffix);
         const extentQuery = deriveRelationshipExtentQuery(uiState.uncertaintyFilter);
         const params = new URLSearchParams();
         params.set('concept_id', conceptId);
-        params.set('limit', '500');
+        params.set('limit', '50');
+        params.set('offset', String(offset));
+        params.set('bounded_only', 'true');
         if (extentQuery.uncertaintyMode) {
             params.set('uncertainty_mode', extentQuery.uncertaintyMode);
         }
@@ -7211,26 +7323,54 @@ async function renderRelationships(conceptId, suffix, kind) {
         const resp = await fetch(`/vontology/api/vontology/relationships/extent?${params.toString()}`);
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok || !data.success) {
-            throw new Error(data.error || `HTTP ${resp.status}`);
+            const error = new Error(data.error || `HTTP ${resp.status}`);
+            error.code = data.error_code || '';
+            error.retryable = data.retryable === true;
+            throw error;
         }
 
-        let rows = Array.isArray(data.rows) ? data.rows : [];
-        if (!rows.length) {
-            try {
-                const conceptResp = await conceptApiFetch(`/api/concepts/${encodeURIComponent(conceptId)}`);
-                if (conceptResp.ok) {
-                    const conceptPayload = await conceptResp.json().catch(() => null);
-                    const fallbackRows = deriveRelationshipExtentFallbackRows(conceptId, conceptPayload);
-                    if (fallbackRows.length) {
-                        rows = fallbackRows;
-                    }
-                }
-            } catch (fallbackErr) {
-                console.debug('[dynamicTabs] Relationship fallback synthesis failed', fallbackErr);
+        const pageRows = Array.isArray(data.rows) ? data.rows : [];
+        const stateKey = relationshipExtentStateKey(conceptId, suffix);
+        const existingState = append
+            ? relationshipExtentPageState.get(stateKey) || { rows: [], metadata: {} }
+            : { rows: [], metadata: {} };
+        const mergedRows = [...existingState.rows];
+        const seenRows = new Set(mergedRows.map((row) => JSON.stringify([
+            row.role,
+            row.source,
+            row.relation_kind,
+            row.predicate_id,
+            row.arg1_value,
+            row.arg2_value,
+            row.arg2_lang,
+        ])));
+        for (const row of pageRows) {
+            const key = JSON.stringify([
+                row.role,
+                row.source,
+                row.relation_kind,
+                row.predicate_id,
+                row.arg1_value,
+                row.arg2_value,
+                row.arg2_lang,
+            ]);
+            if (!seenRows.has(key)) {
+                seenRows.add(key);
+                mergedRows.push(row);
             }
         }
+        const responseMetadata = data.display_metadata && typeof data.display_metadata === 'object'
+            ? data.display_metadata
+            : {};
+        const metadata = { ...existingState.metadata, ...responseMetadata };
+        relationshipExtentPageState.set(stateKey, { rows: mergedRows, metadata });
+        let rows = mergedRows;
         if (!rows.length) {
-            content.innerHTML = '<i>No relationships yet.</i>';
+            content.replaceChildren();
+            const empty = document.createElement('i');
+            empty.textContent = 'No relationships yet.';
+            content.appendChild(empty);
+            content.dataset.panelState = 'complete';
             setRelationshipExtentResizeEnabled(content, suffix, false);
             return;
         }
@@ -7247,25 +7387,18 @@ async function renderRelationships(conceptId, suffix, kind) {
             return normalisePotentialConceptId(trimmed) || normalisePotentialConceptId(`#V#${trimmed}`) || '';
         };
 
-        const conceptIds = new Set();
-        rows.forEach((row) => {
-            const arg1ConceptId = normalisePotentialConceptId(row.arg1_value);
-            if (arg1ConceptId) conceptIds.add(arg1ConceptId);
-            const arg2ConceptId = normalisePotentialConceptId(row.arg2_value);
-            if (arg2ConceptId) conceptIds.add(arg2ConceptId);
-            const predicateConceptId = toPredicateConceptId(row.predicate_id);
-            if (predicateConceptId) {
-                conceptIds.add(predicateConceptId);
-            }
-        });
-
         const metadataMap = new Map();
-        await Promise.all(
-            Array.from(conceptIds).map(async (id) => {
-                const metadata = await getConceptMetadata(id);
-                metadataMap.set(id, metadata || { kind: 'individual', name: id });
-            })
-        );
+        Object.entries(metadata).forEach(([id, value]) => {
+            if (!id.startsWith('#V#') || !value || typeof value !== 'object') return;
+            metadataMap.set(id, {
+                kind: ['type', 'predicate', 'individual'].includes(value.kind)
+                    ? value.kind
+                    : 'individual',
+                name: typeof value.name === 'string' && value.name.trim()
+                    ? value.name.trim()
+                    : id,
+            });
+        });
 
         const createConceptCell = (conceptIdValue, fallbackName = null) => {
             const cell = document.createElement('td');
@@ -7539,11 +7672,45 @@ async function renderRelationships(conceptId, suffix, kind) {
 
         table.appendChild(tbody);
         tableContainer.appendChild(table);
-        content.innerHTML = '';
+        content.replaceChildren();
         content.appendChild(tableContainer);
+        if (data.has_more === true && Number.isInteger(data.next_offset)) {
+            const paging = document.createElement('div');
+            paging.className = 'relationship-extent-paging';
+            const loadMore = document.createElement('button');
+            loadMore.type = 'button';
+            loadMore.className = 'relationship-extent-load-more';
+            loadMore.textContent = 'Load more relationships';
+            loadMore.addEventListener('click', async () => {
+                loadMore.disabled = true;
+                loadMore.textContent = 'Loading...';
+                await renderRelationships(conceptId, suffix, kind, {
+                    offset: data.next_offset,
+                    append: true,
+                });
+            });
+            paging.appendChild(loadMore);
+            content.appendChild(paging);
+        }
+        content.dataset.panelState = data.has_more === true ? 'partial' : 'complete';
         setRelationshipExtentResizeEnabled(content, suffix, true);
     } catch (e) {
-        content.innerHTML = `<span class="relationships-error">Failed to load relationships (${e.message})</span>`;
+        content.replaceChildren();
+        const error = document.createElement('span');
+        error.className = 'relationships-error';
+        error.textContent = e.code === 'relationship_extent_index_not_ready'
+            ? 'Relationships are temporarily unavailable while the bounded index is prepared.'
+            : `Failed to load relationships (${e.message})`;
+        content.appendChild(error);
+        if (e.retryable || e.code === 'relationship_extent_index_not_ready') {
+            const retry = document.createElement('button');
+            retry.type = 'button';
+            retry.className = 'relationship-extent-retry';
+            retry.textContent = 'Retry';
+            retry.addEventListener('click', () => renderRelationships(conceptId, suffix, kind));
+            content.appendChild(retry);
+        }
+        content.dataset.panelState = 'degraded';
         setRelationshipExtentResizeEnabled(content, suffix, false);
     }
 }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -11225,6 +11225,178 @@ button.prompt-vontology-cartouche {
     margin: 0 0 14px;
 }
 
+.concept-effective-assertions-mount {
+    margin: 0 0 14px;
+}
+
+.concept-effective-assertions {
+    display: grid;
+    gap: 12px;
+    padding: 14px 16px;
+    border: 1px solid #cbd5e1;
+    border-left: 4px solid #4f46e5;
+    border-radius: 12px;
+    background: #f8fafc;
+}
+
+.concept-effective-assertions-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.concept-effective-assertions-title {
+    margin: 0;
+    color: #0f172a;
+    font-size: 1rem;
+}
+
+.concept-effective-assertions-intro,
+.concept-effective-assertions-status {
+    margin: 3px 0 0;
+    color: #475569;
+    font-size: 0.84rem;
+    line-height: 1.4;
+}
+
+.concept-effective-assertions-status {
+    flex: 0 1 260px;
+    text-align: right;
+}
+
+.concept-effective-assertions-status.error {
+    color: #b91c1c;
+}
+
+.concept-effective-assertions-rows {
+    display: grid;
+    gap: 8px;
+}
+
+.concept-effective-assertion-group,
+.concept-effective-assertion-group-rows {
+    display: grid;
+    gap: 8px;
+}
+
+.concept-effective-assertion-group-title {
+    margin: 2px 0 0;
+    color: #334155;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.concept-effective-assertion-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 12px;
+    align-items: center;
+    padding: 10px 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #fff;
+}
+
+.concept-effective-assertion-statement {
+    display: grid;
+    grid-template-columns: minmax(120px, 0.35fr) minmax(0, 1fr);
+    gap: 10px;
+    align-items: baseline;
+}
+
+.concept-effective-assertion-predicate {
+    color: #475569;
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.concept-effective-assertion-value {
+    color: #0f172a;
+    overflow-wrap: anywhere;
+}
+
+.concept-effective-assertion-scope {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24px;
+    padding: 2px 9px;
+    border-radius: 999px;
+    font-size: 0.74rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.concept-effective-assertion-scope-personal {
+    background: #ede9fe;
+    color: #5b21b6;
+}
+
+.concept-effective-assertion-scope-organisation {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.concept-effective-assertion-details {
+    grid-column: 1 / -1;
+    color: #475569;
+    font-size: 0.8rem;
+}
+
+.concept-effective-assertion-details summary {
+    cursor: pointer;
+    width: max-content;
+}
+
+.concept-effective-assertion-details dl {
+    display: grid;
+    grid-template-columns: minmax(100px, max-content) minmax(0, 1fr);
+    gap: 3px 10px;
+    margin: 8px 0 0;
+}
+
+.concept-effective-assertion-details dt {
+    font-weight: 700;
+}
+
+.concept-effective-assertion-details dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.concept-effective-assertions-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.concept-effective-assertions-load-more {
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    padding: 5px 12px;
+    background: #fff;
+    color: #1e293b;
+    cursor: pointer;
+}
+
+@media (max-width: 720px) {
+    .concept-effective-assertions-header,
+    .concept-effective-assertion-row {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .concept-effective-assertions-status {
+        text-align: left;
+    }
+
+    .concept-effective-assertion-statement {
+        grid-template-columns: 1fr;
+        gap: 3px;
+    }
+}
+
 .concept-summary-card {
     display: grid;
     gap: 10px;

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -21,6 +21,7 @@
     <span id="conceptFormTitleText">Select or Create Concept</span>
   </div>
   <div id="conceptSummaryRendererMount" class="concept-summary-renderer-mount"></div>
+  <div id="conceptEffectiveAssertionsMount" class="concept-effective-assertions-mount"></div>
   <!-- Legacy single-note notes UI removed; multi-note relations UI injected dynamically -->
   <!-- Ordinary discussion is distinct from the specialised concept-improvement Q&A below. -->
   <button id="discussConceptButton" class="concept-discuss-button"

--- a/tests/backend/test_concept_effective_assertion_routes.py
+++ b/tests/backend/test_concept_effective_assertion_routes.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server.routes.concept_routes import concept_bp
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(concept_bp, url_prefix="/api/concepts")
+    return app
+
+
+def test_anonymous_effective_assertion_route_returns_base_only_without_lookup(
+    monkeypatch,
+) -> None:
+    app = _make_app()
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_concept_effective_assertions",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("anonymous requests must not inspect scoped assertions")
+        ),
+    )
+
+    with app.test_client() as client:
+        response = client.get(
+            "/api/concepts/%23V%23public/effective_assertions"
+            "?user_concept_id=%23V%23other&organisation_concept_id=%23V%23secret"
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["context_view"] == "base_publication"
+    assert payload["items"] == []
+    assert payload["has_more"] is False
+
+
+def test_authenticated_effective_assertion_route_uses_bounded_query_only(
+    monkeypatch,
+) -> None:
+    app = _make_app()
+    captured = {}
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: "#V#actor",
+    )
+
+    def _load(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "concept_id": kwargs["concept_id"],
+            "context_view": "actor_effective",
+            "items": [{"assertion_id": "ska_visible"}],
+            "returned": 1,
+            "offset": int(kwargs["offset"]),
+            "limit": int(kwargs["limit"]),
+            "has_more": False,
+            "next_offset": None,
+            "truncated": False,
+            "counts_are_lower_bounds": False,
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_concept_effective_assertions",
+        _load,
+    )
+
+    with app.test_client() as client:
+        response = client.get(
+            "/api/concepts/%23V%23event/effective_assertions"
+            "?limit=12&offset=24&user_concept_id=%23V%23other"
+        )
+
+    assert response.status_code == 200
+    assert captured == {
+        "concept_id": "#V#event",
+        "limit": "12",
+        "offset": "24",
+    }
+    assert response.get_json()["items"] == [{"assertion_id": "ska_visible"}]
+
+
+def test_effective_assertion_route_returns_retryable_degraded_state(
+    monkeypatch,
+) -> None:
+    app = _make_app()
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: "#V#actor",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_concept_effective_assertions",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("store unavailable")),
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/concepts/%23V%23event/effective_assertions")
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "Actor-effective assertions are temporarily unavailable",
+        "error_code": "actor_effective_assertions_unavailable",
+        "retryable": True,
+    }

--- a/tests/backend/test_concept_effective_assertion_service.py
+++ b/tests/backend/test_concept_effective_assertion_service.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import mongomock
+import pytest
+
+from src.backend.security.access_control import override_current_actor
+import src.backend.services.concept_effective_assertion_service as service
+import src.backend.services.scoped_assertion_service as scoped_service
+
+
+def test_load_effective_assertions_projects_scopes_and_batches_names(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    def _list_page(**kwargs):
+        captured["page"] = kwargs
+        return {
+            "items": [
+                {
+                    "assertion_id": "ska_personal",
+                    "assertion_revision": 1,
+                    "subject_concept_id": "#V#event",
+                    "predicate": "#V#date_of_event",
+                    "object_kind": "text",
+                    "object_text": {"text": "June 2026", "language": "en-NZ"},
+                    "scope": {"mode": "user"},
+                    "status": "asserted",
+                    "provenance": {"capability_name": "upsert_scoped_assertion"},
+                },
+                {
+                    "assertion_id": "ska_org",
+                    "assertion_revision": 2,
+                    "subject_concept_id": "#V#event",
+                    "predicate": "#V#event_location",
+                    "object_kind": "concept",
+                    "object_concept_id": "#V#room",
+                    "scope": {
+                        "mode": "organisation",
+                        "organisation_concept_id": "#V#lab",
+                    },
+                    "status": "asserted",
+                    "provenance": {"capability_name": "upsert_scoped_assertion"},
+                },
+            ],
+            "has_more": True,
+            "next_offset": 2,
+            "truncated": True,
+            "counts_are_lower_bounds": True,
+        }
+
+    def _find(filter, projection, *, limit):
+        captured["find"] = {
+            "filter": filter,
+            "projection": projection,
+            "limit": limit,
+        }
+        return [
+            {"concept_id": "#V#date_of_event", "name": "Date of event"},
+            {"concept_id": "#V#event_location", "name": "Event location"},
+            {"concept_id": "#V#room", "name": "Room 1"},
+            {"concept_id": "#V#lab", "name": "Example Lab"},
+        ]
+
+    monkeypatch.setattr(service, "list_visible_scoped_assertions_page", _list_page)
+    monkeypatch.setattr(service.ConceptsRepository, "find", _find)
+    monkeypatch.setattr(
+        service,
+        "resolve_concept_display_names",
+        lambda docs: {row["concept_id"]: row["name"] for row in docs},
+    )
+
+    result = service.load_concept_effective_assertions(
+        concept_id="#V#event",
+        limit=2,
+        offset=0,
+    )
+
+    assert captured["page"] == {
+        "subject_concept_ids": ["#V#event"],
+        "limit": 2,
+        "offset": 0,
+        "limit_per_subject": 2,
+    }
+    assert captured["find"]["filter"] == {
+        "concept_id": {
+            "$in": [
+                "#V#date_of_event",
+                "#V#event_location",
+                "#V#room",
+                "#V#lab",
+            ]
+        }
+    }
+    assert captured["find"]["limit"] == 4
+    assert result["has_more"] is True
+    assert result["next_offset"] == 2
+    assert result["counts_are_lower_bounds"] is True
+    assert result["items"][0]["predicate"]["display_name"] == "Date of event"
+    assert result["items"][0]["object"] == {
+        "kind": "text",
+        "text": "June 2026",
+        "language": "en-NZ",
+    }
+    assert result["items"][0]["source_context"] == {
+        "kind": "personal",
+        "label": "Personal — visible only to you",
+        "organisation_concept_id": None,
+        "organisation_display_name": None,
+    }
+    assert result["items"][1]["object"]["display_name"] == "Room 1"
+    assert result["items"][1]["source_context"]["label"] == (
+        "Organisation — Example Lab"
+    )
+
+
+def test_load_effective_assertions_does_not_query_metadata_for_empty_page(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "list_visible_scoped_assertions_page",
+        lambda **_kwargs: {
+            "items": [],
+            "has_more": False,
+            "next_offset": None,
+            "truncated": False,
+            "counts_are_lower_bounds": False,
+        },
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("empty assertion pages must not query concept metadata")
+        ),
+    )
+
+    result = service.load_concept_effective_assertions(concept_id="#V#empty")
+
+    assert result["items"] == []
+    assert result["returned"] == 0
+
+
+def test_effective_projection_respects_personal_and_current_org_audiences(
+    monkeypatch,
+) -> None:
+    collection = mongomock.MongoClient().db.scoped_knowledge_assertions
+    now = datetime.now(timezone.utc)
+    collection.insert_many(
+        [
+            {
+                "_id": "ska_personal",
+                "assertion_id": "ska_personal",
+                "assertion_revision": 1,
+                "subject_concept_id": "#V#event",
+                "predicate": "#V#date_of_event",
+                "object_kind": "text",
+                "object_text": {"text": "June 2026", "language": "en-NZ"},
+                "scope": {
+                    "mode": "user",
+                    "audience_keys": ["user:#V#owner"],
+                },
+                "status": "asserted",
+                "canonical_publication": False,
+                "created_at": now,
+                "updated_at": now,
+                "provenance": {"asserted_by_user_concept_id": "#V#owner"},
+            },
+            {
+                "_id": "ska_org",
+                "assertion_id": "ska_org",
+                "assertion_revision": 1,
+                "subject_concept_id": "#V#event",
+                "predicate": "#V#event_location",
+                "object_kind": "text",
+                "object_text": {"text": "Main office", "language": "en-NZ"},
+                "scope": {
+                    "mode": "organisation",
+                    "organisation_concept_id": "#V#org_a",
+                    "audience_keys": ["org:#V#org_a"],
+                },
+                "status": "asserted",
+                "canonical_publication": False,
+                "created_at": now,
+                "updated_at": now,
+                "provenance": {"asserted_by_user_concept_id": "#V#owner"},
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        scoped_service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        scoped_service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [],
+    )
+
+    with override_current_actor("#V#owner", "#V#org_a"):
+        owner = service.load_concept_effective_assertions(concept_id="#V#event")
+    with override_current_actor("#V#colleague", "#V#org_a"):
+        colleague = service.load_concept_effective_assertions(concept_id="#V#event")
+    with override_current_actor("#V#outsider", "#V#org_b"):
+        outsider = service.load_concept_effective_assertions(concept_id="#V#event")
+
+    assert {item["assertion_id"] for item in owner["items"]} == {
+        "ska_personal",
+        "ska_org",
+    }
+    assert [item["assertion_id"] for item in colleague["items"]] == ["ska_org"]
+    assert outsider["items"] == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"concept_id": "not-an-id"}, "exact #V# concept ID"),
+        ({"concept_id": "#V#x", "limit": 0}, "limit must be between"),
+        ({"concept_id": "#V#x", "limit": 101}, "limit must be between"),
+        ({"concept_id": "#V#x", "offset": -1}, "offset must be between"),
+    ],
+)
+def test_load_effective_assertions_rejects_unbounded_page_inputs(
+    monkeypatch,
+    kwargs,
+    message,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "list_visible_scoped_assertions_page",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid inputs must fail before retrieval")
+        ),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        service.load_concept_effective_assertions(**kwargs)

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -108,14 +108,19 @@ def test_summary_field_resolver_resolves_type_field_bindings(monkeypatch) -> Non
     }
 
     monkeypatch.setattr(
+        resolver_module.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: list(concept_docs.values()),
+    )
+    monkeypatch.setattr(
         resolver_module,
         "get_concept_by_concept_id",
         lambda concept_id: concept_docs[concept_id],
     )
     monkeypatch.setattr(
         resolver_module,
-        "get_texts_for_concept",
-        lambda subject_concept_id, predicate=None, limit=5: [],
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: {},
     )
 
     resolver = resolver_module.ConceptSummaryFieldResolver(cache_ttl_seconds=60.0)

--- a/tests/backend/test_concept_summary_renderer_service.py
+++ b/tests/backend/test_concept_summary_renderer_service.py
@@ -53,6 +53,54 @@ def _install_summary_field_resolver(monkeypatch) -> None:
         lambda: _FakeSummaryFieldResolver(),
     )
 
+    def _type_closure(type_ids):
+        direct = list(type_ids)
+        queue = list(direct)
+        ordered = list(direct)
+        seen = set(direct)
+        docs = {}
+        while queue:
+            type_id = queue.pop(0)
+            try:
+                doc = service.get_concept_by_concept_id(type_id)
+            except Exception:
+                continue
+            docs[type_id] = doc
+            for parent_id in (doc.get("relationships") or {}).get("is_a_type_of") or []:
+                if parent_id in seen:
+                    continue
+                seen.add(parent_id)
+                ordered.append(parent_id)
+                queue.append(parent_id)
+        return {
+            "ordered_type_ids": ordered,
+            "ancestor_type_ids": ordered[len(direct):],
+            "documents_by_id": docs,
+            "truncated": False,
+        }
+
+    monkeypatch.setattr(service, "load_type_closure", _type_closure)
+    monkeypatch.setattr(
+        service,
+        "resolve_concept_display_names",
+        lambda docs: {
+            doc["concept_id"]: doc.get("name") or doc["concept_id"]
+            for doc in docs
+        },
+    )
+
+    def _find_concepts(filter_value, *_args, **_kwargs):
+        ids = (filter_value.get("concept_id") or {}).get("$in") or []
+        docs = []
+        for concept_id in ids:
+            try:
+                docs.append(service.get_concept_by_concept_id(concept_id))
+            except Exception:
+                pass
+        return docs
+
+    monkeypatch.setattr(service.ConceptsRepository, "find", _find_concepts)
+
 
 def test_load_concept_summary_renderer_builds_person_identity_payload(monkeypatch) -> None:
     _install_summary_field_resolver(monkeypatch)

--- a/tests/backend/test_concept_type_closure_service.py
+++ b/tests/backend/test_concept_type_closure_service.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from src.backend.services import concept_type_closure_service as service
+
+
+def test_load_type_closure_batches_each_depth_and_stops_cycles(monkeypatch) -> None:
+    documents = {
+        "#V#research_fellow": {
+            "concept_id": "#V#research_fellow",
+            "relationships": {"is_a_type_of": ["#V#researcher", "#V#person"]},
+        },
+        "#V#researcher": {
+            "concept_id": "#V#researcher",
+            "relationships": {"is_a_type_of": ["#V#person"]},
+        },
+        "#V#person": {
+            "concept_id": "#V#person",
+            "relationships": {"is_a_type_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "relationships": {"is_a_type_of": ["#V#research_fellow"]},
+        },
+    }
+    calls: list[list[str]] = []
+
+    def _find(query, *_args, **_kwargs):
+        ids = list(query["concept_id"]["$in"])
+        calls.append(ids)
+        return [documents[concept_id] for concept_id in ids if concept_id in documents]
+
+    monkeypatch.setattr(service.ConceptsRepository, "find", _find)
+
+    result = service.load_type_closure(["#V#research_fellow"])
+
+    assert result["ordered_type_ids"] == [
+        "#V#research_fellow",
+        "#V#researcher",
+        "#V#person",
+        "#V#thing",
+    ]
+    assert calls == [
+        ["#V#research_fellow"],
+        ["#V#researcher", "#V#person"],
+        ["#V#thing"],
+    ]
+    assert result["truncated"] is False
+
+
+def test_load_type_closure_reports_bounded_truncation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda query, *_args, **_kwargs: [
+            {
+                "concept_id": query["concept_id"]["$in"][0],
+                "relationships": {"is_a_type_of": ["#V#next"]},
+            }
+        ],
+    )
+
+    result = service.load_type_closure(["#V#start"], max_depth=1)
+
+    assert result["ordered_type_ids"] == ["#V#start", "#V#next"]
+    assert result["truncated"] is True

--- a/tests/backend/test_paper_recommendation_profile_vontology_service.py
+++ b/tests/backend/test_paper_recommendation_profile_vontology_service.py
@@ -83,6 +83,16 @@ def test_load_paper_recommendation_profile_returns_profile_and_derived_context(
         ]
 
     monkeypatch.setattr(service, "get_texts_for_concept", _fake_get_texts_for_concept)
+    monkeypatch.setattr(
+        service,
+        "load_type_closure",
+        lambda _type_ids: {
+            "ordered_type_ids": [
+                "#V#machine_learning_researcher",
+                service.RESEARCHER_TYPE_ID,
+            ]
+        },
+    )
 
     payload = service.load_paper_recommendation_profile(
         user_concept_id="#V#lu_yunli",
@@ -166,6 +176,16 @@ def test_upsert_paper_recommendation_profile_normalises_fields_before_write(
         "persist_subject_paper_matching_profile",
         lambda **kwargs: mirrored.update(kwargs)
         or {"success": True, "subject_concept_id": kwargs["subject_concept_id"]},
+    )
+    monkeypatch.setattr(
+        service,
+        "load_type_closure",
+        lambda _type_ids: {
+            "ordered_type_ids": [
+                "#V#research_fellow",
+                service.RESEARCHER_TYPE_ID,
+            ]
+        },
     )
 
     result = service.upsert_paper_recommendation_profile(
@@ -295,6 +315,17 @@ def test_subject_relevant_for_profile_follows_researcher_type_ancestry(monkeypat
             },
         }.get(concept_id),
     )
+    monkeypatch.setattr(
+        service,
+        "load_type_closure",
+        lambda _type_ids: {
+            "ordered_type_ids": [
+                "#V#postdoctoral_researcher",
+                "#V#research_staff",
+                service.RESEARCHER_TYPE_ID,
+            ]
+        },
+    )
 
     assert (
         service.is_subject_relevant_for_paper_recommendation_profile(
@@ -335,6 +366,13 @@ def test_upsert_paper_recommendation_profile_rejects_ineligible_subject(monkeypa
                 "relationships": {},
             },
         }.get(concept_id),
+    )
+    monkeypatch.setattr(
+        service,
+        "load_type_closure",
+        lambda _type_ids: {
+            "ordered_type_ids": ["#V#organisation", "#V#group"]
+        },
     )
 
     try:

--- a/tests/backend/test_relationship_extent_index_service.py
+++ b/tests/backend/test_relationship_extent_index_service.py
@@ -9,11 +9,15 @@ def _reset_relationship_extent_readiness_cache():
     from src.backend.security import access_control
     from src.backend.services import relationship_extent_index_service as service
 
-    service._READINESS_CACHE.update({"ready": None, "checked_at": 0.0})
+    service._READINESS_CACHE.update(
+        {"ready": None, "checked_at": 0.0, "state": None}
+    )
     service._SUCCESSFUL_OPERATION_MAX_SECONDS.clear()
     access_control.invalidate_current_access_evaluator()
     yield
-    service._READINESS_CACHE.update({"ready": None, "checked_at": 0.0})
+    service._READINESS_CACHE.update(
+        {"ready": None, "checked_at": 0.0, "state": None}
+    )
     service._SUCCESSFUL_OPERATION_MAX_SECONDS.clear()
     access_control.invalidate_current_access_evaluator()
 
@@ -228,6 +232,144 @@ def test_relationship_extent_rebuild_enforces_batch_size_for_dense_source(
         {"setting_name": service.RELATIONSHIP_EXTENT_INDEX_STATE_SETTING}
     )
     assert state["value"]["status"] == "ready"
+
+
+def test_failed_relationship_extent_rebuild_preserves_prior_generation(
+    monkeypatch,
+):
+    from src.backend.services import relationship_extent_index_service as service
+
+    client = mongomock.MongoClient()
+    coll = client.db.relationship_extent_index
+    settings = client.db.application_settings
+    coll.insert_one(
+        {
+            "relation_id": "prior-row",
+            "source_concept_id": "#V#prior",
+            "schema_version": service.RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
+        }
+    )
+    monkeypatch.setattr(
+        service,
+        "get_relationship_extent_index_collection",
+        lambda: coll,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_application_settings_collection",
+        lambda: settings,
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {
+                "concept_id": "#V#new",
+                "relationships": {"#V#mentions": ["#V#target"]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        coll,
+        "bulk_write",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("simulated rebuild failure")
+        ),
+    )
+
+    result = service.rebuild_relationship_extent_index(reason="failure_test")
+
+    assert result["success"] is False
+    assert coll.find_one({"relation_id": "prior-row"}) is not None
+    state = settings.find_one(
+        {"setting_name": service.RELATIONSHIP_EXTENT_INDEX_STATE_SETTING}
+    )
+    assert state["value"]["status"] == "failed"
+
+
+def test_reconcile_relationship_extent_index_repairs_missing_state(monkeypatch):
+    from src.backend.services import relationship_extent_index_service as service
+
+    monkeypatch.setattr(service, "relationship_extent_index_ready", lambda: False)
+    monkeypatch.setattr(
+        service,
+        "relationship_extent_index_state",
+        lambda: {"available": True, "status": "missing"},
+    )
+    calls = []
+    monkeypatch.setattr(
+        service,
+        "rebuild_relationship_extent_index",
+        lambda **kwargs: calls.append(kwargs)
+        or {"success": True, "status": "ready"},
+    )
+
+    result = service.reconcile_relationship_extent_index_if_needed(
+        reason="startup_test"
+    )
+
+    assert result == {"success": True, "status": "ready", "changed": True}
+    assert calls == [{"reason": "startup_test"}]
+
+
+def test_reconcile_relationship_extent_index_repairs_stale_rebuild_state(monkeypatch):
+    from src.backend.services import relationship_extent_index_service as service
+
+    monkeypatch.setattr(service, "relationship_extent_index_ready", lambda: False)
+    monkeypatch.setattr(
+        service,
+        "relationship_extent_index_state",
+        lambda: {
+            "available": True,
+            "status": "rebuilding",
+            "started_at": "2020-01-01T00:00:00+00:00",
+        },
+    )
+    calls = []
+    monkeypatch.setattr(
+        service,
+        "rebuild_relationship_extent_index",
+        lambda **kwargs: calls.append(kwargs)
+        or {"success": True, "status": "ready"},
+    )
+
+    result = service.reconcile_relationship_extent_index_if_needed(
+        reason="stale_startup_test"
+    )
+
+    assert result == {"success": True, "status": "ready", "changed": True}
+    assert calls == [{"reason": "stale_startup_test"}]
+
+
+def test_reconcile_relationship_extent_index_defers_to_recent_rebuild(monkeypatch):
+    from src.backend.services import relationship_extent_index_service as service
+
+    monkeypatch.setattr(service, "relationship_extent_index_ready", lambda: False)
+    monkeypatch.setattr(
+        service,
+        "relationship_extent_index_state",
+        lambda: {
+            "available": True,
+            "status": "rebuilding",
+            "started_at": service._utc_now().isoformat(),
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "rebuild_relationship_extent_index",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("must not rebuild")
+        ),
+    )
+
+    result = service.reconcile_relationship_extent_index_if_needed()
+
+    assert result == {
+        "success": True,
+        "status": "rebuilding",
+        "changed": False,
+        "reason": "rebuild_already_recorded",
+    }
 
 
 def test_relationship_extent_query_cursor_and_count_complete_without_deadline(

--- a/tests/backend/test_relationship_extent_index_startup.py
+++ b/tests/backend/test_relationship_extent_index_startup.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from src.backend.server import utils_flask
+from src.backend.services import relationship_extent_index_service as index_service
+
+
+def test_startup_relationship_extent_reconciliation_runs_in_background(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    calls: list[dict] = []
+
+    monkeypatch.setattr(utils_flask, "_is_running_under_pytest", lambda: False)
+    monkeypatch.setattr(utils_flask, "_is_agent_test_instance", lambda: False)
+    monkeypatch.setattr(utils_flask, "_env_bool", lambda _name, _default: True)
+    monkeypatch.setattr(
+        index_service,
+        "reconcile_relationship_extent_index_if_needed",
+        lambda **kwargs: calls.append(kwargs)
+        or {"success": True, "status": "ready", "changed": True},
+    )
+
+    class _ImmediateThread:
+        def __init__(self, *, target, **_kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(utils_flask.threading, "Thread", _ImmediateThread)
+
+    utils_flask._maybe_start_relationship_extent_index_reconciliation(app)
+
+    assert calls == [{"reason": "server_startup_reconciliation"}]
+    assert app.config["RELATIONSHIP_EXTENT_INDEX_RECONCILIATION"] == {
+        "success": True,
+        "status": "ready",
+        "changed": True,
+    }
+
+
+def test_startup_relationship_extent_reconciliation_skips_agent_test(
+    monkeypatch,
+) -> None:
+    app = Flask(__name__)
+    monkeypatch.setattr(utils_flask, "_is_running_under_pytest", lambda: False)
+    monkeypatch.setattr(utils_flask, "_is_agent_test_instance", lambda: True)
+    monkeypatch.setattr(
+        utils_flask.threading,
+        "Thread",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("agent-test startup must not launch reconciliation")
+        ),
+    )
+
+    utils_flask._maybe_start_relationship_extent_index_reconciliation(app)
+
+    assert "RELATIONSHIP_EXTENT_INDEX_RECONCILIATION" not in app.config

--- a/tests/backend/test_renderer_applicability_vontology_service.py
+++ b/tests/backend/test_renderer_applicability_vontology_service.py
@@ -15,21 +15,23 @@ def test_load_renderer_definitions_from_concept_ids_parses_profile_json(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
-        service,
-        "get_concept_by_concept_id",
-        lambda concept_id: {"concept_id": concept_id, "relationships": {}},
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#timeline_renderer", "relationships": {}}
+        ],
     )
     monkeypatch.setattr(
         service,
-        "get_texts_for_concept",
-        lambda concept_id, predicate=None, limit=50: [
-            {
-                "predicate": predicate,
-                "text": '{"renderer_type":"timeline","modalities":["visual"],"priority":80,"screen_element_families":["timeline"]}',
-            }
-        ]
-        if predicate == "#V#has_renderer_profile_json"
-        else [],
+        "get_texts_for_concepts",
+        lambda concept_ids, predicates=None, limit_per_concept=20: {
+            concept_ids[0]: [
+                {
+                    "predicate": "#V#has_renderer_profile_json",
+                    "text": '{"renderer_type":"timeline","modalities":["visual"],"priority":80,"screen_element_families":["timeline"]}',
+                }
+            ]
+        },
     )
 
     definitions, diagnostics = service.load_renderer_definitions_from_concept_ids(
@@ -48,21 +50,23 @@ def test_load_renderer_definitions_reports_malformed_profile_json(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
-        service,
-        "get_concept_by_concept_id",
-        lambda concept_id: {"concept_id": concept_id, "relationships": {}},
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#timeline_renderer", "relationships": {}}
+        ],
     )
     monkeypatch.setattr(
         service,
-        "get_texts_for_concept",
-        lambda concept_id, predicate=None, limit=50: [
-            {
-                "predicate": predicate,
-                "text": "{not valid json}",
-            }
-        ]
-        if predicate == "#V#has_renderer_profile_json"
-        else [],
+        "get_texts_for_concepts",
+        lambda concept_ids, predicates=None, limit_per_concept=20: {
+            concept_ids[0]: [
+                {
+                    "predicate": "#V#has_renderer_profile_json",
+                    "text": "{not valid json}",
+                }
+            ]
+        },
     )
 
     definitions, diagnostics = service.load_renderer_definitions_from_concept_ids(

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -689,6 +689,66 @@ def test_relationship_extent_route_falls_back_before_extent_index_build(
     assert rows[0]["predicate_id"] == "#V#attended_event"
 
 
+def test_relationship_extent_route_bounded_only_fails_without_legacy_scan(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.relationship_extent_index_ready",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.relationship_extent_index_readiness_snapshot",
+        lambda: {
+            "ready": False,
+            "status": "rebuilding",
+            "schema_version": 1,
+            "revision": None,
+            "watermark": None,
+            "source_count": None,
+            "edge_count": None,
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find_one",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("bounded-only unready reads must fail before concept lookup")
+        ),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.aggregate",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("bounded-only reads must not run the legacy aggregate")
+        ),
+    )
+
+    resp = client.get(
+        "/vontology/api/vontology/relationships/extent?"
+        "concept_id=%23V%23focus&role=arg2&bounded_only=true"
+    )
+
+    assert resp.status_code == 503
+    payload = resp.get_json()
+    assert payload["error_code"] == "relationship_extent_index_not_ready"
+    assert payload["retryable"] is True
+    assert payload["extent_index"] == {
+        "ready": False,
+        "used_extent_index": False,
+        "fallback_used": False,
+        "reason": "relationship_extent_index_not_ready",
+        "index_state": {
+            "ready": False,
+            "status": "rebuilding",
+            "schema_version": 1,
+            "revision": None,
+            "watermark": None,
+            "source_count": None,
+            "edge_count": None,
+        },
+    }
+
+
 def test_relationship_extent_route_supports_uncertain_filters(app_client, monkeypatch):
     _, client = app_client
 

--- a/tests/frontend/conceptEffectiveAssertionsPanel.test.js
+++ b/tests/frontend/conceptEffectiveAssertionsPanel.test.js
@@ -1,0 +1,221 @@
+/** @jest-environment jsdom */
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    getJsonDetailed: jest.fn(),
+}));
+
+function fixture() {
+    document.body.innerHTML = `
+        <div id="conceptStep1_test">
+            <div id="conceptEffectiveAssertionsMount_test"></div>
+        </div>
+    `;
+}
+
+function assertion(overrides = {}) {
+    return {
+        assertion_id: 'ska_personal',
+        assertion_revision: 1,
+        status: 'asserted',
+        predicate: {
+            concept_id: '#V#date_of_event',
+            storage_id: '#V#date_of_event',
+            display_name: 'Date of event',
+        },
+        object: { kind: 'text', text: 'June 2026', language: 'en-NZ' },
+        source_context: {
+            kind: 'personal',
+            label: 'Personal — visible only to you',
+        },
+        provenance: {
+            asserted_by_user_concept_id: '#V#actor',
+            capability_name: 'upsert_scoped_assertion',
+            evidence: { source: '<b>user supplied</b>' },
+        },
+        updated_at: '2026-08-23T09:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('concept actor-effective assertions panel', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        fixture();
+        jest.resetModules();
+        jest.clearAllMocks();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => warnSpy.mockRestore());
+
+    test('renders personal and organisation assertions with distinct context labels', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                context_view: 'actor_effective',
+                items: [
+                    assertion(),
+                    assertion({
+                        assertion_id: 'ska_org',
+                        predicate: { display_name: 'Event location' },
+                        object: {
+                            kind: 'concept',
+                            concept_id: '#V#room',
+                            display_name: 'Meeting Room',
+                        },
+                        source_context: {
+                            kind: 'organisation',
+                            label: 'Organisation — Example Lab',
+                        },
+                    }),
+                ],
+                has_more: false,
+                next_offset: null,
+                counts_are_lower_bounds: false,
+            },
+        });
+
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+        const result = await ensureConceptEffectiveAssertionsPanel({
+            conceptId: '#V#event',
+            suffix: 'test',
+        });
+
+        expect(result).toEqual({ rendered: true, contextView: 'actor_effective' });
+        const panel = document.getElementById('conceptEffectiveAssertionsPanel_test');
+        expect(panel.classList.contains('hidden')).toBe(false);
+        expect(panel.querySelectorAll('.concept-effective-assertion-row')).toHaveLength(2);
+        expect(panel.querySelector('.concept-effective-assertion-group-title').textContent)
+            .toBe('Date of event');
+        expect(panel.textContent).toContain('Personal — visible only to you');
+        expect(panel.textContent).toContain('Organisation — Example Lab');
+        expect(panel.textContent).toContain('Meeting Room');
+        expect(panel.querySelector('b')).toBeNull();
+        panel.querySelector('details').open = true;
+        expect(panel.textContent).toContain('<b>user supplied</b>');
+        expect(panel.textContent).toContain('ska_personal');
+    });
+
+    test('keeps anonymous base-only and empty effective projections hidden', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed
+            .mockResolvedValueOnce({
+                data: { context_view: 'base_publication', items: [], has_more: false },
+            })
+            .mockResolvedValueOnce({
+                data: { context_view: 'actor_effective', items: [], has_more: false },
+            });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#public', suffix: 'test' });
+        expect(document.getElementById('conceptEffectiveAssertionsPanel_test').classList)
+            .toContain('hidden');
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#empty', suffix: 'test' });
+        expect(document.getElementById('conceptEffectiveAssertionsPanel_test').classList)
+            .toContain('hidden');
+    });
+
+    test('loads the next bounded page without replacing earlier assertions', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed
+            .mockResolvedValueOnce({
+                data: {
+                    context_view: 'actor_effective',
+                    items: [assertion()],
+                    has_more: true,
+                    next_offset: 25,
+                    counts_are_lower_bounds: true,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    context_view: 'actor_effective',
+                    items: [assertion({ assertion_id: 'ska_second' })],
+                    has_more: false,
+                    next_offset: null,
+                    counts_are_lower_bounds: false,
+                },
+            });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#event', suffix: 'test' });
+        const button = document.getElementById('conceptEffectiveAssertionsLoadMore_test');
+        expect(button.classList.contains('hidden')).toBe(false);
+        await button.onclick();
+
+        expect(api.getJsonDetailed.mock.calls[1][0]).toContain('offset=25');
+        expect(document.querySelectorAll('.concept-effective-assertion-row')).toHaveLength(2);
+        expect(button.classList.contains('hidden')).toBe(true);
+    });
+
+    test('shows a retryable degraded state without claiming completion', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockRejectedValue(new Error('HTTP 503'));
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        const result = await ensureConceptEffectiveAssertionsPanel({
+            conceptId: '#V#event',
+            suffix: 'test',
+        });
+
+        expect(result.contextView).toBe('degraded');
+        const panel = document.getElementById('conceptEffectiveAssertionsPanel_test');
+        expect(panel.classList.contains('hidden')).toBe(false);
+        expect(panel.textContent).toContain('temporarily unavailable');
+        expect(document.getElementById('conceptEffectiveAssertionsLoadMore_test').textContent)
+            .toBe('Retry');
+    });
+
+    test('clears stale scoped rows and reloads after an organisation switch', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed
+            .mockResolvedValueOnce({
+                data: {
+                    context_view: 'actor_effective',
+                    items: [assertion()],
+                    has_more: false,
+                    next_offset: null,
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    context_view: 'actor_effective',
+                    items: [assertion({
+                        assertion_id: 'ska_org',
+                        source_context: {
+                            kind: 'organisation',
+                            label: 'Organisation — Example Lab',
+                        },
+                    })],
+                    has_more: false,
+                    next_offset: null,
+                },
+            });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#event', suffix: 'test' });
+        const panel = document.getElementById('conceptEffectiveAssertionsPanel_test');
+        expect(panel.textContent).toContain('Personal — visible only to you');
+
+        document.dispatchEvent(new CustomEvent('orgSwitched'));
+        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(panel.querySelectorAll('.concept-effective-assertion-row')).toHaveLength(0);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(api.getJsonDetailed).toHaveBeenCalledTimes(2);
+        expect(panel.classList.contains('hidden')).toBe(false);
+        expect(panel.textContent).toContain('Organisation — Example Lab');
+        expect(panel.textContent).not.toContain('Personal — visible only to you');
+    });
+});

--- a/tests/frontend/dynamicTabsIdCollision.test.js
+++ b/tests/frontend/dynamicTabsIdCollision.test.js
@@ -382,6 +382,14 @@ describe('Relation Extent resize persistence', () => {
         const { initializeRelationshipsUI } = require(dynamicTabsModulePath);
         await initializeRelationshipsUI('#V#resize_test', 'resize_test', 'type');
 
+        const initialRelationshipRequest = global.fetch.mock.calls
+            .map(([url]) => String(url))
+            .find((url) => url.startsWith('/vontology/api/vontology/relationships/extent?'));
+        expect(initialRelationshipRequest).toContain('bounded_only=true');
+        expect(initialRelationshipRequest).toContain('limit=50');
+        expect(initialRelationshipRequest).toContain('offset=0');
+        expect(global.fetch.mock.calls.some(([url]) => String(url).startsWith('/api/concepts/'))).toBe(false);
+
         const content = document.getElementById('relationshipsContent_resize_test');
         const increaseButton = document.querySelector('[data-resize-action="increase"]');
         expect(content.classList.contains('von-resizable-viewport-active')).toBe(true);
@@ -856,6 +864,35 @@ describe('newly-created concept description hydration', () => {
         expect(urls).toHaveLength(1);
         expect(urls[0]).toContain('/texts?predicate=hasDescription');
         expect(document.getElementById(`typeDescriptionDisplay_${suffix}`).textContent).toContain('No description available.');
+    });
+
+    test('treats an empty bounded description read as authoritative for concept-page loading', async () => {
+        const { populateTypeDescription } = require(dynamicTabsModulePath);
+        const conceptId = '#V#bounded_description_concept';
+        const suffix = 'bounded_description';
+        mountDescriptionElements(suffix);
+        global.fetch.mockImplementation(async (url) => {
+            const requestUrl = String(url);
+            if (requestUrl.includes('/texts?predicate=hasDescription')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ texts: [], count: 0 })
+                };
+            }
+            throw new Error(`Unexpected fetch: ${requestUrl}`);
+        });
+
+        await populateTypeDescription(conceptId, suffix, {
+            allowLegacyFallback: false,
+            fallbackDescription: 'Inline description from the direct concept read.'
+        });
+
+        const urls = global.fetch.mock.calls.map(([url]) => String(url));
+        expect(urls).toHaveLength(1);
+        expect(urls[0]).toContain('/texts?predicate=hasDescription');
+        expect(document.getElementById(`typeDescriptionDisplay_${suffix}`).dataset.rawText)
+            .toBe('Inline description from the direct concept read.');
     });
 
     test('does not present reconstructed node-content title as a description', async () => {


### PR DESCRIPTION
## Summary

- add a bounded actor-effective assertion projection and scope-labelled concept-page panel
- split primary readiness from optional panels and remove serial legacy retrieval from the interactive path
- batch type, renderer, field, preview, and relationship metadata reads
- add fail-safe relationship-extent index startup reconciliation and bounded first-page behaviour

## Validation

- backend: 78 affected tests passed; 3 unrelated virtual-predicate failures reproduced on unchanged main
- frontend: 81 suites, 445 tests passed
- authenticated browser: primary ready in 33 ms; actor-effective first page in 978 ms
- relationship index: 70,283 source concepts and 238,193 edges reconciled; restart reused ready state
- Python compilation, diff checks, and ESLint passed with 0 errors

Jira: JVNAUTOSCI-530