### PR TITLE
JVNAUTOSCI-2683: Add footer organisation switcher

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/footerOrganisationSwitcher.js
+++ b/src/frontend/web/von_interface/static/js/components/footerOrganisationSwitcher.js
@@ -1,0 +1,349 @@
+import { getUserContext } from '../apiService.js';
+import {
+  loadMyOrganisations,
+  normaliseOrganisationDisplayName,
+  switchOrganisation,
+} from './orgSelector.js';
+
+const MEMBERSHIP_CACHE_TTL_MS = 60_000;
+
+let membershipCache = {
+  userConceptId: null,
+  organisations: null,
+  loadedAtMs: 0,
+  pending: null,
+};
+
+function normaliseConceptId(value) {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text || null;
+}
+
+function currentUserConceptId() {
+  return normaliseConceptId(getUserContext()?.user_id);
+}
+
+function normaliseMemberships(items) {
+  const seen = new Set();
+  const organisations = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    const conceptId = normaliseConceptId(item?.concept_id);
+    if (!conceptId || seen.has(conceptId)) continue;
+    seen.add(conceptId);
+    organisations.push({
+      conceptId,
+      name: normaliseOrganisationDisplayName(item?.name) || conceptId,
+      role: typeof item?.role === 'string' ? item.role.trim() : '',
+    });
+  }
+  return organisations;
+}
+
+export function invalidateFooterOrganisationMemberships() {
+  membershipCache = {
+    userConceptId: null,
+    organisations: null,
+    loadedAtMs: 0,
+    pending: null,
+  };
+}
+
+async function getFooterOrganisationMemberships({ force = false } = {}) {
+  const userConceptId = currentUserConceptId();
+  if (membershipCache.userConceptId !== userConceptId) {
+    membershipCache = {
+      userConceptId,
+      organisations: null,
+      loadedAtMs: 0,
+      pending: null,
+    };
+  }
+
+  const cacheFresh = Array.isArray(membershipCache.organisations)
+    && (Date.now() - membershipCache.loadedAtMs) < MEMBERSHIP_CACHE_TTL_MS;
+  if (!force && cacheFresh) return membershipCache.organisations;
+  if (membershipCache.pending) return membershipCache.pending;
+
+  const requestCache = membershipCache;
+  requestCache.pending = loadMyOrganisations()
+    .then((items) => {
+      const organisations = normaliseMemberships(items);
+      if (membershipCache === requestCache) {
+        requestCache.organisations = organisations;
+        requestCache.loadedAtMs = Date.now();
+      }
+      return organisations;
+    })
+    .finally(() => {
+      if (membershipCache === requestCache) requestCache.pending = null;
+    });
+  return requestCache.pending;
+}
+
+function setNativeTitle(element, value) {
+  const title = String(value || '').trim();
+  if (!title) {
+    element.removeAttribute('title');
+    element.removeAttribute('data-original-title');
+    element.removeAttribute('data-keep-title');
+    return;
+  }
+  element.title = title;
+  element.dataset.originalTitle = title;
+  element.dataset.keepTitle = 'true';
+}
+
+function writeSwitchingContext(conceptId, name) {
+  try {
+    sessionStorage.setItem('von_org_switching', JSON.stringify({
+      concept_id: conceptId || null,
+      name: name || null,
+    }));
+  } catch (_) {
+    // Display-only hint. The authoritative switch remains server-bound.
+  }
+}
+
+function clearSwitchingContext() {
+  try { sessionStorage.removeItem('von_org_switching'); } catch (_) { /* ignore */ }
+}
+
+export function createFooterOrganisationSwitcher({
+  organisationInfo = {},
+  onOpenConcept = null,
+} = {}) {
+  let currentConceptId = normaliseConceptId(organisationInfo?.conceptId);
+  let currentName = normaliseOrganisationDisplayName(organisationInfo?.name)
+    || currentConceptId
+    || 'Personal';
+  let latestOrganisations = null;
+  let switching = false;
+
+  const segment = document.createElement('span');
+  segment.className = 'footer-segment footer-org-switcher';
+
+  const label = document.createElement('span');
+  label.className = 'footer-label-inline';
+  label.textContent = 'Org:';
+  segment.appendChild(label);
+
+  const control = document.createElement('span');
+  control.className = 'footer-org-control';
+
+  const currentButton = document.createElement('button');
+  currentButton.type = 'button';
+  currentButton.className = 'concept-footer-button footer-org-current-button';
+  currentButton.textContent = currentName;
+  currentButton.disabled = !currentConceptId;
+  currentButton.dataset.conceptId = currentConceptId || '';
+  currentButton.dataset.conceptName = currentConceptId ? currentName : '';
+  setNativeTitle(
+    currentButton,
+    currentConceptId
+      ? `Open ${currentName} in Vontology\nID: ${currentConceptId}`
+      : 'Personal context has no organisation concept',
+  );
+  currentButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    if (!currentConceptId || typeof onOpenConcept !== 'function') return;
+    void onOpenConcept({
+      conceptId: currentConceptId,
+      conceptName: currentName,
+      displayName: currentName,
+    });
+  });
+  control.appendChild(currentButton);
+
+  const details = document.createElement('details');
+  details.className = 'footer-org-menu-details';
+
+  const summary = document.createElement('summary');
+  summary.className = 'concept-footer-button footer-org-menu-trigger';
+  summary.setAttribute('aria-label', 'Switch organisation');
+  setNativeTitle(summary, 'Switch organisation');
+  summary.textContent = '▾';
+  details.appendChild(summary);
+
+  const menu = document.createElement('span');
+  menu.className = 'footer-org-menu';
+  menu.setAttribute('role', 'menu');
+  menu.setAttribute('aria-label', 'Available organisations');
+
+  const status = document.createElement('span');
+  status.className = 'footer-org-switch-status';
+  status.setAttribute('aria-live', 'polite');
+  status.textContent = 'Loading organisations…';
+  menu.appendChild(status);
+
+  const options = document.createElement('span');
+  options.className = 'footer-org-options';
+  menu.appendChild(options);
+
+  const retryButton = document.createElement('button');
+  retryButton.type = 'button';
+  retryButton.className = 'footer-org-retry-button';
+  retryButton.textContent = 'Retry';
+  retryButton.hidden = true;
+  menu.appendChild(retryButton);
+
+  details.appendChild(menu);
+  control.appendChild(details);
+  segment.appendChild(control);
+
+  const setCurrentDisplay = (conceptId, name) => {
+    currentConceptId = normaliseConceptId(conceptId);
+    currentName = normaliseOrganisationDisplayName(name)
+      || currentConceptId
+      || 'Personal';
+    currentButton.textContent = currentName;
+    currentButton.disabled = !currentConceptId;
+    currentButton.dataset.conceptId = currentConceptId || '';
+    currentButton.dataset.conceptName = currentConceptId ? currentName : '';
+    setNativeTitle(
+      currentButton,
+      currentConceptId
+        ? `Open ${currentName} in Vontology\nID: ${currentConceptId}`
+        : 'Personal context has no organisation concept',
+    );
+  };
+
+  const setOptionsDisabled = (disabled) => {
+    for (const button of options.querySelectorAll('button')) {
+      button.disabled = disabled || button.dataset.current === 'true';
+    }
+    summary.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+    details.classList.toggle('is-switching', disabled);
+  };
+
+  const renderOptions = (organisations) => {
+    latestOrganisations = Array.isArray(organisations) ? organisations : [];
+    options.replaceChildren();
+
+    const choices = [{ conceptId: null, name: 'Personal', role: '' }, ...latestOrganisations];
+    if (currentConceptId && !choices.some((choice) => choice.conceptId === currentConceptId)) {
+      choices.push({ conceptId: currentConceptId, name: currentName, role: '', unavailable: true });
+    }
+
+    for (const choice of choices) {
+      const optionButton = document.createElement('button');
+      optionButton.type = 'button';
+      optionButton.className = 'footer-org-option';
+      optionButton.setAttribute('role', 'menuitemradio');
+      const isCurrent = (choice.conceptId || null) === (currentConceptId || null);
+      optionButton.setAttribute('aria-checked', isCurrent ? 'true' : 'false');
+      optionButton.dataset.current = isCurrent ? 'true' : 'false';
+      optionButton.dataset.organisationConceptId = choice.conceptId || '';
+      optionButton.disabled = isCurrent || switching || choice.unavailable === true;
+
+      const check = document.createElement('span');
+      check.className = 'footer-org-option-check';
+      check.setAttribute('aria-hidden', 'true');
+      check.textContent = isCurrent ? '✓' : '';
+      optionButton.appendChild(check);
+
+      const name = document.createElement('span');
+      name.className = 'footer-org-option-name';
+      name.textContent = choice.name;
+      optionButton.appendChild(name);
+
+      if (choice.role) {
+        const role = document.createElement('span');
+        role.className = 'footer-org-option-role';
+        role.textContent = choice.role;
+        optionButton.appendChild(role);
+      }
+
+      optionButton.addEventListener('click', async (event) => {
+        event.stopPropagation();
+        if (switching || isCurrent || choice.unavailable) return;
+
+        switching = true;
+        retryButton.hidden = true;
+        writeSwitchingContext(choice.conceptId, choice.name);
+        setOptionsDisabled(true);
+        status.classList.remove('error');
+        status.textContent = `Switching to ${choice.name}…`;
+
+        try {
+          const response = await switchOrganisation(choice.conceptId, choice.conceptId ? choice.name : null);
+          const committedConceptId = normaliseConceptId(response?.organisation_id);
+          const committedName = committedConceptId ? choice.name : 'Personal';
+          setCurrentDisplay(committedConceptId, committedName);
+          switching = false;
+          clearSwitchingContext();
+          renderOptions(latestOrganisations);
+          status.textContent = `Switched to ${committedName}. Refreshing organisation data…`;
+          details.open = false;
+        } catch (error) {
+          switching = false;
+          clearSwitchingContext();
+          renderOptions(latestOrganisations);
+          status.classList.add('error');
+          status.textContent = 'Switch failed. Choose an organisation to retry.';
+          setNativeTitle(status, error?.message || 'Organisation switch failed');
+        }
+      });
+
+      options.appendChild(optionButton);
+    }
+
+    status.classList.remove('error');
+    status.textContent = latestOrganisations.length > 0
+      ? 'Choose an organisation for this window.'
+      : 'No organisation memberships are available.';
+    setOptionsDisabled(switching);
+  };
+
+  const loadOptions = async ({ force = false } = {}) => {
+    const userConceptIdAtStart = currentUserConceptId();
+    retryButton.hidden = true;
+    status.classList.remove('error');
+    status.textContent = force ? 'Retrying organisation list…' : 'Loading organisations…';
+    try {
+      const organisations = await getFooterOrganisationMemberships({ force });
+      if (currentUserConceptId() !== userConceptIdAtStart) return;
+      if (!segment.isConnected && document.body?.contains(segment) === false) return;
+      renderOptions(organisations);
+    } catch (error) {
+      status.classList.add('error');
+      status.textContent = 'Organisations are temporarily unavailable.';
+      setNativeTitle(status, error?.message || 'Organisation list unavailable');
+      retryButton.hidden = false;
+    }
+  };
+
+  retryButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    void loadOptions({ force: true });
+  });
+
+  details.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      details.open = false;
+      summary.focus();
+    }
+  });
+
+  let outsidePointerListener = null;
+  details.addEventListener('toggle', () => {
+    if (details.open) {
+      if (!latestOrganisations) void loadOptions();
+      outsidePointerListener = (event) => {
+        if (!details.contains(event.target)) details.open = false;
+      };
+      document.addEventListener('pointerdown', outsidePointerListener);
+    } else if (outsidePointerListener) {
+      document.removeEventListener('pointerdown', outsidePointerListener);
+      outsidePointerListener = null;
+    }
+  });
+
+  void loadOptions();
+  return segment;
+}
+
+try {
+  document.addEventListener('authStatusChanged', invalidateFooterOrganisationMemberships);
+} catch (_) {
+  // Constrained test environments may not provide document at import time.
+}

--- a/src/frontend/web/von_interface/static/js/components/orgSelector.js
+++ b/src/frontend/web/von_interface/static/js/components/orgSelector.js
@@ -95,28 +95,51 @@ function renderRetryableOrgSelectorFailure(container, containerId, error) {
  * Switch to a different organisation
  * JVNAUTOSCI-1011: Now stores in sessionStorage for window-scoped contexts,
  * but also writes to localStorage for persistence across restarts/new windows.
- * @param {string} orgConceptId - The organisation concept ID to switch to
+ * @param {string|null} orgConceptId - The organisation concept ID, or null for Personal
  * @param {string} [orgName] - Optional organisation name for event detail
  */
 export async function switchOrganisation(orgConceptId, orgName = null) {
     try {
+        const targetOrganisationId = orgConceptId || null;
         const response = await postJson('/von/api/session/set_organisation', {
-            organisation_concept_id: orgConceptId
+            organisation_concept_id: targetOrganisationId
         });
 
         if (response.status === 'updated') {
-            const orgData = {
-                concept_id: response.organisation_id,
-                namespace: response.namespace
-            };
+            if (response.organisation_id) {
+                const orgData = {
+                    concept_id: response.organisation_id,
+                    namespace: response.namespace
+                };
+                const currentOrgData = {
+                    id: null,
+                    concept_id: response.organisation_id,
+                    name: orgName || null
+                };
 
-            // JVNAUTOSCI-1011: Store in sessionStorage for window-scoped context
-            sessionStorage.setItem(SS_ORG_CONTEXT, JSON.stringify(orgData));
-            sessionStorage.setItem(SS_ORG_ROLE, response.role);
+                // JVNAUTOSCI-1011: Store in sessionStorage for window-scoped context
+                sessionStorage.setItem(SS_ORG_CONTEXT, JSON.stringify(orgData));
+                sessionStorage.setItem(SS_ORG_ROLE, response.role || 'member');
+                sessionStorage.setItem(SS_CURRENT_ORG, JSON.stringify(currentOrgData));
 
-            // Also store in localStorage for persistence across restarts/new windows
-            localStorage.setItem(LS_ORG_CONTEXT, JSON.stringify(orgData));
-            localStorage.setItem(LS_ORG_ROLE, response.role);
+                // Also store in localStorage for persistence across restarts/new windows
+                localStorage.setItem(LS_ORG_CONTEXT, JSON.stringify(orgData));
+                localStorage.setItem(LS_ORG_ROLE, response.role || 'member');
+                localStorage.setItem(SS_CURRENT_ORG, JSON.stringify(currentOrgData));
+            } else {
+                sessionStorage.removeItem(SS_ORG_CONTEXT);
+                sessionStorage.removeItem(SS_ORG_ROLE);
+                sessionStorage.removeItem(SS_CURRENT_ORG);
+                localStorage.removeItem(LS_ORG_CONTEXT);
+                localStorage.removeItem(LS_ORG_ROLE);
+                localStorage.removeItem(SS_CURRENT_ORG);
+            }
+
+            if (response.namespace) {
+                sessionStorage.setItem(SS_CURRENT_NAMESPACE, response.namespace);
+                localStorage.setItem(SS_CURRENT_NAMESPACE, response.namespace);
+            }
+            sessionStorage.removeItem('von_org_switching');
 
             // Dispatch event so other components can react to org change
             const event = new CustomEvent('orgSwitched', {
@@ -212,61 +235,11 @@ export async function renderOrgSelector(containerId) {
                             window.updateModelInfoFooterDisplay();
                         }
                     } catch { }
-                    if (orgId) {
-                        // Get the org name from the selected option
-                        const selected = e.target.selectedOptions?.[0];
-                        const orgDisplayName = normaliseOrganisationDisplayName(selected?.textContent);
-                        const response = await switchOrganisation(orgId, orgDisplayName || null);
-                        try {
-                            const orgData = {
-                                id: null,
-                                concept_id: orgId,
-                                name: orgDisplayName || null
-                            };
-                            // JVNAUTOSCI-1011: Use sessionStorage for window-scoped context
-                            sessionStorage.setItem(SS_CURRENT_ORG, JSON.stringify(orgData));
-                            // Also persist to localStorage for restart/new window scenarios
-                            localStorage.setItem('von_current_org', JSON.stringify(orgData));
-                        } catch { }
-                        try {
-                            if (response?.namespace) {
-                                sessionStorage.setItem(SS_CURRENT_NAMESPACE, response.namespace);
-                                localStorage.setItem('current_user_namespace', response.namespace);
-                            }
-                        } catch { }
-                        try { sessionStorage.removeItem('von_org_switching'); } catch { }
-                    } else {
-                        // Switch back to personal (no org)
-                        const response = await postJson('/von/api/session/set_organisation', {
-                            organisation_concept_id: null
-                        });
-                        // JVNAUTOSCI-1011: Clear both sessionStorage and localStorage
-                        sessionStorage.removeItem(SS_ORG_CONTEXT);
-                        sessionStorage.removeItem(SS_ORG_ROLE);
-                        localStorage.removeItem(LS_ORG_CONTEXT);
-                        localStorage.removeItem(LS_ORG_ROLE);
-                        try { sessionStorage.removeItem(SS_CURRENT_ORG); } catch { }
-                        try { localStorage.removeItem('von_current_org'); } catch { }
-                        try {
-                            if (response?.namespace) {
-                                sessionStorage.setItem(SS_CURRENT_NAMESPACE, response.namespace);
-                                localStorage.setItem('current_user_namespace', response.namespace);
-                            }
-                        } catch { }
-                        try { sessionStorage.removeItem('von_org_switching'); } catch { }
-
-                        // Dispatch event
-                        const event = new CustomEvent('orgSwitched', {
-                            detail: {
-                                organisation_id: null,
-                                organisation_name: null,
-                                role: null,
-                                namespace: response.namespace,
-                                window_session_id: response.window_session_id
-                            }
-                        });
-                        document.dispatchEvent(event);
-                    }
+                    const selected = e.target.selectedOptions?.[0];
+                    const orgDisplayName = orgId
+                        ? normaliseOrganisationDisplayName(selected?.textContent)
+                        : null;
+                    await switchOrganisation(orgId, orgDisplayName || null);
 
                     // Refresh the selector to show updated state
                     await renderOrgSelector(containerId);

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -8,6 +8,7 @@ import {
   refreshWorkflowCapabilityIndexStatus,
   subscribeToWorkflowCapabilityIndexStatus,
 } from './utils/workflowCapabilityStatusCoordinator.js';
+import { createFooterOrganisationSwitcher } from './components/footerOrganisationSwitcher.js';
 
 export const elements = {};
 
@@ -1225,6 +1226,60 @@ function normaliseWorkflowCapabilityIndexFooterStatus(report) {
   };
 }
 
+async function openFooterConcept({ conceptId, conceptName, displayName }) {
+  const id = conceptId || null;
+  const name = conceptName || null;
+  try {
+    const tabBtn = document.querySelector('.tab-button[data-tab="vontologyTab"]');
+    if (tabBtn) tabBtn.click();
+    if (id) {
+      // Footer user/organisation concepts are individuals, so open their tab directly.
+      document.dispatchEvent(new CustomEvent('open-concept-tab', {
+        detail: { conceptId: id, conceptName: name || displayName || id, kind: 'individual', activate: true }
+      }));
+      // Highlight the best parent type for the individual using the existing chooser.
+      try {
+        const resp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(id)}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          const rawParents = data?.is_an_instance_of || data?.is_a || [];
+          const candidateIds = [];
+          if (Array.isArray(rawParents)) {
+            for (const parent of rawParents) {
+              if (!parent) continue;
+              if (typeof parent === 'string') candidateIds.push(parent);
+              else if (parent.concept_id) candidateIds.push(parent.concept_id);
+              else if (parent.id) candidateIds.push(parent.id);
+              else if (parent['@id']) candidateIds.push(parent['@id']);
+            }
+          }
+          if (candidateIds.length) {
+            let bestParent = null;
+            try {
+              const vmod = await import('./vontology.js');
+              if (vmod.chooseBestTypeForIndividual) {
+                bestParent = await vmod.chooseBestTypeForIndividual(candidateIds);
+              }
+            } catch (_) { /* use first parent below */ }
+            if (!bestParent) bestParent = candidateIds[0];
+            if (bestParent) {
+              document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+                detail: { conceptId: bestParent, createConceptTab: false }
+              }));
+            }
+          }
+        }
+      } catch (_) { /* parent highlighting is non-fatal */ }
+    } else if (name) {
+      document.dispatchEvent(new CustomEvent('von:selectConceptByName', {
+        detail: { name, createConceptTab: true }
+      }));
+    }
+  } catch (error) {
+    console.warn('Concept button navigation failed', error);
+  }
+}
+
 export async function setModelInfoFooterText() {
   const footer = document.getElementById('modelInfoFooter');
   if (!footer) return;
@@ -1356,54 +1411,9 @@ export async function setModelInfoFooterText() {
       if (conceptId) tooltipParts.push(`ID: ${conceptId}`);
       if (conceptName) tooltipParts.push(`Name: ${conceptName}`);
       setKeptNativeTitle(btn, tooltipParts.join('\n'));
-      btn.addEventListener('click', async (ev) => {
+      btn.addEventListener('click', (ev) => {
         ev.stopPropagation();
-        const id = conceptId || null;
-        const name = conceptName || null;
-        try {
-          const tabBtn = document.querySelector('.tab-button[data-tab="vontologyTab"]');
-          if (tabBtn) { tabBtn.click(); }
-          if (id) {
-            // These footer entities (current user/org) are guaranteed individuals – open their tab directly as individual
-            document.dispatchEvent(new CustomEvent('open-concept-tab', {
-              detail: { conceptId: id, conceptName: name || displayName || id, kind: 'individual', activate: true }
-            }));
-            // Highlight the best parent TYPE for this individual using chooser logic
-            try {
-              const resp = await fetch(`/vontology/api/vontology/node_content?identifier=${encodeURIComponent(id)}`);
-              if (resp.ok) {
-                const data = await resp.json();
-                const rawParents = data?.is_an_instance_of || data?.is_a || [];
-                const candidateIds = [];
-                if (Array.isArray(rawParents)) {
-                  for (const p of rawParents) {
-                    if (!p) continue;
-                    if (typeof p === 'string') candidateIds.push(p);
-                    else if (p.concept_id) candidateIds.push(p.concept_id);
-                    else if (p.id) candidateIds.push(p.id);
-                    else if (p['@id']) candidateIds.push(p['@id']);
-                  }
-                }
-                if (candidateIds.length) {
-                  let bestParent = null;
-                  try {
-                    const vmod = await import('./vontology.js');
-                    if (vmod.chooseBestTypeForIndividual) {
-                      bestParent = await vmod.chooseBestTypeForIndividual(candidateIds);
-                    }
-                  } catch (_) { /* fallback below */ }
-                  if (!bestParent) { bestParent = candidateIds[0]; }
-                  if (bestParent) {
-                    document.dispatchEvent(new CustomEvent('von:selectConceptById', { detail: { conceptId: bestParent, createConceptTab: false } }));
-                  }
-                }
-              }
-            } catch (_) { /* non-fatal */ }
-          } else if (name) {
-            // Fall back to name-based selection (may create individual tab heuristically)
-            document.dispatchEvent(new CustomEvent('von:selectConceptByName', { detail: { name, createConceptTab: true } }));
-          }
-        } catch (e) { console.warn('Concept button navigation failed', e); }
+        void openFooterConcept({ conceptId, conceptName, displayName });
       });
     }
     span.appendChild(btn);
@@ -1600,22 +1610,11 @@ export async function setModelInfoFooterText() {
     // We do not pass concept id unless actually known to avoid misleading navigation.
     segments.push(makeConceptButton('User', dName, userInfo?.conceptId || null, userInfo?.name || null));
   }
-  // Organisation segment
-  if (orgInfo.name || orgInfo.conceptId || orgInfo.id) {
-    const dName = orgInfo.name || orgInfo.conceptId || (orgInfo.id ? orgInfo.id.substring(0, 8) + '…' : 'Org');
-    segments.push(makeConceptButton('Org', dName, orgInfo.conceptId, orgInfo.name));
-  } else {
-    const placeholder = document.createElement('span');
-    placeholder.className = 'footer-segment footer-placeholder';
-    const label = document.createElement('span');
-    label.className = 'footer-label-inline';
-    label.textContent = 'Org: ';
-    const value = document.createElement('span');
-    value.textContent = '(none)';
-    placeholder.appendChild(label);
-    placeholder.appendChild(value);
-    segments.push(placeholder);
-  }
+  // Organisation segment: retain concept navigation and add direct switching.
+  segments.push(createFooterOrganisationSwitcher({
+    organisationInfo: orgInfo,
+    onOpenConcept: openFooterConcept,
+  }));
 
   if (workflowCapabilityStatus && workflowCapabilityStatus.ready === false) {
     const workflowIndexSegment = makeActionButton(
@@ -1742,7 +1741,7 @@ export async function setModelInfoFooterText() {
   footer.style.cursor = 'pointer';
   setKeptNativeTitle(footer, 'Click empty area to open settings');
   footer.addEventListener('click', (ev) => {
-    if (ev.target.closest('.concept-footer-button, .conversation-runtime-cost-button')) { return; }
+    if (ev.target.closest('.concept-footer-button, .conversation-runtime-cost-button, .footer-org-switcher')) { return; }
     const settingsTabButton = document.querySelector('.tab-button[data-tab="settingsTab"]');
     if (settingsTabButton) { settingsTabButton.click(); }
   });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6384,6 +6384,167 @@ footer {
     box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.4);
 }
 
+/* Footer organisation context: keep the current concept action and expose a
+ * compact, window-scoped switch list without routing through Settings. */
+.footer-org-switcher {
+    white-space: nowrap;
+}
+
+.footer-org-control {
+    display: inline-flex;
+    align-items: stretch;
+    position: relative;
+    min-width: 0;
+}
+
+.footer-org-current-button {
+    max-width: min(34vw, 360px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-radius: 12px 0 0 12px;
+}
+
+.footer-org-current-button:disabled {
+    cursor: default;
+    opacity: 1;
+    color: #475569;
+    background: #f8fafc;
+}
+
+.footer-org-menu-details {
+    position: relative;
+}
+
+.footer-org-menu-details[open] {
+    z-index: 1200;
+}
+
+.footer-org-menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 27px;
+    height: 100%;
+    padding: 2px 7px;
+    border-left: 0;
+    border-radius: 0 12px 12px 0;
+    list-style: none;
+    user-select: none;
+}
+
+.footer-org-menu-trigger::-webkit-details-marker {
+    display: none;
+}
+
+.footer-org-menu-details[open] > .footer-org-menu-trigger {
+    background: #e3f2fd;
+    border-color: #90caf9;
+}
+
+.footer-org-menu {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    z-index: 1;
+    display: block;
+    width: max-content;
+    min-width: 250px;
+    max-width: min(380px, calc(100vw - 24px));
+    padding: 7px;
+    color: #1f2937;
+    background: #fff;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.2);
+    white-space: normal;
+}
+
+.footer-org-switch-status {
+    display: block;
+    padding: 3px 7px 7px;
+    color: #64748b;
+    font-size: 0.68rem;
+    line-height: 1.3;
+}
+
+.footer-org-switch-status.error {
+    color: #b42318;
+}
+
+.footer-org-options {
+    display: grid;
+    gap: 2px;
+}
+
+.footer-org-option {
+    display: grid;
+    grid-template-columns: 16px minmax(0, 1fr) auto;
+    gap: 6px;
+    align-items: center;
+    width: 100%;
+    padding: 7px 8px;
+    color: #1f2937;
+    text-align: left;
+    background: transparent;
+    border: 0;
+    border-radius: 7px;
+    cursor: pointer;
+}
+
+.footer-org-option:hover:not(:disabled),
+.footer-org-option:focus-visible {
+    background: #eaf3ff;
+    outline: none;
+}
+
+.footer-org-option:disabled {
+    cursor: default;
+    opacity: 1;
+}
+
+.footer-org-option[data-current="true"] {
+    color: #0d47a1;
+    background: #eef6ff;
+    font-weight: 600;
+}
+
+.footer-org-option-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.footer-org-option-role {
+    color: #64748b;
+    font-size: 0.64rem;
+    font-weight: 400;
+}
+
+.footer-org-retry-button {
+    margin: 3px 7px 5px;
+    padding: 4px 9px;
+    color: #0d47a1;
+    background: #fff;
+    border: 1px solid #90caf9;
+    border-radius: 7px;
+    cursor: pointer;
+}
+
+.footer-org-menu-details.is-switching .footer-org-menu-trigger {
+    cursor: progress;
+}
+
+@media (max-width: 760px) {
+    .footer-org-current-button {
+        max-width: min(46vw, 230px);
+    }
+
+    .footer-org-menu {
+        width: min(250px, calc(100vw - 24px));
+        min-width: 0;
+    }
+}
+
 /* Informational only: conversation cost changes arrive through a dedicated
  * telemetry event and do not reload the rest of the footer. */
 .conversation-runtime-cost-button {

--- a/tests/frontend/footerOrganisationSwitcher.test.js
+++ b/tests/frontend/footerOrganisationSwitcher.test.js
@@ -1,0 +1,194 @@
+/** @jest-environment jsdom */
+
+const componentPath = '../../src/frontend/web/von_interface/static/js/components/footerOrganisationSwitcher.js';
+const apiServicePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+const orgSelectorPath = '../../src/frontend/web/von_interface/static/js/components/orgSelector.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    getUserContext: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/components/orgSelector.js', () => ({
+    loadMyOrganisations: jest.fn(),
+    normaliseOrganisationDisplayName: jest.fn((value) => String(value || '').replace(/\s*\([^()]+\)\s*$/, '').trim() || null),
+    switchOrganisation: jest.fn(),
+}));
+
+const { getUserContext } = require(apiServicePath);
+const { loadMyOrganisations, switchOrganisation } = require(orgSelectorPath);
+const {
+    createFooterOrganisationSwitcher,
+    invalidateFooterOrganisationMemberships,
+} = require(componentPath);
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function memberships() {
+    return [
+        {
+            concept_id: '#V#university_of_auckland_strong_ai_lab',
+            name: 'University of Auckland Strong AI Lab',
+            role: 'owner',
+        },
+        {
+            concept_id: '#V#the_lu_witbrock_household',
+            name: 'The Lu Witbrock Household',
+            role: 'member',
+        },
+    ];
+}
+
+describe('footer organisation switcher', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="footer"></div>';
+        localStorage.clear();
+        sessionStorage.clear();
+        jest.clearAllMocks();
+        invalidateFooterOrganisationMemberships();
+        getUserContext.mockReturnValue({ user_id: '#V#michael_witbrock' });
+        loadMyOrganisations.mockResolvedValue(memberships());
+        switchOrganisation.mockImplementation(async (conceptId) => ({
+            status: 'updated',
+            organisation_id: conceptId || null,
+            namespace: conceptId ? '#V#michael_witbrock@org' : '#V#michael_witbrock',
+            role: conceptId ? 'member' : null,
+        }));
+    });
+
+    test('prefetches and renders Personal plus all memberships with the current organisation marked', async () => {
+        const openConcept = jest.fn();
+        const segment = createFooterOrganisationSwitcher({
+            organisationInfo: {
+                conceptId: '#V#university_of_auckland_strong_ai_lab',
+                name: 'University of Auckland Strong AI Lab',
+            },
+            onOpenConcept: openConcept,
+        });
+        document.getElementById('footer').appendChild(segment);
+
+        await flushMicrotasks();
+
+        const options = [...segment.querySelectorAll('.footer-org-option')];
+        expect(options.map((button) => button.querySelector('.footer-org-option-name')?.textContent)).toEqual([
+            'Personal',
+            'University of Auckland Strong AI Lab',
+            'The Lu Witbrock Household',
+        ]);
+        expect(options[1].getAttribute('aria-checked')).toBe('true');
+        expect(options[1].disabled).toBe(true);
+        expect(segment.querySelector('.footer-org-option-role')?.textContent).toBe('owner');
+
+        segment.querySelector('.footer-org-current-button').click();
+        expect(openConcept).toHaveBeenCalledWith({
+            conceptId: '#V#university_of_auckland_strong_ai_lab',
+            conceptName: 'University of Auckland Strong AI Lab',
+            displayName: 'University of Auckland Strong AI Lab',
+        });
+    });
+
+    test('switches exactly once, exposes progress, and updates the current footer concept', async () => {
+        let resolveSwitch;
+        switchOrganisation.mockReturnValue(new Promise((resolve) => { resolveSwitch = resolve; }));
+        const segment = createFooterOrganisationSwitcher({
+            organisationInfo: {
+                conceptId: '#V#university_of_auckland_strong_ai_lab',
+                name: 'University of Auckland Strong AI Lab',
+            },
+        });
+        document.getElementById('footer').appendChild(segment);
+        await flushMicrotasks();
+
+        const target = [...segment.querySelectorAll('.footer-org-option')]
+            .find((button) => button.dataset.organisationConceptId === '#V#the_lu_witbrock_household');
+        target.click();
+
+        expect(switchOrganisation).toHaveBeenCalledTimes(1);
+        expect(switchOrganisation).toHaveBeenCalledWith(
+            '#V#the_lu_witbrock_household',
+            'The Lu Witbrock Household',
+        );
+        expect(segment.querySelector('.footer-org-switch-status').textContent)
+            .toContain('Switching to The Lu Witbrock Household');
+        expect(JSON.parse(sessionStorage.getItem('von_org_switching'))).toEqual({
+            concept_id: '#V#the_lu_witbrock_household',
+            name: 'The Lu Witbrock Household',
+        });
+
+        target.click();
+        expect(switchOrganisation).toHaveBeenCalledTimes(1);
+
+        resolveSwitch({
+            status: 'updated',
+            organisation_id: '#V#the_lu_witbrock_household',
+            namespace: '#V#michael_witbrock@the_lu_witbrock_household',
+            role: 'member',
+        });
+        await flushMicrotasks();
+
+        expect(segment.querySelector('.footer-org-current-button').textContent)
+            .toBe('The Lu Witbrock Household');
+        expect(sessionStorage.getItem('von_org_switching')).toBeNull();
+    });
+
+    test('switches to Personal through the same server-validated switch helper', async () => {
+        const segment = createFooterOrganisationSwitcher({
+            organisationInfo: {
+                conceptId: '#V#university_of_auckland_strong_ai_lab',
+                name: 'University of Auckland Strong AI Lab',
+            },
+        });
+        document.getElementById('footer').appendChild(segment);
+        await flushMicrotasks();
+
+        segment.querySelector('.footer-org-option[data-organisation-concept-id=""]').click();
+        await flushMicrotasks();
+
+        expect(switchOrganisation).toHaveBeenCalledWith(null, null);
+        expect(segment.querySelector('.footer-org-current-button').textContent).toBe('Personal');
+        expect(segment.querySelector('.footer-org-current-button').disabled).toBe(true);
+    });
+
+    test('keeps the previous organisation visible and permits retry after failure', async () => {
+        switchOrganisation.mockRejectedValueOnce(new Error('organisation_membership_unavailable'));
+        const segment = createFooterOrganisationSwitcher({
+            organisationInfo: {
+                conceptId: '#V#university_of_auckland_strong_ai_lab',
+                name: 'University of Auckland Strong AI Lab',
+            },
+        });
+        document.getElementById('footer').appendChild(segment);
+        await flushMicrotasks();
+
+        const target = [...segment.querySelectorAll('.footer-org-option')]
+            .find((button) => button.dataset.organisationConceptId === '#V#the_lu_witbrock_household');
+        target.click();
+        await flushMicrotasks();
+
+        expect(segment.querySelector('.footer-org-current-button').textContent)
+            .toBe('University of Auckland Strong AI Lab');
+        expect(segment.querySelector('.footer-org-switch-status').textContent)
+            .toContain('Switch failed');
+        const retryTarget = [...segment.querySelectorAll('.footer-org-option')]
+            .find((button) => button.dataset.organisationConceptId === '#V#the_lu_witbrock_household');
+        expect(retryTarget.disabled).toBe(false);
+        expect(sessionStorage.getItem('von_org_switching')).toBeNull();
+    });
+
+    test('shares one in-flight membership request across repeated footer repaints', async () => {
+        let resolveMemberships;
+        loadMyOrganisations.mockReturnValue(new Promise((resolve) => { resolveMemberships = resolve; }));
+
+        const first = createFooterOrganisationSwitcher();
+        const second = createFooterOrganisationSwitcher();
+        document.getElementById('footer').append(first, second);
+
+        expect(loadMyOrganisations).toHaveBeenCalledTimes(1);
+        resolveMemberships(memberships());
+        await flushMicrotasks();
+
+        expect(first.querySelectorAll('.footer-org-option')).toHaveLength(3);
+        expect(second.querySelectorAll('.footer-org-option')).toHaveLength(3);
+    });
+});

--- a/tests/frontend/orgSwitchStorage.test.js
+++ b/tests/frontend/orgSwitchStorage.test.js
@@ -1,0 +1,88 @@
+/** @jest-environment jsdom */
+
+const apiServicePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+const orgSelectorPath = '../../src/frontend/web/von_interface/static/js/components/orgSelector.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    getJsonDetailed: jest.fn(),
+    getUserContext: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+const { postJson } = require(apiServicePath);
+const { switchOrganisation } = require(orgSelectorPath);
+
+describe('organisation switch storage and event contract', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        jest.clearAllMocks();
+    });
+
+    test('stores an accepted organisation before publishing orgSwitched', async () => {
+        postJson.mockResolvedValue({
+            status: 'updated',
+            organisation_id: '#V#the_lu_witbrock_household',
+            namespace: '#V#michael_witbrock@the_lu_witbrock_household',
+            role: 'owner',
+            window_session_id: 'ws-test',
+        });
+        const observations = [];
+        document.addEventListener('orgSwitched', (event) => {
+            observations.push({
+                detail: event.detail,
+                stored: JSON.parse(sessionStorage.getItem('von_current_org')),
+            });
+        }, { once: true });
+
+        await switchOrganisation(
+            '#V#the_lu_witbrock_household',
+            'The Lu Witbrock Household',
+        );
+
+        expect(postJson).toHaveBeenCalledWith('/von/api/session/set_organisation', {
+            organisation_concept_id: '#V#the_lu_witbrock_household',
+        });
+        expect(observations).toEqual([{
+            detail: {
+                organisation_id: '#V#the_lu_witbrock_household',
+                organisation_name: 'The Lu Witbrock Household',
+                role: 'owner',
+                namespace: '#V#michael_witbrock@the_lu_witbrock_household',
+                window_session_id: 'ws-test',
+            },
+            stored: {
+                id: null,
+                concept_id: '#V#the_lu_witbrock_household',
+                name: 'The Lu Witbrock Household',
+            },
+        }]);
+    });
+
+    test('clears organisation storage when Personal is accepted', async () => {
+        for (const storage of [localStorage, sessionStorage]) {
+            storage.setItem('von_org_context', '{"concept_id":"#V#old"}');
+            storage.setItem('von_org_role', 'member');
+            storage.setItem('von_current_org', '{"concept_id":"#V#old"}');
+        }
+        postJson.mockResolvedValue({
+            status: 'updated',
+            organisation_id: null,
+            namespace: '#V#michael_witbrock',
+            role: null,
+            window_session_id: 'ws-test',
+        });
+
+        await switchOrganisation(null, null);
+
+        expect(postJson).toHaveBeenCalledWith('/von/api/session/set_organisation', {
+            organisation_concept_id: null,
+        });
+        for (const storage of [localStorage, sessionStorage]) {
+            expect(storage.getItem('von_org_context')).toBeNull();
+            expect(storage.getItem('von_org_role')).toBeNull();
+            expect(storage.getItem('von_current_org')).toBeNull();
+            expect(storage.getItem('current_user_namespace')).toBe('#V#michael_witbrock');
+        }
+    });
+});


### PR DESCRIPTION
## Outcome

Adds a compact list in the persistent footer so a member can switch the current window between Personal and any organisation membership without routing through Settings. The current organisation remains a Vontology concept link.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2683

## Material behaviour

- Reuses the existing authenticated, window-scoped set_organisation route.
- Commits accepted storage before orgSwitched so existing scoped consumers reload consistently.
- Coalesces membership reads and blocks duplicate switches.
- Retains the prior organisation on failure and exposes retry/progress state.
- Fits the upward-opening menu at desktop and 390px mobile widths, with Enter/Escape support.

## Evidence

- 12 affected frontend Jest suites: 80 passed.
- Frontend static lint: passed.
- Backend session organisation routes: 16 passed.
- Authenticated AgentTest replay: Personal and organisation switches accepted with footer/header read-back and scoped content clearing; return switch visible in about 1.36 seconds.
- Mobile 390x844 and keyboard browser replay: passed.
- git diff --check: passed.

## Ship boundary

Merge decision ready: minimum ship criteria are met and no stop-ship condition was observed. No backend authority, membership semantics, deployment, or activation change is included.