### PR TITLE
Fix browser concept creation and footer selector height

### DIFF
--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -27,7 +27,10 @@ from ...services.rag_text_relation_change_hook_service import (
     maybe_delete_text_relation_doc_from_rag,
     maybe_sync_concept_text_relations_to_rag,
 )
-from ...services.ontology_mutation_command_service import delete_legacy_name
+from ...services.ontology_mutation_command_service import (
+    OntologyMutationCommandError,
+    delete_legacy_name,
+)
 from ...services.paper_recommendation_profile_vontology_service import (
     load_paper_recommendation_profile,
     upsert_paper_recommendation_profile,
@@ -476,6 +479,7 @@ def create_concept_route():
         return jsonify(error="Request body must be JSON"), 400
 
     name = data.get("name")
+    kind = data.get("kind")
     concept_id = data.get("concept_id")
     vontology_path = data.get("vontology_path")
     description = data.get("description")
@@ -488,8 +492,6 @@ def create_concept_route():
 
     if not name:
         return jsonify(error="concept name is required"), 400
-    if not concept_id and not vontology_path:
-        return jsonify(error="Either concept_id or vontology_path is required"), 400
     if parent_concept_ids is not None and not isinstance(parent_concept_ids, list):
         return jsonify(error="parent_concept_ids must be a list"), 400
 
@@ -508,13 +510,13 @@ def create_concept_route():
                     {
                         "concept_id": concept_id,
                         "name": name,
+                        "kind": kind,
                         "description": description,
                         "notes": notes,
                         "attributes": attributes,
                         "system_tags": system_tags,
                         "user_tags": user_tags,
                         "linked_concepts": linked_concepts,
-                        "create_as_instance": data.get("create_as_instance", True),
                         "instance_of_type": data.get("instance_of_type"),
                         "vontology_path": vontology_path,
                     }
@@ -531,7 +533,6 @@ def create_concept_route():
                 "attributes": attributes,
                 "system_tags": system_tags,
                 "user_tags": user_tags,
-                "create_as_instance": data.get("create_as_instance", True),
                 "vontology_path": vontology_path,
                 "description": description,
                 "notes": notes,
@@ -540,6 +541,7 @@ def create_concept_route():
         )
         resolved_concept = create_arguments["concepts"][0]
         resolved_parent_ids = create_arguments.get("parent_concept_ids")
+        resolved_kind = resolved_concept.get("kind")
         result = _execute_governed_http_mutation(
             method_name="create_concepts",
             arguments=create_arguments,
@@ -554,7 +556,7 @@ def create_concept_route():
                 user_tags=resolved_concept.get("user_tags"),
                 linked_concepts=resolved_concept.get("linked_concepts"),
                 parent_concept_ids=resolved_parent_ids,
-                create_as_instance=resolved_concept.get("create_as_instance", True),
+                create_as_instance=resolved_kind in {"instance", "predicate"},
                 instance_of_type=resolved_concept.get("instance_of_type"),
                 created_by_concept_id=trusted_actor,
                 organisation_concept_id=trusted_org,
@@ -565,6 +567,20 @@ def create_concept_route():
             ),
         )
         return _governed_mutation_response(result, success_status=201)
+    except OntologyMutationCommandError as e:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                    "error_code": e.reason_code,
+                    "error": e.public_message,
+                }
+            ),
+            400,
+        )
     except InvalidConceptDataError as e:
         current_app.logger.warning(f"Invalid data for creating concept: {e}")
         return jsonify(error=str(e)), 400

--- a/src/frontend/web/von_interface/static/js/apiService.js
+++ b/src/frontend/web/von_interface/static/js/apiService.js
@@ -403,52 +403,38 @@ export async function searchTypes(q, limit = 8, opts = {}) {
   }
 }
 
-// Create a new instance under a selected parent type concept
+// Create one explicitly typed concept through the governed HTTP boundary.
+export async function createConcept(parentConceptId, name, kind, fields = {}) {
+  const cleanName = String(name || '').trim();
+  if (!cleanName) throw new Error('name required');
+  if (!['instance', 'type', 'predicate'].includes(kind)) {
+    throw new Error("kind must be 'instance', 'type', or 'predicate'");
+  }
+
+  const payload = { ...fields, name: cleanName, kind };
+  if (parentConceptId) payload.parent_concept_ids = [parentConceptId];
+  const { data } = await postJsonDetailed('/api/concepts/', payload);
+  return data;
+}
+
+// Create a new instance under a selected parent type concept.
 export async function createInstance(parentConceptId, name) {
-  if (!parentConceptId || !name) throw new Error('parentConceptId and name required');
-  const payload = { parent_id: parentConceptId, new_concept_name: name, create_as_instance: true };
-  const url = '/vontology/api/vontology/create_concept';
+  if (!parentConceptId) throw new Error('parentConceptId required');
   try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
-    const text = await res.text();
-    let json = {};
-    try { json = text ? JSON.parse(text) : {}; } catch (_) { json = { parse_error: true, raw: text }; }
-    if (!res.ok || !json.success) {
-      console.warn('[annotations] createInstance non-OK', { status: res.status, body: json, raw: text.slice(0, 200) });
-      const msg = (json && (json.message || json.error)) ? `${json.message || json.error} (HTTP ${res.status})` : `Create instance failed (HTTP ${res.status})`;
-      throw new Error(msg);
-    }
-    return json.concept || json;
+    const response = await createConcept(parentConceptId, name, 'instance');
+    return response?.concept || response;
   } catch (e) {
     console.error('[annotations] createInstance error', e);
     throw e;
   }
 }
 
-// Create a new TYPE (subtype) under a selected parent type concept
+// Create a new TYPE (subtype) under a selected parent type concept.
 export async function createType(parentConceptId, name) {
-  if (!parentConceptId || !name) throw new Error('parentConceptId and name required');
-  const payload = { parent_id: parentConceptId, new_concept_name: name, create_as_instance: false };
-  const url = '/vontology/api/vontology/create_concept';
+  if (!parentConceptId) throw new Error('parentConceptId required');
   try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
-    const text = await res.text();
-    let json = {};
-    try { json = text ? JSON.parse(text) : {}; } catch (_) { json = { parse_error: true, raw: text }; }
-    if (!res.ok || !json.success) {
-      console.warn('[annotations] createType non-OK', { status: res.status, body: json, raw: text.slice(0, 200) });
-      const msg = (json && (json.message || json.error)) ? `${json.message || json.error} (HTTP ${res.status})` : `Create type failed (HTTP ${res.status})`;
-      throw new Error(msg);
-    }
-    return json.concept || json;
+    const response = await createConcept(parentConceptId, name, 'type');
+    return response?.concept || response;
   } catch (e) {
     console.error('[annotations] createType error', e);
     throw e;

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1,4 +1,4 @@
-import { deleteJson, getJson, patchJson, postJson, putJson } from './apiService.js';
+import { createConcept, deleteJson, getJson, patchJson, postJson, putJson } from './apiService.js';
 import { elements, getCurrentUserConceptId, getUserClientId } from './domUtils.js';
 import { populateLanguageSelect } from './languageConfig.js';
 import { renderMarkdownViaServer } from './markdownUtils.js';
@@ -1355,16 +1355,15 @@ export async function handleSaveConceptOrNotes(suffix = '') {
           // no-op, keep existing
         }
       }
-      const result = await postJson('/vontology/api/vontology/create_concept', {
-        new_concept_name: `Concept ${new Date().toISOString().slice(0, 10)}`,
-        parent_id: parentIdForCreate,
-        create_as_instance: true,  // TRUE = individual (no subtype relationships), FALSE = type
-        // Persist initial notes entered by the user during creation
-        notes: notes || ''
-      });
+      const result = await createConcept(
+        parentIdForCreate,
+        `Concept ${new Date().toISOString().slice(0, 10)}`,
+        'instance',
+        { notes: notes || '' }
+      );
 
       if (result && result.success) {
-        const newConceptId = result.concept_id;
+        const newConceptId = result.concept_id || result.concept?.concept_id;
         setCurrentlySelectedConceptId(newConceptId);
         setSelectedConceptOriginalName('(unnamed)');
         if (conceptStep1Status) {
@@ -3745,7 +3744,7 @@ export async function loadConceptAttributes(conceptId, suffix = '') {
  * Handle creating a new subtype from the concept tab
  * @param {string} suffix - The tab suffix
  */
-async function handleCreateSubtype(suffix = '') {
+export async function handleCreateSubtype(suffix = '') {
   const getSuffixElement = (baseId) => {
     const id = suffix ? `${baseId}_${suffix}` : baseId;
     return document.getElementById(id);
@@ -3796,11 +3795,7 @@ async function handleCreateSubtype(suffix = '') {
       }
     }
 
-    const response = await postJson('/vontology/api/vontology/create_concept', {
-      new_concept_name: finalSubtypeName,
-      parent_id: parentId,
-      create_as_instance: false  // Create as type (subtype)
-    });
+    const response = await createConcept(parentId, finalSubtypeName, 'type');
     recordNameNormalizationMetric('subtype');
 
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;
@@ -3861,7 +3856,7 @@ async function handleCreateSubtype(suffix = '') {
  * Handle creating a new instance from the concept tab
  * @param {string} suffix - The tab suffix
  */
-async function handleCreateInstance(suffix = '') {
+export async function handleCreateInstance(suffix = '') {
   const getSuffixElement = (baseId) => {
     const id = suffix ? `${baseId}_${suffix}` : baseId;
     return document.getElementById(id);
@@ -3912,11 +3907,7 @@ async function handleCreateInstance(suffix = '') {
       instancesStatus.style.color = "black";
     }
 
-    const response = await postJson('/vontology/api/vontology/create_concept', {
-      new_concept_name: sanitizedName,
-      parent_id: parentId,
-      create_as_instance: true  // Create as instance (individual)
-    });
+    const response = await createConcept(parentId, sanitizedName, 'instance');
     recordNameNormalizationMetric('instance');
 
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -348,12 +348,13 @@ async function createConceptForId(conceptId, options, fetchFn) {
     const description = (options?.description || '').toString().trim();
 
     const payload = {
-        new_concept_name: name,
-        parent_id: parentId,
-        create_as_instance: createAsInstance
+        concept_id: id,
+        name,
+        kind: createAsInstance ? 'instance' : 'type',
+        parent_concept_ids: parentId ? [parentId] : []
     };
 
-    const res = await fetchFn('/vontology/api/vontology/create_concept', {
+    const res = await fetchFn('/api/concepts/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         body: JSON.stringify(payload)

--- a/src/frontend/web/von_interface/static/js/vontology.js
+++ b/src/frontend/web/von_interface/static/js/vontology.js
@@ -1,7 +1,7 @@
 import { fetchConceptList, resetConceptTab, updateConceptTabUI } from './conceptTab.js';
 import { clearContainer, elements, getCurrentUserConceptId } from './domUtils.js';
 import { handleVontologyNodeSelection } from './dynamicTabs.js';
-import { getWindowSessionId, WINDOW_SESSION_HEADER } from './apiService.js';
+import { createConcept, getWindowSessionId, WINDOW_SESSION_HEADER } from './apiService.js';
 import { createPredicateBadge, getPredicateType } from './predicateUtils.js';
 import { ProgressManager, ProgressPhase } from './progress.js';
 import {
@@ -4470,22 +4470,12 @@ export async function handleCreateType() {
       elements.createConceptStatusP.style.color = "black";
     }
 
-    // CHICKEN-AND-EGG FIX: For root creation, omit parent_id entirely
-    const requestPayload = {
-      new_concept_name: newConceptName,
-      create_as_instance: false
-    };
-    if (!isRootCreation && parentId) {
-      requestPayload.parent_id = parentId;
-    }
-
-    const res = await vontologyFetch('/vontology/api/vontology/create_concept', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestPayload)
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const response = await res.json();
+    // For root creation, omit the parent while retaining the explicit type kind.
+    const response = await createConcept(
+      isRootCreation ? null : parentId,
+      newConceptName,
+      'type'
+    );
 
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;
     const createdConceptName = response?.concept?.name || newConceptName;
@@ -4576,17 +4566,7 @@ export async function handleCreateInstance() {
       elements.createConceptStatusP.style.color = "black";
     }
 
-    const res = await vontologyFetch('/vontology/api/vontology/create_concept', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        new_concept_name: newConceptName,
-        parent_id: parentId,
-        create_as_instance: true
-      })
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const response = await res.json();
+    const response = await createConcept(parentId, newConceptName, 'instance');
 
     const createdConceptId = response?.concept_id || response?.concept?.concept_id;
     const createdConceptName = response?.concept?.name || newConceptName;

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6392,7 +6392,7 @@ footer {
 
 .footer-org-control {
     display: inline-flex;
-    align-items: stretch;
+    align-items: center;
     position: relative;
     min-width: 0;
 }
@@ -6413,6 +6413,8 @@ footer {
 }
 
 .footer-org-menu-details {
+    display: inline-flex;
+    align-items: center;
     position: relative;
 }
 
@@ -6426,12 +6428,16 @@ footer {
     justify-content: center;
     box-sizing: border-box;
     min-width: 27px;
-    height: 100%;
+    height: auto;
     padding: 2px 7px;
     border-left: 0;
     border-radius: 0 12px 12px 0;
     list-style: none;
     user-select: none;
+}
+
+.footer-org-menu-trigger:focus {
+    box-shadow: inset 0 0 0 2px rgba(33, 150, 243, 0.4);
 }
 
 .footer-org-menu-trigger::-webkit-details-marker {

--- a/tests/backend/test_ontology_create_authority_containment.py
+++ b/tests/backend/test_ontology_create_authority_containment.py
@@ -42,7 +42,7 @@ def test_ordinary_create_exposes_scope_choice_but_binds_scope_identity() -> None
     ]
 
 
-def test_governed_create_preserves_default_type_and_one_exact_parent(
+def test_governed_create_preserves_explicit_type_and_one_exact_parent(
     monkeypatch,
 ) -> None:
     from src.backend.services import ontology_mutation_command_service as command
@@ -55,7 +55,7 @@ def test_governed_create_preserves_default_type_and_one_exact_parent(
     resolved = command.resolve_governed_ontology_arguments(
         "create_concepts",
         {
-            "concepts": [{"name": "Default type"}],
+            "concepts": [{"name": "Explicit type", "kind": "type"}],
             "parent_concept_ids": ["#V#parent"],
         },
     )
@@ -75,7 +75,7 @@ def test_governed_create_preserves_default_type_and_one_exact_parent(
         command.resolve_governed_ontology_arguments(
             "create_concepts",
             {
-                "concepts": [{"name": "Conflicting parent"}],
+                "concepts": [{"name": "Conflicting parent", "kind": "type"}],
                 "parent_id": "#V#parent_a",
                 "parent_concept_ids": ["#V#parent_b"],
             },
@@ -812,11 +812,12 @@ def test_http_create_binds_every_actual_field_and_disables_inverse_writes(
     captured: dict[str, Any] = {}
     mutation_kwargs: dict[str, Any] = {}
 
-    monkeypatch.setattr(
-        command,
-        "resolve_governed_ontology_arguments",
-        lambda _method, arguments: dict(arguments),
-    )
+    def resolve(_method, arguments):
+        resolved = dict(arguments)
+        resolved["concepts"] = [{**arguments["concepts"][0], "concept_id": "#V#record"}]
+        return resolved
+
+    monkeypatch.setattr(command, "resolve_governed_ontology_arguments", resolve)
     monkeypatch.setattr(
         concept_routes,
         "_get_current_user_concept_id",
@@ -850,7 +851,7 @@ def test_http_create_binds_every_actual_field_and_disables_inverse_writes(
         "/api/concepts/",
         json={
             "name": "Record",
-            "concept_id": "#V#record",
+            "kind": "type",
             "description": "description",
             "notes": "notes",
             "attributes": {"source": "catalogue"},
@@ -858,7 +859,6 @@ def test_http_create_binds_every_actual_field_and_disables_inverse_writes(
             "user_tags": ["user"],
             "linked_concepts": [{"concept_id": "#V#linked"}],
             "parent_concept_ids": ["#V#record_type", "#V#research_object"],
-            "create_as_instance": False,
             "instance_of_type": "#V#represented_entity",
             "scope_mode": "organisation_general",
             "request_id": "create-record-1",
@@ -872,10 +872,41 @@ def test_http_create_binds_every_actual_field_and_disables_inverse_writes(
     ]
     assert captured["linked_concepts"] == [{"concept_id": "#V#linked"}]
     assert captured["attributes"] == {"source": "catalogue"}
+    assert captured["concepts"][0]["kind"] == "type"
     assert captured["concepts"][0]["instance_of_type"] == ("#V#represented_entity")
+    assert mutation_kwargs["create_as_instance"] is False
     assert mutation_kwargs["maintain_relationship_inverses"] is False
     assert mutation_kwargs["parent_concept_ids"] == captured["parent_concept_ids"]
     assert mutation_kwargs["linked_concepts"] == captured["linked_concepts"]
+
+
+def test_http_create_requires_explicit_kind_without_starting_an_effect() -> None:
+    from src.backend.server.routes import concept_routes
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.register_blueprint(concept_routes.concept_bp, url_prefix="/api/concepts")
+
+    response = app.test_client().post(
+        "/api/concepts/",
+        json={
+            "name": "Ambiguous browser creation",
+            "parent_concept_ids": ["#V#research_object"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "effect_status": "not_started",
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "error_code": "concept_kind_required",
+        "error": (
+            "A governed concept create requires an explicit kind: "
+            "'instance', 'type', or 'predicate'."
+        ),
+    }
 
 
 def test_failed_create_readback_never_follows_an_existing_concept_id(

--- a/tests/backend/test_ontology_http_actor_provenance.py
+++ b/tests/backend/test_ontology_http_actor_provenance.py
@@ -123,6 +123,7 @@ def _create_request(client, *, headers: dict[str, str]):
         json={
             "name": "Governed HTTP creation probe",
             "concept_id": "#V#governed_http_creation_probe",
+            "kind": "type",
             "scope_mode": "global_general",
         },
     )

--- a/tests/frontend/apiServiceConceptCreation.test.js
+++ b/tests/frontend/apiServiceConceptCreation.test.js
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+
+import { createConcept } from '../../src/frontend/web/von_interface/static/js/apiService.js';
+
+describe('governed browser concept creation', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        sessionStorage.setItem('von_window_session_id', 'ws_creation_test');
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            status: 201,
+            headers: new Headers(),
+            json: async () => ({
+                success: true,
+                concept: {
+                    concept_id: '#V#primary_labs',
+                    name: 'Primary Labs',
+                },
+            }),
+        }));
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+    });
+
+    test('posts an explicit instance kind to the governed HTTP route', async () => {
+        const response = await createConcept(
+            '#V#von_user_organisation',
+            ' Primary Labs ',
+            'instance',
+            { notes: 'Created from the concept page' },
+        );
+
+        expect(response.concept.concept_id).toBe('#V#primary_labs');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = global.fetch.mock.calls[0];
+        expect(url).toBe('/api/concepts/');
+        expect(options.method).toBe('POST');
+        expect(JSON.parse(options.body)).toEqual({
+            notes: 'Created from the concept page',
+            name: 'Primary Labs',
+            kind: 'instance',
+            parent_concept_ids: ['#V#von_user_organisation'],
+        });
+        expect(options.headers['X-Von-Window-Session']).toBe('ws_creation_test');
+    });
+
+    test('does not invent a kind when the caller omits it', async () => {
+        await expect(
+            createConcept('#V#von_user_organisation', 'Primary Labs'),
+        ).rejects.toThrow("kind must be 'instance', 'type', or 'predicate'");
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/tests/frontend/conceptTabCreation.test.js
+++ b/tests/frontend/conceptTabCreation.test.js
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    createConcept: jest.fn(),
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+    putJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    getCurrentUserConceptId: jest.fn(() => null),
+    getUserClientId: jest.fn(() => null),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/languageConfig.js', () => ({
+    populateLanguageSelect: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/markdownUtils.js', () => ({
+    renderMarkdownViaServer: jest.fn(async (text) => String(text ?? '')),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/nameUtils.js', () => ({
+    checkDuplicateName: jest.fn(() => false),
+    normalizeConceptName: jest.fn((name) => ({ normalized: name, changed: false, notes: '' })),
+    recordNameNormalizationMetric: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/state.js', () => ({
+    defaultSelectedConceptType: '#V#thing',
+    getConceptTypeDisplayNames: jest.fn(() => ({ singular: 'Concept', plural: 'Concepts' })),
+    getCurrentConceptType: jest.fn(() => '#V#von_user_organisation'),
+    getCurrentlySelectedConceptId: jest.fn(() => '#V#von_user_organisation'),
+    setCurrentConceptType: jest.fn(),
+    setCurrentlySelectedConceptId: jest.fn(),
+    setSelectedConceptOriginalName: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/sessionScopedStorage.js', () => ({
+    getSessionScopedOrgId: jest.fn(() => null),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/textDecorator.js', () => ({
+    annotateElementText: jest.fn(),
+    linkifyVontologyTokensInElement: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/vontology.js', () => ({
+    chooseBestTypeForIndividual: jest.fn(),
+    insertNodeIntoVontologyTree: jest.fn(),
+    selectVontologyNodeByIdentifier: jest.fn(),
+}));
+
+const { createConcept } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+const {
+    handleCreateInstance,
+    handleCreateSubtype,
+} = require('../../src/frontend/web/von_interface/static/js/conceptTab.js');
+
+describe('concept tab creation controls', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        document.body.innerHTML = `
+            <input id="newInstanceInput_probe" value="Primary Labs" />
+            <button id="createInstanceButton_probe"></button>
+            <div id="instancesStatus_probe"></div>
+            <input id="newSubtypeInput_probe" value="Research Organisation" />
+            <button id="createSubtypeButton_probe"></button>
+            <div id="subtypesStatus_probe"></div>
+        `;
+        createConcept.mockImplementation(async (_parent, name) => ({
+            success: true,
+            concept: {
+                concept_id: `#V#${name.toLowerCase().replace(/\s+/g, '_')}`,
+                name,
+            },
+        }));
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    test('Add Instance supplies the selected type and explicit instance kind', async () => {
+        await handleCreateInstance('probe');
+
+        expect(createConcept).toHaveBeenCalledWith(
+            '#V#von_user_organisation',
+            'Primary Labs',
+            'instance',
+        );
+        expect(document.getElementById('instancesStatus_probe').textContent)
+            .toBe('Instance "Primary Labs" created successfully!');
+        expect(document.getElementById('newInstanceInput_probe').value).toBe('');
+    });
+
+    test('Add Subtype supplies the selected type and explicit type kind', async () => {
+        await handleCreateSubtype('probe');
+
+        expect(createConcept).toHaveBeenCalledWith(
+            '#V#von_user_organisation',
+            'Research Organisation',
+            'type',
+        );
+        expect(document.getElementById('subtypesStatus_probe').textContent)
+            .toBe('Subtype "Research Organisation" created successfully!');
+        expect(document.getElementById('newSubtypeInput_probe').value).toBe('');
+    });
+});

--- a/tests/frontend/footerOrganisationSwitcher.test.js
+++ b/tests/frontend/footerOrganisationSwitcher.test.js
@@ -95,12 +95,19 @@ describe('footer organisation switcher', () => {
         });
     });
 
-    test('uses border-box sizing for the split trigger and responsive menu dimensions', () => {
+    test('keeps the split trigger at the natural centred chip height', () => {
+        const controlRule = styles.match(/\.footer-org-control\s*\{([^}]*)\}/)?.[1] || '';
+        const detailsRule = styles.match(/\.footer-org-menu-details\s*\{([^}]*)\}/)?.[1] || '';
         const triggerRule = styles.match(/\.footer-org-menu-trigger\s*\{([^}]*)\}/)?.[1] || '';
+        const focusRule = styles.match(/\.footer-org-menu-trigger:focus\s*\{([^}]*)\}/)?.[1] || '';
         const menuRule = styles.match(/\.footer-org-menu\s*\{([^}]*)\}/)?.[1] || '';
 
+        expect(controlRule).toMatch(/align-items:\s*center/);
+        expect(detailsRule).toMatch(/display:\s*inline-flex/);
+        expect(detailsRule).toMatch(/align-items:\s*center/);
         expect(triggerRule).toMatch(/box-sizing:\s*border-box/);
-        expect(triggerRule).toMatch(/height:\s*100%/);
+        expect(triggerRule).toMatch(/height:\s*auto/);
+        expect(focusRule).toMatch(/box-shadow:\s*inset/);
         expect(menuRule).toMatch(/box-sizing:\s*border-box/);
     });
 

--- a/tests/frontend/selectConceptByIdHandler.test.js
+++ b/tests/frontend/selectConceptByIdHandler.test.js
@@ -187,11 +187,11 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 const body = JSON.parse(opts.body);
-                expect(body.new_concept_name).toBe('disambiguation_result');
-                expect(body.parent_id).toBe('#V#thing');
-                expect(body.create_as_instance).toBe(false);
+                expect(body.name).toBe('disambiguation_result');
+                expect(body.parent_concept_ids).toEqual(['#V#thing']);
+                expect(body.kind).toBe('type');
                 created = true;
                 return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: '#V#disambiguation_result' }) });
             }
@@ -267,10 +267,10 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 const body = JSON.parse(opts.body);
                 // Name derived from canonicalised concept id.
-                expect(body.new_concept_name).toBe('foo_bar');
+                expect(body.name).toBe('foo_bar');
                 created = true;
                 return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: '#V#foo_bar' }) });
             }
@@ -317,9 +317,9 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 const body = JSON.parse(opts.body);
-                expect(body.new_concept_name).toBe('cafe');
+                expect(body.name).toBe('cafe');
                 created = true;
                 return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: '#V#cafe' }) });
             }
@@ -381,7 +381,7 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 created = true;
                 return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: '#V#workflow_result' }) });
             }
@@ -464,13 +464,13 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: false, status: 404, text: async () => 'not found' });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 const body = JSON.parse(opts.body);
-                createOrder.push(body.new_concept_name);
-                if (body.new_concept_name === 'child_concept') {
+                createOrder.push(body.name);
+                if (body.name === 'child_concept') {
                     childCreated = true;
                 }
-                return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: `#V#${body.new_concept_name}` }) });
+                return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({ concept_id: `#V#${body.name}` }) });
             }
             return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
         });
@@ -528,7 +528,7 @@ describe('handleSelectConceptByIdDetail', () => {
                 }
                 return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });
             }
-            if (typeof url === 'string' && url === '/vontology/api/vontology/create_concept') {
+            if (typeof url === 'string' && url === '/api/concepts/') {
                 throw new Error('create_concept should not be called when concept appears before create');
             }
             return Promise.resolve({ ok: true, status: 200, text: async () => JSON.stringify({}) });


### PR DESCRIPTION
## Outcome
- routes Add Instance, Add Subtype, Vontology creation, annotations, and cartouche-created concepts through the governed HTTP creation API
- supplies an explicit instance/type kind and preserves the no-default creation contract
- returns structured pre-effect errors for missing kinds
- centres both footer organisation selector halves at the same natural chip height

## Ship evidence
- backend ontology creation/authority containment: 30 passed
- focused frontend creation, selector, and concept-ID handling: 27 passed
- frontend ESLint: no errors
- real Chrome geometry: both selector halves 20.5625px high with identical top/bottom coordinates
- no browser references remain to the retired 410 creation endpoint

## Stop-ship conditions checked
- no fallback/default kind was reintroduced
- no retired ungoverned endpoint was re-enabled
- no live ontology mutation was used for validation

## Non-goals
- deployment or activation of a running Von instance
- broader footer restyling