### PR TITLE
JVNAUTOSCI-2244: resolve DOI and public-source paper references

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -43,7 +43,7 @@ from src.backend.services.actor_scoped_referent_identity_service import (
 )
 from src.backend.services.workflow_actor_scope_service import WorkflowActorScopeError
 
-from .dynamic_tool_loader import load_dynamic_method_definitions
+from . import crossref_metadata as crossref, dynamic_tool_loader
 from .gateway import MethodCatalogue, MethodDefinition
 from .schemas import Schema, make_error_response
 from .spreadsheet_record_tools import build_spreadsheet_record_tool_definitions
@@ -43616,7 +43616,7 @@ def _register_dynamic_catalogue_methods(
         built_in_definitions = {
             definition.name: definition for definition in definitions
         }
-        dynamic_result = load_dynamic_method_definitions(
+        dynamic_result = dynamic_tool_loader.load_dynamic_method_definitions(
             base_definitions=built_in_definitions,
             protected_method_names=built_in_definitions.keys(),
         )
@@ -43633,7 +43633,7 @@ def build_default_catalogue() -> MethodCatalogue:
     """Return a catalogue pre-populated with the baseline method set."""
 
     catalogue = MethodCatalogue()
-    definitions: List[MethodDefinition] = []
+    definitions = [crossref.build_crossref_metadata_tool_definition()]
     definitions.extend(_build_default_catalogue_core_definitions())
     definitions.extend(_build_operational_learning_release_definitions())
     definitions.extend(_build_default_catalogue_knowledge_io_definitions())

--- a/src/backend/integrations/internal_mcp/crossref_metadata.py
+++ b/src/backend/integrations/internal_mcp/crossref_metadata.py
@@ -1,0 +1,314 @@
+"""Exact public DOI metadata retrieval through the Crossref REST API.
+
+The caller supplies only a DOI.  This module owns the fixed HTTPS endpoint,
+normalises and verifies the returned DOI, and projects a bounded
+source-neutral paper-metadata record.  It deliberately does not follow URLs
+or expose arbitrary fetched content, so an untrusted email or model output
+cannot turn this read into an SSRF primitive or enlarge write authority.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import quote, unquote
+
+import requests
+
+from .gateway import MethodDefinition
+from .schemas import Schema
+
+_CROSSREF_API_BASE_URL = "https://api.crossref.org/works"
+_CROSSREF_USER_AGENT = "VonResearchAssistant/1.0 (https://github.com/Strong-AI-Lab/Von)"
+_DOI_PATTERN = re.compile(r"^10\.\d{4,9}/\S+$", re.IGNORECASE)
+_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+
+
+def normalise_doi(value: Any) -> str:
+    """Return one canonical comparison form for a DOI, or ``""``."""
+
+    text = unquote(str(value or "")).strip().strip("<>")
+    lowered = text.lower()
+    for prefix in (
+        "https://doi.org/",
+        "http://doi.org/",
+        "https://dx.doi.org/",
+        "http://dx.doi.org/",
+        "doi:",
+    ):
+        if lowered.startswith(prefix):
+            text = text[len(prefix) :]
+            break
+    text = text.strip().rstrip(".,;")
+    if not _DOI_PATTERN.fullmatch(text):
+        return ""
+    return text.lower()
+
+
+def _first_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            text = _first_text(item)
+            if text:
+                return text
+    return ""
+
+
+def _author_names(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    names: list[str] = []
+    for item in value[:500]:
+        if not isinstance(item, Mapping):
+            continue
+        name = _first_text(item.get("name"))
+        if not name:
+            name = " ".join(
+                part
+                for part in (
+                    _first_text(item.get("given")),
+                    _first_text(item.get("family")),
+                )
+                if part
+            ).strip()
+        if name and name not in names:
+            names.append(name[:500])
+    return names
+
+
+def _publication_date(message: Mapping[str, Any]) -> str:
+    for key in (
+        "published-print",
+        "published-online",
+        "published",
+        "issued",
+        "created",
+    ):
+        value = message.get(key)
+        if not isinstance(value, Mapping):
+            continue
+        date_parts = value.get("date-parts")
+        if not isinstance(date_parts, Sequence) or not date_parts:
+            continue
+        first = date_parts[0]
+        if not isinstance(first, Sequence) or isinstance(
+            first, (str, bytes, bytearray)
+        ):
+            continue
+        integers = [part for part in first[:3] if isinstance(part, int)]
+        if not integers:
+            continue
+        year = integers[0]
+        if len(integers) == 1:
+            return f"{year:04d}"
+        month = integers[1]
+        if len(integers) == 2:
+            return f"{year:04d}-{month:02d}"
+        return f"{year:04d}-{month:02d}-{integers[2]:02d}"
+    return ""
+
+
+def _clean_abstract(value: Any) -> str:
+    text = _first_text(value)
+    if not text:
+        return ""
+    return " ".join(html.unescape(_HTML_TAG_PATTERN.sub(" ", text)).split())[:50_000]
+
+
+def _error(error_code: str, message: str, *, doi: str = "") -> dict[str, Any]:
+    return {
+        "success": False,
+        "error_code": error_code,
+        "error": message,
+        "doi": doi or None,
+        "exact_doi_verified": False,
+        "metadata_source": "crossref_rest_api",
+    }
+
+
+def fetch_crossref_doi_metadata(
+    doi: Any,
+    *,
+    timeout_sec: float = 20.0,
+    session: Any = None,
+) -> dict[str, Any]:
+    """Fetch, verify, and project public metadata for one exact DOI."""
+
+    canonical_doi = normalise_doi(doi)
+    if not canonical_doi:
+        return _error("invalid_doi", "A valid DOI is required.")
+
+    api_url = f"{_CROSSREF_API_BASE_URL}/{quote(canonical_doi, safe='')}"
+    client = session or requests
+    try:
+        response = client.get(
+            api_url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": _CROSSREF_USER_AGENT,
+            },
+            timeout=max(1.0, min(float(timeout_sec), 30.0)),
+        )
+    except requests.Timeout:
+        return _error(
+            "crossref_timeout",
+            "Crossref metadata retrieval timed out.",
+            doi=canonical_doi,
+        )
+    except requests.RequestException as exc:
+        return _error(
+            "crossref_request_failed",
+            f"Crossref metadata retrieval failed: {type(exc).__name__}.",
+            doi=canonical_doi,
+        )
+
+    if int(getattr(response, "status_code", 0) or 0) == 404:
+        return _error(
+            "crossref_doi_not_found",
+            "Crossref did not find the supplied DOI.",
+            doi=canonical_doi,
+        )
+    try:
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError, TypeError) as exc:
+        return _error(
+            "crossref_response_invalid",
+            f"Crossref returned an unusable response: {type(exc).__name__}.",
+            doi=canonical_doi,
+        )
+
+    if not isinstance(payload, Mapping) or payload.get("status") != "ok":
+        return _error(
+            "crossref_response_invalid",
+            "Crossref returned an unusable response envelope.",
+            doi=canonical_doi,
+        )
+    message = payload.get("message")
+    if not isinstance(message, Mapping):
+        return _error(
+            "crossref_response_invalid",
+            "Crossref returned no work metadata.",
+            doi=canonical_doi,
+        )
+
+    observed_doi = normalise_doi(message.get("DOI"))
+    if observed_doi != canonical_doi:
+        return _error(
+            "crossref_doi_mismatch",
+            "Crossref metadata did not read back the requested DOI.",
+            doi=canonical_doi,
+        )
+
+    title = _first_text(message.get("title"))[:2_000]
+    if not title:
+        return _error(
+            "crossref_metadata_incomplete",
+            "Crossref returned no paper title for the requested DOI.",
+            doi=canonical_doi,
+        )
+
+    author_names = _author_names(message.get("author"))
+    abstract = _clean_abstract(message.get("abstract"))
+    publication_date = _publication_date(message)
+    topic_labels = [
+        text[:500]
+        for item in (message.get("subject") or [])[:100]
+        if (text := _first_text(item))
+    ]
+    source_uri = normalise_doi(message.get("URL"))
+    source_uri = (
+        f"https://doi.org/{source_uri}"
+        if source_uri
+        else f"https://doi.org/{canonical_doi}"
+    )
+
+    paper_metadata: dict[str, Any] = {
+        "title": title,
+        "doi": canonical_doi,
+        "source_uri": source_uri,
+    }
+    if author_names:
+        paper_metadata["authors"] = author_names
+    if abstract:
+        paper_metadata["abstract"] = abstract
+    if publication_date:
+        paper_metadata["publication_date"] = publication_date
+    if topic_labels:
+        paper_metadata["categories"] = topic_labels
+
+    return {
+        "success": True,
+        "doi": canonical_doi,
+        "source_uri": source_uri,
+        "title": title,
+        "author_names": author_names,
+        "summary": abstract or None,
+        "publication_date": publication_date or None,
+        "topic_labels": topic_labels,
+        "paper_metadata": paper_metadata,
+        "exact_doi_verified": True,
+        "metadata_source": "crossref_rest_api",
+        "metadata_source_uri": api_url,
+    }
+
+
+def build_crossref_metadata_tool_definition() -> MethodDefinition:
+    """Return the self-contained internal-MCP definition for exact DOI reads."""
+
+    return MethodDefinition(
+        name="get_doi_metadata",
+        handler=lambda **kwargs: fetch_crossref_doi_metadata(kwargs.get("doi")),
+        input_schema=Schema(
+            required={"doi": str},
+            optional={},
+            allow_unknown=False,
+            description=(
+                "get_doi_metadata input: doi (str, required, exact DOI or doi.org "
+                "URL). The tool queries only the fixed Crossref REST endpoint."
+            ),
+        ),
+        output_schema=Schema(
+            required={
+                "success": bool,
+                "exact_doi_verified": bool,
+                "metadata_source": str,
+            },
+            optional={
+                "doi": (str, type(None)),
+                "source_uri": (str, type(None)),
+                "title": (str, type(None)),
+                "author_names": (list, type(None)),
+                "summary": (str, type(None)),
+                "publication_date": (str, type(None)),
+                "topic_labels": (list, type(None)),
+                "paper_metadata": (dict, type(None)),
+                "metadata_source_uri": (str, type(None)),
+                "error_code": (str, type(None)),
+                "error": (str, type(None)),
+            },
+            allow_unknown=False,
+            description=(
+                "get_doi_metadata output: exact-DOI-verified Crossref metadata in "
+                "a source-neutral paper_metadata record, or a typed failure."
+            ),
+        ),
+        category="read",
+        ordinary_turn_public=True,
+        timeout_sec=25.0,
+        description=(
+            "Resolve one exact DOI to public scholarly metadata through the fixed "
+            "Crossref REST endpoint. The returned DOI must exactly match the request."
+        ),
+    )
+
+
+__all__ = [
+    "build_crossref_metadata_tool_definition",
+    "fetch_crossref_doi_metadata",
+    "normalise_doi",
+]

--- a/src/backend/workflows/durable/paper_representation_workflow.py
+++ b/src/backend/workflows/durable/paper_representation_workflow.py
@@ -2291,6 +2291,22 @@ def _build_prepare_public_title_search_handler():
             or metadata.get("authors")
         )
 
+        # A source-neutral reference commonly carries its stable public identity
+        # at the workflow top level rather than inside ``paper_metadata``.  Keep
+        # one complete metadata projection so the downstream represented
+        # workflow does not silently lose the DOI/source identity that admitted
+        # the public-paper path.
+        if doi_candidates:
+            metadata["doi"] = doi_candidates[0]
+        if stable_source_uri:
+            metadata["source_uri"] = stable_source_uri
+        if title:
+            metadata["title"] = title
+        if publication_date:
+            metadata["publication_date"] = publication_date
+        if author_names:
+            metadata["authors"] = author_names
+
         bibliographic_fallback_basis: str | None = None
         if doi_candidates:
             bibliographic_fallback_basis = "doi"
@@ -2303,7 +2319,9 @@ def _build_prepare_public_title_search_handler():
             return WorkflowActionResult(
                 status="success",
                 outputs={
-                    "paper_metadata": metadata or None,
+                    "paper_metadata": metadata,
+                    "doi": doi_candidates[0] if doi_candidates else None,
+                    "source_uri": stable_source_uri or None,
                     "public_paper_title": title,
                     "public_paper_title_query": title,
                     "public_paper_title_search_required": False,
@@ -2316,6 +2334,8 @@ def _build_prepare_public_title_search_handler():
                 status="failed",
                 outputs={
                     "paper_metadata": metadata or None,
+                    "doi": None,
+                    "source_uri": None,
                     "public_paper_title_search_required": False,
                     "bibliographic_fallback_sufficient": False,
                     "bibliographic_fallback_basis": "insufficient",
@@ -2328,6 +2348,8 @@ def _build_prepare_public_title_search_handler():
                 "public_paper_title": title,
                 "public_paper_title_query": title,
                 "paper_metadata": metadata or {"title": title},
+                "doi": None,
+                "source_uri": None,
                 "public_paper_title_search_required": True,
                 "bibliographic_fallback_sufficient": bool(bibliographic_fallback_basis),
                 "bibliographic_fallback_basis": (

--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "31",
+  "seed_version": "32",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
@@ -30,6 +30,11 @@
         "7940a52c0bd65dcffd0838c6aefff7b2d538665e40ae7b1527cbc320172f679c",
         "85b5a8a7700645f21b322a6258861be251f8a37fba87910089b102afa7dcaf31"
       ]
+    },
+    "#V#public_paper_title_resolution_workflow": {
+      "31": [
+        "489e5fe07d965cfcd08343e5d72d1ccb7436b16e30455fc208426c38921ee6c6"
+      ]
     }
   },
   "source_tag": "JVNAUTOSCI-2244",
@@ -46,6 +51,7 @@
     "get_paper_metadata",
     "import_url_file_copy",
     "workflow_invoke_subworkflow",
+    "workflow_mcp.invoke_tool",
     "workflow_control.context_set",
     "workflow_control.context_template",
     "workflow_control.for_each",
@@ -5073,8 +5079,8 @@
     {
       "workflow_id": "#V#public_paper_title_resolution_workflow",
       "display_name": "Public Paper Title Resolution Workflow",
-      "description": "Resolves an otherwise unidentified scholarly-paper title against public arXiv records, accepts only one exact normalised title match, and delegates the verified public identity to the canonical arXiv representation workflow. If public lookup cannot establish one identity, it falls back to the metadata workflow, which succeeds only when the supplied bibliographic evidence is independently sufficient.",
-      "content": "Prepare a public-title query, search arXiv, accept exactly one normalised title match (using supplied year or authors only to disambiguate exact-title duplicates), and represent the resolved public paper. Never invent an identifier or choose a merely similar title. Failed or ambiguous public resolution may use the bibliographic metadata fallback, but title alone is not sufficient for that fallback.",
+      "description": "Resolves public scholarly-paper references from exact DOIs, direct public source URLs, or titles. It verifies DOI metadata against Crossref, extracts direct public-source content, or accepts only one exact normalised arXiv title match before delegating to the canonical global paper-representation workflows.",
+      "content": "For an exact DOI, retrieve public Crossref metadata and require the returned DOI to match. For a direct public source URL, extract that exact source for metadata interpretation without broad-search substitution. Otherwise search arXiv by title and accept exactly one normalised title match, using supplied year or authors only to disambiguate exact-title duplicates. Never invent an identifier or choose a merely similar result. Title alone remains insufficient after public lookup fails.",
       "text_relations": [
         {
           "predicate": "#V#hasWorkflowLifecycleJson",
@@ -5103,6 +5109,24 @@
             "on_failure_state": "decide_metadata_fallback",
             "conditional_transitions": [
               {
+                "to_state": "resolve_public_doi_metadata",
+                "reason": "exact_doi_available",
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "bibliographic_fallback_basis",
+                  "value": "doi"
+                }
+              },
+              {
+                "to_state": "extract_public_source_metadata",
+                "reason": "direct_public_source_available",
+                "condition_spec": {
+                  "kind": "context_value_equals",
+                  "key": "bibliographic_fallback_basis",
+                  "value": "source_uri"
+                }
+              },
+              {
                 "to_state": "decide_metadata_fallback",
                 "reason": "stable_bibliographic_identity_already_available",
                 "condition_spec": {
@@ -5129,6 +5153,16 @@
                 "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_paper_metadata_to_paper_metadata"
               },
               {
+                "context_key": "doi",
+                "tool_output_field": "doi",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_doi_to_doi"
+              },
+              {
+                "context_key": "source_uri",
+                "tool_output_field": "source_uri",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_source_uri_to_source_uri"
+              },
+              {
                 "context_key": "public_paper_title_search_required",
                 "tool_output_field": "public_paper_title_search_required",
                 "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_prepare_title_search_public_paper_title_search_required_to_public_paper_title_search_required"
@@ -5148,9 +5182,150 @@
               "public_paper_title",
               "public_paper_title_query",
               "paper_metadata",
+              "doi",
+              "source_uri",
               "public_paper_title_search_required",
               "bibliographic_fallback_sufficient",
               "bibliographic_fallback_basis"
+            ]
+          },
+          {
+            "state_id": "resolve_public_doi_metadata",
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "next_state": "ingest_metadata_fallback",
+            "on_failure_state": "reject_public_reference_metadata_resolution",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "doi": {
+                    "$context_key": "doi"
+                  }
+                }
+              ],
+              [
+                "tool_name",
+                "get_doi_metadata"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "context_key": "paper_metadata",
+                "tool_output_field": "result.paper_metadata",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_paper_metadata_to_paper_metadata"
+              },
+              {
+                "context_key": "doi",
+                "tool_output_field": "result.doi",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_doi_to_doi"
+              },
+              {
+                "context_key": "source_uri",
+                "tool_output_field": "result.source_uri",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_source_uri_to_source_uri"
+              },
+              {
+                "context_key": "public_paper_title",
+                "tool_output_field": "result.title",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_title_to_public_paper_title"
+              },
+              {
+                "context_key": "publication_date",
+                "tool_output_field": "result.publication_date",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_publication_date_to_publication_date"
+              },
+              {
+                "context_key": "author_names",
+                "tool_output_field": "result.author_names",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_resolve_public_doi_metadata_result_author_names_to_author_names"
+              }
+            ],
+            "writes_context_keys": [
+              "paper_metadata",
+              "doi",
+              "source_uri",
+              "public_paper_title",
+              "publication_date",
+              "author_names"
+            ]
+          },
+          {
+            "state_id": "extract_public_source_metadata",
+            "action_id": "workflow_mcp.invoke_tool",
+            "execution_mode": "deterministic",
+            "next_state": "ingest_metadata_fallback",
+            "on_failure_state": "reject_public_reference_metadata_resolution",
+            "static_input_bindings": [
+              [
+                "tool_arguments",
+                {
+                  "url": {
+                    "$context_key": "source_uri"
+                  }
+                }
+              ],
+              [
+                "tool_name",
+                "extract_url"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "context_key": "prompt",
+                "tool_output_field": "result.content",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_extract_public_source_metadata_result_content_to_prompt"
+              },
+              {
+                "context_key": "public_source_page_title",
+                "tool_output_field": "result.title",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_extract_public_source_metadata_result_title_to_public_source_page_title"
+              }
+            ],
+            "writes_context_keys": [
+              "prompt",
+              "public_source_page_title"
+            ]
+          },
+          {
+            "state_id": "reject_public_reference_metadata_resolution",
+            "action_id": "paper_reference.fail_item",
+            "execution_mode": "deterministic",
+            "static_input_bindings": [
+              [
+                "error_code",
+                "public_paper_metadata_resolution_failed"
+              ],
+              [
+                "error_message",
+                "The exact public DOI or source URL could not be resolved to sufficient paper metadata."
+              ],
+              [
+                "reference_kind",
+                "metadata"
+              ]
+            ],
+            "tool_output_mapping_specs": [
+              {
+                "context_key": "paper_reference_item_status",
+                "tool_output_field": "paper_reference_item_status",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_public_reference_metadata_resolution_paper_reference_item_status_to_paper_reference_item_status"
+              },
+              {
+                "context_key": "paper_reference_error_code",
+                "tool_output_field": "paper_reference_error_code",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_public_reference_metadata_resolution_paper_reference_error_code_to_paper_reference_error_code"
+              },
+              {
+                "context_key": "paper_reference_error_message",
+                "tool_output_field": "paper_reference_error_message",
+                "concept_id": "#V#workflow_mapping_tool_field_public_paper_title_resolution_workflow_reject_public_reference_metadata_resolution_paper_reference_error_message_to_paper_reference_error_message"
+              }
+            ],
+            "writes_context_keys": [
+              "paper_reference_item_status",
+              "paper_reference_error_code",
+              "paper_reference_error_message"
             ]
           },
           {
@@ -5402,6 +5577,24 @@
                 "context_key": "paper_metadata",
                 "required": false,
                 "concept_id": "#V#workflow_mapping_public_paper_title_resolution_workflow_ingest_metadata_fallback_paper_metadata_to_paper_metadata_parameter"
+              },
+              {
+                "tool_param": "doi",
+                "context_key": "doi",
+                "required": false,
+                "concept_id": "#V#workflow_mapping_public_paper_title_resolution_workflow_ingest_metadata_fallback_doi_to_doi_parameter"
+              },
+              {
+                "tool_param": "source_uri",
+                "context_key": "source_uri",
+                "required": false,
+                "concept_id": "#V#workflow_mapping_public_paper_title_resolution_workflow_ingest_metadata_fallback_source_uri_to_source_uri_parameter"
+              },
+              {
+                "tool_param": "prompt",
+                "context_key": "prompt",
+                "required": false,
+                "concept_id": "#V#workflow_mapping_public_paper_title_resolution_workflow_ingest_metadata_fallback_prompt_to_prompt_parameter"
               },
               {
                 "tool_param": "title",

--- a/tests/backend/test_crossref_metadata.py
+++ b/tests/backend/test_crossref_metadata.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import requests
+
+from src.backend.integrations.internal_mcp.crossref_metadata import (
+    fetch_crossref_doi_metadata,
+    normalise_doi,
+)
+
+
+class _Response:
+    def __init__(self, payload, *, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status={self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, response=None, *, error: Exception | None = None):
+        self.response = response
+        self.error = error
+        self.calls: list[dict] = []
+
+    def get(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def test_normalise_doi_accepts_exact_doi_and_doi_url() -> None:
+    assert normalise_doi(" DOI:10.1007/Example.1 ") == "10.1007/example.1"
+    assert normalise_doi("https://doi.org/10.1145%2FABC.DEF") == ("10.1145/abc.def")
+    assert normalise_doi("https://example.org/not-a-doi") == ""
+
+
+def test_fetch_crossref_doi_metadata_verifies_and_projects_exact_work() -> None:
+    session = _Session(
+        _Response(
+            {
+                "status": "ok",
+                "message": {
+                    "DOI": "10.1007/978-3-031-82039-7_10",
+                    "URL": "https://doi.org/10.1007/978-3-031-82039-7_10",
+                    "title": [
+                        "Norm Violation Detection in Multi-Agent Systems Using Large Language Models"
+                    ],
+                    "author": [
+                        {"given": "Ada", "family": "Lovelace"},
+                        {"name": "Grace Hopper"},
+                    ],
+                    "abstract": "<jats:p>A public abstract.</jats:p>",
+                    "published": {"date-parts": [[2025, 2, 3]]},
+                    "subject": ["Artificial intelligence"],
+                },
+            }
+        )
+    )
+
+    result = fetch_crossref_doi_metadata(
+        "https://doi.org/10.1007/978-3-031-82039-7_10",
+        session=session,
+    )
+
+    assert result["success"] is True
+    assert result["exact_doi_verified"] is True
+    assert result["doi"] == "10.1007/978-3-031-82039-7_10"
+    assert result["author_names"] == ["Ada Lovelace", "Grace Hopper"]
+    assert result["publication_date"] == "2025-02-03"
+    assert result["summary"] == "A public abstract."
+    assert result["paper_metadata"]["categories"] == ["Artificial intelligence"]
+    assert session.calls[0]["url"].endswith("/10.1007%2F978-3-031-82039-7_10")
+
+
+def test_fetch_crossref_doi_metadata_rejects_mismatched_readback() -> None:
+    session = _Session(
+        _Response(
+            {
+                "status": "ok",
+                "message": {
+                    "DOI": "10.1000/a-different-work",
+                    "title": ["Wrong work"],
+                },
+            }
+        )
+    )
+
+    result = fetch_crossref_doi_metadata("10.1000/requested", session=session)
+
+    assert result["success"] is False
+    assert result["error_code"] == "crossref_doi_mismatch"
+    assert result["exact_doi_verified"] is False
+
+
+def test_fetch_crossref_doi_metadata_returns_typed_not_found_and_timeout() -> None:
+    not_found = fetch_crossref_doi_metadata(
+        "10.1000/missing",
+        session=_Session(_Response({}, status_code=404)),
+    )
+    timed_out = fetch_crossref_doi_metadata(
+        "10.1000/slow",
+        session=_Session(error=requests.Timeout("slow")),
+    )
+
+    assert not_found["error_code"] == "crossref_doi_not_found"
+    assert timed_out["error_code"] == "crossref_timeout"

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -46,6 +46,7 @@ def test_internal_mcp_catalogue_builds_and_includes_relationship_tools():
     methods = set(catalogue.list_methods())
 
     assert "add_relationship" in methods
+    assert "get_doi_metadata" in methods
     assert "add_text_assertion_concept_links" in methods
     assert "store_text_assertion" in methods
     assert "upsert_scoped_assertion" in methods

--- a/tests/backend/test_paper_representation_workflow.py
+++ b/tests/backend/test_paper_representation_workflow.py
@@ -696,18 +696,40 @@ def test_public_title_resolution_workflow_preserves_stronger_doi_identity() -> N
     )[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID]
     registry = _paper_registry()
     register_control_flow_actions(registry)
-    registry.register(
-        ActionSpec(
-            action_id="workflow_mcp.invoke_tool",
-            handler=lambda _request: pytest.fail(
-                "stable DOI reference must not be replaced by a title search"
-            ),
+    def resolve_doi(request):
+        assert request.inputs["tool_name"] == "get_doi_metadata"
+        assert request.inputs["tool_arguments"]["doi"] == "10.1000/example"
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "doi": "10.1000/example",
+                    "source_uri": "https://doi.org/10.1000/example",
+                    "title": "A Paper With A DOI",
+                    "author_names": ["Ada Lovelace"],
+                    "publication_date": "1843",
+                    "paper_metadata": {
+                        "title": "A Paper With A DOI",
+                        "doi": "10.1000/example",
+                        "source_uri": "https://doi.org/10.1000/example",
+                        "authors": ["Ada Lovelace"],
+                        "publication_date": "1843",
+                    },
+                }
+            },
         )
+
+    registry.register(
+        ActionSpec(action_id="workflow_mcp.invoke_tool", handler=resolve_doi)
     )
 
     def invoke_metadata(request):
         assert request.workflow_state_id == "ingest_metadata_fallback"
         assert request.inputs["paper_metadata"]["doi"] == "10.1000/example"
+        assert request.inputs["doi"] == "10.1000/example"
+        assert request.inputs["source_uri"] == (
+            "https://doi.org/10.1000/example"
+        )
         return WorkflowActionResult(
             status="success",
             outputs={
@@ -740,6 +762,68 @@ def test_public_title_resolution_workflow_preserves_stronger_doi_identity() -> N
 
     assert result.completed is True
     assert result.data["paper_concept_id"] == "#V#public_doi_10_1000_example"
+
+
+def test_public_title_resolution_workflow_extracts_exact_public_source() -> None:
+    definition = build_repo_seed_workflow_definitions(
+        bundle_paths=[_REPO_SEED_ASSET_PATH],
+        target_workflow_ids=[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID],
+    )[PUBLIC_PAPER_TITLE_RESOLUTION_WORKFLOW_ID]
+    registry = _paper_registry()
+    register_control_flow_actions(registry)
+
+    def extract_source(request):
+        assert request.inputs["tool_name"] == "extract_url"
+        assert request.inputs["tool_arguments"]["url"] == (
+            "https://example.org/public-paper.pdf"
+        )
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "content": "Public Paper Title\nAda Lovelace\nA public abstract.",
+                    "title": "public-paper.pdf",
+                    "url": "https://example.org/public-paper.pdf",
+                }
+            },
+        )
+
+    def invoke_metadata(request):
+        assert request.workflow_state_id == "ingest_metadata_fallback"
+        assert request.inputs["source_uri"] == (
+            "https://example.org/public-paper.pdf"
+        )
+        assert "Public Paper Title" in request.inputs["prompt"]
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "result": {
+                    "paper_concept_id": "#V#public_paper_from_source",
+                    "article_readback": {
+                        "concept_id": "#V#public_paper_from_source"
+                    },
+                }
+            },
+        )
+
+    registry.register(
+        ActionSpec(action_id="workflow_mcp.invoke_tool", handler=extract_source)
+    )
+    registry.register(
+        ActionSpec(
+            action_id="workflow_invoke_subworkflow",
+            handler=invoke_metadata,
+        )
+    )
+
+    result = WorkflowExecutor(registry=registry, max_transitions=8).run(
+        definition,
+        environment=WorkflowEnvironment(llm_client=None),
+        data={"source_uri": "https://example.org/public-paper.pdf"},
+    )
+
+    assert result.completed is True
+    assert result.data["paper_concept_id"] == "#V#public_paper_from_source"
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -2328,7 +2328,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "31" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "32" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID


### PR DESCRIPTION
Implements the observed mixed-source email repair for JVNAUTOSCI-2244. Exact DOIs are resolved through a fixed Crossref endpoint with DOI read-back validation; direct public paper URLs are extracted without broad-search substitution; both reuse the existing global scholarly-article representation workflow. Top-level DOI/source identity now remains in the metadata projection. The represented workflow seed advances from v31 to v32 with the reviewed live-authority digest.\n\nValidation: 38 focused paper/Crossref/catalogue tests pass; the 40-test represented paper workflow suite passed after updating the v32 assertion, with 2 skips; targeted seed materialisation and v31-to-v32 migration checks pass; workflow purity gate passes with advisory findings; live Crossref gateway probe returned the exact requested DOI, title, four authors, and exact_doi_verified=true.\n\nMerge decision: ready once required CI passes. Live mixed-source Gmail replay remains a post-deployment acceptance step, not a claim made by this PR.