### PR TITLE
Fix user-scoped organisation discovery

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -18640,115 +18640,50 @@ def stream_shared_conversation():
 @von_bp.route("/api/organisations/my_organisations", methods=["GET"])
 def get_my_organisations():
     """
-    Get list of organisations the user is member of.
+    Get the authenticated user's organisation memberships.
+
+    Membership discovery deliberately does not use the active organisation
+    context: that context selects a working namespace, while this endpoint must
+    enumerate every organisation the actor can switch to. Client-supplied user
+    identifiers are ignored; the actor always comes from trusted server context.
 
     Returns: {organisations: [{concept_id, name, role}, ...], total_count}
     """
     try:
-        from ...security.role_resolver import get_all_user_organisations, get_user_role
-        from ...services.concept_service import get_concept_by_concept_id
-
-        user_id = (
-            session.get("user_id")
-            or session.get("user_concept_id")
-            or session.get("user_email")
+        from ...security.access_control import (
+            LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+            get_effective_user_concept_id_with_source,
         )
-        if not user_id:
+        from ...services.organisation_membership_service import get_user_memberships
+
+        user_concept_id, actor_source = get_effective_user_concept_id_with_source()
+        if (
+            not user_concept_id
+            or actor_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE
+        ):
             return jsonify({"error": "Not authenticated"}), 401
-
-        requested_user_concept_id = request.args.get("user_concept_id")
-        user_concept_id = requested_user_concept_id or session.get("user_concept_id")
-        user_email = session.get("user_email")
-
-        def _normalise_relationships(rel):
-            if not isinstance(rel, (dict, list)):
-                return {}
-            if isinstance(rel, list):
-                out = {}
-                for item in rel:
-                    if not isinstance(item, dict):
-                        continue
-                    pred = item.get("predicate")
-                    tgt = item.get("target")
-                    if not pred or not tgt:
-                        continue
-                    out.setdefault(pred, [])
-                    if isinstance(tgt, list):
-                        out[pred].extend(tgt)
-                    else:
-                        out[pred].append(tgt)
-                return out
-            return rel or {}
 
         def _prettify_concept_id(concept_id: str) -> str:
             return concept_id.replace("#V#", "").replace("_", " ").title()
 
-        # Derive a slug for stub role resolution.
-        # Prefer identifiers that are stable/meaningful (concept ID or email) over
-        # opaque auth subjects.
-        slug_source = user_concept_id or user_email or user_id
-
-        user_slug = str(slug_source)
-        if user_slug.startswith("#V#"):
-            user_slug = user_slug[3:]
-        if "@" in user_slug:
-            user_slug = user_slug.split("@", 1)[0]
-        if "+" in user_slug:
-            user_slug = user_slug.split("+", 1)[0]
-
-        import re
-
-        user_slug = re.sub(r"[^a-z0-9]+", "_", user_slug.strip().lower()).strip("_")
-
-        USER_PREF_ORG_PREDICATE = "#V#member_of_organisation"
-
+        membership_result = get_user_memberships(user_concept_id)
         organisations = []
-
-        # Prefer memberships stored on the selected/authenticated user concept.
-        if isinstance(user_concept_id, str) and user_concept_id.strip():
-            try:
-                user_concept = get_concept_by_concept_id(concept_id=user_concept_id)
-            except Exception:
-                user_concept = None
-            if isinstance(user_concept, dict):
-                rel = _normalise_relationships(user_concept.get("relationships", {}))
-                org_raw = rel.get(USER_PREF_ORG_PREDICATE)
-
-                org_targets: list[str] = []
-                if isinstance(org_raw, str) and org_raw:
-                    org_targets = [org_raw]
-                elif isinstance(org_raw, list):
-                    org_targets = [t for t in org_raw if isinstance(t, str) and t]
-
-                for org_cid in org_targets:
-                    org_cid = org_cid if org_cid.startswith("#V#") else f"#V#{org_cid}"
-                    org_slug = org_cid[3:] if org_cid.startswith("#V#") else org_cid
-                    org_slug = org_slug.strip().lower().replace(" ", "_")
-                    try:
-                        role = get_user_role(user_slug, org_slug)
-                    except Exception:
-                        role = "member"
-
-                    organisations.append(
-                        {
-                            "concept_id": org_cid,
-                            "name": _prettify_concept_id(org_cid),
-                            "role": role,
-                        }
-                    )
-
-        # Fallback: stub role resolver mappings (Phase 1 hardcoded)
-        if not organisations:
-            org_roles = get_all_user_organisations(user_slug)
-            for org_id, role in org_roles.items():
-                concept_id = org_id if org_id.startswith("#V#") else f"#V#{org_id}"
-                organisations.append(
-                    {
-                        "concept_id": concept_id,
-                        "name": _prettify_concept_id(concept_id),
-                        "role": role,
-                    }
-                )
+        for membership in membership_result.get("memberships", []):
+            if not isinstance(membership, dict):
+                continue
+            concept_id = membership.get("organisation_concept_id")
+            if not isinstance(concept_id, str) or not concept_id.strip():
+                continue
+            concept_id = concept_id.strip()
+            if not concept_id.startswith("#V#"):
+                concept_id = f"#V#{concept_id}"
+            organisations.append(
+                {
+                    "concept_id": concept_id,
+                    "name": _prettify_concept_id(concept_id),
+                    "role": str(membership.get("role") or "member"),
+                }
+            )
 
         return (
             jsonify(

--- a/src/frontend/web/von_interface/static/js/components/orgSelector.js
+++ b/src/frontend/web/von_interface/static/js/components/orgSelector.js
@@ -9,7 +9,7 @@
  * windows without interference.
  */
 
-import { getJsonDetailed, getUserContext, postJson } from '../apiService.js';
+import { getJsonDetailed, postJson } from '../apiService.js';
 import {
     armRetryableLoadState,
     clearRetryableLoadState,
@@ -36,13 +36,7 @@ export function normaliseOrganisationDisplayName(label) {
  * Load user's available organisations from backend
  */
 export async function loadMyOrganisations() {
-    const ctx = getUserContext();
-    const userConceptId = ctx?.user_id;
-    const url = userConceptId
-        ? `/von/api/organisations/my_organisations?user_concept_id=${encodeURIComponent(userConceptId)}`
-        : '/von/api/organisations/my_organisations';
-
-    const { data } = await getJsonDetailed(url);
+    const { data } = await getJsonDetailed('/von/api/organisations/my_organisations');
     return data?.organisations || [];
 }
 

--- a/src/frontend/web/von_interface/static/js/test/orgSelectorRetryableState.test.js
+++ b/src/frontend/web/von_interface/static/js/test/orgSelectorRetryableState.test.js
@@ -4,7 +4,7 @@ jest.mock('../apiService.js', () => ({
     postJson: jest.fn(),
 }));
 
-import { renderOrgSelector } from '../components/orgSelector.js';
+import { loadMyOrganisations, renderOrgSelector } from '../components/orgSelector.js';
 import { getJsonDetailed, getUserContext } from '../apiService.js';
 
 function flushMicrotasks() {
@@ -23,6 +23,25 @@ describe('org selector retryable load state', () => {
 
     afterEach(() => {
         consoleErrorSpy.mockRestore();
+    });
+
+    test('loads memberships without a client-selected user or organisation', async () => {
+        getJsonDetailed.mockResolvedValue({
+            data: {
+                organisations: [
+                    {
+                        concept_id: '#V#the_lu_witbrock_household',
+                        name: 'The Lu Witbrock Household',
+                        role: 'owner',
+                    },
+                ],
+            },
+        });
+
+        await expect(loadMyOrganisations()).resolves.toHaveLength(1);
+        expect(getJsonDetailed).toHaveBeenCalledWith(
+            '/von/api/organisations/my_organisations'
+        );
     });
 
     test('renders retryable failure state and recovers on retry click', async () => {

--- a/tests/backend/test_organisation_membership_service.py
+++ b/tests/backend/test_organisation_membership_service.py
@@ -308,6 +308,39 @@ class TestGetUserMemberships:
         assert result["total_memberships"] == 0
         assert result["memberships"] == []
 
+    def test_get_memberships_merges_canonical_and_legacy_relationships(
+        self, mock_concepts_repo, mock_access_control, mock_text_repos
+    ):
+        """Both stored membership predicates remain visible and deduplicated."""
+        user_id = "#V#michael_witbrock"
+        mock_concepts_repo.find_one.return_value = {
+            "concept_id": user_id,
+            "relationships": {
+                "memberOf": ["#V#university_of_auckland_strong_ai_lab"],
+                "#V#member_of_organisation": [
+                    "#V#the_lu_witbrock_household",
+                    "#V#university_of_auckland_strong_ai_lab",
+                ],
+            },
+        }
+        text_rels, _ = mock_text_repos
+        text_rels.find.return_value = []
+
+        result = get_user_memberships(user_id)
+
+        assert result["memberships"] == [
+            {
+                "organisation_concept_id": (
+                    "#V#university_of_auckland_strong_ai_lab"
+                ),
+                "role": "member",
+            },
+            {
+                "organisation_concept_id": "#V#the_lu_witbrock_household",
+                "role": "member",
+            },
+        ]
+
     def test_get_memberships_decodes_scope_distinct_equal_roles(
         self, mock_concepts_repo, mock_access_control, mock_text_repos
     ):

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -102,6 +102,31 @@ def app_client(monkeypatch):
             ),
         },
     )
+    represented_memberships = {
+        "#V#michael_witbrock": [
+            {
+                "organisation_concept_id": "#V#university_of_auckland_strong_ai_lab",
+                "role": "admin",
+            }
+        ],
+        "#V#lu_yunli": [
+            {
+                "organisation_concept_id": "#V#the_lu_witbrock_household",
+                "role": "member",
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        memberships,
+        "get_user_memberships",
+        lambda user_concept_id: {
+            "user_concept_id": user_concept_id,
+            "memberships": represented_memberships.get(user_concept_id, []),
+            "total_memberships": len(
+                represented_memberships.get(user_concept_id, [])
+            ),
+        },
+    )
 
     app = utils_flask.create_flask_app(
         list_models_func=lambda: ["dummy-model"],
@@ -415,11 +440,12 @@ def test_get_my_organisations_requires_authentication(app_client):
     assert resp.get_json()["error"] == "Not authenticated"
 
 
-def test_get_my_organisations_returns_stubbed_memberships(app_client):
+def test_get_my_organisations_returns_represented_memberships(app_client):
     _, client = app_client
 
     with client.session_transaction() as sess:
         sess["user_id"] = "michael_witbrock"
+        sess["user_concept_id"] = "#V#michael_witbrock"
 
     resp = client.get("/von/api/organisations/my_organisations")
 
@@ -432,12 +458,13 @@ def test_get_my_organisations_returns_stubbed_memberships(app_client):
     assert org["name"] == "University Of Auckland Strong Ai Lab"
 
 
-def test_get_my_organisations_uses_user_email_for_stub_memberships(app_client):
+def test_get_my_organisations_uses_authenticated_user_not_email(app_client):
     _, client = app_client
 
     with client.session_transaction() as sess:
         sess["user_id"] = "opaque-oauth-subject"
         sess["user_email"] = "lu.yunli@example.com"
+        sess["user_concept_id"] = "#V#michael_witbrock"
 
     resp = client.get("/von/api/organisations/my_organisations")
 
@@ -445,17 +472,17 @@ def test_get_my_organisations_uses_user_email_for_stub_memberships(app_client):
     data = resp.get_json()
     assert data["total_count"] == 1
     org = data["organisations"][0]
-    assert org["concept_id"] == "#V#the_lu_witbrock_household"
-    assert org["role"] == "member"
-    assert org["name"] == "The Lu Witbrock Household"
+    assert org["concept_id"] == "#V#university_of_auckland_strong_ai_lab"
+    assert org["role"] == "admin"
+    assert org["name"] == "University Of Auckland Strong Ai Lab"
 
 
-def test_get_my_organisations_allows_selected_user_concept_id_override(app_client):
+def test_get_my_organisations_ignores_selected_user_concept_id(app_client):
     _, client = app_client
 
-    # Authenticated session identity does not match stub mapping.
     with client.session_transaction() as sess:
-        sess["user_id"] = "jeremyluyunli123@gmail.com"
+        sess["user_id"] = "michael_witbrock"
+        sess["user_concept_id"] = "#V#michael_witbrock"
 
     resp = client.get(
         "/von/api/organisations/my_organisations?user_concept_id=%23V%23lu_yunli"
@@ -465,9 +492,9 @@ def test_get_my_organisations_allows_selected_user_concept_id_override(app_clien
     data = resp.get_json()
     assert data["total_count"] == 1
     org = data["organisations"][0]
-    assert org["concept_id"] == "#V#the_lu_witbrock_household"
-    assert org["role"] == "member"
-    assert org["name"] == "The Lu Witbrock Household"
+    assert org["concept_id"] == "#V#university_of_auckland_strong_ai_lab"
+    assert org["role"] == "admin"
+    assert org["name"] == "University Of Auckland Strong Ai Lab"
 
 
 def test_get_my_organisations_prefers_memberships_from_user_concept_relationships(
@@ -475,33 +502,41 @@ def test_get_my_organisations_prefers_memberships_from_user_concept_relationship
 ):
     _, client = app_client
 
-    # Stub concept lookup via the normal concept service path.
-    import src.backend.services.concept_service as concept_service
+    import src.backend.services.organisation_membership_service as memberships
 
-    def _fake_get_concept_by_concept_id(concept_id: str, **_kwargs):
-        if concept_id == "#V#lu_yunli":
-            return {
-                "concept_id": "#V#lu_yunli",
-                "relationships": {
-                    "#V#member_of_organisation": ["#V#the_lu_witbrock_household"]
-                },
-            }
-        return None
+    seen_user_ids = []
+
+    def _fake_get_user_memberships(user_concept_id: str):
+        seen_user_ids.append(user_concept_id)
+        return {
+            "user_concept_id": user_concept_id,
+            "memberships": [
+                {
+                    "organisation_concept_id": "#V#the_lu_witbrock_household",
+                    "role": "owner",
+                }
+            ],
+            "total_memberships": 1,
+        }
 
     monkeypatch.setattr(
-        concept_service, "get_concept_by_concept_id", _fake_get_concept_by_concept_id
+        memberships,
+        "get_user_memberships",
+        _fake_get_user_memberships,
     )
 
     with client.session_transaction() as sess:
         sess["user_id"] = "lu_yunli"
         sess["user_concept_id"] = "#V#lu_yunli"
+        sess["organisation_concept_id"] = "university_of_auckland_strong_ai_lab"
 
     resp = client.get("/von/api/organisations/my_organisations")
 
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["total_count"] == 1
+    assert seen_user_ids == ["#V#lu_yunli"]
     org = data["organisations"][0]
     assert org["concept_id"] == "#V#the_lu_witbrock_household"
-    assert org["role"] == "member"
+    assert org["role"] == "owner"
     assert org["name"] == "The Lu Witbrock Household"


### PR DESCRIPTION
## Outcome
Footer and Settings organisation selectors now enumerate the authenticated user’s full represented membership list, independent of the active organisation.

## Changes
- derive the actor only from trusted server context
- use canonical cross-organisation membership discovery
- ignore client-supplied user selectors
- remove the redundant user query parameter from the shared frontend loader

## Validation
- 39 targeted backend tests passed
- 8 targeted frontend tests passed
- static frontend lint passed
- live read-only route check returned all expected memberships under a conflicting active context and query user