### PR TITLE
JVNAUTOSCI-2681: reduce repeated startup loads

### DIFF
--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -2678,6 +2678,21 @@ def _bootstrap_concept_summary_fields_for_startup(app: Flask) -> None:
 
         report = bootstrap_canonical_concept_summary_fields()
         app.config["CONCEPT_SUMMARY_FIELD_BOOTSTRAP_REPORT"] = report
+        try:
+            app.logger.info(
+                "[concept_summary_fields] bootstrap success=%s changed=%s "
+                "read_strategy=%s read_phases=%s duration_ms=%s raw_relations=%s",
+                report.get("success"),
+                report.get("changed"),
+                report.get("read_strategy"),
+                report.get("read_phases"),
+                report.get("duration_ms"),
+                (report.get("text_query_metadata") or {}).get(
+                    "raw_relation_count"
+                ),
+            )
+        except Exception:
+            pass
         if not bool(report.get("success", False)):
             app.logger.warning(
                 "[concept_summary_fields] bootstrap failed: %s",
@@ -2718,6 +2733,21 @@ def _bootstrap_publication_scope_profiles_for_startup(app: Flask) -> None:
 
         report = bootstrap_canonical_publication_scope_profiles()
         app.config["PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"] = report
+        try:
+            app.logger.info(
+                "[publication_scope_profiles] bootstrap success=%s changed=%s "
+                "read_strategy=%s read_phases=%s duration_ms=%s raw_relations=%s",
+                report.get("success"),
+                report.get("changed"),
+                report.get("read_strategy"),
+                report.get("read_phases"),
+                report.get("duration_ms"),
+                (report.get("profile_query_metadata") or {}).get(
+                    "raw_relation_count"
+                ),
+            )
+        except Exception:
+            pass
         if not bool(report.get("success", False)):
             app.logger.warning(
                 "[publication_scope_profiles] bootstrap failed: %s",
@@ -4276,21 +4306,29 @@ def _start_prewarm(app: Flask) -> None:
                         )
                 except Exception as exc:
                     app.logger.warning("[prewarm] Model list failed: %s", exc)
-                try:
-                    with app.test_client() as client:
-                        response = client.get("/vontology/api/vontology/tree?refresh=1")
-                        if response.status_code == 200:
-                            app.logger.info(
-                                "[prewarm] Tree build OK (len bytes=%s)",
-                                len(response.data),
+                if _env_bool("VON_PREWARM_TREE_ENABLE", False):
+                    try:
+                        with app.test_client() as client:
+                            response = client.get(
+                                "/vontology/api/vontology/tree?refresh=1"
                             )
-                        else:
-                            app.logger.warning(
-                                "[prewarm] Tree build non-200 status=%s",
-                                response.status_code,
-                            )
-                except Exception as exc:
-                    app.logger.warning("[prewarm] Tree build failed: %s", exc)
+                            if response.status_code == 200:
+                                app.logger.info(
+                                    "[prewarm] Tree build OK (len bytes=%s)",
+                                    len(response.data),
+                                )
+                            else:
+                                app.logger.warning(
+                                    "[prewarm] Tree build non-200 status=%s",
+                                    response.status_code,
+                                )
+                    except Exception as exc:
+                        app.logger.warning("[prewarm] Tree build failed: %s", exc)
+                else:
+                    app.logger.info(
+                        "[prewarm] Vontology tree remains demand-loaded; set "
+                        "VON_PREWARM_TREE_ENABLE=1 to opt in."
+                    )
             finally:
                 app.logger.info("[prewarm] Completed in %.2fs", time.time() - t0)
 

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -1059,6 +1059,85 @@ def get_concept_by_concept_id_exact(concept_id: str) -> Optional[Dict[str, Any]]
         )
 
 
+def get_concepts_by_concept_ids_exact(
+    concept_ids: Iterable[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Retrieve many canonical concept IDs with one bounded collection read.
+
+    The result is keyed by the caller-supplied IDs.  This is the bulk analogue
+    of :func:`get_concept_by_concept_id_exact`: it deliberately performs no
+    alias or name resolution and is intended for callers that already hold
+    authoritative machine IDs.  Missing IDs are omitted.
+    """
+
+    from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+
+    ordered_ids: List[str] = []
+    canonical_by_requested: Dict[str, str] = {}
+    query_ids: set[str] = set()
+    for raw_id in concept_ids:
+        if not isinstance(raw_id, str):
+            continue
+        requested_id = raw_id.strip()
+        if not requested_id or requested_id in canonical_by_requested:
+            continue
+        canonical_id = canonicalise_vontology_concept_id(requested_id) or requested_id
+        ordered_ids.append(requested_id)
+        canonical_by_requested[requested_id] = canonical_id
+        query_ids.add(requested_id)
+        query_ids.add(canonical_id)
+
+    if not ordered_ids:
+        return {}
+
+    concepts_coll = ConceptsRepository.collection()
+    if concepts_coll is None:
+        raise ConceptServiceError("Database collection 'concepts' not available.")
+
+    try:
+        raw_docs = list(
+            concepts_coll.find(
+                {"concept_id": {"$in": sorted(query_ids)}},
+            )
+        )
+        raw_by_id = {
+            str(doc.get("concept_id") or "").strip(): doc
+            for doc in raw_docs
+            if isinstance(doc, dict)
+            and isinstance(doc.get("concept_id"), str)
+            and str(doc.get("concept_id")).strip()
+        }
+        resolved: Dict[str, Dict[str, Any]] = {}
+        for requested_id in ordered_ids:
+            canonical_id = canonical_by_requested[requested_id]
+            raw_doc = raw_by_id.get(canonical_id) or raw_by_id.get(requested_id)
+            if not isinstance(raw_doc, dict):
+                continue
+            finalised = _finalise_concept_lookup_doc(
+                dict(raw_doc),
+                requested_concept_id=requested_id,
+            )
+            try:
+                from ..security.access_control import sanitize_concept_document
+
+                finalised = sanitize_concept_document(finalised)
+            except Exception:
+                pass
+            if isinstance(finalised, dict):
+                resolved[requested_id] = finalised
+        return resolved
+    except Exception as exc:
+        logger.error(
+            "Error retrieving %d concepts by exact concept_id: %s",
+            len(ordered_ids),
+            exc,
+            exc_info=True,
+        )
+        raise ConceptServiceError(
+            f"Could not retrieve concepts by exact concept_id: {str(exc)}"
+        ) from exc
+
+
 def get_concept_by_concept_id(concept_id: str) -> Optional[Dict[str, Any]]:
     """Retrieve a concept by its ontological concept_id (e.g., '#V#person').
     Returns the full document with 'id' as string if found; otherwise raises ConceptNotFoundError.

--- a/src/backend/services/concept_summary_field_vontology_service.py
+++ b/src/backend/services/concept_summary_field_vontology_service.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from . import concept_service
 from .concept_summary_field_resolver import get_concept_summary_field_resolver
-from .text_value_service import upsert_singleton_text_relation
+from .text_value_service import get_texts_for_concepts, upsert_singleton_text_relation
 
 SUMMARY_FIELD_SEED_SCHEMA_VERSION = "concept_summary_field_seed_bundle.v1"
 SUMMARY_FIELD_TYPE_ID = "#V#summary_field"
@@ -50,27 +51,23 @@ def _load_seed_bundle(asset_path: str | Path | None) -> Mapping[str, Any]:
     return {**payload, "asset_path": str(path)}
 
 
-def _concept_exists(concept_id: str) -> bool:
-    try:
-        return isinstance(
-            concept_service.get_concept_by_concept_id_exact(concept_id),
-            Mapping,
-        )
-    except Exception:
-        return False
-
-
-def _ensure_concept(spec: Mapping[str, Any], *, source_tag: str, managed_by: str) -> str:
+def _ensure_concept(
+    spec: Mapping[str, Any],
+    *,
+    source_tag: str,
+    managed_by: str,
+    concepts_by_id: dict[str, Mapping[str, Any]],
+) -> tuple[str, bool]:
     concept_id = _text(spec.get("concept_id"))
     name = _text(spec.get("name"))
     if not concept_id or not name:
         raise ValueError("concept_identity_missing")
-    if _concept_exists(concept_id):
-        return concept_id
+    if concept_id in concepts_by_id:
+        return concept_id, False
     attributes = dict(spec.get("attributes") or {})
     attributes.setdefault("repo_seed_source_tag", source_tag)
     attributes.setdefault("repo_seed_managed_by", managed_by)
-    concept_service.create_concept(
+    created = concept_service.create_concept(
         name=name,
         concept_id=concept_id,
         parent_concept_ids=_strings(spec.get("parent_concept_ids")),
@@ -81,7 +78,31 @@ def _ensure_concept(spec: Mapping[str, Any], *, source_tag: str, managed_by: str
         attributes=attributes,
         visibility_scope_mode="global_general",
     )
-    return concept_id
+    if isinstance(created, Mapping):
+        concepts_by_id[concept_id] = dict(created)
+    return concept_id, True
+
+
+def _seed_text(spec: Mapping[str, Any]) -> str:
+    text = _text(spec.get("text"))
+    if not text and "text_json" in spec:
+        text = json.dumps(_strings(spec.get("text_json")), ensure_ascii=True)
+    return text
+
+
+def _singleton_text_is_current(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    predicate: str,
+    text: str,
+    lang: str,
+) -> bool:
+    same_slot = [
+        row
+        for row in rows
+        if _text(row.get("predicate")) == predicate and _text(row.get("lang")) == lang
+    ]
+    return len(same_slot) == 1 and _text(same_slot[0].get("text")) == text
 
 
 def _upsert_seed_text_relation(
@@ -89,19 +110,27 @@ def _upsert_seed_text_relation(
     *,
     source_tag: str,
     managed_by: str,
-) -> str:
+    current_rows: Sequence[Mapping[str, Any]],
+) -> tuple[str, bool]:
     subject_id = _text(spec.get("subject_concept_id"))
     predicate = _text(spec.get("predicate"))
-    text = _text(spec.get("text"))
-    if not text and "text_json" in spec:
-        text = json.dumps(_strings(spec.get("text_json")), ensure_ascii=True)
+    text = _seed_text(spec)
     if not subject_id or not predicate or not text:
         raise ValueError("text_relation_identity_missing")
+    lang = _text(spec.get("lang")) or "en-NZ"
+    identity = f"{subject_id}:{predicate}"
+    if _singleton_text_is_current(
+        current_rows,
+        predicate=predicate,
+        text=text,
+        lang=lang,
+    ):
+        return identity, False
     upsert_singleton_text_relation(
         subject_concept_id=subject_id,
         predicate=predicate,
         text=text,
-        lang=_text(spec.get("lang")) or "en-NZ",
+        lang=lang,
         context={
             "schema_version": SUMMARY_FIELD_SEED_SCHEMA_VERSION,
             "source": source_tag,
@@ -109,24 +138,35 @@ def _upsert_seed_text_relation(
         },
         garbage_collect=True,
     )
-    return f"{subject_id}:{predicate}"
+    return identity, True
 
 
-def _merge_relationship(spec: Mapping[str, Any]) -> str:
+def _merge_relationship(
+    spec: Mapping[str, Any],
+    *,
+    concepts_by_id: dict[str, Mapping[str, Any]],
+) -> tuple[str, bool]:
     subject_id = _text(spec.get("subject_concept_id"))
     predicate = _text(spec.get("predicate"))
     targets = _strings(spec.get("object_concept_ids"))
     if not subject_id or not predicate or not targets:
         raise ValueError("relationship_identity_missing")
-    concept = concept_service.get_concept_by_concept_id(subject_id)
+    concept = concepts_by_id.get(subject_id)
     if not isinstance(concept, Mapping):
         raise ValueError(f"relationship_subject_missing:{subject_id}")
     relationships = dict(concept.get("relationships") or {})
     existing = _strings(relationships.get(predicate))
     updated = _strings([*existing, *targets])
     if updated != existing:
-        concept_service.update_concept(subject_id, {f"relationships.{predicate}": updated})
-    return f"{subject_id}:{predicate}"
+        concept_service.update_concept(
+            subject_id, {f"relationships.{predicate}": updated}
+        )
+        refreshed = {
+            **dict(concept),
+            "relationships": {**relationships, predicate: updated},
+        }
+        concepts_by_id[subject_id] = refreshed
+    return f"{subject_id}:{predicate}", updated != existing
 
 
 def bootstrap_canonical_concept_summary_fields(
@@ -135,6 +175,7 @@ def bootstrap_canonical_concept_summary_fields(
 ) -> dict[str, Any]:
     """Materialise canonical concept-summary field metadata into Vontology."""
 
+    started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
     source_tag = _text(bundle.get("source_tag")) or "JVNAUTOSCI-1958"
     managed_by = (
@@ -142,51 +183,99 @@ def bootstrap_canonical_concept_summary_fields(
     )
     errors: list[dict[str, str]] = []
 
-    def apply_many(section: str, callback) -> list[str]:
-        applied: list[str] = []
-        for spec in bundle.get(section) or ():
-            if not isinstance(spec, Mapping):
-                continue
+    concept_specs = [
+        spec for spec in bundle.get("concepts") or () if isinstance(spec, Mapping)
+    ]
+    text_specs = [
+        spec for spec in bundle.get("text_relations") or () if isinstance(spec, Mapping)
+    ]
+    relationship_specs = [
+        spec for spec in bundle.get("relationships") or () if isinstance(spec, Mapping)
+    ]
+    required_concept_ids = _strings(
+        [
+            *[_text(spec.get("concept_id")) for spec in concept_specs],
+            *[
+                _text(spec.get("subject_concept_id"))
+                for spec in relationship_specs
+            ],
+        ]
+    )
+    concepts_by_id: dict[str, Mapping[str, Any]] = dict(
+        concept_service.get_concepts_by_concept_ids_exact(required_concept_ids)
+    )
+    text_query_metadata: dict[str, Any] = {}
+    rows_by_concept = get_texts_for_concepts(
+        [_text(spec.get("subject_concept_id")) for spec in text_specs],
+        predicates=_strings([_text(spec.get("predicate")) for spec in text_specs]),
+        limit_per_concept=50,
+        query_metadata=text_query_metadata,
+    )
+
+    def apply_many(
+        section: str,
+        specs: Sequence[Mapping[str, Any]],
+        callback,
+    ) -> tuple[list[str], list[str]]:
+        seen: list[str] = []
+        changed: list[str] = []
+        for spec in specs:
             identity = _text(
                 spec.get("concept_id")
                 or spec.get("subject_concept_id")
                 or spec.get("predicate")
             )
             try:
-                applied.append(callback(spec))
+                applied_id, did_change = callback(spec)
+                seen.append(applied_id)
+                if did_change:
+                    changed.append(applied_id)
             except Exception as exc:
                 errors.append(
                     {"section": section, "id": identity, "reason_code": str(exc)}
                 )
-        return applied
+        return seen, changed
 
-    concept_ids = apply_many(
+    concept_ids, created_concept_ids = apply_many(
         "concepts",
+        concept_specs,
         lambda spec: _ensure_concept(
             spec,
             source_tag=source_tag,
             managed_by=managed_by,
+            concepts_by_id=concepts_by_id,
         ),
     )
-    text_relation_ids = apply_many(
+    text_relation_ids, changed_text_relation_ids = apply_many(
         "text_relations",
+        text_specs,
         lambda spec: _upsert_seed_text_relation(
             spec,
             source_tag=source_tag,
             managed_by=managed_by,
+            current_rows=rows_by_concept.get(
+                _text(spec.get("subject_concept_id")), []
+            ),
         ),
     )
-    relationship_ids = apply_many("relationships", _merge_relationship)
+    relationship_ids, changed_relationship_ids = apply_many(
+        "relationships",
+        relationship_specs,
+        lambda spec: _merge_relationship(spec, concepts_by_id=concepts_by_id),
+    )
     field_concept_ids = [
         concept_id
-        for spec in bundle.get("concepts") or ()
-        if isinstance(spec, Mapping)
-        and SUMMARY_FIELD_TYPE_ID in _strings(spec.get("parent_concept_ids"))
+        for spec in concept_specs
+        if SUMMARY_FIELD_TYPE_ID in _strings(spec.get("parent_concept_ids"))
         for concept_id in [_text(spec.get("concept_id"))]
         if concept_id in concept_ids
     ]
 
-    get_concept_summary_field_resolver().invalidate_cache()
+    changed = bool(
+        created_concept_ids or changed_text_relation_ids or changed_relationship_ids
+    )
+    if changed:
+        get_concept_summary_field_resolver().invalidate_cache()
     return {
         "success": not errors,
         "asset_path": bundle.get("asset_path"),
@@ -195,15 +284,27 @@ def bootstrap_canonical_concept_summary_fields(
         "source_tag": source_tag,
         "managed_by": managed_by,
         "concept_ids": concept_ids,
+        "created_concept_ids": created_concept_ids,
         "field_concept_ids": field_concept_ids,
         "text_relation_ids": text_relation_ids,
+        "changed_text_relation_ids": changed_text_relation_ids,
         "relationship_ids": relationship_ids,
+        "changed_relationship_ids": changed_relationship_ids,
+        "changed": changed,
+        "read_strategy": "batched_canonical_state",
+        "read_phases": 2,
+        "canonical_read_batches": {"concepts": 1, "text_assertions": 1},
+        "text_query_metadata": text_query_metadata,
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
         "errors": errors,
         "counts": {
             "concepts_seen": len(concept_ids),
+            "concepts_created": len(created_concept_ids),
             "fields_seen": len(field_concept_ids),
             "field_configs_written": len(text_relation_ids),
+            "field_configs_changed": len(changed_text_relation_ids),
             "type_bindings_written": len(relationship_ids),
+            "type_bindings_changed": len(changed_relationship_ids),
             "errors": len(errors),
         },
     }

--- a/src/backend/services/model_registry_service.py
+++ b/src/backend/services/model_registry_service.py
@@ -19,7 +19,9 @@ from .settings_service import resolve_enabled_llm_settings, resolve_llm_setting
 logger = logging.getLogger(__name__)
 
 _DEFAULT_REGISTRY_NAME = "default_model_registry"
+_DEFAULT_REGISTRY_CONCEPT_ID = "#V#default_model_registry"
 _LEGACY_REGISTRY_JSON_PREDICATE_NAME = "has_model_registry_json"
+_MODEL_REGISTRY_GRAPH_LOADER_SCHEMA_VERSION = "model_registry_graph_loader.v2-batched"
 
 PRED_HAS_MODEL_ENTRY = "#V#has_model_entry"
 PRED_REFERS_TO_MODEL = "#V#refers_to_model"
@@ -202,6 +204,9 @@ def _model_registry_authority_fingerprint() -> str:
                 effective_mongo_uri
             ),
             "namespace": namespace,
+            "graph_loader_schema_version": (
+                _MODEL_REGISTRY_GRAPH_LOADER_SCHEMA_VERSION
+            ),
         }
     except Exception:
         # The fallback remains secret-free and separates configured databases.
@@ -211,6 +216,9 @@ def _model_registry_authority_fingerprint() -> str:
             "database_name": str(os.getenv("VON_DB_NAME") or "von_db").strip(),
             "mongo_location": {"available": False},
             "namespace": namespace,
+            "graph_loader_schema_version": (
+                _MODEL_REGISTRY_GRAPH_LOADER_SCHEMA_VERSION
+            ),
         }
     encoded = json.dumps(
         authority,
@@ -610,6 +618,375 @@ def _get_related_concept_ids(concept_id: str, predicate: str) -> list[str]:
     ]
 
 
+def _related_concept_ids_from_doc(
+    concept: Mapping[str, Any] | None,
+    predicate: str,
+) -> list[str]:
+    """Read canonical relationship targets from an already-fetched concept."""
+
+    if not isinstance(concept, Mapping):
+        return []
+    relationships = concept.get("relationships")
+    if not isinstance(relationships, Mapping):
+        return []
+    direct_targets = relationships.get(predicate)
+    if isinstance(direct_targets, str) and direct_targets.strip():
+        return [direct_targets.strip()]
+    if isinstance(direct_targets, Sequence) and not isinstance(
+        direct_targets, (str, bytes, bytearray)
+    ):
+        targets = [
+            str(item).strip()
+            for item in direct_targets
+            if isinstance(item, str) and str(item).strip()
+        ]
+        if targets:
+            return targets
+    linked_to = relationships.get("linked_to")
+    if isinstance(linked_to, Sequence) and not isinstance(
+        linked_to, (str, bytes, bytearray)
+    ):
+        return [
+            str(item.get("target") or item.get("concept_id") or "").strip()
+            for item in linked_to
+            if isinstance(item, Mapping)
+            and item.get("predicate") == predicate
+            and str(item.get("target") or item.get("concept_id") or "").strip()
+        ]
+    return []
+
+
+def _first_batched_text(
+    rows_by_concept: Mapping[str, Sequence[Mapping[str, Any]]],
+    concept_id: str,
+    predicate: str,
+) -> str | None:
+    for row in rows_by_concept.get(concept_id, ()):
+        if row.get("predicate") != predicate:
+            continue
+        raw_text = row.get("text")
+        if isinstance(raw_text, str) and raw_text.strip():
+            return raw_text.strip()
+    return None
+
+
+def _batched_text_relationship_targets(
+    rows_by_concept: Mapping[str, Sequence[Mapping[str, Any]]],
+    concept_id: str,
+    predicate: str,
+) -> list[str]:
+    return [
+        str(row.get("text")).strip()
+        for row in rows_by_concept.get(concept_id, ())
+        if row.get("predicate") == predicate
+        and isinstance(row.get("text"), str)
+        and str(row.get("text")).strip().startswith("#V#")
+    ]
+
+
+def _load_registry_from_vontology_graph_batched(
+    *, preferred_language: str | None = None
+) -> Optional[Mapping[str, Any]]:
+    """Hydrate the canonical registry in bounded graph waves.
+
+    The represented graph remains authority.  This function changes only the
+    physical read shape: related concept documents are fetched in batches and
+    all semantic text predicates are resolved in one joined text read.  Legacy
+    text-encoded relationship graphs fall back to the compatibility loader.
+    """
+
+    del preferred_language  # Existing graph text selection is insertion ordered.
+    from .concept_service import get_concepts_by_concept_ids_exact
+    from .text_value_service import get_texts_for_concepts
+
+    root_docs = get_concepts_by_concept_ids_exact([_DEFAULT_REGISTRY_CONCEPT_ID])
+    root = root_docs.get(_DEFAULT_REGISTRY_CONCEPT_ID)
+    entry_ids = _related_concept_ids_from_doc(root, PRED_HAS_MODEL_ENTRY)
+    if not entry_ids:
+        return None
+
+    entry_docs = get_concepts_by_concept_ids_exact(entry_ids)
+    model_ids: list[str] = []
+    profile_ids: list[str] = []
+    for entry_id in entry_ids:
+        entry_doc = entry_docs.get(entry_id)
+        referred_models = _related_concept_ids_from_doc(entry_doc, PRED_REFERS_TO_MODEL)
+        if not referred_models:
+            # A model entry without a direct/linked model edge may be using the
+            # legacy text-relation encoding. Let the compatibility loader decide.
+            return None
+        model_ids.extend(referred_models[:1])
+        profile_ids.extend(
+            _related_concept_ids_from_doc(entry_doc, PRED_HAS_MODEL_API_PROFILE)
+        )
+
+    model_and_profile_docs = get_concepts_by_concept_ids_exact(
+        [*model_ids, *profile_ids]
+    )
+    provider_ids: list[str] = []
+    for model_id in model_ids:
+        provider_ids.extend(
+            _related_concept_ids_from_doc(
+                model_and_profile_docs.get(model_id), PRED_HAS_PROVIDER
+            )[:1]
+        )
+    constraint_ids: list[str] = []
+    for profile_id in profile_ids:
+        constraint_ids.extend(
+            _related_concept_ids_from_doc(
+                model_and_profile_docs.get(profile_id),
+                PRED_HAS_MODEL_PARAMETER_CONSTRAINT,
+            )
+        )
+
+    provider_and_constraint_docs = get_concepts_by_concept_ids_exact(
+        [*provider_ids, *constraint_ids]
+    )
+    parameter_ids: list[str] = []
+    for constraint_id in constraint_ids:
+        parameter_ids.extend(
+            _related_concept_ids_from_doc(
+                provider_and_constraint_docs.get(constraint_id),
+                PRED_CONSTRAINS_MODEL_PARAMETER,
+            )[:1]
+        )
+    parameter_docs = get_concepts_by_concept_ids_exact(parameter_ids)
+    concept_docs: dict[str, Mapping[str, Any]] = {
+        **root_docs,
+        **entry_docs,
+        **model_and_profile_docs,
+        **provider_and_constraint_docs,
+        **parameter_docs,
+    }
+
+    text_subject_ids = [
+        *entry_ids,
+        *model_ids,
+        *provider_ids,
+        *profile_ids,
+        *constraint_ids,
+    ]
+    text_predicates = [
+        "hasName",
+        PRED_HAS_MODEL_API_PROFILE,
+        PRED_HAS_PROVIDER,
+        PRED_HAS_MODEL_PARAMETER_CONSTRAINT,
+        PRED_CONSTRAINS_MODEL_PARAMETER,
+        PRED_HAS_MODEL_ID,
+        PRED_HAS_MODEL_PRICING_JSON,
+        PRED_HAS_MODEL_CAPABILITIES_JSON,
+        PRED_HAS_API_SURFACE,
+        PRED_HAS_STRUCTURED_TOOL_CALLING,
+        PRED_HAS_TOOL_CONTINUATION_MODE,
+        PRED_HAS_RESPONSE_STORAGE_POLICY,
+        PRED_HAS_PROVIDER_CONNECTION_ID,
+        PRED_HAS_DEPLOYMENT_ID,
+        PRED_HAS_PARAMETER_ACTION,
+        PRED_HAS_FIXED_PARAMETER_VALUE,
+        PRED_HAS_ALLOWED_PARAMETER_VALUE,
+    ]
+    rows_by_concept = get_texts_for_concepts(
+        text_subject_ids,
+        predicates=text_predicates,
+        limit_per_concept=100,
+    )
+
+    # Relationship targets historically stored as text assertions remain
+    # supported by the legacy loader. If one is present where this bounded
+    # loader saw no canonical concept edge, delegate the whole snapshot to the
+    # compatibility path rather than silently returning a partial registry.
+    relationship_subjects = [
+        *[
+            (entry_id, entry_docs.get(entry_id), PRED_HAS_MODEL_API_PROFILE)
+            for entry_id in entry_ids
+        ],
+        *[
+            (model_id, model_and_profile_docs.get(model_id), PRED_HAS_PROVIDER)
+            for model_id in model_ids
+        ],
+        *[
+            (
+                profile_id,
+                model_and_profile_docs.get(profile_id),
+                PRED_HAS_MODEL_PARAMETER_CONSTRAINT,
+            )
+            for profile_id in profile_ids
+        ],
+        *[
+            (
+                constraint_id,
+                provider_and_constraint_docs.get(constraint_id),
+                PRED_CONSTRAINS_MODEL_PARAMETER,
+            )
+            for constraint_id in constraint_ids
+        ],
+    ]
+    for subject_id, subject_doc, predicate in relationship_subjects:
+        if _related_concept_ids_from_doc(subject_doc, predicate):
+            continue
+        if _batched_text_relationship_targets(
+            rows_by_concept, subject_id, predicate
+        ):
+            return None
+
+    models: list[dict[str, Any]] = []
+    for registry_entry_id in entry_ids:
+        entry_doc = entry_docs.get(registry_entry_id)
+        referred_models = _related_concept_ids_from_doc(entry_doc, PRED_REFERS_TO_MODEL)
+        if not referred_models:
+            continue
+        model_concept_id = referred_models[0]
+        model_doc = concept_docs.get(model_concept_id)
+        entry_provider_ids = _related_concept_ids_from_doc(model_doc, PRED_HAS_PROVIDER)
+        provider_concept_id = entry_provider_ids[0] if entry_provider_ids else None
+        provider = None
+        if provider_concept_id:
+            provider = _normalise_provider_name(
+                _first_batched_text(rows_by_concept, provider_concept_id, "hasName")
+                or provider_concept_id
+            )
+
+        aliases: list[str] = []
+        seen_aliases: set[str] = set()
+        for row in rows_by_concept.get(model_concept_id, ()):
+            if row.get("predicate") != "hasName":
+                continue
+            raw_text = row.get("text")
+            if not isinstance(raw_text, str):
+                continue
+            candidate = raw_text.strip().replace(": ", ":")
+            if not _looks_like_machine_model_name(candidate):
+                continue
+            for alias in (candidate, _strip_provider_prefix(candidate, provider)):
+                alias_key = _normalise_lookup_token(alias)
+                if alias_key and alias_key not in seen_aliases:
+                    seen_aliases.add(alias_key)
+                    aliases.append(alias.strip())
+
+        model_id = _first_batched_text(
+            rows_by_concept, registry_entry_id, PRED_HAS_MODEL_ID
+        ) or _derive_model_id_from_aliases(aliases=aliases, provider=provider)
+
+        api_profiles: list[dict[str, Any]] = []
+        for profile_concept_id in _related_concept_ids_from_doc(
+            entry_doc, PRED_HAS_MODEL_API_PROFILE
+        ):
+            constraints: list[dict[str, Any]] = []
+            for constraint_concept_id in _related_concept_ids_from_doc(
+                concept_docs.get(profile_concept_id),
+                PRED_HAS_MODEL_PARAMETER_CONSTRAINT,
+            ):
+                parameter_ids_for_constraint = _related_concept_ids_from_doc(
+                    concept_docs.get(constraint_concept_id),
+                    PRED_CONSTRAINS_MODEL_PARAMETER,
+                )
+                parameter_concept_id = (
+                    parameter_ids_for_constraint[0]
+                    if parameter_ids_for_constraint
+                    else None
+                )
+                allowed_values = [
+                    str(row.get("text")).strip()
+                    for row in rows_by_concept.get(constraint_concept_id, ())
+                    if row.get("predicate") == PRED_HAS_ALLOWED_PARAMETER_VALUE
+                    and isinstance(row.get("text"), str)
+                    and str(row.get("text")).strip()
+                ]
+                constraints.append(
+                    {
+                        "constraint_concept_id": constraint_concept_id,
+                        "parameter_concept_id": parameter_concept_id,
+                        "parameter": _normalise_parameter_name(parameter_concept_id),
+                        "action": _first_batched_text(
+                            rows_by_concept,
+                            constraint_concept_id,
+                            PRED_HAS_PARAMETER_ACTION,
+                        ),
+                        "fixed_value": _first_batched_text(
+                            rows_by_concept,
+                            constraint_concept_id,
+                            PRED_HAS_FIXED_PARAMETER_VALUE,
+                        ),
+                        "allowed_values": allowed_values,
+                        "profile_concept_id": profile_concept_id,
+                    }
+                )
+            api_profiles.append(
+                {
+                    "profile_concept_id": profile_concept_id,
+                    "api_surface": _first_batched_text(
+                        rows_by_concept, profile_concept_id, PRED_HAS_API_SURFACE
+                    ),
+                    "structured_tool_calling": _first_batched_text(
+                        rows_by_concept,
+                        profile_concept_id,
+                        PRED_HAS_STRUCTURED_TOOL_CALLING,
+                    ),
+                    "tool_continuation_mode": _first_batched_text(
+                        rows_by_concept,
+                        profile_concept_id,
+                        PRED_HAS_TOOL_CONTINUATION_MODE,
+                    ),
+                    "response_storage_policy": _first_batched_text(
+                        rows_by_concept,
+                        profile_concept_id,
+                        PRED_HAS_RESPONSE_STORAGE_POLICY,
+                    ),
+                    "connection_id": _first_batched_text(
+                        rows_by_concept,
+                        profile_concept_id,
+                        PRED_HAS_PROVIDER_CONNECTION_ID,
+                    ),
+                    "deployment_id": _first_batched_text(
+                        rows_by_concept,
+                        profile_concept_id,
+                        PRED_HAS_DEPLOYMENT_ID,
+                    ),
+                    "parameter_constraints": constraints,
+                }
+            )
+
+        entry: dict[str, Any] = {
+            "model_id": model_id,
+            "model_aliases": aliases,
+            "provider": provider,
+            "locality": "local" if provider == "ollama" else "external",
+            "concept_id": model_concept_id,
+            "registry_entry_id": registry_entry_id,
+            "api_profiles": api_profiles,
+        }
+        pricing = _parse_registry_json(
+            _first_batched_text(
+                rows_by_concept, registry_entry_id, PRED_HAS_MODEL_PRICING_JSON
+            )
+            or ""
+        )
+        capabilities = _parse_registry_json(
+            _first_batched_text(
+                rows_by_concept,
+                registry_entry_id,
+                PRED_HAS_MODEL_CAPABILITIES_JSON,
+            )
+            or ""
+        )
+        if pricing is not None:
+            entry["pricing"] = dict(pricing)
+        if capabilities is not None:
+            entry["capabilities"] = dict(capabilities)
+        models.append(entry)
+
+    if not models:
+        return None
+    return {
+        "registry_concept_id": _DEFAULT_REGISTRY_CONCEPT_ID,
+        "models": models,
+        "read_strategy": "batched_graph",
+        "read_phases": 6,
+        "canonical_read_batches": {"concepts": 5, "text_assertions": 1},
+        "loader_schema_version": _MODEL_REGISTRY_GRAPH_LOADER_SCHEMA_VERSION,
+    }
+
+
 def _strip_provider_prefix(model_id: str, provider: str | None = None) -> str:
     cleaned = _normalise_lookup_token(model_id)
     if not cleaned:
@@ -822,7 +1199,7 @@ def _resolve_model_entry_from_graph(
     return entry
 
 
-def _load_registry_from_vontology_graph(
+def _load_registry_from_vontology_graph_legacy(
     *, preferred_language: str | None = None
 ) -> Optional[Mapping[str, Any]]:
     registry_concept_id = _resolve_concept_id_by_name(
@@ -855,6 +1232,21 @@ def _load_registry_from_vontology_graph(
         "registry_concept_id": registry_concept_id,
         "models": models,
     }
+
+
+def _load_registry_from_vontology_graph(
+    *, preferred_language: str | None = None
+) -> Optional[Mapping[str, Any]]:
+    """Use the bounded batch loader with compatibility fallback."""
+
+    registry = _load_registry_from_vontology_graph_batched(
+        preferred_language=preferred_language
+    )
+    if registry is not None:
+        return registry
+    return _load_registry_from_vontology_graph_legacy(
+        preferred_language=preferred_language
+    )
 
 
 def _load_registry_from_vontology_json(
@@ -1280,10 +1672,14 @@ def preload_model_registry_snapshot(
     """Load represented profile authority before the HTTP server accepts calls."""
 
     started_at = time.time()
-    get_model_registry_snapshot(preferred_language=preferred_language)
+    snapshot = get_model_registry_snapshot(preferred_language=preferred_language)
     status = get_model_registry_snapshot_status(preferred_language=preferred_language)
     return {
         **status,
+        "read_strategy": snapshot.get("read_strategy"),
+        "read_phases": snapshot.get("read_phases"),
+        "loader_schema_version": snapshot.get("loader_schema_version"),
+        "model_count": len(snapshot.get("models") or ()),
         "preload_duration_ms": int((time.time() - started_at) * 1000),
     }
 

--- a/src/backend/services/publication_scope_profile_vontology_service.py
+++ b/src/backend/services/publication_scope_profile_vontology_service.py
@@ -9,6 +9,7 @@ decisions without a Python release or being undone by restart.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,7 @@ from .publication_scope_profile_service import (
 )
 from .text_value_service import (
     get_texts_for_concept,
+    get_texts_for_concepts,
     upsert_singleton_text_relation,
 )
 
@@ -87,12 +89,13 @@ def _ensure_concept(
     *,
     source_tag: str,
     managed_by: str,
+    concepts_by_id: dict[str, Mapping[str, Any]],
 ) -> tuple[str, bool]:
     concept_id = _text(spec.get("concept_id"))
     name = _text(spec.get("name"))
     if not concept_id.startswith("#V#") or not name:
         raise ValueError("publication_scope_seed_concept_identity_invalid")
-    if _get_concept(concept_id) is not None:
+    if concept_id in concepts_by_id:
         return concept_id, False
     attributes = dict(spec.get("attributes") or {})
     attributes.update(
@@ -114,10 +117,12 @@ def _ensure_concept(
         visibility_scope_mode="global_general",
         maintain_relationship_inverses=False,
     )
-    if _get_concept(concept_id) is None:
+    readback = _get_concept(concept_id)
+    if readback is None:
         raise RuntimeError(
             f"publication_scope_seed_concept_readback_failed:{concept_id}"
         )
+    concepts_by_id[concept_id] = dict(readback)
     return concept_id, True
 
 
@@ -126,13 +131,14 @@ def _merge_relationship(
     subject_concept_id: str,
     predicate: str,
     object_concept_ids: Sequence[str],
+    concepts_by_id: dict[str, Mapping[str, Any]],
 ) -> tuple[str, bool]:
     subject_id = _text(subject_concept_id)
     predicate_id = _text(predicate)
     targets = _strings(object_concept_ids)
     if not subject_id.startswith("#V#") or not predicate_id or not targets:
         raise ValueError("publication_scope_seed_relationship_invalid")
-    concept = _get_concept(subject_id)
+    concept = concepts_by_id.get(subject_id)
     if not isinstance(concept, Mapping):
         raise TypeError(f"publication_scope_seed_subject_missing:{subject_id}")
     relationships = dict(concept.get("relationships") or {})
@@ -144,7 +150,7 @@ def _merge_relationship(
             subject_id,
             {f"relationships.{predicate_id}": updated},
         )
-    readback = _get_concept(subject_id)
+    readback = _get_concept(subject_id) if changed else concept
     readback_relationships = (
         readback.get("relationships") if isinstance(readback, Mapping) else None
     )
@@ -157,6 +163,8 @@ def _merge_relationship(
         raise RuntimeError(
             f"publication_scope_seed_relationship_readback_failed:{subject_id}:{predicate_id}"
         )
+    if isinstance(readback, Mapping):
+        concepts_by_id[subject_id] = dict(readback)
     return f"{subject_id}:{predicate_id}", changed
 
 
@@ -184,6 +192,7 @@ def bootstrap_canonical_publication_scope_profiles(
 ) -> dict[str, Any]:
     """Materialise missing represented profiles and read them back exactly."""
 
+    started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
     source_tag = _text(bundle.get("source_tag")) or "JVNAUTOSCI-2671"
     managed_by = (
@@ -219,6 +228,43 @@ def bootstrap_canonical_publication_scope_profiles(
             }
         )
 
+    relationship_specs: list[Mapping[str, Any]] = [
+        spec for spec in bundle.get("relationships") or () if isinstance(spec, Mapping)
+    ]
+    for profile_spec in profile_specs:
+        profile_id = _text(profile_spec.get("profile_concept_id"))
+        for subject_id in _profile_subject_ids(profile_spec):
+            relationship_specs.append(
+                {
+                    "subject_concept_id": subject_id,
+                    "predicate": PUBLICATION_SCOPE_PROFILE_LINK_PREDICATE,
+                    "object_concept_ids": [profile_id],
+                }
+            )
+
+    required_concept_ids = _strings(
+        [
+            *[_text(spec.get("concept_id")) for spec in concept_specs],
+            *[_text(spec.get("subject_concept_id")) for spec in relationship_specs],
+        ]
+    )
+    concepts_by_id: dict[str, Mapping[str, Any]] = dict(
+        concept_service.get_concepts_by_concept_ids_exact(required_concept_ids)
+    )
+    profile_ids = [_text(spec.get("profile_concept_id")) for spec in profile_specs]
+    profile_query_metadata: dict[str, Any] = {}
+    profile_rows_by_id = get_texts_for_concepts(
+        profile_ids,
+        predicates=_PROFILE_TEXT_PREDICATE_ALIASES,
+        limit_per_concept=10,
+        query_metadata=profile_query_metadata,
+    )
+    profile_ids_with_payload = {
+        profile_id
+        for profile_id, rows in profile_rows_by_id.items()
+        if any(_text(row.get("text")) for row in rows)
+    }
+
     for spec in concept_specs:
         concept_id = _text(spec.get("concept_id"))
         try:
@@ -226,6 +272,7 @@ def bootstrap_canonical_publication_scope_profiles(
                 spec,
                 source_tag=source_tag,
                 managed_by=managed_by,
+                concepts_by_id=concepts_by_id,
             )
             (created_concept_ids if created else existing_concept_ids).append(
                 resolved_id
@@ -244,20 +291,6 @@ def bootstrap_canonical_publication_scope_profiles(
                 }
             )
 
-    relationship_specs: list[Mapping[str, Any]] = [
-        spec for spec in bundle.get("relationships") or () if isinstance(spec, Mapping)
-    ]
-    for profile_spec in profile_specs:
-        profile_id = _text(profile_spec.get("profile_concept_id"))
-        for subject_id in _profile_subject_ids(profile_spec):
-            relationship_specs.append(
-                {
-                    "subject_concept_id": subject_id,
-                    "predicate": PUBLICATION_SCOPE_PROFILE_LINK_PREDICATE,
-                    "object_concept_ids": [profile_id],
-                }
-            )
-
     for spec in relationship_specs:
         subject_id = _text(spec.get("subject_concept_id"))
         predicate = _text(spec.get("predicate"))
@@ -266,6 +299,7 @@ def bootstrap_canonical_publication_scope_profiles(
                 subject_concept_id=subject_id,
                 predicate=predicate,
                 object_concept_ids=_strings(spec.get("object_concept_ids")),
+                concepts_by_id=concepts_by_id,
             )
             relationship_ids.append(relationship_id)
             if changed:
@@ -308,7 +342,7 @@ def bootstrap_canonical_publication_scope_profiles(
             )
             continue
         try:
-            if force_profile_seed or not _profile_has_payload(profile_id):
+            if force_profile_seed or profile_id not in profile_ids_with_payload:
                 upsert_singleton_text_relation(
                     subject_concept_id=profile_id,
                     predicate=PUBLICATION_SCOPE_PROFILE_TEXT_PREDICATE,
@@ -323,11 +357,12 @@ def bootstrap_canonical_publication_scope_profiles(
                     },
                     garbage_collect=True,
                 )
+                if not _profile_has_payload(profile_id):
+                    raise RuntimeError("publication_scope_profile_text_readback_failed")
+                profile_ids_with_payload.add(profile_id)
                 seeded_profile_ids.append(profile_id)
             else:
                 preserved_profile_ids.append(profile_id)
-            if not _profile_has_payload(profile_id):
-                raise RuntimeError("publication_scope_profile_text_readback_failed")
         except (
             TypeError,
             ValueError,
@@ -355,6 +390,14 @@ def bootstrap_canonical_publication_scope_profiles(
         "preserved_profile_ids": preserved_profile_ids,
         "relationship_ids": relationship_ids,
         "changed_relationship_ids": changed_relationship_ids,
+        "changed": bool(
+            created_concept_ids or seeded_profile_ids or changed_relationship_ids
+        ),
+        "read_strategy": "batched_canonical_state",
+        "read_phases": 2,
+        "canonical_read_batches": {"concepts": 1, "text_assertions": 1},
+        "profile_query_metadata": profile_query_metadata,
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
         "errors": errors,
         "counts": {
             "concepts_created": len(created_concept_ids),

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -69,6 +69,18 @@ _shared_workflow_registry_lock = Lock()
 _shared_workflow_registry: WorkflowRegistry | None = None
 _shared_action_registry_lock = Lock()
 _shared_action_registry: ActionRegistry | None = None
+_core_workflow_prewarm_lock = Lock()
+_core_workflow_prewarm_generation = 0
+_core_workflow_prewarm_inflight: set[int] = set()
+
+
+def _advance_core_workflow_prewarm_generation() -> int:
+    """Cancel superseded prewarm work and return the new process generation."""
+
+    global _core_workflow_prewarm_generation
+    with _core_workflow_prewarm_lock:
+        _core_workflow_prewarm_generation += 1
+        return _core_workflow_prewarm_generation
 
 
 def _core_workflow_definition_prewarm_enabled() -> bool:
@@ -92,49 +104,76 @@ def _start_core_workflow_definition_prewarm(registry: WorkflowRegistry) -> bool:
     if not workflow_ids:
         return False
 
+    with _core_workflow_prewarm_lock:
+        generation = _core_workflow_prewarm_generation
+        if generation in _core_workflow_prewarm_inflight:
+            logger.info(
+                "[workflow_registry] Core workflow prewarm already in flight "
+                "for generation=%d; coalescing duplicate request.",
+                generation,
+            )
+            return False
+        _core_workflow_prewarm_inflight.add(generation)
+
     def _prewarm() -> None:
         start = time.monotonic()
         loaded: list[str] = []
         missing: list[str] = []
         errors: dict[str, str] = {}
-        for workflow_id in workflow_ids:
-            try:
-                definition = registry.get(workflow_id)
-                if definition is None:
-                    missing.append(workflow_id)
-                else:
-                    loaded.append(workflow_id)
-            except Exception as exc:
-                errors[workflow_id] = type(exc).__name__
-                logger.debug(
-                    "[workflow_registry] Core workflow prewarm failed for %s: %s",
-                    workflow_id,
-                    exc,
-                    exc_info=True,
-                )
-        elapsed_ms = (time.monotonic() - start) * 1000.0
-        logger.info(
-            "[workflow_registry] Core workflow prewarm completed loaded=%d "
-            "missing=%d errors=%d duration_ms=%.0f",
-            len(loaded),
-            len(missing),
-            len(errors),
-            elapsed_ms,
-        )
-        if missing or errors:
-            logger.warning(
-                "[workflow_registry] Core workflow prewarm incomplete missing=%s "
-                "errors=%s",
-                missing[:10],
-                errors,
+        cancelled = False
+        try:
+            for workflow_id in workflow_ids:
+                with _core_workflow_prewarm_lock:
+                    if generation != _core_workflow_prewarm_generation:
+                        cancelled = True
+                        break
+                try:
+                    definition = registry.get(workflow_id)
+                    if definition is None:
+                        missing.append(workflow_id)
+                    else:
+                        loaded.append(workflow_id)
+                except Exception as exc:
+                    errors[workflow_id] = type(exc).__name__
+                    logger.debug(
+                        "[workflow_registry] Core workflow prewarm failed for %s: %s",
+                        workflow_id,
+                        exc,
+                        exc_info=True,
+                    )
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            logger.info(
+                "[workflow_registry] Core workflow prewarm completed generation=%d "
+                "loaded=%d missing=%d errors=%d cancelled=%s duration_ms=%.0f",
+                generation,
+                len(loaded),
+                len(missing),
+                len(errors),
+                cancelled,
+                elapsed_ms,
             )
+            if missing or errors:
+                logger.warning(
+                    "[workflow_registry] Core workflow prewarm incomplete missing=%s "
+                    "errors=%s",
+                    missing[:10],
+                    errors,
+                )
+        finally:
+            with _core_workflow_prewarm_lock:
+                _core_workflow_prewarm_inflight.discard(generation)
 
     thread = threading.Thread(
         target=_prewarm,
         name="workflow-registry-core-prewarm",
         daemon=True,
     )
-    thread.start()
+    try:
+        thread.start()
+    except Exception:
+        with _core_workflow_prewarm_lock:
+            _core_workflow_prewarm_inflight.discard(generation)
+        raise
     return True
 
 
@@ -253,6 +292,8 @@ def get_shared_workflow_registry_read_only(
     created_registry = False
     with _shared_workflow_registry_lock:
         if force_rebuild or _shared_workflow_registry is None:
+            if force_rebuild and _shared_workflow_registry is not None:
+                _advance_core_workflow_prewarm_generation()
             _shared_workflow_registry = build_workflow_registry_read_only(
                 defer_parity_work=defer_parity_work,
                 start_deferred_registry_work=start_deferred_registry_work,
@@ -297,6 +338,11 @@ def invalidate_shared_workflow_registry_read_only() -> dict[str, Any]:
     with _shared_workflow_registry_lock:
         had_registry = _shared_workflow_registry is not None
         _shared_workflow_registry = None
+        prewarm_generation = (
+            _advance_core_workflow_prewarm_generation()
+            if had_registry
+            else _core_workflow_prewarm_generation
+        )
     capability_index_invalidated = False
     try:
         from ...services.workflow_capability_service import (
@@ -314,6 +360,7 @@ def invalidate_shared_workflow_registry_read_only() -> dict[str, Any]:
         "success": True,
         "cache": "shared_workflow_registry_read_only",
         "had_cached_value": had_registry,
+        "prewarm_generation": prewarm_generation,
         "capability_index_invalidated": capability_index_invalidated,
     }
 

--- a/src/workflows/von/main.py
+++ b/src/workflows/von/main.py
@@ -369,10 +369,14 @@ def main():
         registry_preload = preload_model_registry_snapshot()
         logger.info(
             "Model registry startup preload ready=%s source=%s "
-            "cache_state=%s duration_ms=%s.",
+            "cache_state=%s read_strategy=%s read_phases=%s models=%s "
+            "duration_ms=%s.",
             registry_preload.get("ready"),
             registry_preload.get("source"),
             registry_preload.get("cache_state"),
+            registry_preload.get("read_strategy"),
+            registry_preload.get("read_phases"),
+            registry_preload.get("model_count"),
             registry_preload.get("preload_duration_ms"),
         )
     except Exception as exc:

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -4,11 +4,12 @@ from typing import Any
 
 import pytest
 
+import src.backend.services.concept_summary_field_resolver as resolver_module
+import src.backend.services.concept_summary_field_vontology_service as summary_seed_module
 from src.backend.services import concept_service
 from src.backend.services.concept_summary_field_vontology_service import (
     bootstrap_canonical_concept_summary_fields,
 )
-import src.backend.services.concept_summary_field_resolver as resolver_module
 
 
 @pytest.fixture
@@ -163,3 +164,65 @@ def test_summary_field_bootstrap_materialises_vontology_metadata(
         "affiliation",
         "authored_work",
     )
+
+
+def test_summary_field_bootstrap_uses_batched_noop_fast_path(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = bootstrap_canonical_concept_summary_fields()
+    assert first["success"] is True
+
+    concept_reads = 0
+    text_reads = 0
+    original_concept_read = concept_service.get_concepts_by_concept_ids_exact
+    original_text_read = summary_seed_module.get_texts_for_concepts
+
+    def _concept_read(concept_ids):
+        nonlocal concept_reads
+        concept_reads += 1
+        return original_concept_read(concept_ids)
+
+    def _text_read(*args, **kwargs):
+        nonlocal text_reads
+        text_reads += 1
+        return original_text_read(*args, **kwargs)
+
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        _concept_read,
+    )
+    monkeypatch.setattr(summary_seed_module, "get_texts_for_concepts", _text_read)
+    monkeypatch.setattr(
+        summary_seed_module,
+        "upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current singleton text must not be rewritten")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "create_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current concepts must not be recreated")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "update_concept",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current relationships must not be rewritten")
+        ),
+    )
+
+    second = bootstrap_canonical_concept_summary_fields()
+
+    assert second["success"] is True
+    assert second["changed"] is False
+    assert second["read_strategy"] == "batched_canonical_state"
+    assert second["read_phases"] == 2
+    assert second["counts"]["field_configs_changed"] == 0
+    assert second["counts"]["type_bindings_changed"] == 0
+    assert concept_reads == 1
+    assert text_reads == 1

--- a/tests/backend/test_model_registry_service.py
+++ b/tests/backend/test_model_registry_service.py
@@ -13,6 +13,129 @@ def _build_text_row_lookup(text_map):
     return _get_text_rows
 
 
+def test_batched_graph_loader_preserves_registry_semantics_with_bounded_reads(
+    monkeypatch,
+) -> None:
+    import src.backend.services.model_registry_service as mod
+    from src.backend.services import concept_service, text_value_service
+
+    relation_map = {
+        ("#V#default_model_registry", mod.PRED_HAS_MODEL_ENTRY): [
+            "#V#test_registry_entry"
+        ],
+        ("#V#test_registry_entry", mod.PRED_REFERS_TO_MODEL): ["#V#test_model"],
+        ("#V#test_registry_entry", mod.PRED_HAS_MODEL_API_PROFILE): ["#V#test_profile"],
+        ("#V#test_model", mod.PRED_HAS_PROVIDER): ["#V#test_provider"],
+        ("#V#test_profile", mod.PRED_HAS_MODEL_PARAMETER_CONSTRAINT): [
+            "#V#test_constraint"
+        ],
+        ("#V#test_constraint", mod.PRED_CONSTRAINS_MODEL_PARAMETER): [
+            "#V#temperature_parameter"
+        ],
+    }
+    concept_docs: dict[str, dict] = {}
+    for (subject_id, predicate), targets in relation_map.items():
+        concept_docs.setdefault(
+            subject_id,
+            {"concept_id": subject_id, "relationships": {}},
+        )["relationships"][predicate] = targets
+        for target in targets:
+            concept_docs.setdefault(
+                target,
+                {"concept_id": target, "relationships": {}},
+            )
+
+    text_map = {
+        ("#V#test_provider", "hasName"): ["OpenAI Provider"],
+        ("#V#test_model", "hasName"): ["openai:test-model", "test-model"],
+        ("#V#test_registry_entry", mod.PRED_HAS_MODEL_ID): ["test-model"],
+        ("#V#test_profile", mod.PRED_HAS_API_SURFACE): ["responses"],
+        ("#V#test_profile", mod.PRED_HAS_STRUCTURED_TOOL_CALLING): ["required"],
+        ("#V#test_constraint", mod.PRED_HAS_PARAMETER_ACTION): ["omit"],
+    }
+    concept_read_batches: list[tuple[str, ...]] = []
+    text_read_calls = 0
+
+    def _bulk_concepts(concept_ids):
+        batch = tuple(dict.fromkeys(concept_ids))
+        concept_read_batches.append(batch)
+        return {
+            concept_id: concept_docs[concept_id]
+            for concept_id in batch
+            if concept_id in concept_docs
+        }
+
+    def _bulk_text(subject_ids, *, predicates, **_kwargs):
+        nonlocal text_read_calls
+        text_read_calls += 1
+        predicate_set = set(predicates)
+        return {
+            subject_id: [
+                {"predicate": predicate, "text": value}
+                for (candidate_id, predicate), values in text_map.items()
+                if candidate_id == subject_id and predicate in predicate_set
+                for value in values
+            ]
+            for subject_id in dict.fromkeys(subject_ids)
+        }
+
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        _bulk_concepts,
+    )
+    monkeypatch.setattr(text_value_service, "get_texts_for_concepts", _bulk_text)
+
+    snapshot = mod._load_registry_from_vontology_graph_batched()
+
+    assert snapshot is not None
+    assert snapshot["read_strategy"] == "batched_graph"
+    assert snapshot["read_phases"] == 6
+    assert len(concept_read_batches) == 5
+    assert text_read_calls == 1
+    assert snapshot["models"] == [
+        {
+            "model_id": "test-model",
+            "model_aliases": ["openai:test-model", "test-model"],
+            "provider": "openai",
+            "locality": "external",
+            "concept_id": "#V#test_model",
+            "registry_entry_id": "#V#test_registry_entry",
+            "api_profiles": [
+                {
+                    "profile_concept_id": "#V#test_profile",
+                    "api_surface": "responses",
+                    "structured_tool_calling": "required",
+                    "tool_continuation_mode": None,
+                    "response_storage_policy": None,
+                    "connection_id": None,
+                    "deployment_id": None,
+                    "parameter_constraints": [
+                        {
+                            "constraint_concept_id": "#V#test_constraint",
+                            "parameter_concept_id": "#V#temperature_parameter",
+                            "parameter": "temperature",
+                            "action": "omit",
+                            "fixed_value": None,
+                            "allowed_values": [],
+                            "profile_concept_id": "#V#test_profile",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    del concept_docs["#V#test_registry_entry"]["relationships"][
+        mod.PRED_HAS_MODEL_API_PROFILE
+    ]
+    text_map[
+        ("#V#test_registry_entry", mod.PRED_HAS_MODEL_API_PROFILE)
+    ] = ["#V#test_profile"]
+
+    assert mod._load_registry_from_vontology_graph_batched() is None
+
+
 def test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_publication_scope_profile_service.py
+++ b/tests/backend/test_publication_scope_profile_service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+import src.backend.services.publication_scope_profile_vontology_service as publication_seed_module
 from src.backend.services import concept_service
 from src.backend.services.publication_scope_profile_service import (
     PUBLICATION_SCOPE_PROFILE_LINK_PREDICATE,
@@ -527,10 +528,59 @@ def test_live_profile_edit_changes_fresh_decision_and_bootstrap_preserves_it(
 
 def test_bootstrap_is_idempotent_when_profiles_are_unchanged(
     publication_profile_store: None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    concept_reads = 0
+    text_reads = 0
+    original_concept_read = concept_service.get_concepts_by_concept_ids_exact
+    original_text_read = publication_seed_module.get_texts_for_concepts
+
+    def _concept_read(concept_ids):
+        nonlocal concept_reads
+        concept_reads += 1
+        return original_concept_read(concept_ids)
+
+    def _text_read(*args, **kwargs):
+        nonlocal text_reads
+        text_reads += 1
+        return original_text_read(*args, **kwargs)
+
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        _concept_read,
+    )
+    monkeypatch.setattr(publication_seed_module, "get_texts_for_concepts", _text_read)
+    monkeypatch.setattr(
+        publication_seed_module,
+        "upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current profile payloads must not be rewritten")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "create_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current concepts must not be recreated")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "update_concept",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("current relationships must not be rewritten")
+        ),
+    )
+
     second = bootstrap_canonical_publication_scope_profiles()
     assert second["success"] is True
+    assert second["changed"] is False
+    assert second["read_strategy"] == "batched_canonical_state"
+    assert second["read_phases"] == 2
     assert second["counts"]["concepts_created"] == 0
     assert second["counts"]["profiles_seeded"] == 0
     assert second["counts"]["profiles_preserved"] == 19
     assert second["counts"]["relationships_changed"] == 0
+    assert concept_reads == 1
+    assert text_reads == 1

--- a/tests/backend/test_utils_flask_orchestrator_startup.py
+++ b/tests/backend/test_utils_flask_orchestrator_startup.py
@@ -114,6 +114,45 @@ def test_retired_orchestrator_startup_does_not_build_or_spawn(monkeypatch):
     assert isinstance(status["started_at"], str)
 
 
+def test_optional_prewarm_keeps_large_vontology_tree_demand_loaded(monkeypatch):
+    import src.backend.server.utils_flask as utils_flask
+
+    listed_models: list[bool] = []
+    log_messages: list[str] = []
+
+    class _Logger:
+        def info(self, message, *_args):
+            log_messages.append(message)
+
+        def warning(self, *_args, **_kwargs):
+            return None
+
+    class _SynchronousThread:
+        def __init__(self, *, target, name=None, daemon=None):
+            self._target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            self._target()
+
+    class _App:
+        config = {"LIST_MODELS_FUNC": lambda: listed_models.append(True) or ["model"]}
+        logger = _Logger()
+
+        def test_client(self):
+            raise AssertionError("tree endpoint must not be called by default")
+
+    monkeypatch.delenv("VON_PREWARM_DISABLE", raising=False)
+    monkeypatch.delenv("VON_PREWARM_TREE_ENABLE", raising=False)
+    monkeypatch.setattr(utils_flask.threading, "Thread", _SynchronousThread)
+
+    utils_flask._start_prewarm(_App())
+
+    assert listed_models == [True]
+    assert any("demand-loaded" in message for message in log_messages)
+
+
 def test_create_flask_app_defers_durable_workflow_startup(monkeypatch):
     _install_google_oauth_stubs()
 

--- a/tests/backend/test_workflow_registry_factory_parity.py
+++ b/tests/backend/test_workflow_registry_factory_parity.py
@@ -137,12 +137,117 @@ def test_core_workflow_definition_prewarm_resolves_conversation_turn_family(
         "_core_workflow_definition_prewarm_enabled",
         lambda: True,
     )
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_generation", 0)
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_inflight", set())
     monkeypatch.setattr(registry_factory.threading, "Thread", _SynchronousThread)
 
     started = registry_factory._start_core_workflow_definition_prewarm(_FakeRegistry())
 
     assert started is True
     assert warmed == list(registry_factory.CONVERSATION_TURN_WORKFLOW_IDS)
+
+
+def test_core_workflow_definition_prewarm_coalesces_same_generation(monkeypatch):
+    queued_targets: list[object] = []
+
+    class _DeferredThread:
+        def __init__(self, *, target, name=None, daemon=None):
+            queued_targets.append(target)
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            return None
+
+    class _FakeRegistry:
+        def get(self, _workflow_id: str):
+            return object()
+
+    monkeypatch.setattr(
+        registry_factory,
+        "_core_workflow_definition_prewarm_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_generation", 7)
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_inflight", set())
+    monkeypatch.setattr(registry_factory.threading, "Thread", _DeferredThread)
+
+    first = registry_factory._start_core_workflow_definition_prewarm(_FakeRegistry())
+    duplicate = registry_factory._start_core_workflow_definition_prewarm(
+        _FakeRegistry()
+    )
+
+    assert first is True
+    assert duplicate is False
+    assert len(queued_targets) == 1
+    assert registry_factory._core_workflow_prewarm_inflight == {7}
+
+    queued_targets[0]()
+    assert registry_factory._core_workflow_prewarm_inflight == set()
+
+
+def test_core_workflow_definition_prewarm_stops_after_generation_changes(
+    monkeypatch,
+):
+    warmed: list[str] = []
+
+    class _FakeRegistry:
+        def get(self, workflow_id: str):
+            warmed.append(workflow_id)
+            registry_factory._advance_core_workflow_prewarm_generation()
+            return object()
+
+    class _SynchronousThread:
+        def __init__(self, *, target, name=None, daemon=None):
+            self._target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(
+        registry_factory,
+        "_core_workflow_definition_prewarm_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_generation", 3)
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_inflight", set())
+    monkeypatch.setattr(registry_factory.threading, "Thread", _SynchronousThread)
+
+    started = registry_factory._start_core_workflow_definition_prewarm(_FakeRegistry())
+
+    assert started is True
+    assert warmed == [registry_factory.CONVERSATION_TURN_WORKFLOW_IDS[0]]
+    assert registry_factory._core_workflow_prewarm_generation == 4
+    assert registry_factory._core_workflow_prewarm_inflight == set()
+
+
+def test_core_workflow_definition_prewarm_releases_singleflight_on_start_error(
+    monkeypatch,
+):
+    class _BrokenThread:
+        def __init__(self, *, target, name=None, daemon=None):
+            self._target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            raise RuntimeError("thread_unavailable")
+
+    monkeypatch.setattr(
+        registry_factory,
+        "_core_workflow_definition_prewarm_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_generation", 5)
+    monkeypatch.setattr(registry_factory, "_core_workflow_prewarm_inflight", set())
+    monkeypatch.setattr(registry_factory.threading, "Thread", _BrokenThread)
+
+    with pytest.raises(RuntimeError, match="thread_unavailable"):
+        registry_factory._start_core_workflow_definition_prewarm(object())
+
+    assert registry_factory._core_workflow_prewarm_inflight == set()
 
 
 def test_invalidate_shared_workflow_registry_read_only_resets_capability_index(


### PR DESCRIPTION
Merge decision: ready — this bounded slice removes repeated remote reads without changing canonical model, seed, or workflow authority.

## User outcome

Ordinary startup and cold recovery impose fewer Atlas round trips and avoid duplicate background work while still deriving current state from Vontology and canonical text relations.

## Material changes

- Add a bounded exact-ID bulk concept read and use it with joined text reads for unchanged summary-field and publication-profile checks.
- Hydrate the seven-model represented registry in five concept batches plus one joined text read; retain a legacy representation fallback.
- Coalesce same-generation core workflow prewarms and cancel superseded generations between definition loads.
- Keep the large Vontology tree demand-loaded by default with an explicit opt-in prewarm flag.
- Expose read shape, duration, model count, and change/no-change telemetry.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2681

## Evidence

- 85 targeted tests passed across seed bootstraps, model registry and policy resolution, workflow registry/prewarm, and Flask startup.
- Current configured store, read-only: legacy and batched registry outputs were semantically equal for all seven models; legacy hydration took 77,146 ms and batched hydration took 3,558 ms.
- Separate cold batched sample took 12,843 ms versus the Jira baseline of 73,821 ms.
- Write-disabled live probes proved current summary and publication bundles execute zero changes and zero errors in their batched paths.
- One broader unrelated test fails unchanged in isolation: test_repo_seed_workflow_definitions_include_gmail_arxiv_discovery_metadata expects wording absent from the current seed purpose. This candidate touches neither that test nor seed.

## Ship boundary

- **Minimum ship criteria:** exact registry semantic equivalence; bounded batch shape; unchanged seed paths perform no writes; duplicate/superseded prewarm regression tests pass; required CI passes.
- **Stop-ship conditions:** incomplete or changed registry resolution, seed overwrite, stale prewarm publication, required CI failure, or a candidate-caused material startup regression.
- **Non-blocking observations:** the overall Jira remains In Progress. Dependency-generation or change-stream receipts, complete unchanged-startup scan elimination, three repeated 10-second-or-less restarts, and per-workflow incremental indexing are not implemented by this slice.
- **Non-goals:** deployment or live activation; model/provider policy changes; replacing Vontology authority; implementing JVNAUTOSCI-2390 workflow indexing.