### PR TITLE
Recover critical policy bootstrap from transient Mongo gaps

### DIFF
--- a/src/backend/db/mongo_error_classification.py
+++ b/src/backend/db/mongo_error_classification.py
@@ -32,6 +32,15 @@ _TRANSIENT_MONGO_ERROR_MARKERS = (
     "server selection timeout",
     "networktimeout",
     "temporarily unavailable",
+    # Repository accessors return ``None`` when the shared client cannot be
+    # established.  Write wrappers surface that state with this bounded,
+    # retryable message rather than a PyMongo exception.
+    "collection not available",
+)
+_MONGO_TRANSPORT_ERROR_MARKERS = tuple(
+    marker
+    for marker in _TRANSIENT_MONGO_ERROR_MARKERS
+    if marker != "collection not available"
 )
 
 
@@ -58,4 +67,4 @@ def is_mongo_transport_error(exc: Exception | str | None) -> bool:
     if isinstance(exc, _MONGO_TRANSPORT_ERROR_TYPES):
         return True
     message = str(exc).lower()
-    return any(marker in message for marker in _TRANSIENT_MONGO_ERROR_MARKERS)
+    return any(marker in message for marker in _MONGO_TRANSPORT_ERROR_MARKERS)

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -443,7 +443,8 @@ def _start_durable_workflow_system(
 ) -> dict | None:
     """Start the durable workflow worker and scheduler.
 
-    Returns the system components dict or None if disabled/failed.
+    Returns the system components dict, returns ``None`` when disabled, and
+    raises when an attempted startup fails so lifecycle status remains truthful.
     """
     global _durable_workflow_registry, _durable_action_registry
 
@@ -548,9 +549,22 @@ def _start_durable_workflow_system(
             *,
             label: str,
             bootstrap_fn: Callable[[], dict[str, Any]],
+            retry_transient_mongo: bool = False,
         ) -> dict[str, Any]:
             try:
-                report = dict(bootstrap_fn())
+                if retry_transient_mongo:
+                    bootstrap_result = run_with_transient_mongo_retry(
+                        bootstrap_fn,
+                        operation_name=(
+                            "durable_startup_"
+                            + label.replace("-", "_").replace(" ", "_")
+                            + "_bootstrap"
+                        ),
+                        logger_obj=app_logger,
+                    )
+                else:
+                    bootstrap_result = bootstrap_fn()
+                report = dict(bootstrap_result)
                 report.setdefault("success", True)
                 return report
             except Exception as bootstrap_exc:
@@ -574,6 +588,7 @@ def _start_durable_workflow_system(
         paper_workflow_bootstrap_report = _run_workflow_family_bootstrap(
             label="paper workflow",
             bootstrap_fn=bootstrap_canonical_paper_representation_workflows,
+            retry_transient_mongo=True,
         )
         paper_policy_ready = bool(
             paper_workflow_bootstrap_report.get("success", False)
@@ -589,6 +604,7 @@ def _start_durable_workflow_system(
                             )
                         )
                     ),
+                    retry_transient_mongo=True,
                 )
             )
         else:
@@ -1251,7 +1267,10 @@ def _start_durable_workflow_system(
             app_logger.warning("[durable_workflows] Failed to start: %s", exc)
         except Exception:
             pass
-        return None
+        # Disabled startup returns ``None`` above.  An attempted startup that
+        # fails must remain distinguishable so the outer lifecycle publishes a
+        # truthful failed state instead of the misleading ``not_started``.
+        raise
 
 
 def _stop_durable_workflow_system():

--- a/tests/backend/test_mongo_recovery_behaviour.py
+++ b/tests/backend/test_mongo_recovery_behaviour.py
@@ -298,6 +298,38 @@ def test_non_transport_pymongo_retry_does_not_rotate_route(monkeypatch) -> None:
     assert calls[0]["route_degraded"] is False
 
 
+def test_temporarily_unavailable_collection_retries_without_rotating_route(
+    monkeypatch,
+) -> None:
+    calls: list[dict] = []
+    attempts = 0
+
+    def _operation() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("text_values collection not available")
+        return "ok"
+
+    monkeypatch.setattr(
+        transient_errors,
+        "attempt_reconnect",
+        lambda **kwargs: calls.append(dict(kwargs)),
+    )
+    monkeypatch.setattr(transient_errors.time, "sleep", lambda _delay: None)
+
+    assert (
+        transient_errors.run_with_transient_mongo_retry(
+            _operation,
+            operation_name="email-policy-bootstrap",
+            max_attempts=2,
+        )
+        == "ok"
+    )
+    assert attempts == 2
+    assert calls[0]["route_degraded"] is False
+
+
 def test_replica_election_retry_does_not_rotate_route(monkeypatch) -> None:
     calls: list[dict] = []
     attempts = 0

--- a/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
+++ b/tests/backend/test_utils_flask_identity_resolution_bootstrap.py
@@ -135,6 +135,7 @@ def test_build_durable_workflow_bootstrap_summary_surfaces_seed_repair_drift() -
 
 def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
     import src.backend.server.utils_flask as utils_flask
+    from src.backend.db import transient_errors
     from src.backend.workflows.durable import startup as durable_startup
     from src.backend.services import (
         ai_chat_session_source_profile_vontology_service as ai_chat_session_source_profile_bootstrap,
@@ -174,6 +175,13 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
 
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
     startup_events: list[str] = []
+    reconnect_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        transient_errors,
+        "attempt_reconnect",
+        lambda **kwargs: reconnect_calls.append(dict(kwargs)),
+    )
+    monkeypatch.setattr(transient_errors.time, "sleep", lambda _delay: None)
 
     # Reset globals to force fresh startup path.
     monkeypatch.setattr(utils_flask, "_durable_workflow_registry", None)
@@ -392,12 +400,18 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
         },
     )
 
+    email_bootstrap_attempts = 0
+
     def _bootstrap_email_source_convergence(
         *, paper_workflow_dependency_report=None
     ):
+        nonlocal email_bootstrap_attempts
+        email_bootstrap_attempts += 1
         startup_events.append("email_source_bootstrap")
         assert paper_workflow_dependency_report is not None
         assert paper_workflow_dependency_report.get("success") is True
+        if email_bootstrap_attempts == 1:
+            raise RuntimeError("text_values collection not available")
         return {
             "success": True,
             "workflow_ids": [
@@ -589,12 +603,15 @@ def test_start_durable_system_bootstraps_identity_schedule(monkeypatch) -> None:
         is True
     )
     assert "entity_workflow_bootstrap" not in queue_ready_components[0]
-    assert startup_events[:4] == [
+    assert startup_events[:5] == [
         "paper_bootstrap",
+        "email_source_bootstrap",
         "email_source_bootstrap",
         "worker_started",
         "entity_bootstrap",
     ]
+    assert len(reconnect_calls) == 1
+    assert reconnect_calls[0]["route_degraded"] is False
     assert result.get("startup_queue_ready") == {
         "stage": "after_critical_email_paper_policy_bootstraps",
         "recovered_orphaned_instances": 0,

--- a/tests/backend/test_utils_flask_orchestrator_startup.py
+++ b/tests/backend/test_utils_flask_orchestrator_startup.py
@@ -234,6 +234,44 @@ def test_durable_workflow_startup_keeps_core_ready_when_maintenance_fails(
     }
 
 
+def test_durable_workflow_startup_reports_failure_before_queue_ready(
+    monkeypatch,
+):
+    from flask import Flask
+
+    import src.backend.server.utils_flask as utils_flask
+
+    monkeypatch.setenv("VON_DURABLE_WORKFLOWS_BLOCKING_STARTUP", "0")
+    monkeypatch.setattr(utils_flask, "_is_running_under_pytest", lambda: False)
+    monkeypatch.setattr(utils_flask, "_is_agent_test_instance", lambda: False)
+
+    def _critical_failure(_app_logger, *, queue_ready_callback=None):
+        assert queue_ready_callback is not None
+        raise RuntimeError("critical_email_paper_policy_not_ready")
+
+    monkeypatch.setattr(
+        utils_flask,
+        "_start_durable_workflow_system",
+        _critical_failure,
+    )
+
+    app = Flask(__name__)
+    utils_flask._configure_durable_workflow_startup(app)
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
+        if status.get("state") == "failed":
+            break
+        time.sleep(0.01)
+
+    status = app.config.get("DURABLE_WORKFLOW_STARTUP_STATUS") or {}
+    assert status.get("state") == "failed"
+    assert status.get("ready") is False
+    assert status.get("error") == "critical_email_paper_policy_not_ready"
+    assert app.config.get("DURABLE_WORKFLOW_COMPONENTS") is None
+
+
 def test_build_durable_workflow_registry_uses_shared_deferred_read_only_builder(
     monkeypatch,
 ):


### PR DESCRIPTION
## Outcome
- retries execution-critical policy bootstraps when a repository collection is temporarily unavailable
- reconnects on that bounded condition without unnecessarily rotating Mongo routes
- reports an exhausted attempted startup as failed instead of not_started

## Validation
- 23 focused startup and Mongo recovery tests passed
- Python compilation and diff checks passed

## Delivery decision
Ready when required CI passes. Stop ship if the worker can start before critical policy readiness, an exhausted critical failure is hidden, or retry rotates a healthy route for a collection-readiness gap.