### PR TITLE
JVNAUTOSCI-2683: Correct footer organisation control sizing

### DIFF
--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6424,6 +6424,7 @@ footer {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    box-sizing: border-box;
     min-width: 27px;
     height: 100%;
     padding: 2px 7px;
@@ -6448,6 +6449,7 @@ footer {
     bottom: calc(100% + 8px);
     z-index: 1;
     display: block;
+    box-sizing: border-box;
     width: max-content;
     min-width: 250px;
     max-width: min(380px, calc(100vw - 24px));

--- a/tests/frontend/footerOrganisationSwitcher.test.js
+++ b/tests/frontend/footerOrganisationSwitcher.test.js
@@ -1,8 +1,15 @@
 /** @jest-environment jsdom */
 
+const fs = require('fs');
+const path = require('path');
+
 const componentPath = '../../src/frontend/web/von_interface/static/js/components/footerOrganisationSwitcher.js';
 const apiServicePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
 const orgSelectorPath = '../../src/frontend/web/von_interface/static/js/components/orgSelector.js';
+const styles = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/styles.css'),
+    'utf8',
+);
 
 jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
     getUserContext: jest.fn(),
@@ -86,6 +93,15 @@ describe('footer organisation switcher', () => {
             conceptName: 'University of Auckland Strong AI Lab',
             displayName: 'University of Auckland Strong AI Lab',
         });
+    });
+
+    test('uses border-box sizing for the split trigger and responsive menu dimensions', () => {
+        const triggerRule = styles.match(/\.footer-org-menu-trigger\s*\{([^}]*)\}/)?.[1] || '';
+        const menuRule = styles.match(/\.footer-org-menu\s*\{([^}]*)\}/)?.[1] || '';
+
+        expect(triggerRule).toMatch(/box-sizing:\s*border-box/);
+        expect(triggerRule).toMatch(/height:\s*100%/);
+        expect(menuRule).toMatch(/box-sizing:\s*border-box/);
     });
 
     test('switches exactly once, exposes progress, and updates the current footer concept', async () => {


### PR DESCRIPTION
## Outcome

Corrects the footer organisation split control shown in the user screenshot so the chevron matches the adjacent organisation pill height. It also makes the responsive dropdown panel honour its declared width including padding.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2683
Follow-up to: https://github.com/Strong-AI-Lab/Von/pull/455

## Cause and fix

The current organisation button is border-box, while the summary trigger and menu panel defaulted to content-box. The trigger therefore rendered at 27.0625px despite a 21.0625px assigned height. The mobile panel rendered at 266px despite a declared 250px width.

This adds box-sizing: border-box to those two elements and a stylesheet regression assertion. No switching behaviour or authority changes.

## Evidence

- Desktop button and trigger: both 21.0625px.
- 390x844 button and trigger: both 21.0625px.
- Mobile panel: exactly 250px and fully within the viewport.
- Enter/Escape interaction passed.
- Affected frontend lane: 12 suites, 81 tests passed.
- Static lint and git diff --check passed.

## Ship boundary

Merge decision ready: the reported mismatch is corrected, the adjacent responsive sizing issue is corrected by the same box-model rule, and no stop-ship condition is present.