### PR TITLE
Fix explicit concept identity preflight

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -2264,6 +2264,9 @@ def _create_concepts(**kwargs):
 
             duplicate_match = find_existing_concept_for_create_concepts(
                 concept_name=str(name),
+                requested_concept_id=(
+                    canonical_concept_id_override or concept_data.get("concept_id")
+                ),
                 kind=kind,
                 parent_id_for_concept=parent_id_for_concept,
                 preferred_language="en-NZ",

--- a/src/backend/services/create_concepts_duplicate_guard_service.py
+++ b/src/backend/services/create_concepts_duplicate_guard_service.py
@@ -322,6 +322,7 @@ def _find_concept(concept_id: str) -> dict[str, Any] | None:
 def find_existing_concept_for_create_concepts(
     *,
     concept_name: str,
+    requested_concept_id: str | None = None,
     kind: str | None,
     parent_id_for_concept: str | None,
     preferred_language: str | None = None,
@@ -336,6 +337,9 @@ def find_existing_concept_for_create_concepts(
 
     ``canonical_id_only`` retains the normal exact match and scope checks, but
     deliberately returns after an exact miss instead of searching text values.
+    When the create request supplies a stable concept ID, that ID is the exact
+    identity to check; the display-name-derived ID remains the compatibility
+    default only when no explicit ID was supplied.
     """
 
     from .concept_external_identity_service import (
@@ -499,7 +503,14 @@ def find_existing_concept_for_create_concepts(
             retryable=True,
         )
 
-    canonical_requested_id = canonicalise_vontology_concept_id(concept_name)
+    explicit_requested_id = (
+        requested_concept_id.strip()
+        if isinstance(requested_concept_id, str) and requested_concept_id.strip()
+        else None
+    )
+    canonical_requested_id = canonicalise_vontology_concept_id(
+        explicit_requested_id if explicit_requested_id is not None else concept_name
+    )
     if canonical_requested_id:
         doc = _find_concept(canonical_requested_id)
         if isinstance(doc, dict):

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -140,6 +140,64 @@ def test_canonical_id_only_skips_semantic_resolution_after_exact_miss(
     assert exact_queries == [{"concept_id": "#V#stable_represented_identity"}]
 
 
+def test_canonical_id_only_honours_explicit_identity_before_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common_preflights(monkeypatch)
+    exact_queries: list[dict[str, Any]] = []
+    create_calls: list[dict[str, Any]] = []
+    explicit_id = "#V#paper_under_preparation_deterministic_identity"
+    display_name_id = "#V#existing_public_paper_title"
+
+    def _find_one(
+        query: dict[str, Any],
+        _projection: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        exact_queries.append(query)
+        if query.get("concept_id") == display_name_id:
+            return {
+                "concept_id": display_name_id,
+                "relationships": {"is_an_instance_of": ["#V#scholarly_article"]},
+            }
+        return None
+
+    def _create(**kwargs: Any) -> dict[str, Any]:
+        create_calls.append(kwargs)
+        return {
+            "success": True,
+            "message": "created",
+            "concept": {"concept_id": explicit_id},
+            "canonical_concept_id": explicit_id,
+            "input_name": kwargs["new_concept_name"],
+        }
+
+    monkeypatch.setattr(
+        "src.backend.db.repositories.concepts_repository.ConceptsRepository.find_one",
+        _find_one,
+    )
+    monkeypatch.setattr(
+        "src.backend.vontology.utils_vontology.create_vontology_concept",
+        _create,
+    )
+
+    result = _create_concepts(
+        parent_id=_PARENT_ID,
+        concepts=[
+            {
+                "name": "Existing public paper title",
+                "concept_id": explicit_id,
+                "kind": "instance",
+            }
+        ],
+        duplicate_resolution_mode="canonical_id_only",
+    )
+
+    assert result["successful"] == 1
+    assert {"concept_id": explicit_id} in exact_queries
+    assert {"concept_id": display_name_id} not in exact_queries
+    assert create_calls[0]["canonical_concept_id_override"] == explicit_id
+
+
 def test_default_mode_retains_semantic_duplicate_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Outcome

Ensure governed concept creation checks a caller-supplied deterministic concept ID before any display-name-derived compatibility identity. This lets an organisation-scoped paper-under-preparation referent remain distinct from a same-titled public scholarly article while preserving existing behaviour when no explicit ID is supplied.

## Validation

- 35 duplicate-resolution tests passed
- 106 paper/workflow tests passed; 2 expected skips
- diff check passed

## Release decision

Merge after required CI. Stop ship if explicit-ID reuse/conflict tests regress or name-derived behaviour changes for callers that omit an ID.