### PR TITLE
Fix email signal extraction payload bounds

### DIFF
--- a/scripts/publish_email_resource_link_extraction_workflow.py
+++ b/scripts/publish_email_resource_link_extraction_workflow.py
@@ -55,6 +55,11 @@ def _build_authoring_spec() -> dict:
                 "state_key": "fetch_payload",
                 "action_id": SOURCE_TOOL_ACTION_ID,
                 "execution_mode": "deterministic",
+                "static_input_bindings": [
+                    {"tool_param": "format", "value": "full"},
+                    {"tool_param": "include_body", "value": True},
+                    {"tool_param": "max_body_chars", "value": 65_536},
+                ],
                 "context_input_mappings": [
                     {
                         "tool_param": "message_id",
@@ -81,6 +86,10 @@ def _build_authoring_spec() -> dict:
                     {
                         "tool_param": "source_tool_concept",
                         "value": SOURCE_TOOL_CONCEPT_ID,
+                    },
+                    {
+                        "tool_param": "payload_max_chars",
+                        "value": 100_000,
                     },
                 ],
                 "context_input_mappings": [

--- a/src/backend/services/tool_result_hints.py
+++ b/src/backend/services/tool_result_hints.py
@@ -32,6 +32,10 @@ from .text_value_service import get_texts_for_concept
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS = 12_000
+MAX_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS = 200_000
+
+
 @dataclass(frozen=True)
 class LLMGenerationResult:
     """Provider-agnostic LLM result plus optional model-policy telemetry."""
@@ -92,6 +96,10 @@ class StructuredSignals:
     aux_llm_calls: tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
     selected_model: str | None = None
     selected_candidate: Mapping[str, Any] | None = None
+    payload_serialised_chars: int = 0
+    payload_included_chars: int = 0
+    payload_max_chars: int = DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS
+    payload_truncated: bool = False
 
 
 def resolve_hint_body(
@@ -184,15 +192,36 @@ def _parse_signals(raw_response: str) -> tuple[Mapping[str, Any], tuple[str, ...
     return {}, ("non_object_response",)
 
 
-def _serialise_payload(payload: Any, *, max_chars: int = 12_000) -> str:
+def _serialise_payload_with_diagnostics(
+    payload: Any,
+    *,
+    max_chars: int = DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
+) -> tuple[str, int, int, bool]:
     """JSON-serialise the tool payload with a defensive size cap."""
 
     try:
         serialised = json.dumps(payload, default=str, ensure_ascii=False)
     except (TypeError, ValueError):
         serialised = str(payload)
-    if len(serialised) > max_chars:
-        return serialised[:max_chars] + "...[truncated]"
+    serialised_chars = len(serialised)
+    included_chars = min(serialised_chars, max_chars)
+    truncated = serialised_chars > max_chars
+    if truncated:
+        serialised = serialised[:max_chars] + "...[truncated]"
+    return serialised, serialised_chars, included_chars, truncated
+
+
+def _serialise_payload(
+    payload: Any,
+    *,
+    max_chars: int = DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
+) -> str:
+    """Compatibility wrapper returning only the bounded payload text."""
+
+    serialised, _, _, _ = _serialise_payload_with_diagnostics(
+        payload,
+        max_chars=max_chars,
+    )
     return serialised
 
 
@@ -240,6 +269,7 @@ def extract_signals_from_tool_result(
     llm_client: Any,
     model: Optional[str] = None,
     llm_generate: Callable[..., Any] | None = None,
+    payload_max_chars: int = DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
     hint_predicate_id: str = OUTPUT_ITEM_SIGNAL_EXTRACTION_HINT_PREDICATE_ID,
     lang: str = "en-NZ",
 ) -> StructuredSignals:
@@ -271,6 +301,9 @@ def extract_signals_from_tool_result(
         llm_generate: Optional provider-agnostic generation hook. Callers that
             need workflow model-policy fallbacks can provide this without
             changing the Vontology-authored hint body or embedding policy here.
+        payload_max_chars: Maximum serialised tool-payload characters supplied
+            to the model. Durable callers may author a larger capability-specific
+            bound while the generic compatibility default remains 12,000.
         hint_predicate_id: The predicate to resolve. Defaults to the canonical
             signal-extraction hint; overridable for testing or for alternative
             hint families with the same shape.
@@ -308,7 +341,15 @@ def extract_signals_from_tool_result(
             warnings=("no_llm_client",),
         )
 
-    payload_text = _serialise_payload(tool_payload)
+    (
+        payload_text,
+        payload_serialised_chars,
+        payload_included_chars,
+        payload_truncated,
+    ) = _serialise_payload_with_diagnostics(
+        tool_payload,
+        max_chars=payload_max_chars,
+    )
     prompt = (
         f"{hint_body}\n\n"
         "Apply the instructions above to the following tool result payload "
@@ -360,6 +401,10 @@ def extract_signals_from_tool_result(
             warnings=(f"llm_error:{error_class}",),
             llm_calls=tuple(llm_calls),
             aux_llm_calls=tuple(aux_llm_calls),
+            payload_serialised_chars=payload_serialised_chars,
+            payload_included_chars=payload_included_chars,
+            payload_max_chars=payload_max_chars,
+            payload_truncated=payload_truncated,
         )
 
     (
@@ -380,10 +425,16 @@ def extract_signals_from_tool_result(
         aux_llm_calls=aux_llm_calls,
         selected_model=selected_model,
         selected_candidate=selected_candidate,
+        payload_serialised_chars=payload_serialised_chars,
+        payload_included_chars=payload_included_chars,
+        payload_max_chars=payload_max_chars,
+        payload_truncated=payload_truncated,
     )
 
 
 __all__ = [
+    "DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS",
+    "MAX_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS",
     "LLMGenerationError",
     "LLMGenerationResult",
     "StructuredSignals",

--- a/src/backend/workflows/durable/tool_result_hint_actions.py
+++ b/src/backend/workflows/durable/tool_result_hint_actions.py
@@ -14,6 +14,7 @@ default ``#V#output_item_signal_extraction_hint``). Callers supply only:
 * ``tool_payload``        -- the raw output of that tool
 * (optional) ``hint_predicate_id`` -- override the hint predicate
 * (optional) ``lang``     -- language for the hint resolution
+* (optional) ``payload_max_chars`` -- authored serialised-payload bound
 
 Anti-drift: this module names no specific external integration. All semantic
 behaviour lives in Vontology hint bodies.
@@ -30,6 +31,8 @@ from ...services.output_hint_contracts import (
     OUTPUT_ITEM_SIGNAL_EXTRACTION_HINT_PREDICATE_ID,
 )
 from ...services.tool_result_hints import (
+    DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
+    MAX_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
     LLMGenerationError,
     LLMGenerationResult,
     extract_signals_from_tool_result,
@@ -287,6 +290,22 @@ def _handle_extract_signals_from_tool_result(
     )
     lang = _safe_str(inputs.get("lang")) or "en-NZ"
     model = _safe_str(inputs.get("model")) or None
+    raw_payload_max_chars = inputs.get(
+        "payload_max_chars",
+        DEFAULT_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS,
+    )
+    try:
+        payload_max_chars = int(raw_payload_max_chars)
+    except (TypeError, ValueError):
+        payload_max_chars = 0
+    if not (1_000 <= payload_max_chars <= MAX_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS):
+        return WorkflowActionResult(
+            status="failed",
+            error=(
+                "payload_max_chars must be an integer from 1000 through "
+                f"{MAX_SIGNAL_EXTRACTION_PAYLOAD_MAX_CHARS}."
+            ),
+        )
     policy_stage = _resolve_model_policy_stage(request, inputs)
     llm_generate = _build_model_policy_generate(
         request,
@@ -310,6 +329,7 @@ def _handle_extract_signals_from_tool_result(
         llm_client=llm_client,
         model=model,
         llm_generate=llm_generate,
+        payload_max_chars=payload_max_chars,
         hint_predicate_id=hint_predicate_id,
         lang=lang,
     )
@@ -333,6 +353,10 @@ def _handle_extract_signals_from_tool_result(
         ),
         "llm_calls": list(llm_calls),
         "aux_llm_calls": list(aux_llm_calls),
+        "payload_serialised_chars": result.payload_serialised_chars,
+        "payload_included_chars": result.payload_included_chars,
+        "payload_max_chars": result.payload_max_chars,
+        "payload_truncated": result.payload_truncated,
     }
 
     # Treat "hint not authored" or any LLM-side failure as a workflow failure

--- a/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/email_source_representation_convergence_workflow_seed_bundle.json
@@ -2,8 +2,13 @@
   "family_id": "email_source_representation_convergence_workflow_seed_bundle",
   "managed_by": "email_source_representation_convergence_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "20",
+  "seed_version": "21",
   "known_legacy_authority_payload_sha256_by_seed_version": {
+    "#V#email_resource_link_extraction": {
+      "20": [
+        "9706da2f51399e67008283cd74af82f8e58bcb3d1779c76c535f903ed439d6c3"
+      ]
+    },
     "#V#zhan_gmail_arxiv_ingestion_workflow": {
       "19": [
         "fd6a3142054690216ed961920ae2984657951d3f7921db3a1379fc59d318e6ce"
@@ -2339,6 +2344,7 @@
                 {
                   "format": "full",
                   "include_body": true,
+                  "max_body_chars": 65536,
                   "message_id": {
                     "$context_key": "message_id"
                   },
@@ -2381,6 +2387,10 @@
               [
                 "source_tool_concept",
                 "#V#gmail_get_message_tool"
+              ],
+              [
+                "payload_max_chars",
+                100000
               ]
             ],
             "tool_output_mapping_specs": [

--- a/tests/backend/test_email_source_representation_convergence_bootstrap.py
+++ b/tests/backend/test_email_source_representation_convergence_bootstrap.py
@@ -52,20 +52,45 @@ def _reset_schedule_bootstrap_state(mod) -> None:
     mod._bootstrap_completed = False
 
 
-def test_email_source_seed_authorises_only_the_observed_v19_zhan_migration() -> None:
+def test_email_source_seed_authorises_only_reviewed_exact_migrations() -> None:
     from src.backend.services import (
         email_source_representation_convergence_workflow_vontology_service as mod,
     )
 
     bundle = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
-    assert bundle["seed_version"] == "20"
+    assert bundle["seed_version"] == "21"
     assert bundle["known_legacy_authority_payload_sha256_by_seed_version"] == {
+        mod.EMAIL_RESOURCE_LINK_EXTRACTION_WORKFLOW_ID: {
+            "20": ["9706da2f51399e67008283cd74af82f8e58bcb3d1779c76c535f903ed439d6c3"]
+        },
         mod.ZHAN_GMAIL_ARXIV_INGESTION_WORKFLOW_ID: {
             "19": [
                 "fd6a3142054690216ed961920ae2984657951d3f7921db3a1379fc59d318e6ce"
             ]
         }
     }
+
+
+def test_email_resource_extraction_authors_sufficient_observable_payload_bounds() -> (
+    None
+):
+    from src.backend.services import (
+        email_source_representation_convergence_workflow_vontology_service as mod,
+    )
+
+    bundle = json.loads(mod._REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    workflow = next(
+        item
+        for item in bundle["workflows"]
+        if item["workflow_id"] == mod.EMAIL_RESOURCE_LINK_EXTRACTION_WORKFLOW_ID
+    )
+    steps = {step["state_id"]: step for step in workflow["publication_spec"]["steps"]}
+    fetch_bindings = dict(steps["fetch_payload"]["static_input_bindings"])
+    extraction_bindings = dict(steps["extract_signals"]["static_input_bindings"])
+
+    assert fetch_bindings["tool_arguments"]["include_body"] is True
+    assert fetch_bindings["tool_arguments"]["max_body_chars"] == 65_536
+    assert extraction_bindings["payload_max_chars"] == 100_000
 
 
 def test_email_source_workflow_bootstrap_materialises_bundle_and_hint(

--- a/tests/backend/test_tool_result_hint_actions.py
+++ b/tests/backend/test_tool_result_hint_actions.py
@@ -6,10 +6,10 @@ from typing import Any
 
 import pytest
 
+from src.backend.services import tool_result_hints as svc
 from src.backend.services.output_hint_contracts import (
     OUTPUT_ITEM_SIGNAL_EXTRACTION_HINT_PREDICATE_ID,
 )
-from src.backend.services import tool_result_hints as svc
 from src.backend.workflows.action_registry import (
     ActionRegistry,
     WorkflowActionRequest,
@@ -144,6 +144,60 @@ def test_happy_path_returns_signals(
     assert isinstance(signals, dict)
     assert signals["items"][0]["url"] == "https://example.com"
     assert "Extract things." in fake_llm.calls[0]["prompt"]
+    assert result.outputs["payload_max_chars"] == 12_000
+    assert result.outputs["payload_truncated"] is False
+
+
+def test_action_applies_authored_payload_bound(
+    registry: ActionRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        svc,
+        "resolve_hint_body",
+        lambda concept_id, predicate_id, lang="en-NZ": "Extract things.",
+    )
+    fake_llm = _FakeLLM('{"items": []}')
+    tail_marker = "https://arxiv.org/abs/2608.12345"
+    spec = registry.get(EXTRACT_SIGNALS_FROM_TOOL_RESULT_ACTION_ID)
+    assert spec is not None
+
+    result = spec.handler(
+        _make_request(
+            inputs={
+                "source_tool_concept": "#V#some_tool",
+                "tool_payload": {
+                    "body": ("earlier context " * 1_000) + tail_marker
+                },
+                "payload_max_chars": 100_000,
+            },
+            llm_client=fake_llm,
+        )
+    )
+
+    assert result.status == "success", result.error
+    assert tail_marker in fake_llm.calls[0]["prompt"]
+    assert result.outputs["payload_max_chars"] == 100_000
+    assert result.outputs["payload_truncated"] is False
+
+
+def test_action_rejects_invalid_payload_bound(registry: ActionRegistry) -> None:
+    spec = registry.get(EXTRACT_SIGNALS_FROM_TOOL_RESULT_ACTION_ID)
+    assert spec is not None
+
+    result = spec.handler(
+        _make_request(
+            inputs={
+                "source_tool_concept": "#V#some_tool",
+                "tool_payload": {"body": "paper"},
+                "payload_max_chars": 500,
+            },
+            llm_client=_FakeLLM('{"items": []}'),
+        )
+    )
+
+    assert result.status == "failed"
+    assert "payload_max_chars" in (result.error or "")
 
 
 def test_payload_falls_back_to_data(

--- a/tests/backend/test_tool_result_hints.py
+++ b/tests/backend/test_tool_result_hints.py
@@ -114,6 +114,58 @@ def test_extract_signals_parses_plain_json(monkeypatch: pytest.MonkeyPatch) -> N
     assert '"items"' in prompt  # payload was JSON-serialised into the prompt
 
 
+def test_extract_signals_respects_larger_authored_payload_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tool_result_hints,
+        "get_texts_for_concept",
+        lambda **_: [{"text": "Extract every reference."}],
+    )
+    llm = _FakeLLM(response='{"items": []}')
+    tail_marker = "https://arxiv.org/abs/2608.12345"
+    payload = {"body": ("earlier context " * 1_000) + tail_marker}
+
+    result = extract_signals_from_tool_result(
+        "#V#tool_x",
+        payload,
+        None,
+        llm_client=llm,
+        payload_max_chars=30_000,
+    )
+
+    assert tail_marker in llm.calls[0]["prompt"]
+    assert result.payload_max_chars == 30_000
+    assert result.payload_serialised_chars > 12_000
+    assert result.payload_included_chars == result.payload_serialised_chars
+    assert result.payload_truncated is False
+
+
+def test_extract_signals_reports_default_payload_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tool_result_hints,
+        "get_texts_for_concept",
+        lambda **_: [{"text": "Extract every reference."}],
+    )
+    llm = _FakeLLM(response='{"items": []}')
+    tail_marker = "https://arxiv.org/abs/2608.12345"
+
+    result = extract_signals_from_tool_result(
+        "#V#tool_x",
+        {"body": ("earlier context " * 1_000) + tail_marker},
+        None,
+        llm_client=llm,
+    )
+
+    assert tail_marker not in llm.calls[0]["prompt"]
+    assert result.payload_max_chars == 12_000
+    assert result.payload_included_chars == 12_000
+    assert result.payload_serialised_chars > result.payload_included_chars
+    assert result.payload_truncated is True
+
+
 def test_extract_signals_strips_code_fence(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         tool_result_hints,


### PR DESCRIPTION
## Outcome

Prevents paper references late in an inspected email from being silently omitted before represented signal extraction.

## Changes

- makes the generic extraction payload bound authored per workflow and records serialised/included size plus truncation
- sets the email extraction workflow to request the supported 65,536-character Gmail body maximum and allow a 100,000-character structured extraction payload
- advances the exact-authority repo seed to v21 with a reviewed v20 digest migration
- keeps the one-shot authoring script aligned and adds focused regression coverage

## Evidence

- 69 affected-path tests pass
- broader affected catalogue/workflow run: 264 passed, 2 skipped; one unrelated pre-existing stale purpose-string assertion failed because Gmail-to-arXiv is absent from an unchanged workflow purpose
- git diff --check and seed JSON validation pass

## Delivery decision

Merge when required CI passes. Stop-ship if the exact v20 authority migration fails, the authored bound is not visible at runtime, or the live replay still omits source links or produces non-global scope for public arXiv papers. Live replay and canonical read-back follow deployment of the merged exact build.