### PR TITLE
Fix Relation Extent predicate kind rendering

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1830,9 +1830,11 @@ def _create_concepts(**kwargs):
         # Analyse what's being created to give better guidance
         concept_names = [c.get("name", "") for c in concepts if isinstance(c, dict)]
         creating_multiple = len(concepts) > 1
-        kind_requested = "instance"
+        kind_requested = "unspecified"
         if concepts and isinstance(concepts[0], dict):
-            kind_requested = (concepts[0].get("kind") or "type").strip().lower()
+            raw_kind_requested = concepts[0].get("kind")
+            if isinstance(raw_kind_requested, str) and raw_kind_requested.strip():
+                kind_requested = raw_kind_requested.strip().lower()
 
         # Build contextual suggestions
         suggestions = [
@@ -1943,14 +1945,15 @@ def _create_concepts(**kwargs):
         )
     requested_non_predicate_kinds = {
         (
-            str(concept_data.get("kind") or "type").strip().lower()
+            str(concept_data.get("kind") or "unspecified").strip().lower()
             if isinstance(concept_data, dict)
             else "invalid"
         )
         for concept_data in concepts
         if not (
             isinstance(concept_data, dict)
-            and str(concept_data.get("kind") or "type").strip().lower() == "predicate"
+            and str(concept_data.get("kind") or "unspecified").strip().lower()
+            == "predicate"
         )
     }
     if (
@@ -2095,7 +2098,46 @@ def _create_concepts(**kwargs):
                 continue
 
             name = concept_data.get("name")
-            kind = (concept_data.get("kind") or "type").strip().lower()
+            raw_kind = concept_data.get("kind")
+
+            if not isinstance(raw_kind, str) or not raw_kind.strip():
+                results.append(
+                    {
+                        "success": False,
+                        "effect_status": "failed",
+                        "changed": False,
+                        "error_code": "concept_kind_required",
+                        "message": (
+                            "Concept kind is required; choose 'instance', 'type', "
+                            "or 'predicate'. No concept was created."
+                        ),
+                        "concept": None,
+                        "input_name": str(name or ""),
+                        "requested_name": str(name or ""),
+                        "requested_kind": None,
+                    }
+                )
+                continue
+
+            kind = raw_kind.strip().lower()
+            if kind not in {"instance", "individual", "type", "predicate"}:
+                results.append(
+                    {
+                        "success": False,
+                        "effect_status": "failed",
+                        "changed": False,
+                        "error_code": "invalid_concept_kind",
+                        "message": (
+                            f"Unsupported concept kind '{raw_kind}'; choose "
+                            "'instance', 'type', or 'predicate'. No concept was created."
+                        ),
+                        "concept": None,
+                        "input_name": str(name or ""),
+                        "requested_name": str(name or ""),
+                        "requested_kind": kind,
+                    }
+                )
+                continue
 
             if not name:
                 results.append(
@@ -10257,9 +10299,9 @@ def _concepts_create_input_schema() -> Schema:
         description=(
             "Governed create_concepts input: parent_id is one exact semantic type "
             "concept ID, and concepts must contain exactly one core concept "
-            "specification: {name, concept_id?, kind?, description?, notes?, "
+            "specification: {name, kind, concept_id?, description?, notes?, "
             "vontology_path?, instance_of_type?}. kind is 'instance' for an "
-            "individual, 'type' for a subtype (the default), or 'predicate' for a "
+            "individual, 'type' for a subtype, or 'predicate' for a "
             "relationship type. duplicate_resolution_mode='canonical_id_only' "
             "skips semantic name resolution after an exact concept-ID miss; "
             "omitting it preserves the default semantic duplicate check. A name "
@@ -38397,9 +38439,9 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             ordinary_turn_effect=True,
             description=(
                 "Create exactly one governed core concept per effect. Supply one "
-                "concept specification with name and optional concept_id, kind, "
-                "description, notes, vontology_path, or instance_of_type. kind is "
-                "'instance' for an individual, 'type' for a subtype/default, or "
+                "concept specification with required name and kind, plus optional "
+                "concept_id, description, notes, vontology_path, or instance_of_type. "
+                "kind is 'instance' for an individual, 'type' for a subtype, or "
                 "'predicate' for a relationship type. This governed effect "
                 "idempotently reuses an exact actor-visible concept when canonical "
                 "read-back verifies the requested core. An actor-hidden instance-ID "

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -62,6 +62,7 @@ from ...services.relationship_extent_index_service import (
 from ...services.concept_search_service import (
     search_concepts as search_concepts_service,
 )
+from ...services.relationship_write_service import compute_kind_from_relationships
 from ...security.access_control import (
     bypass_access_control,
     cache_scope_key,
@@ -4025,12 +4026,18 @@ def get_relationships_extent_route():
         metadata_ids: list[str] = []
         seen_metadata_ids: set[str] = set()
         for row in paged_rows:
-            for raw_id in (
-                row.get("predicate_id"),
-                row.get("arg1_value"),
-                row.get("arg2_value"),
+            for raw_id, is_predicate_id in (
+                (row.get("predicate_id"), True),
+                (row.get("arg1_value"), False),
+                (row.get("arg2_value"), False),
             ):
                 candidate = str(raw_id or "").strip()
+                if (
+                    candidate
+                    and is_predicate_id
+                    and not candidate.startswith("#V#")
+                ):
+                    candidate = f"#V#{candidate}"
                 if not candidate.startswith("#V#") or candidate in seen_metadata_ids:
                     continue
                 seen_metadata_ids.add(candidate)
@@ -4054,6 +4061,20 @@ def get_relationships_extent_route():
             if metadata_ids
             else []
         )
+        persisted_metadata_ids = {
+            str(doc.get("concept_id") or "").strip()
+            for doc in metadata_docs
+            if isinstance(doc, Mapping)
+        }
+        if len(persisted_metadata_ids) < len(metadata_ids):
+            from ...vontology.code_concepts_registry import build_virtual_concept_doc
+
+            for metadata_id in metadata_ids:
+                if metadata_id in persisted_metadata_ids:
+                    continue
+                virtual_doc = build_virtual_concept_doc(metadata_id)
+                if virtual_doc is not None:
+                    metadata_docs.append(virtual_doc)
         metadata_names = resolve_concept_display_names(metadata_docs)
         display_metadata: dict[str, dict[str, str]] = {}
         for doc in metadata_docs:
@@ -4068,13 +4089,16 @@ def get_relationships_extent_route():
                 else ""
             )
             relationships = doc.get("relationships")
-            relation_payload = relationships if isinstance(relationships, Mapping) else {}
-            if stored_kind in {"type", "predicate", "individual"}:
+            relation_payload = (
+                relationships if isinstance(relationships, Mapping) else {}
+            )
+            relationship_kind = compute_kind_from_relationships(relation_payload)
+            if relationship_kind in {"type", "predicate"}:
+                display_kind = relationship_kind
+            elif stored_kind in {"type", "predicate", "individual"}:
                 display_kind = stored_kind
-            elif metadata_kind == "predicate":
-                display_kind = "predicate"
-            elif relation_payload.get("is_a_type_of"):
-                display_kind = "type"
+            elif metadata_kind in {"type", "predicate", "individual"}:
+                display_kind = metadata_kind
             else:
                 display_kind = "individual"
             display_metadata[metadata_concept_id] = {

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -960,11 +960,26 @@ def resolve_governed_ontology_arguments(
                         "A concept name must resolve to one exact canonical ID.",
                     )
                 item["concept_id"] = canonical_id
-            if not _clean_text(item.get("kind")):
-                requested_instance = item.get("create_as_instance")
-                if requested_instance is None:
-                    requested_instance = resolved.get("create_as_instance")
-                item["kind"] = "instance" if requested_instance is True else "type"
+            kind = _clean_text(item.get("kind")).lower()
+            if not kind:
+                raise OntologyMutationCommandError(
+                    "concept_kind_required",
+                    (
+                        "A governed concept create requires an explicit kind: "
+                        "'instance', 'type', or 'predicate'."
+                    ),
+                )
+            if kind == "individual":
+                kind = "instance"
+            if kind not in {"instance", "type", "predicate"}:
+                raise OntologyMutationCommandError(
+                    "invalid_concept_kind",
+                    (
+                        "A governed concept create kind must be 'instance', "
+                        "'type', or 'predicate'."
+                    ),
+                )
+            item["kind"] = kind
             canonical_concepts.append(item)
 
         raw_top_level_instance_type = resolved.get("instance_of_type")

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -6189,6 +6189,15 @@ export function sortRelationshipExtentRows(rows, sortBy = 'recency_desc') {
     return working;
 }
 
+export function resolveRelationshipExtentConceptKind(metadataKind, semanticRole = '') {
+    if (semanticRole === 'predicate') {
+        return 'predicate';
+    }
+    return ['type', 'predicate', 'individual'].includes(metadataKind)
+        ? metadataKind
+        : 'individual';
+}
+
 function ensureRelationshipsToolbar(container, conceptId, suffix, kind) {
     if (!container) return;
     const state = getRelationshipExtentUiState(conceptId, suffix);
@@ -7400,7 +7409,11 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             });
         });
 
-        const createConceptCell = (conceptIdValue, fallbackName = null) => {
+        const createConceptCell = (
+            conceptIdValue,
+            fallbackName = null,
+            semanticRole = ''
+        ) => {
             const cell = document.createElement('td');
             const conceptIdText = normalisePotentialConceptId(conceptIdValue);
             if (!conceptIdText) {
@@ -7412,7 +7425,7 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             const metadata = metadataMap.get(conceptIdText) || { kind: 'individual', name: fallbackName || conceptIdText };
             const chip = createVontologyCartouche(conceptIdText, {
                 name: metadata.name || fallbackName || conceptIdText,
-                kind: metadata.kind || 'individual',
+                kind: resolveRelationshipExtentConceptKind(metadata.kind, semanticRole),
                 title: conceptIdText,
                 mode: 'compact_kind_bg'
             });
@@ -7498,7 +7511,7 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             tr.appendChild(roleCell);
 
             const predicateConceptId = toPredicateConceptId(row.predicate_id);
-            tr.appendChild(createConceptCell(predicateConceptId, row.predicate_id || ''));
+            tr.appendChild(createConceptCell(predicateConceptId, row.predicate_id || '', 'predicate'));
 
             const arg1ConceptId = normalisePotentialConceptId(row.arg1_value);
             if (row.arg1_is_concept || arg1ConceptId) {

--- a/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
+++ b/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
@@ -2,6 +2,7 @@ import {
     buildDescriptionMetadataRows,
     deriveRelationshipExtentQuery,
     getRelationshipConfidenceScore,
+    resolveRelationshipExtentConceptKind,
     sortRelationshipExtentRows,
     summariseRelationshipProvenance
 } from '../dynamicTabs.js';
@@ -64,6 +65,13 @@ describe('dynamicTabs uncertain relationship helpers', () => {
         expect(sorted.map((row) => row.relation_id)).toEqual(['c', 'b', 'a']);
     });
 
+    test('predicate columns never present predicate concepts as individuals', () => {
+        expect(resolveRelationshipExtentConceptKind('individual', 'predicate')).toBe('predicate');
+        expect(resolveRelationshipExtentConceptKind(undefined, 'predicate')).toBe('predicate');
+        expect(resolveRelationshipExtentConceptKind('type', 'argument')).toBe('type');
+        expect(resolveRelationshipExtentConceptKind(undefined, 'argument')).toBe('individual');
+    });
+
     test('buildDescriptionMetadataRows surfaces structured provenance and confidence', () => {
         const rows = buildDescriptionMetadataRows({
             context: {
@@ -83,4 +91,3 @@ describe('dynamicTabs uncertain relationship helpers', () => {
         expect(confidenceRow?.value).toBe('83%');
     });
 });
-

--- a/tests/backend/test_blocked_thing_parent_type.py
+++ b/tests/backend/test_blocked_thing_parent_type.py
@@ -225,7 +225,7 @@ def test_mcp_create_concepts_blocks_thing_as_parent():
 
     result = catalogue._create_concepts(
         parent_id="#V#thing",
-        concepts=[{"name": "Test Concept"}],
+        concepts=[{"name": "Test Concept", "kind": "type"}],
     )
 
     # Operation is blocked

--- a/tests/backend/test_mcp_create_concepts_unknown_fields.py
+++ b/tests/backend/test_mcp_create_concepts_unknown_fields.py
@@ -117,6 +117,30 @@ def test_create_concepts_rejects_missing_required_fields():
     assert "parent_id" in result["error"].lower()
 
 
+@pytest.mark.parametrize(
+    ("concept", "expected_error"),
+    [
+        ({"name": "test_concept_missing_kind"}, "concept_kind_required"),
+        (
+            {"name": "test_concept_ambiguous_kind", "kind": "candidature"},
+            "invalid_concept_kind",
+        ),
+    ],
+)
+def test_create_concepts_requires_an_explicit_supported_kind(
+    concept, expected_error
+):
+    result = _create_concepts(
+        parent_id="#V#abstract_object",
+        concepts=[concept],
+    )
+
+    assert result["successful"] == 0
+    assert result["effect_status"] == "failed"
+    assert result["results"][0]["error_code"] == expected_error
+    assert result["results"][0]["changed"] is False
+
+
 def test_create_concepts_accepts_multiple_unknown_fields():
     """
     Verify that create_concepts tolerates multiple unknown fields.

--- a/tests/backend/test_ontology_create_authority_containment.py
+++ b/tests/backend/test_ontology_create_authority_containment.py
@@ -141,6 +141,46 @@ def test_governed_create_uses_trusted_org_and_keeps_omission_private(
 
 
 @pytest.mark.parametrize(
+    ("concept", "expected_reason"),
+    (
+        ({"name": "Ambiguous creation"}, "concept_kind_required"),
+        (
+            {"name": "Ambiguous creation", "kind": "candidature"},
+            "invalid_concept_kind",
+        ),
+    ),
+)
+def test_governed_create_requires_explicit_supported_kind(
+    concept: dict[str, str], expected_reason: str
+) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    with pytest.raises(command.OntologyMutationCommandError) as exc_info:
+        command.resolve_governed_ontology_arguments(
+            "create_concepts",
+            {
+                "parent_id": "#V#research_object",
+                "concepts": [concept],
+            },
+        )
+
+    assert exc_info.value.reason_code == expected_reason
+
+
+def test_governed_create_tool_rejects_missing_kind_before_any_effect() -> None:
+    from src.backend.integrations.internal_mcp import catalogue
+
+    result = catalogue._create_concepts(
+        parent_id="#V#research_object",
+        concepts=[{"name": "Ambiguous creation"}],
+    )
+
+    assert result["error_code"] == "concept_kind_required"
+    assert result["effect_status"] == "not_started"
+    assert result["changed"] is False
+
+
+@pytest.mark.parametrize(
     ("scope_mode", "expected_kind", "role", "role_organisation"),
     (
         (None, "user", None, None),

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -380,6 +380,78 @@ def test_relationship_extent_route_returns_outgoing_rows(app_client, monkeypatch
     )
 
 
+def test_relationship_extent_metadata_classifies_all_predicate_rows_as_predicates(
+    app_client, monkeypatch
+):
+    _, client = app_client
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find_one",
+        lambda *a, **k: {"concept_id": "#V#focus", "relationships": {}},
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.build_concept_relations_payload",
+        lambda *a, **k: {
+            "relations": [
+                {
+                    "relation_id": "custom-predicate-row",
+                    "source_concept_id": "#V#focus",
+                    "predicate_id": "#V#has_candidate_person",
+                    "relation_kind": "binary",
+                    "target_values": ["#V#candidate"],
+                    "matched_argument_indexes": [1],
+                },
+                {
+                    "relation_id": "virtual-predicate-row",
+                    "source_concept_id": "#V#focus",
+                    "predicate_id": "has_instance",
+                    "relation_kind": "binary",
+                    "target_values": ["#V#candidate"],
+                    "matched_argument_indexes": [1],
+                },
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.aggregate",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find",
+        lambda *a, **k: [
+            {
+                "concept_id": "#V#has_candidate_person",
+                "name": "Has Candidate Person",
+                "kind": "individual",
+                "metadata": {"concept_type": "individual"},
+                "relationships": {
+                    "is_an_instance_of": ["#V#binary_predicate"]
+                },
+            },
+            {
+                "concept_id": "#V#focus",
+                "name": "Focus",
+                "relationships": {"is_an_instance_of": ["#V#person"]},
+            },
+            {
+                "concept_id": "#V#candidate",
+                "name": "Candidate",
+                "relationships": {"is_an_instance_of": ["#V#person"]},
+            },
+        ],
+    )
+
+    response = client.get(
+        "/vontology/api/vontology/relationships/extent?concept_id=%23V%23focus"
+    )
+
+    assert response.status_code == 200
+    metadata = response.get_json()["display_metadata"]
+    assert metadata["#V#has_candidate_person"]["kind"] == "predicate"
+    assert metadata["#V#has_instance"]["kind"] == "predicate"
+    assert metadata["#V#focus"]["kind"] == "individual"
+
+
 def test_relationship_extent_route_includes_incoming_dynamic_arg2_rows(
     app_client, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- derive Relation Extent display kinds from canonical structural typing before legacy stored hints
- include virtual and unprefixed structural predicates in display metadata
- force the semantic Predicate column to render predicate cartouches as predicates
- require an explicit supported kind at both the governed creation authority boundary and the underlying create_concepts handler

## Ship criteria and evidence

- backend Relationship Extent subset: 9 passed
- create_concepts explicit-kind handler and authority checks: passed
- create_concepts unknown-fields module: 11 passed
- focused frontend Jest module: 7 passed
- Python compile, Node syntax, and diff checks: passed
- live AgentTest Chrome check on Person Relation Extent: 50 predicate cartouches, all predicate-class purple, zero individual-class predicates

## Stop-ship conditions checked

- no predicate row renders with individual kind
- stored stale individual metadata cannot override canonical predicate typing
- missing or unsupported create kind reaches no mutation effect

## Non-blocking baseline observations

Broader local files still contain unrelated stale expectations for removed uncertain-relation routes, authenticated actor context, and the registered conversation_manage_batch capability. None exercises or changes the affected paths above.