### PR TITLE
Block email paper workers on policy readiness

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -41,7 +41,7 @@ param(
     [int]$LogRetention = 20,
     [string]$AdminToken,
     [switch]$SkipHealth,
-    [int]$HealthTimeoutSec = 60,
+    [int]$HealthTimeoutSec = 960,
     [int]$HealthGraceSec = 45,
     [string[]]$ReadyLogPatterns = @('Running with Waitress', 'Press CTRL+C to quit', 'Flask app running'),
     [switch]$DisableLogReady,
@@ -3731,7 +3731,7 @@ Von Launcher Help
         -AdminToken <token>    Provide explicit shutdown token
     -SkipHealth            Do not wait for health during start
         -ShowRelationCoverage  Show relationship coverage summary on start/status
-        -HealthTimeoutSec <n>  Seconds to wait for /health (default 60)
+        -HealthTimeoutSec <n>  Seconds to wait for /health (default 960)
         -HealthGraceSec <n>    Extra seconds after port listens to keep waiting (default 45)
         -ReadyLogPatterns <p>  One or more substrings that indicate readiness (log shortcut)
         -DisableLogReady       Disable log pattern readiness shortcut
@@ -3764,8 +3764,8 @@ Von Launcher Help
 
     Examples:
         .\run.ps1 start
-        .\run.ps1 restart -AgentTest -HealthTimeoutSec 180
-        .\run.ps1 restart -AgentTest -Port 5011 -HealthTimeoutSec 180
+        .\run.ps1 restart -AgentTest -HealthTimeoutSec 960
+        .\run.ps1 restart -AgentTest -Port 5011 -HealthTimeoutSec 960
         .\run.ps1 status
         .\run.ps1 check          # returns exit code (0 healthy, 2 unhealthy, 3 not running)
         .\run.ps1 logs -Tail 200 -Follow

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,7 @@ FOLLOW=0
 LOG_RETENTION=20
 ADMIN_TOKEN=""
 SKIP_HEALTH=0
-HEALTH_TIMEOUT_SEC=180
+HEALTH_TIMEOUT_SEC=960
 HEALTH_GRACE_SEC=45
 BACKUP_DRY_RUN=0
 BACKUP_TAG="manual"
@@ -3648,7 +3648,7 @@ Von Launcher Help
         -LogRetention <n>
         -AdminToken <token>
         -SkipHealth
-        -HealthTimeoutSec <n>  Initial health wait in seconds (default 180)
+        -HealthTimeoutSec <n>  Initial health wait in seconds (default 960)
         -HealthGraceSec <n>
         -ReadyLogPatterns <p>
         -DisableLogReady
@@ -3683,7 +3683,7 @@ Von Launcher Help
     Examples:
         ./run.sh start
         ./run.sh restart -ForceBrowser
-        ./run.sh restart -AgentTest -HealthTimeoutSec 180
+        ./run.sh restart -AgentTest -HealthTimeoutSec 960
         ./run.sh deploy-main
         ./run.sh logs -Tail 200 -Follow
         ./run.sh backup -BackupDryRun

--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -418,7 +418,7 @@ def deploy(
     remote: str = "origin",
     branch: str = "main",
     health_url: str = "http://127.0.0.1:5001/health",
-    health_timeout_seconds: int = 180,
+    health_timeout_seconds: int = 960,
 ) -> DeploymentResult:
     primary_root = primary_root.resolve()
     runtime_root = runtime_root.resolve()
@@ -492,7 +492,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--remote", default="origin")
     parser.add_argument("--branch", default="main")
     parser.add_argument("--health-url", default="http://127.0.0.1:5001/health")
-    parser.add_argument("--health-timeout-seconds", type=int, default=180)
+    parser.add_argument("--health-timeout-seconds", type=int, default=960)
     return parser
 
 

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -226,6 +226,7 @@ def _build_durable_workflow_bootstrap_summary(
         "multilingual_concept_enrichment_workflow_bootstrap",
         "conversation_turn_workflow_bootstrap",
         "paper_workflow_bootstrap",
+        "email_source_convergence_workflow_bootstrap",
         "episode_evaluation_workflow_bootstrap",
         "paper_recommendation_workflow_bootstrap",
         "talk_workflow_bootstrap",
@@ -564,9 +565,52 @@ def _start_durable_workflow_system(
                 )
                 return report
 
-        # Start the queue-draining worker before slower canonical bootstrap and
-        # schedule maintenance. User-facing workflow submissions should not sit
-        # pending just because startup maintenance is still catching up.
+        # Paper extraction policy, its publication-scope profiles, and the
+        # email workflows that consume it form one execution authority slice.
+        # Materialise and read back that slice before a worker can claim queued
+        # email-paper work. Starting the worker first can run a new workflow
+        # graph with an old extraction hint and create wrongly scoped concepts
+        # that then need backfilling.
+        paper_workflow_bootstrap_report = _run_workflow_family_bootstrap(
+            label="paper workflow",
+            bootstrap_fn=bootstrap_canonical_paper_representation_workflows,
+        )
+        paper_policy_ready = bool(
+            paper_workflow_bootstrap_report.get("success", False)
+        )
+        if paper_policy_ready:
+            email_source_convergence_workflow_bootstrap_report = (
+                _run_workflow_family_bootstrap(
+                    label="email-source representation convergence workflow",
+                    bootstrap_fn=lambda: (
+                        bootstrap_canonical_email_source_representation_convergence_workflows(
+                            paper_workflow_dependency_report=(
+                                paper_workflow_bootstrap_report
+                            )
+                        )
+                    ),
+                )
+            )
+        else:
+            email_source_convergence_workflow_bootstrap_report = {
+                "success": False,
+                "blocked_by": "paper_workflow_bootstrap",
+                "error": "paper_workflow_bootstrap_not_ready",
+            }
+
+        email_policy_ready = bool(
+            email_source_convergence_workflow_bootstrap_report.get("success", False)
+        )
+        if not paper_policy_ready or not email_policy_ready:
+            raise RuntimeError(
+                "critical_email_paper_execution_policy_bootstrap_failed: "
+                f"paper_success={paper_policy_ready} "
+                f"email_success={email_policy_ready}"
+            )
+
+        # Remaining canonical maintenance may continue after the queue is
+        # available. The execution-critical email-paper slice above is the
+        # deliberate blocker; unrelated families do not inherit that gate.
         if _durable_workflow_registry is None:
             _durable_workflow_registry = _build_durable_workflow_registry()
         if _durable_action_registry is None:
@@ -605,10 +649,14 @@ def _start_durable_workflow_system(
             ),
         )
         result["startup_queue_ready"] = {
-            "stage": "before_canonical_bootstraps",
+            "stage": "after_critical_email_paper_policy_bootstraps",
             "recovered_orphaned_instances": recovered,
             "released_ineligible_worker_claims": released_ineligible_claims,
         }
+        result["paper_workflow_bootstrap"] = paper_workflow_bootstrap_report
+        result["email_source_convergence_workflow_bootstrap"] = (
+            email_source_convergence_workflow_bootstrap_report
+        )
         if queue_ready_callback is not None:
             try:
                 queue_ready_callback(dict(result))
@@ -655,17 +703,6 @@ def _start_durable_workflow_system(
         conversation_turn_workflow_bootstrap_report = _run_workflow_family_bootstrap(
             label="explicit chat-support workflows",
             bootstrap_fn=bootstrap_canonical_conversation_turn_workflows,
-        )
-        # Email-paper convergence delegates to the source-neutral paper and
-        # public-title-resolution workflows, so its represented authority must
-        # be materialised only after the paper family is current.
-        paper_workflow_bootstrap_report = _run_workflow_family_bootstrap(
-            label="paper workflow",
-            bootstrap_fn=bootstrap_canonical_paper_representation_workflows,
-        )
-        email_source_convergence_workflow_bootstrap_report = _run_workflow_family_bootstrap(
-            label="email-source representation convergence workflow",
-            bootstrap_fn=bootstrap_canonical_email_source_representation_convergence_workflows,
         )
         episode_evaluation_workflow_bootstrap_report = _run_workflow_family_bootstrap(
             label="episode evaluation workflow",

--- a/src/backend/services/email_source_representation_convergence_workflow_vontology_service.py
+++ b/src/backend/services/email_source_representation_convergence_workflow_vontology_service.py
@@ -9,6 +9,7 @@ the canonical seed when startup detects drift.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -127,10 +128,15 @@ def ensure_email_source_gmail_paper_signal_extraction_hint() -> dict[str, Any]:
 def bootstrap_canonical_email_source_representation_convergence_workflows(
     *,
     force_republish: bool = False,
+    paper_workflow_dependency_report: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Publish or repair the canonical email-source convergence workflow family."""
 
-    paper_workflow_dependency = bootstrap_canonical_paper_representation_workflows()
+    paper_workflow_dependency = (
+        dict(paper_workflow_dependency_report)
+        if paper_workflow_dependency_report is not None
+        else bootstrap_canonical_paper_representation_workflows()
+    )
     completion_hint = ensure_email_source_gmail_completion_hint()
     paper_signal_extraction_hint = (
         ensure_email_source_gmail_paper_signal_extraction_hint()

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -119,6 +119,46 @@ def test_email_source_workflow_bootstrap_materialises_bundle_and_hint(
     assert report["gmail_paper_signal_extraction_hint"]["success"] is True
 
 
+def test_email_source_workflow_bootstrap_reuses_prevalidated_paper_dependency(
+    monkeypatch,
+) -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    def fail_if_paper_bootstrap_repeats() -> None:
+        raise AssertionError("paper bootstrap repeated")
+
+    monkeypatch.setattr(
+        mod,
+        "bootstrap_canonical_paper_representation_workflows",
+        fail_if_paper_bootstrap_repeats,
+    )
+    monkeypatch.setattr(
+        mod,
+        "ensure_email_source_gmail_completion_hint",
+        lambda: {"success": True},
+    )
+    monkeypatch.setattr(
+        mod,
+        "ensure_email_source_gmail_paper_signal_extraction_hint",
+        lambda: {"success": True},
+    )
+    monkeypatch.setattr(
+        mod,
+        "bootstrap_repo_seed_workflow_bundle",
+        lambda **_kwargs: {"publication": {"counts": {"errors": 0}}},
+    )
+
+    paper_report = {"success": True, "publication": {"skipped": True}}
+    report = mod.bootstrap_canonical_email_source_representation_convergence_workflows(
+        paper_workflow_dependency_report=paper_report
+    )
+
+    assert report["success"] is True
+    assert report["paper_workflow_dependency"] == paper_report
+
+
 def test_email_source_seed_keeps_claim_enrichment_out_of_source_completion() -> None:
     from src.backend.services import (
         email_source_representation_convergence_workflow_vontology_service as mod,

--- a/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
+++ b/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
@@ -56,6 +56,13 @@ def test_build_durable_workflow_bootstrap_summary_surfaces_seed_repair_drift() -
                     ],
                 },
             },
+            "email_source_convergence_workflow_bootstrap": {
+                "success": True,
+                "publication": {
+                    "materialisation_status": "current",
+                    "drift_detected": False,
+                },
+            },
             "talk_workflow_bootstrap": {
                 "success": True,
                 "publication": {
@@ -108,6 +115,11 @@ def test_build_durable_workflow_bootstrap_summary_surfaces_seed_repair_drift() -
             "drift_workflow_ids": [
                 "#V#arxiv_paper_representation_workflow",
             ],
+        },
+        "email_source_convergence_workflow_bootstrap": {
+            "success": True,
+            "materialisation_status": "current",
+            "drift_detected": False,
         },
         "talk_workflow_bootstrap": {
             "success": True,
@@ -379,8 +391,13 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
             "publication": {"skipped": True},
         },
     )
-    def _bootstrap_email_source_convergence():
+
+    def _bootstrap_email_source_convergence(
+        *, paper_workflow_dependency_report=None
+    ):
         startup_events.append("email_source_bootstrap")
+        assert paper_workflow_dependency_report is not None
+        assert paper_workflow_dependency_report.get("success") is True
         return {
             "success": True,
             "workflow_ids": [
@@ -560,17 +577,26 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
     assert isinstance(result, dict)
     assert len(queue_ready_components) == 1
     assert queue_ready_components[0].get("startup_queue_ready") == {
-        "stage": "before_canonical_bootstraps",
+        "stage": "after_critical_email_paper_policy_bootstraps",
         "recovered_orphaned_instances": 0,
         "released_ineligible_worker_claims": 0,
     }
-    assert "entity_workflow_bootstrap" not in queue_ready_components[0]
-    assert startup_events[:2] == ["worker_started", "entity_bootstrap"]
-    assert startup_events.index("paper_bootstrap") < startup_events.index(
-        "email_source_bootstrap"
+    assert queue_ready_components[0]["paper_workflow_bootstrap"]["success"] is True
+    assert (
+        queue_ready_components[0]["email_source_convergence_workflow_bootstrap"][
+            "success"
+        ]
+        is True
     )
+    assert "entity_workflow_bootstrap" not in queue_ready_components[0]
+    assert startup_events[:4] == [
+        "paper_bootstrap",
+        "email_source_bootstrap",
+        "worker_started",
+        "entity_bootstrap",
+    ]
     assert result.get("startup_queue_ready") == {
-        "stage": "before_canonical_bootstraps",
+        "stage": "after_critical_email_paper_policy_bootstraps",
         "recovered_orphaned_instances": 0,
         "released_ineligible_worker_claims": 0,
     }

--- a/tests/test_run_ps1_start_behaviour.py
+++ b/tests/test_run_ps1_start_behaviour.py
@@ -491,7 +491,9 @@ $helpText = (& {{ . {ps_quote(str(REPO_ROOT / 'run.ps1'))} help -NoBackupMigrate
 $result = [ordered]@{{
     has_agent_test = $helpText.Contains('-AgentTest')
     has_default_port = $helpText.Contains('5010')
-    has_example = $helpText.Contains('.\\run.ps1 restart -AgentTest -HealthTimeoutSec 180')
+    has_example = $helpText.Contains(
+        '.\\run.ps1 restart -AgentTest -HealthTimeoutSec 960'
+    )
 }}
 """.strip()
 

--- a/tests/test_run_sh_start_behaviour.py
+++ b/tests/test_run_sh_start_behaviour.py
@@ -73,7 +73,7 @@ PY
 """
     )
 
-    assert payload == {"health_timeout_seconds": 180}
+    assert payload == {"health_timeout_seconds": 960}
 
 
 def test_run_sh_accepts_an_explicit_existing_launcher_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Prevents queued email-paper work from running against a new code build while its represented extraction and scope-routing authority is still stale.

## Changes

- materialise and verify the paper workflow family before the dependent email workflow/hints
- build the durable registry and start the worker only after both critical reports succeed
- keep unrelated workflow-family maintenance non-blocking
- expose the email-family bootstrap in startup diagnostics
- reuse the prevalidated paper report in the email bootstrap
- calibrate launcher/deploy readiness defaults to 960 seconds from observed successful critical materialisation durations; explicit overrides remain available

## Evidence

- 80 focused startup, service, launcher, and deploy tests passed; 18 platform-specific tests skipped
- shell syntax, Python compilation, and diff checks passed
- canonical live read-back reports all eight paper workflows current, no drift, no validation failures, and zero errors

## Jira

JVNAUTOSCI-2244