### PR TITLE
Authorise exact Zhan email workflow v20 migration

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -3,6 +3,13 @@
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
   "seed_version": "20",
+  "known_legacy_authority_payload_sha256_by_seed_version": {
+    "#V#zhan_gmail_arxiv_ingestion_workflow": {
+      "19": [
+        "fd6a3142054690216ed961920ae2984657951d3f7921db3a1379fc59d318e6ce"
+      ]
+    }
+  },
   "source_tag": "JVNAUTOSCI-2244",
   "supported_action_ids": [
     "arxiv.inspect_existing_state",

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -52,6 +52,22 @@ def _reset_schedule_bootstrap_state(mod) -> None:
     mod._bootstrap_completed = False
 
 
+def test_email_source_seed_authorises_only_the_observed_v19_zhan_migration() -> None:
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    bundle = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    assert bundle["seed_version"] == "20"
+    assert bundle["known_legacy_authority_payload_sha256_by_seed_version"] == {
+        mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID: {
+            "19": [
+                "fd6a3142054690216ed961920ae2984657951d3f7921db3a1379fc59d318e6ce"
+            ]
+        }
+    }
+
+
 def test_email_source_workflow_bootstrap_materialises_bundle_and_hint(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Outcome
- declares the exact observed v19 authority digest as the only authorised predecessor for the reviewed v20 Zhan Gmail-paper workflow seed
- retains the existing fail-closed seed authority guard; no wildcard or forced republish

## Evidence
- guarded canonical migration published exactly one workflow and repaired one mapping concept
- zero publication errors and zero validation failures
- 90 focused bundle/bootstrap tests passed; JSON and diff checks passed

## Delivery decision
Ready when required CI passes. Stop ship if any workflow other than the exact declared predecessor becomes migration-eligible or canonical validation fails.