### PR TITLE
Fix null optional paper file link

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "32",
+  "seed_version": "33",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
@@ -34,6 +34,11 @@
     "#V#public_paper_title_resolution_workflow": {
       "31": [
         "489e5fe07d965cfcd08343e5d72d1ccb7436b16e30455fc208426c38921ee6c6"
+      ]
+    },
+    "#V#scholarly_article_metadata_representation_workflow": {
+      "32": [
+        "cb9f9c59be22a3e368473e4af5d98889439e4496d7cc8bf124655f2e2efd8b8c"
       ]
     }
   },
@@ -1605,9 +1610,19 @@
                 "to_state": "resolve_file_link_scope",
                 "reason": "file_copy_present",
                 "condition_spec": {
-                  "kind": "context_exists",
-                  "key": "file_copy_concept_id",
-                  "expected": true
+                  "kind": "all",
+                  "conditions": [
+                    {
+                      "kind": "context_exists",
+                      "key": "file_copy_concept_id",
+                      "expected": true
+                    },
+                    {
+                      "kind": "context_is_null",
+                      "key": "file_copy_concept_id",
+                      "expected": false
+                    }
+                  ]
                 }
               }
             ]

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -2328,7 +2328,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "32" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "33" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID
@@ -2799,6 +2799,9 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
             org_concept_id=_LIVE_ARXIV_ACCEPTANCE_ORG_ID,
         ),
         data={
+            # Parent workflows preserve optional mapped fields as explicit nulls.
+            # A null file-copy value must not enter the private file-link branch.
+            "file_copy_concept_id": None,
             "paper_metadata": {
                 "title": "Composable Identity Control for Multi-Character Illustration",
                 "abstract": "A paper about composable identity control.",
@@ -2823,6 +2826,8 @@ def test_metadata_workflow_executes_direct_scholarly_article_representation(
     assert result.final_state.endswith("_completed"), result.data.get(
         "last_action_outputs"
     )
+    assert result.data.get("file_link_gate") == "optional"
+    assert "file_link_scope_mode" not in result.data
     paper_concept_id = result.data.get("paper_concept_id")
     assert isinstance(paper_concept_id, str) and paper_concept_id.startswith("#V#")
     assert result.data.get("verification_passed") is True


### PR DESCRIPTION
## Outcome

Fixes the represented scholarly-paper workflow so an explicitly null optional file-copy input does not enter the private file-link assertion branch. This is the failure exposed when a public DOI paper is delegated through the parent paper-reference workflow.

## Change

- require the optional file-copy concept ID to be both present and non-null before resolving file-link scope
- advance the paper workflow seed bundle to v33 with the reviewed v32 authority digest
- cover the parent-projected null input and confirm no private file-link scope is selected

## Validation

- affected paper/seed suite: 160 passed, 2 skipped; sole stale v32 marker assertion then corrected
- focused post-correction run: 90 passed
- JSON parse and diff checks pass
- live diagnosis: DOI metadata resolved and the public paper/authors were represented globally; the failed child ended specifically at upsert_scoped_assertion with invalid_scoped_assertion because the file-link target was absent

Jira: JVNAUTOSCI-2244