### PR TITLE
JVNAUTOSCI-2682: simplify conversation history controls

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -19,7 +19,7 @@ import hashlib
 from pathlib import Path
 from urllib.parse import unquote
 from dataclasses import asdict, is_dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterator, Mapping, Sequence, cast
 from ...workflows.durable.registry_factory import build_workflow_registry_read_only
 from ...workflows.durable.startup import get_instance_manager
@@ -15646,6 +15646,9 @@ def history_sessions():
         or chat_history_service.CHAT_SESSION_AGENT_VISIBILITY_INCLUDE
     )
     keep_newest_agent_created = request.args.get("keep_newest_agent_created")
+    recent_window_days = request.args.get("recent_window_days", type=int)
+    if recent_window_days is not None:
+        recent_window_days = max(1, min(recent_window_days, 3650))
     active_session_id: str | None = None
     try:
         from ...services.shared_conversation_service import (
@@ -15695,6 +15698,26 @@ def history_sessions():
             agent_visibility=agent_visibility,
             keep_newest_agent_created=keep_newest_agent_created,
         )
+        older_than_window_count: int | None = None
+        if recent_window_days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=recent_window_days)
+            try:
+                older_than_window_count = (
+                    chat_history_service.get_chat_history_sessions_older_than_count(
+                        user_concept_id,
+                        cutoff=cutoff,
+                        namespace=namespace,
+                        include_legacy=include_legacy,
+                        agent_visibility=agent_visibility,
+                    )
+                )
+            except chat_history_service.ChatHistoryServiceError as exc:
+                current_app.logger.warning(
+                    "history_sessions: older-than-window count unavailable for %s: %s",
+                    user_concept_id,
+                    exc,
+                )
+                warnings.append("older_than_window_count_unavailable")
         sessions = (
             session_result.get("sessions") if isinstance(session_result, dict) else []
         )
@@ -15936,6 +15959,13 @@ def history_sessions():
             "sessions": combined,
             "active_session_id": active_session_id,
         }
+        if older_than_window_count is not None:
+            response_payload.update(
+                {
+                    "older_than_window_count": older_than_window_count,
+                    "recent_window_days": recent_window_days,
+                }
+            )
         if isinstance(session_result, dict):
             response_payload.update(
                 {

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -3958,6 +3958,106 @@ def get_chat_history_session_count(
         ) from e
 
 
+def get_chat_history_sessions_older_than_count(
+    user_id: str,
+    *,
+    cutoff: datetime,
+    namespace: Optional[str] = None,
+    include_legacy: bool = True,
+    agent_visibility: Any = CHAT_SESSION_AGENT_VISIBILITY_INCLUDE,
+) -> int:
+    """Count actor-owned, untrashed sessions older than a recency cutoff.
+
+    This deliberately counts through a small metadata query instead of deriving
+    the value from the bounded session-tab result window.  The UI can therefore
+    explain that older conversations exist without materialising their history.
+    """
+
+    if not user_id:
+        raise ChatHistoryServiceError("user_id is required.")
+    if not isinstance(cutoff, datetime):
+        raise ChatHistoryServiceError("cutoff must be a datetime.")
+
+    cutoff_utc = cutoff
+    if cutoff_utc.tzinfo is None:
+        cutoff_utc = cutoff_utc.replace(tzinfo=timezone.utc)
+    else:
+        cutoff_utc = cutoff_utc.astimezone(timezone.utc)
+
+    visibility = _normalise_chat_session_agent_visibility(agent_visibility)
+    chat_history_coll = get_chat_history_collection_service(read_only=True)
+    if chat_history_coll is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    _guard_chat_history_read("get_chat_history_sessions_older_than_count")
+
+    query = build_chat_history_query(
+        user_id=user_id,
+        namespace=namespace,
+        include_legacy=include_legacy,
+    )
+    query["trashed_at"] = None
+    clauses: list[Dict[str, Any]] = [
+        {
+            "$or": [
+                {"updated_at": {"$lt": cutoff_utc}},
+                {
+                    "updated_at": {"$in": [None, ""]},
+                    "created_at": {"$lt": cutoff_utc},
+                },
+            ]
+        }
+    ]
+    agent_created_clause: Dict[str, Any] = {
+        "$or": [
+            {
+                "is_agent_created": {
+                    "$in": [True, "true", "1", "yes", "on", "y"]
+                }
+            },
+            {"origin_kind": {"$in": sorted(CHAT_SESSION_AGENT_CREATED_ORIGIN_KINDS)}},
+            {
+                "test_artifact_kind": {
+                    "$exists": True,
+                    "$nin": [None, "", " "],
+                }
+            },
+        ]
+    }
+    if visibility == CHAT_SESSION_AGENT_VISIBILITY_EXCLUDE:
+        clauses.append({"$nor": [agent_created_clause]})
+    elif visibility == CHAT_SESSION_AGENT_VISIBILITY_ONLY:
+        clauses.append(agent_created_clause)
+    query["$and"] = clauses
+
+    try:
+        summary = next(
+            _read_aggregate(
+                chat_history_coll,
+                [{"$match": query}, {"$count": "session_count"}],
+                operation="get_chat_history_sessions_older_than_count.aggregate",
+            ),
+            None,
+        )
+        count = 0
+        if isinstance(summary, dict):
+            raw_count = summary.get("session_count")
+            if isinstance(raw_count, int) and raw_count >= 0:
+                count = raw_count
+        _record_chat_history_read_success()
+        return count
+    except PyMongoError as e:
+        _record_chat_history_read_failure(
+            "get_chat_history_sessions_older_than_count", e
+        )
+        logger.error(
+            "Error retrieving older chat history session count: %s", e, exc_info=True
+        )
+        raise ChatHistoryServiceError(
+            f"Could not retrieve older chat history session count: {e}"
+        ) from e
+
+
 def _build_session_summary_from_metadata(
     doc: Dict[str, Any],
     *,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1060,7 +1060,6 @@ let _pinnedSessionsUserKey = null; // Track current user's localStorage key
 let _agentCreatedSessionsVisibleUserKey = null;
 let chatSessionLastAccessedMap = new Map();
 let _chatSessionLastAccessedUserKey = null;
-let showAllConversationHistoryMatches = false;
 let chatSessionTabsLayout = CHAT_SESSION_TABS_LAYOUT_HORIZONTAL;
 let chatSessionTabsLayoutMediaQuery = null;
 let chatSessionTabsLayoutMediaListenerBound = false;
@@ -1070,12 +1069,9 @@ let agentCreatedSessionVisibilityState = {
     newestVisibleSessionId: null
 };
 let serverAgentCreatedSessionVisibilityState = null;
-let conversationSearchState = {
-    query: '',
-    trashedOnly: false,
-    nextCursor: null,
-    results: []
-};
+let serverConversationHistoryRecencyState = null;
+let expandedConversationHistoryLimit = null;
+let expandedConversationHistoryBaseLimit = null;
 
 /**
  * Get the user-scoped localStorage key for hidden sessions.
@@ -1371,10 +1367,12 @@ function saveAgentCreatedSessionsVisibilityPreference() {
 
 function buildChatSessionTabsFetchUrl() {
     const params = new URLSearchParams();
+    const conversationHistorySettings = loadConversationHistorySettings((key) => safeLocalStorageGet(key));
     params.set('limit', String(CHAT_SESSION_TABS_FETCH_LIMIT));
     params.set('summary', 'light');
     params.set('agent_visibility', showAgentCreatedSessions ? 'include' : 'exclude');
     params.set('keep_newest_agent_created', 'true');
+    params.set('recent_window_days', String(conversationHistorySettings.recentWindowDays));
     return `/von/history/sessions?${params.toString()}`;
 }
 
@@ -1406,6 +1404,18 @@ function normaliseServerAgentCreatedVisibilityState(data) {
         totalAfterVisibility: readNonNegativeCount(data.total_after_agent_visibility),
         hiddenByLimitCount: readNonNegativeCount(data.hidden_by_limit_count),
         rawSessionCount: readNonNegativeCount(data.raw_session_count)
+    };
+}
+
+function normaliseServerConversationHistoryRecencyState(data) {
+    const recentWindowDays = Number(data?.recent_window_days);
+    const olderThanWindowCount = Number(data?.older_than_window_count);
+    if (!Number.isFinite(recentWindowDays) || !Number.isFinite(olderThanWindowCount)) {
+        return null;
+    }
+    return {
+        recentWindowDays: Math.max(1, Math.trunc(recentWindowDays)),
+        olderThanWindowCount: Math.max(0, Math.trunc(olderThanWindowCount))
     };
 }
 
@@ -1770,6 +1780,9 @@ async function deleteConversation(sessionId) {
         }
         renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
         showToast('Conversation moved to Trash', 'success');
+        document.dispatchEvent(new CustomEvent('von:conversation-trash-changed', {
+            detail: { action: 'trashed', sessionId }
+        }));
         return true;
     } catch (e) {
         console.error('[chatTab] moveConversationToTrash error:', e);
@@ -1778,161 +1791,26 @@ async function deleteConversation(sessionId) {
     }
 }
 
-async function restoreConversation(sessionId) {
-    const sid = String(sessionId || '').trim();
-    if (!sid) return false;
-    try {
-        const response = await fetch('/von/api/session/delete_chat_session', {
-            method: 'POST',
-            headers: buildChatFetchHeaders({ 'Content-Type': 'application/json' }),
-            body: JSON.stringify({ session_id: sid, action: 'restore' })
-        });
-        const data = await response.json().catch(() => ({}));
-        if (!response.ok || data?.status !== 'restored' || data?.trashed !== false) {
-            throw new Error(data?.error || 'Conversation restore could not be verified.');
-        }
-        conversationSearchState.results = conversationSearchState.results.filter(
-            row => row?.session_id !== sid
-        );
-        renderConversationSearchResults();
-        scheduleChatSessionTabsRefresh(true);
-        showToast('Conversation restored', 'success');
-        return true;
-    } catch (error) {
-        showToast(error?.message || 'Failed to restore conversation', 'error');
-        return false;
+async function openConversationSearchResult(row) {
+    const sessionId = String(row?.session_id || row?.id || '').trim();
+    if (!sessionId) return { ok: false, error: 'session_id required' };
+    const existing = sessionTabsCache.find(session => session?.session_id === sessionId) || {};
+    const canonical = normaliseConversationSessionViewModel({ ...existing, ...row, session_id: sessionId });
+    sessionTabsCache = normaliseConversationSessionViewModels([
+        ...sessionTabsCache.filter(session => session?.session_id !== sessionId),
+        canonical
+    ]);
+    activateTab('chatTab');
+    if (activeChatSessionId === sessionId) {
+        renderChatSessionTabs(sessionTabsCache, sessionId);
+        return { ok: true, alreadyActive: true };
     }
-}
-
-function renderConversationSearchResults() {
-    const panel = document.getElementById('conversationSearchPanel');
-    const status = document.getElementById('conversationSearchStatus');
-    const results = document.getElementById('conversationSearchResults');
-    const more = document.getElementById('conversationSearchMore');
-    if (!panel || !status || !results || !more) return;
-    panel.hidden = false;
-    results.innerHTML = '';
-    const rows = Array.isArray(conversationSearchState.results)
-        ? conversationSearchState.results
-        : [];
-    status.textContent = rows.length
-        ? `${rows.length} conversation${rows.length === 1 ? '' : 's'}`
-        : (conversationSearchState.trashedOnly ? 'Trash is empty.' : 'No matching conversations.');
-    rows.forEach((row) => {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'conversation-search-result';
-        const title = document.createElement('button');
-        title.type = 'button';
-        title.className = 'conversation-search-result-title';
-        title.textContent = getSessionDisplayName(row, { fallbackToId: false }) || 'Unnamed conversation';
-        title.addEventListener('click', () => {
-            const sid = String(row?.session_id || '').trim();
-            if (!sid || conversationSearchState.trashedOnly) return;
-            if (!sessionTabsCache.some(session => session?.session_id === sid)) {
-                sessionTabsCache = normaliseConversationSessionViewModels([...sessionTabsCache, row]);
-            }
-            void switchToChatSession(sid);
-        });
-        const actions = document.createElement('div');
-        actions.className = 'conversation-search-result-actions';
-        const date = document.createElement('span');
-        date.className = 'conversation-search-result-date';
-        date.textContent = formatSessionTimestamp(row?.last_message_at || row?.created_at) || '';
-        actions.appendChild(date);
-        if (conversationSearchState.trashedOnly) {
-            const restore = document.createElement('button');
-            restore.type = 'button';
-            restore.textContent = 'Restore';
-            restore.addEventListener('click', () => { void restoreConversation(row?.session_id); });
-            actions.appendChild(restore);
-        }
-        wrapper.append(title, actions);
-        const snippetText = row?.match?.snippet;
-        if (typeof snippetText === 'string' && snippetText.trim()) {
-            const snippet = document.createElement('div');
-            snippet.className = 'conversation-search-result-snippet';
-            snippet.textContent = snippetText;
-            wrapper.appendChild(snippet);
-        }
-        results.appendChild(wrapper);
-    });
-    more.hidden = !conversationSearchState.nextCursor;
-}
-
-async function performConversationSearch({ append = false, trashedOnly = null } = {}) {
-    const input = document.getElementById('conversationSearchInput');
-    const panel = document.getElementById('conversationSearchPanel');
-    const status = document.getElementById('conversationSearchStatus');
-    const requestedTrash = typeof trashedOnly === 'boolean'
-        ? trashedOnly
-        : conversationSearchState.trashedOnly;
-    const query = requestedTrash ? '*' : String(input?.value || '').trim();
-    if (!query) {
-        if (panel) panel.hidden = true;
-        return;
-    }
-    if (panel) panel.hidden = false;
-    if (status) status.textContent = requestedTrash ? 'Loading Trash…' : 'Searching…';
-    const params = new URLSearchParams({
-        q: query,
-        match_mode: requestedTrash ? 'lexical' : 'hybrid',
-        page_size: '20',
-        trashed_only: requestedTrash ? 'true' : 'false'
-    });
-    if (append && conversationSearchState.nextCursor) {
-        params.set('cursor', conversationSearchState.nextCursor);
-    }
-    try {
-        const response = await fetch(`/von/api/session/conversation_search?${params.toString()}`, {
-            cache: 'no-store',
-            headers: buildChatFetchHeaders()
-        });
-        const data = await response.json().catch(() => ({}));
-        if (!response.ok) throw new Error(data?.error || 'Conversation search failed.');
-        conversationSearchState = {
-            query,
-            trashedOnly: requestedTrash,
-            nextCursor: data?.next_cursor || null,
-            results: append
-                ? [...conversationSearchState.results, ...(Array.isArray(data?.results) ? data.results : [])]
-                : (Array.isArray(data?.results) ? data.results : [])
-        };
-        renderConversationSearchResults();
-        if (status && data?.index_coverage?.complete_for_accessible_window === false) {
-            status.textContent += ' Older conversations are still being indexed.';
-        }
-    } catch (error) {
-        if (status) status.textContent = error?.message || 'Conversation search unavailable.';
-    }
-}
-
-function initialiseConversationSearch() {
-    const input = document.getElementById('conversationSearchInput');
-    const search = document.getElementById('conversationSearchButton');
-    const trash = document.getElementById('conversationTrashButton');
-    const more = document.getElementById('conversationSearchMore');
-    search?.addEventListener('click', () => { void performConversationSearch({ trashedOnly: false }); });
-    input?.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter') {
-            event.preventDefault();
-            trash?.setAttribute('aria-pressed', 'false');
-            void performConversationSearch({ trashedOnly: false });
-        }
-    });
-    trash?.addEventListener('click', () => {
-        const next = trash.getAttribute('aria-pressed') !== 'true';
-        trash.setAttribute('aria-pressed', next ? 'true' : 'false');
-        if (!next) {
-            document.getElementById('conversationSearchPanel')?.setAttribute('hidden', '');
-            return;
-        }
-        void performConversationSearch({ trashedOnly: true });
-    });
-    more?.addEventListener('click', () => { void performConversationSearch({ append: true }); });
+    return switchToChatSession(sessionId);
 }
 
 let orgSwitchListenerBound = false;
 let authStatusListenerBound = false;
+let conversationSearchSelectionListenerBound = false;
 let diagnosticsExportShortcutBound = false;
 
 // JVNAUTOSCI-942: Tool-use progress while "Thinking..."
@@ -23126,7 +23004,6 @@ try {
         ) {
             return;
         }
-        showAllConversationHistoryMatches = false;
         if (Array.isArray(sessionTabsCache)) {
             renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
         }
@@ -25703,9 +25580,11 @@ function renderChatSessionTabsPlaceholder(mode = 'loading') {
     if (!container) {
         return;
     }
+    const historyControls = document.getElementById('chatSessionHistoryControls');
 
     container.hidden = false;
     container.innerHTML = '';
+    if (historyControls) historyControls.innerHTML = '';
 
     setChatSessionCount(null);
 
@@ -25866,6 +25745,7 @@ async function refreshChatSessionTabs() {
 
         const sessions = Array.isArray(data?.sessions) ? data.sessions : [];
         serverAgentCreatedSessionVisibilityState = normaliseServerAgentCreatedVisibilityState(data);
+        serverConversationHistoryRecencyState = normaliseServerConversationHistoryRecencyState(data);
         const acceptedInvites = Array.isArray(incomingInviteState?.acceptedInvites)
             ? incomingInviteState.acceptedInvites
             : [];
@@ -26017,6 +25897,8 @@ function renderChatSessionTabs(sessions, activeSessionId) {
     if (!container) {
         return;
     }
+    const historyControls = document.getElementById('chatSessionHistoryControls');
+    if (historyControls) historyControls.innerHTML = '';
 
     const canonicalSessions = normaliseConversationSessionViewModels(sessions);
     if (canonicalSessions.length === 0) {
@@ -26058,12 +25940,19 @@ function renderChatSessionTabs(sessions, activeSessionId) {
         };
 
     const conversationHistorySettings = loadConversationHistorySettings((key) => safeLocalStorageGet(key));
+    if (expandedConversationHistoryBaseLimit !== conversationHistorySettings.recentLimit) {
+        expandedConversationHistoryLimit = null;
+        expandedConversationHistoryBaseLimit = conversationHistorySettings.recentLimit;
+    }
+    const effectiveRecentLimit = Number.isFinite(expandedConversationHistoryLimit)
+        ? Math.max(conversationHistorySettings.recentLimit, Math.trunc(expandedConversationHistoryLimit))
+        : conversationHistorySettings.recentLimit;
     const filteredResult = selectConversationHistorySessions({
         sessions: sessionsAfterAgentFilter,
         accessTimestampBySessionId: getConversationHistoryAccessLookup(sessionsAfterAgentFilter),
-        recentLimit: conversationHistorySettings.recentLimit,
+        recentLimit: effectiveRecentLimit,
         recentWindowDays: conversationHistorySettings.recentWindowDays,
-        showAll: showAllConversationHistoryMatches
+        showAll: false
     });
     let visibleSessions = Array.isArray(filteredResult.sessionsToRender)
         ? filteredResult.sessionsToRender
@@ -26161,6 +26050,56 @@ function renderChatSessionTabs(sessions, activeSessionId) {
 
     // Always show the "+" button to create new chats
     fragment.appendChild(createNewChatTabButton());
+
+    const serverOlderCount = (
+        serverConversationHistoryRecencyState?.recentWindowDays === filteredResult.recentWindowDays
+    )
+        ? serverConversationHistoryRecencyState.olderThanWindowCount
+        : null;
+    const olderThanWindowCount = Number.isFinite(serverOlderCount)
+        ? serverOlderCount
+        : filteredResult.olderThanWindowCount;
+    if (historyControls && olderThanWindowCount > 0) {
+        const olderIndicator = document.createElement('span');
+        const formattedOlderCount = olderThanWindowCount.toLocaleString();
+        olderIndicator.className = 'chat-session-history-indicator';
+        olderIndicator.textContent = `[${formattedOlderCount} > ${filteredResult.recentWindowDays}d]`;
+        olderIndicator.title = `${formattedOlderCount} conversations are older than ${filteredResult.recentWindowDays} days and hidden from this recent-conversation strip. Search can still find them.`;
+        olderIndicator.setAttribute(
+            'aria-label',
+            `${formattedOlderCount} conversations older than ${filteredResult.recentWindowDays} days`
+        );
+        olderIndicator.setAttribute('data-keep-title', 'true');
+        olderIndicator.tabIndex = 0;
+        historyControls.appendChild(olderIndicator);
+    }
+
+    if (historyControls && filteredResult.totalMatchingCount > filteredResult.recentLimit) {
+        const overflowButton = document.createElement('button');
+        const hiddenCount = filteredResult.hiddenByLimitCount;
+        const nextTrancheSize = Math.min(hiddenCount, filteredResult.recentLimit);
+        const ordinaryClickShowsAll = nextTrancheSize >= hiddenCount;
+        overflowButton.type = 'button';
+        overflowButton.className = 'chat-session-history-toggle';
+        overflowButton.textContent = `+${hiddenCount}`;
+        overflowButton.title = ordinaryClickShowsAll
+            ? `${hiddenCount} more conversations fall within the ${filteredResult.recentWindowDays}-day window. Click to show all of them.`
+            : `${hiddenCount} more conversations fall within the ${filteredResult.recentWindowDays}-day window. Click to show the next ${nextTrancheSize}; Shift-click to show all.`;
+        overflowButton.setAttribute(
+            'aria-label',
+            ordinaryClickShowsAll
+                ? `Show all ${hiddenCount} more recent conversations`
+                : `Show the next ${nextTrancheSize} of ${hiddenCount} more recent conversations; Shift-click to show all`
+        );
+        overflowButton.setAttribute('data-keep-title', 'true');
+        overflowButton.addEventListener('click', (event) => {
+            expandedConversationHistoryLimit = event.shiftKey
+                ? filteredResult.totalMatchingCount
+                : filteredResult.recentLimit + nextTrancheSize;
+            renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
+        });
+        historyControls.appendChild(overflowButton);
+    }
 
     if (orderedVisibleSessions.length === 0) {
         const placeholder = document.createElement('div');
@@ -26472,24 +26411,6 @@ function renderChatSessionTabs(sessions, activeSessionId) {
 
         fragment.appendChild(tab);
     });
-
-    if (filteredResult.totalMatchingCount > filteredResult.recentLimit) {
-        const toggleMoreButton = document.createElement('button');
-        toggleMoreButton.type = 'button';
-        toggleMoreButton.className = 'chat-session-tab chat-session-tab-more';
-        if (showAllConversationHistoryMatches) {
-            toggleMoreButton.textContent = '[...] Show less';
-            toggleMoreButton.title = `Collapse to ${filteredResult.recentLimit} conversations`;
-        } else {
-            toggleMoreButton.textContent = `[...] Show all (${filteredResult.hiddenByLimitCount} more)`;
-            toggleMoreButton.title = `Show all ${filteredResult.totalMatchingCount} matching conversations`;
-        }
-        toggleMoreButton.addEventListener('click', () => {
-            showAllConversationHistoryMatches = !showAllConversationHistoryMatches;
-            renderChatSessionTabs(sessionTabsCache, activeChatSessionId);
-        });
-        fragment.appendChild(toggleMoreButton);
-    }
 
     container.appendChild(fragment);
 
@@ -31775,8 +31696,9 @@ async function handleOrgSwitchForChatTab(_detail) {
     // session to null below is a no-op).
     invalidateLlmExecutionContextForOrgSwitch();
     const container = getChatSessionTabsContainer();
-    showAllConversationHistoryMatches = false;
     sessionTabsCache = [];
+    expandedConversationHistoryLimit = null;
+    expandedConversationHistoryBaseLimit = null;
     lastRenderedSessionCount = 0;
     chatSessionMetadataOpenKey = null;
     _clearChatSessionMetadata();
@@ -31852,10 +31774,10 @@ function handleAuthStatusChangeForChatTab(detail) {
     loadChatSessionLastAccessedMap();
     loadChatSessionTabsLayoutPreference();
     setupChatSessionTabsResponsiveLayout();
-    showAllConversationHistoryMatches = false;
-
     const container = getChatSessionTabsContainer();
     sessionTabsCache = [];
+    expandedConversationHistoryLimit = null;
+    expandedConversationHistoryBaseLimit = null;
     lastRenderedSessionCount = 0;
     chatSessionMetadataOpenKey = null;
     _clearChatSessionMetadata();
@@ -31916,7 +31838,18 @@ export function initializeChatTab() {
     loadChatSessionLastAccessedMap();
     loadChatSessionTabsLayoutPreference();
     setupChatSessionTabsResponsiveLayout();
-    initialiseConversationSearch();
+
+    if (!conversationSearchSelectionListenerBound) {
+        conversationSearchSelectionListenerBound = true;
+        document.addEventListener('von:open-conversation-search-result', event => {
+            void openConversationSearchResult(event?.detail?.conversation || {});
+        });
+        document.addEventListener('von:conversation-trash-changed', event => {
+            if (event?.detail?.action === 'restored') {
+                scheduleChatSessionTabsRefresh(true);
+            }
+        });
+    }
 
     // Reload hidden sessions when user changes (settings change event)
     try {
@@ -31940,7 +31873,6 @@ export function initializeChatTab() {
             if (newAccessKey !== _chatSessionLastAccessedUserKey) {
                 console.log(`[chatTab] User changed, reloading conversation last-accessed map (${_chatSessionLastAccessedUserKey} -> ${newAccessKey})`);
                 loadChatSessionLastAccessedMap();
-                showAllConversationHistoryMatches = false;
                 shouldRerenderTabs = true;
             }
 
@@ -38301,14 +38233,8 @@ export function __testOnly_getSessionTabsCache() {
 export async function __testOnly_deleteConversation(sessionId) {
     return deleteConversation(sessionId);
 }
-export async function __testOnly_performConversationSearch(options = {}) {
-    return performConversationSearch(options);
-}
-export async function __testOnly_restoreConversation(sessionId) {
-    return restoreConversation(sessionId);
-}
-export function __testOnly_getConversationSearchState() {
-    return { ...conversationSearchState, results: [...conversationSearchState.results] };
+export async function __testOnly_openConversationSearchResult(row = {}) {
+    return openConversationSearchResult(row);
 }
 export async function __testOnly_refreshChatPromptQueueFromServer() {
     return refreshChatPromptQueueFromServer({ silent: false });

--- a/src/frontend/web/von_interface/static/js/test/conversationHistoryPreferences.test.js
+++ b/src/frontend/web/von_interface/static/js/test/conversationHistoryPreferences.test.js
@@ -49,6 +49,7 @@ describe('conversationHistoryPreferences', () => {
         });
         expect(limited.totalMatchingCount).toBe(3);
         expect(limited.hiddenByLimitCount).toBe(1);
+        expect(limited.olderThanWindowCount).toBe(1);
         expect(limited.sessionsToRender.map((s) => s.session_id)).toEqual(['b', 'a']);
 
         const expanded = selectConversationHistorySessions({

--- a/src/frontend/web/von_interface/static/js/utils/conversationHistoryPreferences.js
+++ b/src/frontend/web/von_interface/static/js/utils/conversationHistoryPreferences.js
@@ -104,9 +104,14 @@ export function selectConversationHistorySessions({
     const safeWindowDays = clampConversationHistoryRecentWindowDays(recentWindowDays);
     const cutoffMs = nowMs - (safeWindowDays * DAY_MS);
 
+    let olderThanWindowCount = 0;
     const sessionsInWindow = sessions.filter((session) => {
         const occurredAtMs = getSessionOccurredAtMs(session);
-        return occurredAtMs !== null && occurredAtMs >= cutoffMs;
+        if (occurredAtMs !== null && occurredAtMs < cutoffMs) {
+            olderThanWindowCount += 1;
+            return false;
+        }
+        return occurredAtMs !== null;
     });
 
     const sorted = sessionsInWindow.slice().sort((a, b) => (
@@ -121,6 +126,7 @@ export function selectConversationHistorySessions({
         sessionsToRender: limited,
         totalMatchingCount: sorted.length,
         hiddenByLimitCount,
+        olderThanWindowCount,
         recentLimit: safeLimit,
         recentWindowDays: safeWindowDays
     };

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -3213,12 +3213,32 @@ let __vontologySearchState = {
   items: [],
   activeIndex: -1,
   lastQuery: '',
-  abortController: null
+  abortController: null,
+  requestGeneration: 0,
+  mode: 'search',
+  concepts: {
+    items: [],
+    status: 'idle',
+    error: ''
+  },
+  conversations: {
+    items: [],
+    status: 'idle',
+    error: '',
+    nextCursor: null,
+    coverage: null
+  },
+  recoveryCount: null,
+  recoveryCountConfirmedZero: false,
+  recoveryCountCoverageComplete: false
 };
 // JVNAUTOSCI-550 additions: queue selections before tree ready & guard init
 let __vontologyTreeReady = false;
 const __pendingTreeSelections = [];
 let __searchUiInitialised = false;
+let __conversationRecoveryInitialised = false;
+let __conversationRecoveryCountAbortController = null;
+let __conversationRecoveryCountGeneration = 0;
 // Session-scoped caches for performance
 const __instanceCountsCache = new Map(); // key: joined candidate ids -> counts object
 const __idToElement = new Map(); // concept_id -> span.vontology-node-name
@@ -3358,15 +3378,27 @@ export function setupVontologySearchUI() {
 
   const debounced = debounce(async () => {
     const q = input.value.trim();
-    if (!q) { clearSearchResults(); return; }
+    if (!q) { clearSearchResults({ invalidate: true }); return; }
     await performVontologySearch(q);
   }, 180);
 
   // Input handlers
-  input.addEventListener('input', debounced);
+  const handleInput = () => {
+    if (!input.value.trim()) {
+      clearSearchResults({ invalidate: true });
+      return;
+    }
+    if (__vontologySearchState.mode !== 'search') {
+      __vontologySearchState.mode = 'search';
+      setRecoveryButtonPressed(false);
+    }
+    debounced();
+  };
+  input.addEventListener('input', handleInput);
+  input.addEventListener('search', handleInput);
   input.addEventListener('focus', () => {
-    if (__vontologySearchState.items.length) openResults();
-    setExpanded(__vontologySearchState.items.length > 0);
+    if (searchHasVisibleContent()) openResults();
+    setExpanded(searchHasVisibleContent());
   });
 
   // Keyboard navigation
@@ -3375,7 +3407,7 @@ export function setupVontologySearchUI() {
     // Allow Escape even if no items
     if (e.key === 'Escape') {
       e.preventDefault();
-      clearSearchResults();
+      clearSearchResults({ invalidate: true });
       input.blur();
       return;
     }
@@ -3415,11 +3447,14 @@ export function setupVontologySearchUI() {
 
   // Click outside to close
   document.addEventListener('click', (e) => {
-    if (!results.contains(e.target) && e.target !== input) {
-      clearSearchResults();
+    const recoveryButton = document.getElementById('conversationRecoveryButton');
+    if (!results.contains(e.target) && e.target !== input && !recoveryButton?.contains(e.target)) {
+      clearSearchResults({ invalidate: true });
       setExpanded(false);
     }
   });
+
+  initialiseConversationRecoveryUI();
 }
 
 function debounce(fn, wait) {
@@ -3430,99 +3465,185 @@ function debounce(fn, wait) {
   };
 }
 
-export async function performVontologySearch(q) {
-  const results = elements.vontologySearchResults;
-  if (!results) return;
-  __vontologySearchState.lastQuery = q;
-  __vontologySearchState.activeIndex = -1;
-  // Cancel previous in-flight request
+function beginUnifiedSearchRequest(mode = 'search') {
   try { __vontologySearchState.abortController?.abort(); } catch (_) { }
-  const ac = new AbortController();
-  __vontologySearchState.abortController = ac;
-  try {
-    const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=20&include_individuals=true`;
-    const res = await vontologyFetch(url, { signal: ac.signal });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    let items = Array.isArray(data?.results) ? data.results : [];
+  const abortController = new AbortController();
+  const requestGeneration = __vontologySearchState.requestGeneration + 1;
+  __vontologySearchState.abortController = abortController;
+  __vontologySearchState.requestGeneration = requestGeneration;
+  __vontologySearchState.mode = mode;
+  __vontologySearchState.activeIndex = -1;
+  return { abortController, requestGeneration };
+}
 
-    const trimmedQuery = q?.trim() || '';
-    if (trimmedQuery.startsWith('#V#')) {
-      const idLower = trimmedQuery.toLowerCase();
-      const alreadyPresent = items.some(it => (it.id || '').toLowerCase() === idLower);
-      if (!alreadyPresent) {
-        try {
-          const nodeRes = await vontologyFetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(trimmedQuery)}`, { signal: ac.signal });
-          if (nodeRes.ok) {
-            const nodeData = await nodeRes.json();
-            if (nodeData && !nodeData.error) {
-              // Derive a friendly label if the node has one; otherwise keep the ID so users know it exists.
-              const deriveName = () => {
-                if (typeof nodeData.name === 'string' && nodeData.name.trim()) return nodeData.name.trim();
-                if (typeof nodeData.display_name === 'string' && nodeData.display_name.trim()) return nodeData.display_name.trim();
-                const raw = nodeData.raw_doc || {};
-                if (typeof raw.name === 'string' && raw.name.trim()) return raw.name.trim();
-                if (typeof raw.display_name === 'string' && raw.display_name.trim()) return raw.display_name.trim();
-                return trimmedQuery;
-              };
-              const deriveKind = () => {
-                if (typeof nodeData.kind === 'string') return nodeData.kind;
-                if (typeof nodeData.computed_kind === 'string') return nodeData.computed_kind;
-                const relationships = nodeData.raw_doc?.relationships || {};
-                const instanceRels = Array.isArray(nodeData.is_an_instance_of) ? nodeData.is_an_instance_of : relationships.is_an_instance_of;
-                const typeRels = Array.isArray(nodeData.is_a_type_of) ? nodeData.is_a_type_of : relationships.is_a_type_of;
-                if (Array.isArray(instanceRels) && instanceRels.length && (!Array.isArray(typeRels) || !typeRels.length)) {
-                  return 'individual';
-                }
-                return 'type';
-              };
-              const fallbackItem = {
-                id: trimmedQuery,
-                name: deriveName(),
-                kind: deriveKind() || 'type'
-              };
-              items = [fallbackItem, ...items];
-            }
-          } else {
-            let errorPayload = null;
-            try { errorPayload = await nodeRes.json(); } catch (_) { }
-            items = [
-              makeExactIdSearchErrorItem(trimmedQuery, nodeRes.status, errorPayload),
-              ...items
-            ];
+function isCurrentUnifiedSearchRequest(requestGeneration) {
+  return __vontologySearchState.requestGeneration === requestGeneration;
+}
+
+function sortConceptSearchItems(items) {
+  if (!items.length || !items.some(it => typeof it.relevance_score === 'number')) {
+    return items;
+  }
+  return items.slice().sort((a, b) => {
+    const aScore = typeof a.relevance_score === 'number' ? a.relevance_score : -1;
+    const bScore = typeof b.relevance_score === 'number' ? b.relevance_score : -1;
+    return bScore - aScore;
+  });
+}
+
+async function fetchConceptSearchItems(q, signal) {
+  const url = `/vontology/api/vontology/search?q=${encodeURIComponent(q)}&limit=20&include_individuals=true`;
+  const res = await vontologyFetch(url, { signal });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  let items = Array.isArray(data?.results) ? data.results : [];
+
+  const trimmedQuery = q?.trim() || '';
+  if (trimmedQuery.startsWith('#V#')) {
+    const idLower = trimmedQuery.toLowerCase();
+    const alreadyPresent = items.some(it => (it.id || '').toLowerCase() === idLower);
+    if (!alreadyPresent) {
+      try {
+        const nodeRes = await vontologyFetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(trimmedQuery)}`, { signal });
+        if (nodeRes.ok) {
+          const nodeData = await nodeRes.json();
+          if (nodeData && !nodeData.error) {
+            const deriveName = () => {
+              if (typeof nodeData.name === 'string' && nodeData.name.trim()) return nodeData.name.trim();
+              if (typeof nodeData.display_name === 'string' && nodeData.display_name.trim()) return nodeData.display_name.trim();
+              const raw = nodeData.raw_doc || {};
+              if (typeof raw.name === 'string' && raw.name.trim()) return raw.name.trim();
+              if (typeof raw.display_name === 'string' && raw.display_name.trim()) return raw.display_name.trim();
+              return trimmedQuery;
+            };
+            const deriveKind = () => {
+              if (typeof nodeData.kind === 'string') return nodeData.kind;
+              if (typeof nodeData.computed_kind === 'string') return nodeData.computed_kind;
+              const relationships = nodeData.raw_doc?.relationships || {};
+              const instanceRels = Array.isArray(nodeData.is_an_instance_of) ? nodeData.is_an_instance_of : relationships.is_an_instance_of;
+              const typeRels = Array.isArray(nodeData.is_a_type_of) ? nodeData.is_a_type_of : relationships.is_a_type_of;
+              if (Array.isArray(instanceRels) && instanceRels.length && (!Array.isArray(typeRels) || !typeRels.length)) {
+                return 'individual';
+              }
+              return 'type';
+            };
+            items = [{
+              id: trimmedQuery,
+              name: deriveName(),
+              kind: deriveKind() || 'type'
+            }, ...items];
           }
-        } catch (lookupErr) {
-          if (lookupErr?.name === 'AbortError') throw lookupErr;
-          console.debug('[vontology search] id lookup failed', lookupErr);
-          items = [
-            makeExactIdSearchErrorItem(trimmedQuery, null, null),
-            ...items
-          ];
+        } else {
+          let errorPayload = null;
+          try { errorPayload = await nodeRes.json(); } catch (_) { }
+          items = [makeExactIdSearchErrorItem(trimmedQuery, nodeRes.status, errorPayload), ...items];
         }
+      } catch (lookupErr) {
+        if (lookupErr?.name === 'AbortError') throw lookupErr;
+        console.debug('[vontology search] id lookup failed', lookupErr);
+        items = [makeExactIdSearchErrorItem(trimmedQuery, null, null), ...items];
       }
     }
-    // Use backend relevance scores if available; otherwise use legacy client-side sorting
-    if (items.length && items.some(it => typeof it.relevance_score === 'number')) {
-      // Sort by relevance_score descending (higher scores first)
-      items = items.slice(); // copy
-      items.sort((a, b) => {
-        const aScore = typeof a.relevance_score === 'number' ? a.relevance_score : -1;
-        const bScore = typeof b.relevance_score === 'number' ? b.relevance_score : -1;
-        return bScore - aScore; // descending order
-      });
-    }
-    __vontologySearchState.items = items;
-    renderSearchResults(items);
-  } catch (err) {
-    if (err?.name === 'AbortError') return; // expected
-    console.warn('[vontology search] error:', err);
-    const trimmedQuery = q?.trim() || '';
-    const errorItems = trimmedQuery.startsWith('#V#')
-      ? [makeExactIdSearchErrorItem(trimmedQuery, null, null)]
-      : [];
-    __vontologySearchState.items = errorItems;
-    renderSearchResults(errorItems);
   }
+  return sortConceptSearchItems(items);
+}
+
+async function fetchConversationSearchPage(query, {
+  cursor = null,
+  signal = null,
+  trashedOnly = false,
+  pageSize = 8,
+  sort = 'relevance'
+} = {}) {
+  const params = new URLSearchParams({
+    q: query,
+    // The interactive UI uses the indexed title/content path for predictable
+    // typeahead latency. The MCP conversation_search capability retains hybrid
+    // RAG search for model-driven retrieval.
+    match_mode: 'lexical',
+    page_size: String(pageSize),
+    sort,
+    trashed_only: trashedOnly ? 'true' : 'false'
+  });
+  if (cursor) params.set('cursor', cursor);
+  const response = await vontologyFetch(`/von/api/session/conversation_search?${params.toString()}`, {
+    cache: 'no-store',
+    signal
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(data?.error || `Conversation search failed (HTTP ${response.status})`);
+  }
+  return data;
+}
+
+export async function performVontologySearch(q) {
+  const results = elements.vontologySearchResults;
+  const trimmedQuery = String(q || '').trim();
+  if (!results) return;
+  if (!trimmedQuery) {
+    clearSearchResults({ invalidate: true });
+    return;
+  }
+
+  const { abortController, requestGeneration } = beginUnifiedSearchRequest('search');
+  __vontologySearchState.lastQuery = trimmedQuery;
+  __vontologySearchState.concepts = { items: [], status: 'loading', error: '' };
+  __vontologySearchState.conversations = {
+    items: [], status: 'loading', error: '', nextCursor: null, coverage: null
+  };
+  setRecoveryButtonPressed(false);
+  renderSearchResults();
+
+  const conceptTask = fetchConceptSearchItems(trimmedQuery, abortController.signal)
+    .then(conceptItems => {
+      if (!isCurrentUnifiedSearchRequest(requestGeneration)) return;
+      __vontologySearchState.concepts = {
+        items: conceptItems,
+        status: conceptItems.length ? 'ready' : 'empty',
+        error: ''
+      };
+      renderSearchResults();
+    })
+    .catch(error => {
+      if (error?.name === 'AbortError' || !isCurrentUnifiedSearchRequest(requestGeneration)) return;
+      console.warn('[unified search] concept provider failed:', error);
+      const exactIdItems = trimmedQuery.startsWith('#V#')
+        ? [makeExactIdSearchErrorItem(trimmedQuery, null, null)]
+        : [];
+      __vontologySearchState.concepts = {
+        items: exactIdItems,
+        status: 'error',
+        error: 'Concept search is temporarily unavailable.'
+      };
+      renderSearchResults();
+    });
+  const conversationTask = fetchConversationSearchPage(trimmedQuery, { signal: abortController.signal })
+    .then(data => {
+      if (!isCurrentUnifiedSearchRequest(requestGeneration)) return;
+      const conversationItems = Array.isArray(data?.results) ? data.results : [];
+      __vontologySearchState.conversations = {
+        items: conversationItems,
+        status: conversationItems.length ? 'ready' : 'empty',
+        error: '',
+        nextCursor: data?.next_cursor || null,
+        coverage: data?.index_coverage || null
+      };
+      renderSearchResults();
+    })
+    .catch(error => {
+      if (error?.name === 'AbortError' || !isCurrentUnifiedSearchRequest(requestGeneration)) return;
+      console.warn('[unified search] conversation provider failed:', error);
+      __vontologySearchState.conversations = {
+        items: [],
+        status: 'error',
+        error: 'Conversation search is temporarily unavailable.',
+        nextCursor: null,
+        coverage: null
+      };
+      renderSearchResults();
+    });
+  await Promise.all([conceptTask, conversationTask]);
 }
 
 function makeExactIdSearchErrorItem(conceptId, status, payload) {
@@ -3572,81 +3693,286 @@ async function copySearchConceptIdToClipboard(conceptId) {
   }
 }
 
-function renderSearchResults(items) {
+function isConversationWorkspaceActive() {
+  return document.body?.dataset?.activeTab === 'chatTab'
+    || document.getElementById('chatTab')?.classList.contains('active') === true;
+}
+
+function searchHasVisibleContent() {
+  return __vontologySearchState.mode === 'recovery'
+    || Boolean(__vontologySearchState.lastQuery)
+    || ['loading', 'ready', 'empty', 'error'].includes(__vontologySearchState.concepts.status)
+    || ['loading', 'ready', 'empty', 'error', 'loading-more'].includes(__vontologySearchState.conversations.status);
+}
+
+function normaliseConceptSearchItem(item) {
+  return { ...item, searchType: 'concept' };
+}
+
+function normaliseConversationSearchItem(item) {
+  const sessionId = String(item?.session_id || '').trim();
+  const displayName = String(item?.display_name || item?.session_name || '').trim() || 'Unnamed conversation';
+  return {
+    ...item,
+    id: sessionId,
+    name: displayName,
+    searchType: 'conversation'
+  };
+}
+
+function getOrderedSearchGroups() {
+  if (__vontologySearchState.mode === 'recovery') return ['conversations'];
+  return isConversationWorkspaceActive()
+    ? ['conversations', 'concepts']
+    : ['concepts', 'conversations'];
+}
+
+function rebuildSearchKeyboardItems() {
+  const providers = {
+    concepts: __vontologySearchState.concepts.items.map(normaliseConceptSearchItem),
+    conversations: __vontologySearchState.mode === 'recovery'
+      ? []
+      : __vontologySearchState.conversations.items.map(normaliseConversationSearchItem)
+  };
+  __vontologySearchState.items = getOrderedSearchGroups()
+    .flatMap(groupKey => providers[groupKey] || [])
+    .filter(item => !item.disabled && item.id);
+}
+
+function formatConversationSearchDate(item) {
+  const raw = item?.last_message_at || item?.created_at;
+  if (!raw) return '';
+  const date = new Date(raw);
+  if (!Number.isFinite(date.getTime())) return '';
+  const options = { day: 'numeric', month: 'short' };
+  if (date.getFullYear() !== new Date().getFullYear()) options.year = 'numeric';
+  return date.toLocaleDateString(undefined, options);
+}
+
+function createSearchGroupHeading(text, id) {
+  const heading = document.createElement('div');
+  heading.className = 'unified-search-group-heading';
+  heading.id = id;
+  heading.textContent = text;
+  return heading;
+}
+
+function createSearchProviderNotice(text, className = '') {
+  const notice = document.createElement('div');
+  notice.className = `unified-search-provider-notice ${className}`.trim();
+  notice.setAttribute('role', 'status');
+  notice.textContent = text;
+  return notice;
+}
+
+function renderConceptSearchRow(item, keyboardIndex) {
+  const row = document.createElement('div');
+  row.className = item.error
+    ? 'vontology-search-item unified-search-option vontology-search-item-error'
+    : 'vontology-search-item unified-search-option';
+  row.setAttribute('role', 'option');
+  if (keyboardIndex !== null) row.dataset.searchIndex = String(keyboardIndex);
+  if (item.disabled) row.setAttribute('aria-disabled', 'true');
+
+  const name = document.createElement('span');
+  name.className = 'vontology-search-item-name';
+  name.textContent = item.name || item.id;
+  if (ENABLE_VONTOLOGY_SEARCH_TOOLTIPS) {
+    name.title = `${item.name || item.id} \u2014 ${item.id}`;
+  }
+  const badgeKind = item.kind;
+  const badgeText = item.kind === 'predicate'
+    ? 'Predicate'
+    : (item.kind === 'individual' ? 'Individual' : (item.kind === 'status' ? 'Status' : 'Type'));
+  const kind = document.createElement('span');
+  kind.className = `vontology-search-item-kind ${badgeKind}`;
+  kind.textContent = badgeText;
+  row.appendChild(name);
+  if (!ENABLE_VONTOLOGY_SEARCH_TOOLTIPS) {
+    const idInline = document.createElement('span');
+    idInline.className = 'vontology-search-item-id-inline';
+    idInline.textContent = item.id;
+    row.appendChild(idInline);
+  }
+  row.appendChild(kind);
+
+  if (!item.disabled && keyboardIndex !== null) {
+    row.addEventListener('mouseenter', () => setActiveIndex(keyboardIndex));
+    row.addEventListener('mouseleave', () => setActiveIndex(-1));
+    row.addEventListener('click', () => selectSearchItem(normaliseConceptSearchItem(item)));
+    row.addEventListener('contextmenu', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void copySearchConceptIdToClipboard(item.id);
+    });
+  }
+  return row;
+}
+
+function renderConversationSearchRow(item, keyboardIndex, { recovery = false } = {}) {
+  const normalised = normaliseConversationSearchItem(item);
+  const row = document.createElement('div');
+  row.className = 'unified-search-conversation-item unified-search-option';
+  row.setAttribute('role', recovery ? 'group' : 'option');
+  if (keyboardIndex !== null) row.dataset.searchIndex = String(keyboardIndex);
+
+  const main = document.createElement('div');
+  main.className = 'unified-search-conversation-main';
+
+  const title = document.createElement('span');
+  title.className = 'unified-search-conversation-title';
+  title.textContent = normalised.name;
+  const date = document.createElement('span');
+  date.className = 'unified-search-conversation-date';
+  date.textContent = formatConversationSearchDate(item);
+  main.appendChild(title);
+  if (date.textContent) main.appendChild(date);
+
+  const snippetText = String(item?.match?.snippet || '').trim();
+  if (snippetText) {
+    const snippet = document.createElement('span');
+    snippet.className = 'unified-search-conversation-snippet';
+    snippet.textContent = snippetText;
+    main.appendChild(snippet);
+  }
+
+  if (!recovery && keyboardIndex !== null) {
+    row.addEventListener('click', () => selectSearchItem(normalised));
+    row.addEventListener('mouseenter', () => setActiveIndex(keyboardIndex));
+    row.addEventListener('mouseleave', () => setActiveIndex(-1));
+  }
+  row.appendChild(main);
+
+  if (recovery) {
+    const restore = document.createElement('button');
+    restore.type = 'button';
+    restore.className = 'unified-search-restore-button';
+    restore.textContent = 'Restore';
+    restore.addEventListener('click', () => { void restoreConversationFromRecovery(item, restore); });
+    row.appendChild(restore);
+  }
+  return row;
+}
+
+function appendSearchProviderState(group, groupKey, provider) {
+  const label = groupKey === 'concepts' ? 'concepts' : 'conversations';
+  if (provider.status === 'loading') {
+    group.appendChild(createSearchProviderNotice(`Searching ${label}\u2026`, 'is-loading'));
+  } else if (provider.status === 'loading-more') {
+    group.appendChild(createSearchProviderNotice(`Loading more ${label}\u2026`, 'is-loading'));
+  } else if (provider.status === 'error') {
+    group.appendChild(createSearchProviderNotice(provider.error || `${label} search is unavailable.`, 'is-error'));
+  } else if (provider.status === 'empty' && provider.items.length === 0) {
+    const emptyMessage = __vontologySearchState.mode === 'recovery' && groupKey === 'conversations'
+      ? 'No removed conversations.'
+      : `No matching ${label}.`;
+    group.appendChild(createSearchProviderNotice(emptyMessage, 'is-empty'));
+  }
+
+  if (groupKey === 'conversations' && provider.coverage) {
+    const coverageIncomplete = provider.coverage.complete_for_accessible_window === false
+      || provider.coverage.candidate_window_complete === false;
+    if (coverageIncomplete) {
+      const notice = createSearchProviderNotice('Some older conversations may not appear yet.', 'is-partial');
+      const limitations = Array.isArray(provider.coverage.limitations)
+        ? provider.coverage.limitations.join(', ')
+        : '';
+      if (limitations) {
+        notice.title = limitations;
+        notice.setAttribute('data-keep-title', 'true');
+      }
+      group.appendChild(notice);
+    }
+  }
+}
+
+function renderSearchResults() {
   const results = elements.vontologySearchResults;
   if (!results) return;
   results.innerHTML = '';
-  if (!items.length) { results.classList.remove('open'); return; }
-  const list = document.createElement('div');
-  list.setAttribute('role', 'listbox');
-  items.forEach((it, idx) => {
-    const row = document.createElement('div');
-    row.className = it.error
-      ? 'vontology-search-item vontology-search-item-error'
-      : 'vontology-search-item';
-    row.setAttribute('role', 'option');
-    row.dataset.index = String(idx);
-    if (it.disabled) row.setAttribute('aria-disabled', 'true');
-    // left: name (with id tooltip)
-    const name = document.createElement('span');
-    name.className = 'vontology-search-item-name';
-    name.textContent = it.name || it.id;
-    if (ENABLE_VONTOLOGY_SEARCH_TOOLTIPS) {
-      // Provide combined name + id via native tooltip when enabled
-      name.title = `${it.name || it.id} \u2014 ${it.id}`;
-    } else {
-      // Ensure no stray title attribute remains (defensive if refactored elsewhere)
-      if (name.hasAttribute('title')) name.removeAttribute('title');
+  rebuildSearchKeyboardItems();
+  __vontologySearchState.activeIndex = -1;
+
+  if (!searchHasVisibleContent()) {
+    results.classList.remove('open');
+    try { elements.vontologySearchInput?.setAttribute('aria-expanded', 'false'); } catch (_) { }
+    return;
+  }
+
+  const keyboardIndexByKey = new Map(
+    __vontologySearchState.items.map((item, index) => [`${item.searchType}:${item.id}`, index])
+  );
+  getOrderedSearchGroups().forEach(groupKey => {
+    const provider = __vontologySearchState[groupKey];
+    const group = document.createElement('section');
+    const headingId = `unifiedSearch${groupKey === 'concepts' ? 'Concepts' : 'Conversations'}Heading`;
+    const headingText = __vontologySearchState.mode === 'recovery' && groupKey === 'conversations'
+      ? 'Removed conversations'
+      : (groupKey === 'concepts' ? 'Concepts' : 'Conversations');
+    group.className = `unified-search-group unified-search-group-${groupKey}`;
+    group.setAttribute('role', 'group');
+    group.setAttribute('aria-labelledby', headingId);
+    group.appendChild(createSearchGroupHeading(headingText, headingId));
+
+    provider.items.forEach(item => {
+      if (groupKey === 'concepts') {
+        const normalised = normaliseConceptSearchItem(item);
+        const index = normalised.disabled ? null : keyboardIndexByKey.get(`concept:${normalised.id}`);
+        group.appendChild(renderConceptSearchRow(item, Number.isInteger(index) ? index : null));
+      } else {
+        const normalised = normaliseConversationSearchItem(item);
+        const index = __vontologySearchState.mode === 'recovery'
+          ? null
+          : keyboardIndexByKey.get(`conversation:${normalised.id}`);
+        group.appendChild(renderConversationSearchRow(item, Number.isInteger(index) ? index : null, {
+          recovery: __vontologySearchState.mode === 'recovery'
+        }));
+      }
+    });
+    appendSearchProviderState(group, groupKey, provider);
+
+    if (groupKey === 'conversations' && provider.nextCursor) {
+      const more = document.createElement('button');
+      more.type = 'button';
+      more.className = 'unified-search-more-button';
+      more.textContent = __vontologySearchState.mode === 'recovery'
+        ? 'More removed conversations'
+        : 'More conversations';
+      more.addEventListener('click', () => { void loadMoreConversationSearchResults(); });
+      group.appendChild(more);
     }
-    // right: kind badge (use backend's three-way classification)
-    const badgeKind = it.kind; // 'type', 'predicate', or 'individual' from backend
-    const badgeText = it.kind === 'predicate' ? 'Predicate' : (it.kind === 'individual' ? 'Individual' : (it.kind === 'status' ? 'Status' : 'Type'));
-    const kind = document.createElement('span');
-    kind.className = `vontology-search-item-kind ${badgeKind}`;
-    kind.textContent = badgeText;
-    row.appendChild(name);
-    if (!ENABLE_VONTOLOGY_SEARCH_TOOLTIPS) {
-      const idInline = document.createElement('span');
-      idInline.className = 'vontology-search-item-id-inline';
-      idInline.textContent = it.id;
-      row.appendChild(idInline);
-    }
-    row.appendChild(kind);
-    // interactions
-    if (!it.disabled) {
-      row.addEventListener('mouseenter', () => setActiveIndex(idx));
-      row.addEventListener('mouseleave', () => setActiveIndex(-1));
-      row.addEventListener('click', () => selectSearchItem(it));
-      row.addEventListener('contextmenu', (e) => {
-        try {
-          e.preventDefault();
-          e.stopPropagation();
-          copySearchConceptIdToClipboard(it.id);
-        } catch (_) {
-          // no-op
-        }
-      });
-    }
-    list.appendChild(row);
+    results.appendChild(group);
   });
-  results.appendChild(list);
   openResults();
 }
 
 function openResults() {
   const results = elements.vontologySearchResults;
   if (!results) return;
-  if (__vontologySearchState.items.length) results.classList.add('open');
-  try { elements.vontologySearchInput?.setAttribute('aria-expanded', __vontologySearchState.items.length ? 'true' : 'false'); } catch (_) { }
+  const open = searchHasVisibleContent();
+  results.classList.toggle('open', open);
+  try { elements.vontologySearchInput?.setAttribute('aria-expanded', open ? 'true' : 'false'); } catch (_) { }
 }
 
-function clearSearchResults() {
+function clearSearchResults({ invalidate = false } = {}) {
   const results = elements.vontologySearchResults;
-  if (!results) return;
-  results.classList.remove('open');
-  results.innerHTML = '';
+  if (invalidate) {
+    try { __vontologySearchState.abortController?.abort(); } catch (_) { }
+    __vontologySearchState.requestGeneration += 1;
+  }
+  if (results) {
+    results.classList.remove('open');
+    results.innerHTML = '';
+  }
   __vontologySearchState.items = [];
   __vontologySearchState.activeIndex = -1;
+  __vontologySearchState.lastQuery = '';
+  __vontologySearchState.concepts = { items: [], status: 'idle', error: '' };
+  __vontologySearchState.conversations = {
+    items: [], status: 'idle', error: '', nextCursor: null, coverage: null
+  };
+  __vontologySearchState.mode = 'search';
+  setRecoveryButtonPressed(false);
   try { elements.vontologySearchInput?.setAttribute('aria-expanded', 'false'); } catch (_) { }
 }
 
@@ -3654,9 +3980,10 @@ function setActiveIndex(idx) {
   __vontologySearchState.activeIndex = idx;
   const results = elements.vontologySearchResults;
   if (!results) return;
-  results.querySelectorAll('.vontology-search-item').forEach((el, i) => {
-    if (i === idx) el.classList.add('active');
-    else el.classList.remove('active');
+  results.querySelectorAll('.unified-search-option[data-search-index]').forEach(el => {
+    const active = Number(el.dataset.searchIndex) === idx;
+    el.classList.toggle('active', active);
+    el.setAttribute('aria-selected', active ? 'true' : 'false');
   });
 }
 
@@ -3666,18 +3993,253 @@ function moveActive(delta) {
   let idx = __vontologySearchState.activeIndex;
   idx = (idx + delta + n) % n;
   setActiveIndex(idx);
-  // ensure visible
   const results = elements.vontologySearchResults;
-  const el = results?.querySelector(`.vontology-search-item[data-index="${idx}"]`);
+  const el = results?.querySelector(`.unified-search-option[data-search-index="${idx}"]`);
   if (el && results) {
-    const r = results.getBoundingClientRect();
-    const e = el.getBoundingClientRect();
-    if (e.bottom > r.bottom) {
-      results.scrollTop += (e.bottom - r.bottom);
-    } else if (e.top < r.top) {
-      results.scrollTop -= (r.top - e.top);
+    const resultBounds = results.getBoundingClientRect();
+    const itemBounds = el.getBoundingClientRect();
+    if (itemBounds.bottom > resultBounds.bottom) {
+      results.scrollTop += (itemBounds.bottom - resultBounds.bottom);
+    } else if (itemBounds.top < resultBounds.top) {
+      results.scrollTop -= (resultBounds.top - itemBounds.top);
     }
   }
+}
+
+function setRecoveryButtonPressed(pressed) {
+  const button = document.getElementById('conversationRecoveryButton');
+  button?.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+}
+
+function updateConversationRecoveryButton() {
+  const button = document.getElementById('conversationRecoveryButton');
+  const badge = document.getElementById('conversationRecoveryCount');
+  if (!button || !badge) return;
+  const active = isConversationWorkspaceActive();
+  button.hidden = !active || __vontologySearchState.recoveryCountConfirmedZero;
+  const count = __vontologySearchState.recoveryCount;
+  if (Number.isFinite(count) && count > 0) {
+    badge.hidden = false;
+    badge.textContent = count > 99 ? '99+' : String(count);
+    const countDescription = __vontologySearchState.recoveryCountCoverageComplete
+      ? `${count} removed conversation${count === 1 ? '' : 's'}`
+      : `at least ${count} removed conversation${count === 1 ? '' : 's'}`;
+    button.title = `Open ${countDescription}`;
+    button.setAttribute('aria-label', `Open ${countDescription}`);
+  } else {
+    badge.hidden = true;
+    badge.textContent = '';
+    button.title = 'Open removed conversations';
+    button.setAttribute('aria-label', 'Open removed conversations');
+  }
+}
+
+function acceptConversationRecoveryCountPayload(data) {
+  const candidateCount = Number(data?.index_coverage?.accessible_window_count);
+  const count = Number.isFinite(candidateCount)
+    ? Math.max(0, Math.trunc(candidateCount))
+    : null;
+  const coverageComplete = data?.index_coverage?.candidate_window_complete === true;
+  __vontologySearchState.recoveryCount = count;
+  __vontologySearchState.recoveryCountCoverageComplete = coverageComplete;
+  __vontologySearchState.recoveryCountConfirmedZero = count === 0 && coverageComplete;
+  updateConversationRecoveryButton();
+}
+
+async function refreshConversationRecoveryCount() {
+  const requestGeneration = __conversationRecoveryCountGeneration + 1;
+  __conversationRecoveryCountGeneration = requestGeneration;
+  try { __conversationRecoveryCountAbortController?.abort(); } catch (_) { }
+  const abortController = new AbortController();
+  __conversationRecoveryCountAbortController = abortController;
+  try {
+    const data = await fetchConversationSearchPage('*', {
+      trashedOnly: true,
+      pageSize: 1,
+      sort: 'updated',
+      signal: abortController.signal
+    });
+    if (__conversationRecoveryCountGeneration !== requestGeneration) return;
+    acceptConversationRecoveryCountPayload(data);
+  } catch (error) {
+    if (error?.name === 'AbortError') return;
+    console.debug('[conversation recovery] count unavailable', error);
+    if (__conversationRecoveryCountGeneration === requestGeneration) {
+      __vontologySearchState.recoveryCountConfirmedZero = false;
+      updateConversationRecoveryButton();
+    }
+  }
+}
+
+async function openRemovedConversations() {
+  const results = elements.vontologySearchResults;
+  if (!results) return;
+  if (__vontologySearchState.mode === 'recovery' && results.classList.contains('open')) {
+    clearSearchResults({ invalidate: true });
+    return;
+  }
+  const input = elements.vontologySearchInput;
+  if (input) input.value = '';
+  const { abortController, requestGeneration } = beginUnifiedSearchRequest('recovery');
+  __vontologySearchState.lastQuery = '';
+  __vontologySearchState.concepts = { items: [], status: 'idle', error: '' };
+  __vontologySearchState.conversations = {
+    items: [], status: 'loading', error: '', nextCursor: null, coverage: null
+  };
+  setRecoveryButtonPressed(true);
+  renderSearchResults();
+  try {
+    const data = await fetchConversationSearchPage('*', {
+      trashedOnly: true,
+      pageSize: 20,
+      sort: 'updated',
+      signal: abortController.signal
+    });
+    if (!isCurrentUnifiedSearchRequest(requestGeneration)) return;
+    const items = Array.isArray(data?.results) ? data.results : [];
+    __vontologySearchState.conversations = {
+      items,
+      status: items.length ? 'ready' : 'empty',
+      error: '',
+      nextCursor: data?.next_cursor || null,
+      coverage: data?.index_coverage || null
+    };
+    acceptConversationRecoveryCountPayload(data);
+    renderSearchResults();
+  } catch (error) {
+    if (error?.name === 'AbortError' || !isCurrentUnifiedSearchRequest(requestGeneration)) return;
+    __vontologySearchState.conversations = {
+      items: [], status: 'error', error: 'Removed conversations are temporarily unavailable.', nextCursor: null, coverage: null
+    };
+    renderSearchResults();
+  }
+}
+
+async function loadMoreConversationSearchResults() {
+  const current = __vontologySearchState.conversations;
+  if (!current.nextCursor) return;
+  const mode = __vontologySearchState.mode;
+  const query = mode === 'recovery' ? '*' : __vontologySearchState.lastQuery;
+  const existingItems = current.items.slice();
+  const { abortController, requestGeneration } = beginUnifiedSearchRequest(mode);
+  __vontologySearchState.conversations = { ...current, status: 'loading-more', error: '' };
+  renderSearchResults();
+  try {
+    const data = await fetchConversationSearchPage(query, {
+      cursor: current.nextCursor,
+      trashedOnly: mode === 'recovery',
+      pageSize: mode === 'recovery' ? 20 : 8,
+      sort: mode === 'recovery' ? 'updated' : 'relevance',
+      signal: abortController.signal
+    });
+    if (!isCurrentUnifiedSearchRequest(requestGeneration)) return;
+    const appended = Array.isArray(data?.results) ? data.results : [];
+    const seen = new Set();
+    const items = [...existingItems, ...appended].filter(item => {
+      const id = String(item?.session_id || '');
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+    __vontologySearchState.conversations = {
+      items,
+      status: items.length ? 'ready' : 'empty',
+      error: '',
+      nextCursor: data?.next_cursor || null,
+      coverage: data?.index_coverage || current.coverage || null
+    };
+    if (mode === 'recovery') acceptConversationRecoveryCountPayload(data);
+    renderSearchResults();
+  } catch (error) {
+    if (error?.name === 'AbortError' || !isCurrentUnifiedSearchRequest(requestGeneration)) return;
+    __vontologySearchState.conversations = {
+      ...current,
+      items: existingItems,
+      status: 'error',
+      error: 'More conversations could not be loaded.'
+    };
+    renderSearchResults();
+  }
+}
+
+async function restoreConversationFromRecovery(item, button) {
+  const sessionId = String(item?.session_id || '').trim();
+  if (!sessionId) return false;
+  const previousLabel = button?.textContent || 'Restore';
+  if (button) {
+    button.disabled = true;
+    button.textContent = 'Restoring\u2026';
+  }
+  try {
+    const response = await vontologyFetch('/von/api/session/delete_chat_session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: sessionId, action: 'restore' })
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || data?.status !== 'restored' || data?.trashed !== false) {
+      throw new Error(data?.error || 'Conversation restore could not be verified.');
+    }
+    __vontologySearchState.conversations.items = __vontologySearchState.conversations.items.filter(
+      row => row?.session_id !== sessionId
+    );
+    if (__vontologySearchState.conversations.items.length === 0 && !__vontologySearchState.conversations.nextCursor) {
+      __vontologySearchState.conversations.status = 'empty';
+    }
+    if (Number.isFinite(__vontologySearchState.recoveryCount)) {
+      __vontologySearchState.recoveryCount = Math.max(0, __vontologySearchState.recoveryCount - 1);
+      __vontologySearchState.recoveryCountConfirmedZero = false;
+    }
+    renderSearchResults();
+    document.dispatchEvent(new CustomEvent('von:conversation-trash-changed', {
+      detail: { action: 'restored', sessionId, source: 'recovery' }
+    }));
+    await refreshConversationRecoveryCount();
+    if (__vontologySearchState.recoveryCountConfirmedZero) {
+      clearSearchResults({ invalidate: true });
+      elements.vontologySearchInput?.focus();
+    }
+    return true;
+  } catch (error) {
+    __vontologySearchState.conversations.status = 'error';
+    __vontologySearchState.conversations.error = error?.message || 'Conversation restore failed.';
+    renderSearchResults();
+    return false;
+  } finally {
+    if (button?.isConnected) {
+      button.disabled = false;
+      button.textContent = previousLabel;
+    }
+  }
+}
+
+function initialiseConversationRecoveryUI() {
+  if (__conversationRecoveryInitialised) return;
+  const button = document.getElementById('conversationRecoveryButton');
+  if (!button) return;
+  __conversationRecoveryInitialised = true;
+  button.addEventListener('click', () => { void openRemovedConversations(); });
+  document.addEventListener('von:conversation-trash-changed', event => {
+    if (event?.detail?.source === 'recovery') return;
+    void refreshConversationRecoveryCount();
+  });
+  document.addEventListener('von:tab-activated', event => {
+    updateConversationRecoveryButton();
+    if (event?.detail?.tabId === 'chatTab') void refreshConversationRecoveryCount();
+  });
+  const resetForActorContext = () => {
+    __vontologySearchState.recoveryCount = null;
+    __vontologySearchState.recoveryCountConfirmedZero = false;
+    __vontologySearchState.recoveryCountCoverageComplete = false;
+    clearSearchResults({ invalidate: true });
+    if (elements.vontologySearchInput) elements.vontologySearchInput.value = '';
+    updateConversationRecoveryButton();
+    void refreshConversationRecoveryCount();
+  };
+  document.addEventListener('orgSwitched', resetForActorContext);
+  document.addEventListener('authStatusChanged', resetForActorContext);
+  updateConversationRecoveryButton();
+  void refreshConversationRecoveryCount();
 }
 
 
@@ -3685,6 +4247,19 @@ async function selectSearchItem(item) {
   const __perfStartSearchSel = (typeof window !== 'undefined' && window.performance ? performance.now() : Date.now());
   if (!item) return;
   if (item.disabled) return;
+  if (item.searchType === 'conversation') {
+    const input = elements?.vontologySearchInput;
+    if (input) input.value = item.name || '';
+    clearSearchResults({ invalidate: true });
+    try {
+      document.dispatchEvent(new CustomEvent('von:open-conversation-search-result', {
+        detail: { conversation: item }
+      }));
+    } catch (error) {
+      console.error('[selectSearchItem] Failed to dispatch conversation selection', error);
+    }
+    return;
+  }
   const inputEl = elements && elements.vontologySearchInput;
   if (inputEl) {
     try {
@@ -4845,6 +5420,22 @@ export function __test_retireVontologyPreload() { retireVontologyPreload(); }
 
 // Export for testing
 export function __test_selectSearchItem(item) { return selectSearchItem(item); }
+export function __test_getUnifiedSearchState() {
+  return {
+    items: __vontologySearchState.items.map(item => ({ ...item })),
+    activeIndex: __vontologySearchState.activeIndex,
+    lastQuery: __vontologySearchState.lastQuery,
+    mode: __vontologySearchState.mode,
+    concepts: { ...__vontologySearchState.concepts, items: __vontologySearchState.concepts.items.map(item => ({ ...item })) },
+    conversations: { ...__vontologySearchState.conversations, items: __vontologySearchState.conversations.items.map(item => ({ ...item })) },
+    recoveryCount: __vontologySearchState.recoveryCount,
+    recoveryCountConfirmedZero: __vontologySearchState.recoveryCountConfirmedZero,
+    recoveryCountCoverageComplete: __vontologySearchState.recoveryCountCoverageComplete
+  };
+}
+export function __test_openRemovedConversations() { return openRemovedConversations(); }
+export function __test_refreshConversationRecoveryCount() { return refreshConversationRecoveryCount(); }
+export function __test_loadMoreConversationSearchResults() { return loadMoreConversationSearchResults(); }
 // Export for testing
 export function __test_renderSelectedNodePathContent(target, selectedNode, parents = []) {
   renderSelectedNodePathContent(target, selectedNode, parents);

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -2566,6 +2566,7 @@ body {
 }
 
 .global-header .vontology-search-results {
+    display: none;
     position: absolute;
     top: 100%;
     left: 0;
@@ -2574,11 +2575,15 @@ body {
     border: 1px solid #d1d5db;
     border-top: none;
     border-radius: 0 0 6px 6px;
-    max-height: 300px;
+    max-height: min(520px, calc(100vh - var(--von-fixed-shell-height, 104px) - 20px));
     overflow-y: auto;
     z-index: 1300;
     /* Above header (1200) */
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.global-header .vontology-search-results.open {
+    display: block;
 }
 
 .global-header .vontology-search {
@@ -2586,6 +2591,186 @@ body {
     flex: 1;
     max-width: none;
     margin: 0;
+}
+
+.conversation-recovery-button {
+    position: relative;
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+    color: #64748b;
+    cursor: pointer;
+}
+
+.conversation-recovery-button[hidden],
+.conversation-recovery-count[hidden] {
+    display: none;
+}
+
+.conversation-recovery-button:hover,
+.conversation-recovery-button[aria-pressed="true"] {
+    border-color: #94a3b8;
+    background: #f1f5f9;
+    color: #334155;
+}
+
+.conversation-recovery-button:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.conversation-recovery-button svg {
+    width: 19px;
+    height: 19px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.conversation-recovery-count {
+    position: absolute;
+    top: -7px;
+    right: -8px;
+    min-width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 0 4px;
+    border: 2px solid #fff;
+    border-radius: 999px;
+    background: #475569;
+    color: #fff;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.unified-search-group + .unified-search-group {
+    border-top: 1px solid #e2e8f0;
+}
+
+.unified-search-group-heading {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 7px 10px 5px;
+    background: #f8fafc;
+    color: #475569;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.unified-search-provider-notice {
+    padding: 8px 10px;
+    color: #64748b;
+    font-size: 12px;
+}
+
+.unified-search-provider-notice.is-error {
+    color: #9f1239;
+}
+
+.unified-search-provider-notice.is-partial {
+    border-top: 1px dashed #e2e8f0;
+    background: #fffbeb;
+    color: #854d0e;
+}
+
+.global-header .vontology-search-results .unified-search-conversation-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    padding: 0;
+    border-bottom: 1px solid #f1f5f9;
+}
+
+.global-header .vontology-search-results .unified-search-conversation-item:hover,
+.global-header .vontology-search-results .unified-search-conversation-item.active {
+    background: #f1f5f9;
+}
+
+.unified-search-conversation-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2px 10px;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 9px 10px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+}
+
+button.unified-search-conversation-main {
+    cursor: pointer;
+}
+
+.unified-search-conversation-title {
+    min-width: 0;
+    overflow: hidden;
+    color: #0f172a;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.unified-search-conversation-date {
+    color: #64748b;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.unified-search-conversation-snippet {
+    grid-column: 1 / -1;
+    min-width: 0;
+    overflow: hidden;
+    color: #64748b;
+    font-size: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.unified-search-more-button,
+.unified-search-restore-button {
+    margin: 7px 10px;
+    padding: 5px 9px;
+    border: 1px solid #cbd5e1;
+    border-radius: 7px;
+    background: #fff;
+    color: #334155;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.unified-search-more-button:hover,
+.unified-search-restore-button:hover {
+    background: #f1f5f9;
+    border-color: #94a3b8;
+}
+
+.unified-search-restore-button:disabled {
+    cursor: wait;
+    opacity: 0.65;
 }
 
 /* Search result items within global header */
@@ -7320,6 +7505,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 
 .chat-session-tabs {
     display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
     align-items: flex-end;
     gap: 6px;
     margin-bottom: 0;
@@ -7334,89 +7521,6 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     gap: 10px;
     margin-bottom: 10px;
     scroll-margin-top: calc(var(--von-fixed-shell-height, 104px) + 10px);
-}
-
-.conversation-search {
-    display: flex;
-    flex: 0 1 360px;
-    gap: 6px;
-    align-items: center;
-}
-
-.conversation-search-input {
-    min-width: 150px;
-    width: 100%;
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    padding: 7px 9px;
-    font: inherit;
-}
-
-.conversation-search-button,
-.conversation-search-more {
-    border: 1px solid #cbd5e1;
-    border-radius: 8px;
-    background: #fff;
-    color: #334155;
-    padding: 7px 10px;
-    cursor: pointer;
-}
-
-.conversation-search-button[aria-pressed="true"] {
-    border-color: #64748b;
-    background: #f1f5f9;
-}
-
-.conversation-search-panel {
-    margin: -2px 0 12px;
-    padding: 10px;
-    border: 1px solid #e2e8f0;
-    border-radius: 10px;
-    background: #f8fafc;
-}
-
-.conversation-search-status {
-    margin-bottom: 7px;
-    color: #64748b;
-    font-size: 12px;
-}
-
-.conversation-search-results {
-    display: grid;
-    gap: 6px;
-}
-
-.conversation-search-result {
-    display: grid;
-    grid-template-columns: minmax(150px, 1fr) auto;
-    gap: 3px 10px;
-    width: 100%;
-    padding: 8px 10px;
-    border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    background: #fff;
-    color: inherit;
-    text-align: left;
-}
-
-.conversation-search-result-title {
-    font-weight: 600;
-}
-
-.conversation-search-result-date,
-.conversation-search-result-snippet {
-    color: #64748b;
-    font-size: 12px;
-}
-
-.conversation-search-result-snippet {
-    grid-column: 1 / -1;
-}
-
-.conversation-search-result-actions {
-    display: flex;
-    align-items: center;
-    gap: 6px;
 }
 
 .chat-session-tab-group-start {
@@ -7464,6 +7568,21 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     font-variant-numeric: tabular-nums;
     -webkit-user-select: none;
     user-select: none;
+}
+
+.chat-session-history-summary,
+.chat-session-history-controls {
+    display: flex;
+    align-items: center;
+}
+
+.chat-session-history-summary {
+    flex: 0 0 auto;
+    gap: 6px;
+}
+
+.chat-session-history-controls {
+    gap: 4px;
 }
 
 .chat-session-tabs::-webkit-scrollbar {
@@ -7655,20 +7774,44 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     justify-content: center;
 }
 
-.chat-session-tab-more {
-    background: #f8fafc;
-    border-style: dashed;
-    border-color: #94a3b8;
-    color: #334155;
-    align-items: center;
-    justify-content: center;
-    max-width: none;
-    padding: 6px 10px;
+.chat-session-history-toggle {
+    flex: 0 0 auto;
+    min-width: 30px;
+    padding: 3px 6px;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: #fff;
+    color: #475569;
+    font: inherit;
+    font-size: 11px;
+    line-height: 1.2;
+    cursor: pointer;
 }
 
-.chat-session-tab-more:hover {
+.chat-session-history-toggle:hover,
+.chat-session-history-toggle:focus-visible {
     background: #f1f5f9;
     border-color: #64748b;
+}
+
+.chat-session-history-indicator {
+    flex: 0 0 auto;
+    align-self: center;
+    padding: 3px 6px;
+    border: 1px dashed #cbd5e1;
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #64748b;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.2;
+    white-space: nowrap;
+    cursor: help;
+}
+
+.chat-session-history-indicator:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
 }
 
 .chat-session-tab-header {
@@ -8013,7 +8156,7 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     scrollbar-color: #cbd5e1 transparent;
 }
 
-.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-count {
+.conversation-workspace[data-effective-tabs-layout="vertical"] .chat-session-history-summary {
     order: -1;
     align-self: flex-end;
     padding-right: 3px;

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -4,25 +4,12 @@
     <div id="conversationWorkspace" class="conversation-workspace" data-tabs-layout="horizontal"
       data-effective-tabs-layout="horizontal">
       <div class="chat-session-tabs-row" aria-label="Conversation sessions">
-        <div class="conversation-search" role="search" aria-label="Search conversations">
-          <label class="sr-only" for="conversationSearchInput">Search conversation titles and content</label>
-          <input id="conversationSearchInput" class="conversation-search-input" type="search"
-            placeholder="Search conversations" autocomplete="off" />
-          <button id="conversationSearchButton" class="conversation-search-button" type="button">Search</button>
-          <button id="conversationTrashButton" class="conversation-search-button" type="button"
-            aria-pressed="false">Trash</button>
-        </div>
         <div id="chatSessionTabs" class="chat-session-tabs" role="tablist" aria-label="Conversation sessions"
           aria-orientation="horizontal"></div>
-        <div id="chatSessionCount" class="chat-session-count" aria-label="Conversation count" title="Conversations">—
+        <div class="chat-session-history-summary" aria-label="Conversation history summary">
+          <div id="chatSessionHistoryControls" class="chat-session-history-controls"></div>
         </div>
       </div>
-      <div id="conversationSearchPanel" class="conversation-search-panel" hidden>
-        <div id="conversationSearchStatus" class="conversation-search-status" role="status" aria-live="polite"></div>
-        <div id="conversationSearchResults" class="conversation-search-results"></div>
-        <button id="conversationSearchMore" class="conversation-search-more" type="button" hidden>Load more</button>
-      </div>
-
       <div class="chat-conversation-main">
         <div class="chat-conversation-masthead">
           <div class="chat-conversation-context">

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -23,7 +23,7 @@
   <!-- Fixed Global Header (title + search above tabs) JVNAUTOSCI-550 -->
   <div class="global-header" id="globalHeader">
     <div class="global-header-shell">
-      <!-- Global Concept Search -->
+      <!-- Global concept and conversation search -->
       <div class="global-concept-search" id="globalConceptSearchRegion">
         <div class="global-concept-search-inner">
           <h2 class="vontology-title" id="vontologyGlobalTitle">
@@ -35,17 +35,28 @@
                   stroke-linecap="round" />
               </svg>
             </span>
-            <span class="visually-hidden">Concept Search</span>
+            <span class="visually-hidden">Search</span>
           </h2>
           <div class="vontology-search" id="globalVontologySearchWrapper">
-            <input type="text" id="vontologySearchInput" placeholder="Search concepts by name…"
-              aria-label="Search concepts" role="combobox" aria-autocomplete="list" aria-expanded="false"
+            <input type="search" id="vontologySearchInput" placeholder="Search conversations and concepts…"
+              aria-label="Search conversations and concepts" role="combobox" aria-autocomplete="list" aria-expanded="false"
               aria-haspopup="listbox" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
               name="_vontology_search" />
             <div id="vontologySearchResults" class="vontology-search-results" role="listbox"
               aria-label="Search results">
             </div>
           </div>
+          <button id="conversationRecoveryButton" class="conversation-recovery-button" type="button" hidden
+            aria-label="Open removed conversations" aria-pressed="false" title="Open removed conversations"
+            data-keep-title="true">
+            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+              <path d="M4 9h16v10H4z" />
+              <path d="M8 5h8l2 4H6z" />
+              <path d="M14.5 12.5a3.5 3.5 0 1 0 1 2.5" />
+              <path d="M14.5 10.8v3h-3" />
+            </svg>
+            <span id="conversationRecoveryCount" class="conversation-recovery-count" hidden aria-hidden="true"></span>
+          </button>
         </div>
       </div>
 

--- a/tests/backend/test_chat_history_session_summaries_resilience.py
+++ b/tests/backend/test_chat_history_session_summaries_resilience.py
@@ -237,6 +237,46 @@ def test_light_session_summaries_bound_agent_visibility_overfetch(monkeypatch):
     assert result["raw_session_count_is_bounded"] is True
 
 
+def test_older_session_count_uses_unbounded_metadata_count_query(monkeypatch):
+    collection = object()
+    captured = {}
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **kwargs: collection,
+    )
+
+    def _fake_aggregate(received_collection, pipeline, **kwargs):
+        captured["collection"] = received_collection
+        captured["pipeline"] = pipeline
+        captured["operation"] = kwargs.get("operation")
+        return iter([{"session_count": 37}])
+
+    monkeypatch.setattr(chat_history_service, "_read_aggregate", _fake_aggregate)
+    cutoff = _utc("2026-01-25T00:00:00Z")
+
+    count = chat_history_service.get_chat_history_sessions_older_than_count(
+        "#V#u",
+        cutoff=cutoff,
+        namespace="#V#u@org",
+        include_legacy=False,
+        agent_visibility="exclude",
+    )
+
+    assert count == 37
+    assert captured["collection"] is collection
+    assert captured["operation"] == (
+        "get_chat_history_sessions_older_than_count.aggregate"
+    )
+    match = captured["pipeline"][0]["$match"]
+    assert match["user_id"] == "#V#u"
+    assert match["namespace"] == "#V#u@org"
+    assert match["trashed_at"] is None
+    assert match["$and"][0]["$or"][0] == {"updated_at": {"$lt": cutoff}}
+    assert "$nor" in match["$and"][1]
+    assert captured["pipeline"][1] == {"$count": "session_count"}
+
+
 def test_chat_history_indexes_include_namespaced_recency_index() -> None:
     class _IndexCollection:
         def __init__(self) -> None:

--- a/tests/backend/test_history_sessions_endpoint.py
+++ b/tests/backend/test_history_sessions_endpoint.py
@@ -92,6 +92,17 @@ def test_history_sessions_passes_agent_visibility_and_returns_counts(
         "get_chat_history_session_summaries_result",
         _fake_summaries,
     )
+    recency_call = {}
+
+    def _fake_older_count(*args, **kwargs):
+        recency_call.update(kwargs)
+        return 41
+
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_sessions_older_than_count",
+        _fake_older_count,
+    )
 
     import src.backend.services.shared_conversation_service as shared_conversation_service
 
@@ -112,7 +123,7 @@ def test_history_sessions_passes_agent_visibility_and_returns_counts(
     )
 
     response = client.get(
-        "/von/history/sessions?limit=50&summary=light&agent_visibility=exclude&keep_newest_agent_created=true",
+        "/von/history/sessions?limit=50&summary=light&agent_visibility=exclude&keep_newest_agent_created=true&recent_window_days=30",
         headers={"X-Von-Window-Session": "ws_test"},
     )
 
@@ -128,6 +139,10 @@ def test_history_sessions_passes_agent_visibility_and_returns_counts(
     assert payload["hidden_agent_created_session_count"] == 59
     assert payload["agent_created_session_total"] == 60
     assert payload["newest_visible_agent_created_session_id"] == "agent-new"
+    assert payload["older_than_window_count"] == 41
+    assert payload["recent_window_days"] == 30
+    assert recency_call["namespace"] == "#V#u@org"
+    assert recency_call["agent_visibility"] == "exclude"
 
 
 def test_history_sessions_projects_server_conversation_preferences(

--- a/tests/frontend/chatSessionDeletion.test.js
+++ b/tests/frontend/chatSessionDeletion.test.js
@@ -178,4 +178,34 @@ describe('chat session Trash', () => {
             'error'
         );
     });
+
+    test('hydrates a selected global-search result into the recent working set', async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({})
+        });
+        const chatTab = require(chatTabModulePath);
+        chatTab.__testOnly_setActiveChatSession('older-session', 'Older conversation');
+        await new Promise(resolve => setTimeout(resolve, 0));
+        global.fetch.mockClear();
+        chatTab.__testOnly_setSessionTabsCache([]);
+
+        const result = await chatTab.__testOnly_openConversationSearchResult({
+            session_id: 'older-session',
+            session_name: 'Older conversation',
+            last_message_at: '2025-08-23T10:00:00Z',
+            match: { snippet: 'historical match' }
+        });
+
+        expect(result).toEqual({ ok: true, alreadyActive: true });
+        expect(chatTab.__testOnly_getSessionTabsCache()).toEqual([
+            expect.objectContaining({
+                session_id: 'older-session',
+                session_name: 'Older conversation'
+            })
+        ]);
+        expect(document.body.dataset.activeTab).toBe('chatTab');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
 });

--- a/tests/frontend/chatSessionPinning.test.js
+++ b/tests/frontend/chatSessionPinning.test.js
@@ -22,7 +22,9 @@ describe('chat session pinning', () => {
         const olderRecentTimestamp = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
         document.body.innerHTML = `
+            <input id="vontologySearchInput" />
             <div id="chatSessionTabs"></div>
+            <div id="chatSessionHistoryControls"></div>
             <div id="chatSessionMetadata"></div>
             <div id="scrollableField"></div>
         `;
@@ -218,5 +220,111 @@ describe('chat session pinning', () => {
             session_id: 's2',
             action: 'unpin',
         });
+    });
+
+    test('keeps compact history controls and reveals recent conversations in tranches', async () => {
+        localStorage.setItem('chatHistoryRecentLimit', '2');
+        localStorage.setItem('chatHistoryRecentWindowDays', '30');
+        const sessions = Array.from({ length: 4 }, (_, index) => ({
+            session_id: `recent-${index}`,
+            session_name: `Recent ${index}`,
+            last_message_at: new Date(Date.now() - index * 60_000).toISOString(),
+            created_at: new Date(Date.now() - index * 60_000).toISOString(),
+        }));
+        global.fetch = jest.fn(async (url) => {
+            if (String(url).startsWith('/von/api/session/context')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        authenticated: true,
+                        user_id: '#V#pin_user',
+                        organisation_id: '#V#test_org',
+                        namespace: '#V#pin_user@test_org',
+                    })
+                };
+            }
+            if (String(url).startsWith('/von/history/sessions')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        authenticated: true,
+                        active_session_id: null,
+                        sessions,
+                        recent_window_days: 30,
+                        older_than_window_count: 37,
+                    })
+                };
+            }
+            return { ok: true, json: async () => ({}) };
+        });
+
+        require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        const container = document.getElementById('chatSessionTabs');
+        const controls = document.getElementById('chatSessionHistoryControls');
+        expect(container.children[0].classList.contains('chat-session-tab-new')).toBe(true);
+        expect(container.children[1].dataset.sessionId).toBeTruthy();
+        expect(controls.children[0].classList.contains('chat-session-history-indicator')).toBe(true);
+        expect(controls.children[0].textContent).toBe('[37 > 30d]');
+        expect(controls.children[0].title).toContain('37 conversations are older than 30 days');
+        expect(controls.children[1].classList.contains('chat-session-history-toggle')).toBe(true);
+        expect(controls.children[1].textContent).toBe('+2');
+
+        controls.children[1].click();
+
+        expect(controls.querySelector('.chat-session-history-toggle')).toBeNull();
+        expect(container.querySelectorAll('[data-session-id]')).toHaveLength(4);
+        expect(container.children[1].dataset.sessionId).toBeTruthy();
+    });
+
+    test('Shift-click reveals every remaining recent conversation at once', async () => {
+        localStorage.setItem('chatHistoryRecentLimit', '2');
+        localStorage.setItem('chatHistoryRecentWindowDays', '30');
+        const sessions = Array.from({ length: 7 }, (_, index) => ({
+            session_id: `recent-${index}`,
+            session_name: `Recent ${index}`,
+            last_message_at: new Date(Date.now() - index * 60_000).toISOString(),
+            created_at: new Date(Date.now() - index * 60_000).toISOString(),
+        }));
+        global.fetch = jest.fn(async (url) => {
+            if (String(url).startsWith('/von/api/session/context')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        authenticated: true,
+                        user_id: '#V#pin_user',
+                        organisation_id: '#V#test_org',
+                        namespace: '#V#pin_user@test_org',
+                    })
+                };
+            }
+            if (String(url).startsWith('/von/history/sessions')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        authenticated: true,
+                        active_session_id: null,
+                        sessions,
+                        recent_window_days: 30,
+                        older_than_window_count: 0,
+                    })
+                };
+            }
+            return { ok: true, json: async () => ({}) };
+        });
+
+        require(chatTabModulePath);
+        await window.refreshChatSessionTabsForOrgSwitch();
+
+        const container = document.getElementById('chatSessionTabs');
+        const overflowButton = document.querySelector('.chat-session-history-toggle');
+        expect(overflowButton.textContent).toBe('+5');
+        expect(overflowButton.title).toContain('Shift-click to show all');
+
+        overflowButton.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+
+        expect(document.querySelector('.chat-session-history-toggle')).toBeNull();
+        expect(container.querySelectorAll('[data-session-id]')).toHaveLength(7);
     });
 });

--- a/tests/frontend/conversationSearch.test.js
+++ b/tests/frontend/conversationSearch.test.js
@@ -1,64 +1,50 @@
 /** @jest-environment jsdom */
 
-const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+function jsonResponse(data, { ok = true, status = 200 } = {}) {
+    return { ok, status, json: async () => data };
+}
 
-jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
-    annotateTurn: jest.fn(),
-    fetchWithTimeout: jest.fn(),
-    getJsonDetailed: jest.fn(),
-    getUserContext: jest.fn(),
-    getWindowSessionId: jest.fn(() => 'window-1'),
-    postJson: jest.fn(),
-    WINDOW_SESSION_HEADER: 'X-Von-Window-Session'
-}));
+function conversationPayload({ results = [], nextCursor = null, accessibleCount = null, complete = true } = {}) {
+    return {
+        success: true,
+        results,
+        next_cursor: nextCursor,
+        index_coverage: {
+            accessible_window_count: accessibleCount ?? results.length,
+            complete_for_accessible_window: complete,
+            candidate_window_complete: complete,
+            limitations: complete ? [] : ['accessible_conversation_window_incomplete']
+        }
+    };
+}
 
-jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
-    elements: {},
-    getCurrentUserConceptId: jest.fn(() => '#V#alice'),
-    renderSpanSuggestions: jest.fn()
-}));
+function installSearchDom({ recovery = false } = {}) {
+    document.body.dataset.activeTab = 'chatTab';
+    document.body.innerHTML = `
+        <div id="chatTab" class="active"></div>
+        <input id="vontologySearchInput" />
+        <div id="vontologySearchResults"></div>
+        ${recovery ? `
+            <button id="conversationRecoveryButton" hidden aria-pressed="false"></button>
+            <span id="conversationRecoveryCount" hidden></span>
+        ` : ''}
+    `;
+}
 
-jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
-    applyCartoucheAppearance: jest.fn(),
-    cartouchifyElementText: jest.fn(),
-    createVontologyAliasCartouche: jest.fn(),
-    createVontologyCartouche: jest.fn(),
-    findPotentialConceptAliasMatches: jest.fn(() => []),
-    getCartoucheAppearanceSettings: jest.fn(() => ({
-        useShortestName: false,
-        showName: true,
-        showId: true,
-        showKind: true,
-        kindAsBackground: false
-    })),
-    linkifyVontologyTokensInElement: jest.fn(),
-    normalisePotentialConceptAlias: jest.fn(() => ''),
-    normalisePotentialConceptId: jest.fn(() => ''),
-    replaceTextNodeWithVontologyAliasCartouches: jest.fn(() => [])
-}));
+function loadSearchModule() {
+    const vontology = require('../../src/frontend/web/von_interface/static/js/vontology.js');
+    const { elements } = require('../../src/frontend/web/von_interface/static/js/domUtils.js');
+    elements.vontologySearchInput = document.getElementById('vontologySearchInput');
+    elements.vontologySearchResults = document.getElementById('vontologySearchResults');
+    return vontology;
+}
 
-jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
-    showToast: jest.fn()
-}));
-
-describe('conversation search UI', () => {
+describe('unified global conversation and concept search', () => {
     beforeEach(() => {
         jest.resetModules();
-        window.matchMedia = jest.fn(() => ({ matches: false }));
-        document.body.innerHTML = `
-            <input id="conversationSearchInput" />
-            <button id="conversationSearchButton"></button>
-            <button id="conversationTrashButton" aria-pressed="false"></button>
-            <div id="conversationSearchPanel" hidden>
-                <div id="conversationSearchStatus"></div>
-                <div id="conversationSearchResults"></div>
-                <button id="conversationSearchMore" hidden></button>
-            </div>
-            <div id="chatSessionTabs"></div>
-            <div id="chatSessionCount"></div>
-            <div id="chatSessionMetadata"></div>
-            <div id="scrollableField"></div>
-        `;
+        installSearchDom();
+        localStorage.setItem('von_current_user', JSON.stringify({ concept_id: '#V#alice' }));
+        sessionStorage.setItem('von_window_session_id', 'window-1');
         global.fetch = jest.fn();
     });
 
@@ -66,88 +52,197 @@ describe('conversation search UI', () => {
         jest.restoreAllMocks();
     });
 
-    test('renders named, dated, bounded results and passes the cursor for more', async () => {
-        global.fetch
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    success: true,
+    test('shows conversations first in the Conversations workspace, with concepts still available', async () => {
+        global.fetch.mockImplementation((url) => {
+            if (String(url).includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({
+                    results: [{ id: '#V#detector', name: 'Detector', kind: 'type' }]
+                }));
+            }
+            if (String(url).includes('/conversation_search')) {
+                return Promise.resolve(jsonResponse(conversationPayload({
                     results: [{
                         session_id: 's1',
-                        session_name: 'Detector calibration',
+                        display_name: 'Detector calibration',
                         last_message_at: '2026-08-23T10:00:00Z',
                         match: { snippet: '...old exact detector phrase...' }
-                    }],
-                    next_cursor: 'opaque-cursor',
-                    index_coverage: { complete_for_accessible_window: false }
-                })
-            })
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    success: true,
-                    results: [{
-                        session_id: 's2',
-                        session_name: 'Collider planning',
-                        created_at: '2026-08-20T09:00:00Z',
-                        match: { snippet: 'semantic topic match' }
-                    }],
-                    next_cursor: null,
-                    index_coverage: { complete_for_accessible_window: true }
-                })
-            });
-        const chatTab = require(chatTabModulePath);
-        document.getElementById('conversationSearchInput').value = 'detector';
+                    }]
+                })));
+            }
+            throw new Error(`Unexpected URL: ${url}`);
+        });
+        const vontology = loadSearchModule();
 
-        await chatTab.__testOnly_performConversationSearch();
-        await chatTab.__testOnly_performConversationSearch({ append: true });
+        await vontology.performVontologySearch('detector');
 
-        expect(global.fetch.mock.calls[0][0]).toContain('q=detector');
-        expect(global.fetch.mock.calls[1][0]).toContain('cursor=opaque-cursor');
-        expect(document.getElementById('conversationSearchResults').textContent).toContain('Detector calibration');
-        expect(document.getElementById('conversationSearchResults').textContent).toContain('Collider planning');
-        expect(document.getElementById('conversationSearchResults').textContent).toContain('old exact detector phrase');
-        expect(chatTab.__testOnly_getConversationSearchState().results).toHaveLength(2);
-        expect(document.getElementById('conversationSearchMore').hidden).toBe(true);
+        const headings = [...document.querySelectorAll('.unified-search-group-heading')]
+            .map(node => node.textContent);
+        expect(headings).toEqual(['Conversations', 'Concepts']);
+        expect(document.getElementById('vontologySearchResults').textContent).toContain('Detector calibration');
+        expect(document.getElementById('vontologySearchResults').textContent).toContain('old exact detector phrase');
+        expect(document.getElementById('vontologySearchResults').textContent).toContain('Detector');
+        expect(vontology.__test_getUnifiedSearchState().items.map(item => item.searchType))
+            .toEqual(['conversation', 'concept']);
+        const conversationUrl = global.fetch.mock.calls
+            .map(call => String(call[0]))
+            .find(url => url.includes('/conversation_search'));
+        expect(conversationUrl).toContain('match_mode=lexical');
     });
 
-    test('Trash view restores through the recoverable lifecycle route', async () => {
-        global.fetch
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    success: true,
-                    results: [{
-                        session_id: 'trashed-1',
-                        session_name: 'Recover me',
-                        trashed: true,
-                        match: {}
-                    }],
-                    next_cursor: null,
-                    index_coverage: { complete_for_accessible_window: true }
-                })
-            })
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    status: 'restored',
-                    session_id: 'trashed-1',
-                    trashed: false,
-                    recoverable: true
-                })
-            });
-        const chatTab = require(chatTabModulePath);
+    test('one failed provider does not suppress results from the other', async () => {
+        global.fetch.mockImplementation((url) => {
+            if (String(url).includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({}, { ok: false, status: 503 }));
+            }
+            return Promise.resolve(jsonResponse(conversationPayload({
+                results: [{ session_id: 's1', session_name: 'Usable conversation', match: {} }]
+            })));
+        });
+        const vontology = loadSearchModule();
 
-        await chatTab.__testOnly_performConversationSearch({ trashedOnly: true });
-        await chatTab.__testOnly_restoreConversation('trashed-1');
+        await vontology.performVontologySearch('usable');
 
-        expect(global.fetch.mock.calls[0][0]).toContain('q=*');
-        expect(global.fetch.mock.calls[0][0]).toContain('trashed_only=true');
-        expect(global.fetch.mock.calls[1][0]).toBe('/von/api/session/delete_chat_session');
-        expect(global.fetch.mock.calls[1][1].body).toBe(JSON.stringify({
-            session_id: 'trashed-1',
-            action: 'restore'
-        }));
-        expect(chatTab.__testOnly_getConversationSearchState().results).toEqual([]);
+        const text = document.getElementById('vontologySearchResults').textContent;
+        expect(text).toContain('Usable conversation');
+        expect(text).toContain('Concept search is temporarily unavailable.');
+    });
+
+    test('renders the fast provider while the other provider is still pending', async () => {
+        let resolveConversation;
+        global.fetch.mockImplementation((url) => {
+            if (String(url).includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({
+                    results: [{ id: '#V#fast', name: 'Fast concept', kind: 'type' }]
+                }));
+            }
+            return new Promise(resolve => { resolveConversation = resolve; });
+        });
+        const vontology = loadSearchModule();
+
+        const pending = vontology.performVontologySearch('fast');
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const interimText = document.getElementById('vontologySearchResults').textContent;
+        expect(interimText).toContain('Fast concept');
+        expect(interimText).toContain('Searching conversations');
+
+        resolveConversation(jsonResponse(conversationPayload()));
+        await pending;
+    });
+
+    test('passes the opaque cursor and appends more conversations', async () => {
+        let conversationCall = 0;
+        global.fetch.mockImplementation((url) => {
+            const raw = String(url);
+            if (raw.includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({ results: [] }));
+            }
+            conversationCall += 1;
+            if (conversationCall === 1) {
+                return Promise.resolve(jsonResponse(conversationPayload({
+                    results: [{ session_id: 's1', session_name: 'First result', match: {} }],
+                    nextCursor: 'opaque-cursor'
+                })));
+            }
+            expect(raw).toContain('cursor=opaque-cursor');
+            return Promise.resolve(jsonResponse(conversationPayload({
+                results: [{ session_id: 's2', session_name: 'Second result', match: {} }]
+            })));
+        });
+        const vontology = loadSearchModule();
+        await vontology.performVontologySearch('result');
+
+        await vontology.__test_loadMoreConversationSearchResults();
+
+        expect(vontology.__test_getUnifiedSearchState().conversations.items.map(row => row.session_id))
+            .toEqual(['s1', 's2']);
+        expect(document.getElementById('vontologySearchResults').textContent).toContain('Second result');
+    });
+
+    test('clearing the native search input immediately invalidates a late response', async () => {
+        let resolveConversation;
+        global.fetch.mockImplementation((url) => {
+            if (String(url).includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({ results: [] }));
+            }
+            return new Promise(resolve => { resolveConversation = resolve; });
+        });
+        const vontology = loadSearchModule();
+        vontology.setupVontologySearchUI();
+        const input = document.getElementById('vontologySearchInput');
+        input.value = 'late';
+        const pending = vontology.performVontologySearch('late');
+
+        input.value = '';
+        input.dispatchEvent(new Event('search', { bubbles: true }));
+        resolveConversation(jsonResponse(conversationPayload({
+            results: [{ session_id: 'late', session_name: 'Late result', match: {} }]
+        })));
+        await pending;
+
+        expect(vontology.__test_getUnifiedSearchState().items).toEqual([]);
+        expect(document.getElementById('vontologySearchResults').textContent).toBe('');
+        expect(document.getElementById('vontologySearchResults').classList.contains('open')).toBe(false);
+    });
+
+    test('selecting a conversation dispatches the canonical open event', async () => {
+        global.fetch.mockImplementation((url) => {
+            if (String(url).includes('/vontology/api/vontology/search')) {
+                return Promise.resolve(jsonResponse({ results: [] }));
+            }
+            return Promise.resolve(jsonResponse(conversationPayload({
+                results: [{ session_id: 's1', session_name: 'Open me', match: {} }]
+            })));
+        });
+        const vontology = loadSearchModule();
+        const selected = [];
+        document.addEventListener('von:open-conversation-search-result', event => selected.push(event.detail));
+        await vontology.performVontologySearch('open');
+
+        document.querySelector('.unified-search-conversation-main').click();
+
+        expect(selected).toHaveLength(1);
+        expect(selected[0].conversation).toMatchObject({ session_id: 's1', name: 'Open me' });
+        expect(document.getElementById('vontologySearchResults').classList.contains('open')).toBe(false);
+    });
+
+    test('recovery count hides only after verified empty read-back', async () => {
+        installSearchDom({ recovery: true });
+        let restored = false;
+        global.fetch.mockImplementation((url, options = {}) => {
+            const raw = String(url);
+            if (raw === '/von/api/session/delete_chat_session') {
+                restored = true;
+                return Promise.resolve(jsonResponse({
+                    status: 'restored', session_id: 'trash-1', trashed: false, recoverable: true
+                }));
+            }
+            if (raw.includes('/conversation_search')) {
+                const results = restored
+                    ? []
+                    : [{ session_id: 'trash-1', session_name: 'Recover me', trashed: true, match: {} }];
+                return Promise.resolve(jsonResponse(conversationPayload({
+                    results,
+                    accessibleCount: restored ? 0 : 1,
+                    complete: true
+                })));
+            }
+            throw new Error(`Unexpected URL: ${url} ${options.method || 'GET'}`);
+        });
+        const vontology = loadSearchModule();
+
+        await vontology.__test_refreshConversationRecoveryCount();
+        expect(document.getElementById('conversationRecoveryButton').hidden).toBe(false);
+        expect(document.getElementById('conversationRecoveryCount').textContent).toBe('1');
+
+        await vontology.__test_openRemovedConversations();
+        expect(document.getElementById('vontologySearchResults').textContent).toContain('Removed conversations');
+        document.querySelector('.unified-search-restore-button').click();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(restored).toBe(true);
+        expect(vontology.__test_getUnifiedSearchState().recoveryCountConfirmedZero).toBe(true);
+        expect(document.getElementById('conversationRecoveryButton').hidden).toBe(true);
     });
 });

--- a/tests/frontend/orgSwitchRefreshChatTabs.test.js
+++ b/tests/frontend/orgSwitchRefreshChatTabs.test.js
@@ -57,7 +57,7 @@ describe('org switch chat session refresh', () => {
         await window.refreshChatSessionTabsForOrgSwitch();
 
         expect(global.fetch).toHaveBeenCalledWith(
-            '/von/history/sessions?limit=200&summary=light&agent_visibility=exclude&keep_newest_agent_created=true',
+            '/von/history/sessions?limit=200&summary=light&agent_visibility=exclude&keep_newest_agent_created=true&recent_window_days=30',
             expect.any(Object)
         );
     });

--- a/tests/frontend/vontologySearchSelection.test.js
+++ b/tests/frontend/vontologySearchSelection.test.js
@@ -50,17 +50,30 @@ describe('Global Vontology search selection', () => {
         localStorage.setItem('von_current_user', JSON.stringify({ concept_id: '#V#michael_witbrock' }));
         sessionStorage.setItem('von_window_session_id', 'ws-search-test');
 
-        global.fetch = jest
-            .fn()
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({ results: [] }),
-            })
-            .mockResolvedValueOnce({
+        global.fetch = jest.fn((url) => {
+            const raw = String(url);
+            if (raw.includes('/vontology/api/vontology/search')) {
+                return Promise.resolve({ ok: true, json: async () => ({ results: [] }) });
+            }
+            if (raw.includes('/von/api/session/conversation_search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        results: [],
+                        next_cursor: null,
+                        index_coverage: {
+                            complete_for_accessible_window: true,
+                            candidate_window_complete: true
+                        }
+                    })
+                });
+            }
+            return Promise.resolve({
                 ok: false,
                 status: 404,
                 json: async () => ({ error: "Concept '#V#missing' not found in MongoDB." }),
             });
+        });
 
         await vontology.performVontologySearch('#V#missing');
 


### PR DESCRIPTION
Merge decision: ready — conversation history is now a compact working set with one global conversation-and-concept search surface and an honest recoverable-history control.

## User outcome

People can work from a small recent conversation strip, find older conversations by title or content through the existing global search, and recover removed conversations without a duplicate control block crowding the left edge.

## Material changes

- Remove the duplicate conversation Search and Trash row from the Conversations workspace.
- Group global search results into Conversations and Concepts, ordering conversations first in that workspace while retaining concept-first behaviour elsewhere.
- Render providers independently, retain opaque-cursor pagination, invalidate stale searches on clear, and disclose incomplete index coverage.
- Present recovery as a neutral tray with a superscript count only when known; hide it only after a complete zero-count read-back. Restore through the canonical recoverable route and verify the result.
- Keep the configured recent working set compact, expose an actor-scoped `[count > days]` older-history indicator, and make `+N` reveal the next tranche or all remaining conversations with Shift-click.
- Hydrate an older conversation selected from search into the existing conversation-opening path.

Jira: JVNAUTOSCI-2682

## Evidence

- `npm run test:frontend -- --runInBand ...`: 83 suites and 459 tests passed.
- Targeted backend history, management, and search tests: 33 passed.
- Changed static JavaScript lint: 0 errors; 22 pre-existing warnings remain in `vontology.js`.
- Node syntax checks and `git diff --check` passed.
- Live MJW Personal browser replay at `/von/#chatTab` verified the compact 50-tab working set, `[59 > 180d] +54`, ordinary expansion from `+54` to `+4`, grouped Gibran conversation/content and concept results, no duplicate search, a badge-free unknown/empty recovery tray, and closed cleared-search state.

## Ship boundary

- **Minimum ship criteria:** one uncluttered search surface; bounded initial tab set with discoverable expansion; title/content conversation result opening; recoverable-history state that is not falsely hidden; directly affected tests and browser path pass.
- **Stop-ship conditions:** duplicate controls remain; clearing can revive stale results; an older result cannot open; recovery can hide without complete zero read-back; actor or organisation scope is widened; the recent working set still expands wholesale by default.
- **Non-blocking observations:** the current conversation index reports partial coverage for part of the accessible older window, which the UI now discloses. Interactive conversation search uses indexed lexical title/content matching for typeahead; the MCP capability retains hybrid RAG retrieval.
- **Non-goals:** rebuilding the conversation index, changing the backend search contract, permanent deletion, or broad redesign of conversation cards and context controls.

Closes JVNAUTOSCI-2682
