### PR TITLE
JVNAUTOSCI-2681: add change-aware startup seed receipts

### DIFF
--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -2688,10 +2688,10 @@ def _bootstrap_concept_summary_fields_for_startup(app: Flask) -> None:
         return
     try:
         from ..services.concept_summary_field_vontology_service import (
-            bootstrap_canonical_concept_summary_fields,
+            ensure_concept_summary_fields_current_for_startup,
         )
 
-        report = bootstrap_canonical_concept_summary_fields()
+        report = ensure_concept_summary_fields_current_for_startup()
         app.config["CONCEPT_SUMMARY_FIELD_BOOTSTRAP_REPORT"] = report
         try:
             app.logger.info(
@@ -2743,10 +2743,10 @@ def _bootstrap_publication_scope_profiles_for_startup(app: Flask) -> None:
         return
     try:
         from ..services.publication_scope_profile_vontology_service import (
-            bootstrap_canonical_publication_scope_profiles,
+            ensure_publication_scope_profiles_current_for_startup,
         )
 
-        report = bootstrap_canonical_publication_scope_profiles()
+        report = ensure_publication_scope_profiles_current_for_startup()
         app.config["PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"] = report
         try:
             app.logger.info(

--- a/src/backend/services/concept_summary_field_vontology_service.py
+++ b/src/backend/services/concept_summary_field_vontology_service.py
@@ -8,11 +8,16 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from . import concept_service
+from . import startup_seed_freshness_service as seed_freshness
 from .concept_summary_field_resolver import get_concept_summary_field_resolver
 from .text_value_service import get_texts_for_concepts, upsert_singleton_text_relation
 
 SUMMARY_FIELD_SEED_SCHEMA_VERSION = "concept_summary_field_seed_bundle.v1"
 SUMMARY_FIELD_TYPE_ID = "#V#summary_field"
+SUMMARY_FIELD_STARTUP_FAMILY_ID = "concept_summary_fields"
+SUMMARY_FIELD_STARTUP_PRODUCER_SCHEMA_VERSION = (
+    "concept_summary_field_startup_materialisation.v1"
+)
 
 _SEED_ASSET_PATH = (
     Path(__file__).resolve().parents[1]
@@ -49,6 +54,43 @@ def _load_seed_bundle(asset_path: str | Path | None) -> Mapping[str, Any]:
     if _text(payload.get("schema_version")) != SUMMARY_FIELD_SEED_SCHEMA_VERSION:
         raise ValueError("concept_summary_field_seed_bundle_schema_unsupported")
     return {**payload, "asset_path": str(path)}
+
+
+def _startup_freshness_scope(bundle: Mapping[str, Any]) -> dict[str, list[str]]:
+    concept_specs = [
+        spec for spec in bundle.get("concepts") or () if isinstance(spec, Mapping)
+    ]
+    text_specs = [
+        spec for spec in bundle.get("text_relations") or () if isinstance(spec, Mapping)
+    ]
+    relationship_specs = [
+        spec for spec in bundle.get("relationships") or () if isinstance(spec, Mapping)
+    ]
+    return {
+        "concept_ids": _strings(
+            [
+                *[_text(spec.get("concept_id")) for spec in concept_specs],
+                *[_text(spec.get("subject_concept_id")) for spec in relationship_specs],
+            ]
+        ),
+        "text_relation_subject_ids": _strings(
+            [_text(spec.get("subject_concept_id")) for spec in text_specs]
+        ),
+        "text_relation_predicates": _strings(
+            [_text(spec.get("predicate")) for spec in text_specs]
+        ),
+    }
+
+
+def _startup_source_digest(bundle: Mapping[str, Any]) -> str:
+    return seed_freshness.build_startup_seed_source_digest(
+        asset_path=_text(bundle.get("asset_path")),
+        producer_paths=[Path(__file__), Path(seed_freshness.__file__)],
+        material_configuration={
+            "seed_schema_version": SUMMARY_FIELD_SEED_SCHEMA_VERSION,
+            "producer_schema_version": (SUMMARY_FIELD_STARTUP_PRODUCER_SCHEMA_VERSION),
+        },
+    )
 
 
 def _ensure_concept(
@@ -169,9 +211,10 @@ def _merge_relationship(
     return f"{subject_id}:{predicate}", updated != existing
 
 
-def bootstrap_canonical_concept_summary_fields(
+def _bootstrap_canonical_concept_summary_fields(
     *,
     asset_path: str | Path | None = None,
+    freshness_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Materialise canonical concept-summary field metadata into Vontology."""
 
@@ -195,10 +238,7 @@ def bootstrap_canonical_concept_summary_fields(
     required_concept_ids = _strings(
         [
             *[_text(spec.get("concept_id")) for spec in concept_specs],
-            *[
-                _text(spec.get("subject_concept_id"))
-                for spec in relationship_specs
-            ],
+            *[_text(spec.get("subject_concept_id")) for spec in relationship_specs],
         ]
     )
     concepts_by_id: dict[str, Mapping[str, Any]] = dict(
@@ -253,9 +293,7 @@ def bootstrap_canonical_concept_summary_fields(
             spec,
             source_tag=source_tag,
             managed_by=managed_by,
-            current_rows=rows_by_concept.get(
-                _text(spec.get("subject_concept_id")), []
-            ),
+            current_rows=rows_by_concept.get(_text(spec.get("subject_concept_id")), []),
         ),
     )
     relationship_ids, changed_relationship_ids = apply_many(
@@ -276,7 +314,7 @@ def bootstrap_canonical_concept_summary_fields(
     )
     if changed:
         get_concept_summary_field_resolver().invalidate_cache()
-    return {
+    report: dict[str, Any] = {
         "success": not errors,
         "asset_path": bundle.get("asset_path"),
         "schema_version": bundle.get("schema_version"),
@@ -308,10 +346,139 @@ def bootstrap_canonical_concept_summary_fields(
             "errors": len(errors),
         },
     }
+    if freshness_context is not None:
+        canonical_read_complete = not bool(
+            text_query_metadata.get("relation_query_truncated")
+        )
+        if report["success"] and not changed and canonical_read_complete:
+            tracked_concept_document_ids = [
+                concept.get("_id") or concept.get("id")
+                for concept in concepts_by_id.values()
+                if isinstance(concept, Mapping)
+                and (concept.get("_id") is not None or concept.get("id") is not None)
+            ]
+            tracked_text_relation_document_ids = [
+                row.get("relation_id")
+                for rows in rows_by_concept.values()
+                for row in rows
+                if isinstance(row, Mapping) and row.get("relation_id") is not None
+            ]
+            tracked_text_value_document_ids = [
+                row.get("text_value_id")
+                for rows in rows_by_concept.values()
+                for row in rows
+                if isinstance(row, Mapping) and row.get("text_value_id") is not None
+            ]
+            receipt_result = seed_freshness.record_startup_seed_freshness(
+                family_id=SUMMARY_FIELD_STARTUP_FAMILY_ID,
+                source_digest=_text(freshness_context.get("source_digest")),
+                producer_schema_version=(SUMMARY_FIELD_STARTUP_PRODUCER_SCHEMA_VERSION),
+                concept_ids=required_concept_ids,
+                text_relation_subject_ids=_strings(
+                    [_text(spec.get("subject_concept_id")) for spec in text_specs]
+                ),
+                text_relation_predicates=_strings(
+                    [_text(spec.get("predicate")) for spec in text_specs]
+                ),
+                tracked_concept_document_ids=tracked_concept_document_ids,
+                tracked_text_relation_document_ids=(tracked_text_relation_document_ids),
+                tracked_text_value_document_ids=tracked_text_value_document_ids,
+                observation=(freshness_context.get("observation") or {}),
+                metadata={
+                    "schema_version": report.get("schema_version"),
+                    "seed_version": report.get("seed_version"),
+                    "source_tag": report.get("source_tag"),
+                    "managed_by": report.get("managed_by"),
+                    "counts": report.get("counts"),
+                },
+            )
+        else:
+            receipt_result = {
+                "persisted": False,
+                "reason": (
+                    "canonical_verification_failed"
+                    if not report["success"]
+                    else (
+                        "canonical_read_truncated"
+                        if not canonical_read_complete
+                        else "canonical_state_changed"
+                    )
+                ),
+            }
+        report["freshness_receipt"] = (
+            seed_freshness.public_startup_seed_freshness_result(receipt_result)
+        )
+    return report
+
+
+def bootstrap_canonical_concept_summary_fields(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Materialise canonical concept-summary metadata without cache shortcuts."""
+
+    return _bootstrap_canonical_concept_summary_fields(asset_path=asset_path)
+
+
+def ensure_concept_summary_fields_current_for_startup(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Use a complete dependency receipt before canonical startup verification."""
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    scope = _startup_freshness_scope(bundle)
+    source_digest = _startup_source_digest(bundle)
+    freshness_check = seed_freshness.check_startup_seed_freshness(
+        family_id=SUMMARY_FIELD_STARTUP_FAMILY_ID,
+        source_digest=source_digest,
+        producer_schema_version=SUMMARY_FIELD_STARTUP_PRODUCER_SCHEMA_VERSION,
+        concept_ids=scope["concept_ids"],
+        text_relation_subject_ids=scope["text_relation_subject_ids"],
+        text_relation_predicates=scope["text_relation_predicates"],
+    )
+    public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    if freshness_check.get("fresh"):
+        metadata = freshness_check.get("metadata")
+        metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+        return {
+            "success": True,
+            "skipped": True,
+            "reason": "dependency_receipt_current",
+            "changed": False,
+            "asset_path": bundle.get("asset_path"),
+            "schema_version": bundle.get("schema_version"),
+            "seed_version": bundle.get("seed_version"),
+            "source_tag": metadata.get("source_tag") or bundle.get("source_tag"),
+            "managed_by": metadata.get("managed_by") or bundle.get("managed_by"),
+            "read_strategy": "dependency_receipt",
+            "read_phases": 1,
+            "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+            "freshness_receipt": public_check,
+            "counts": dict(metadata.get("counts") or {}),
+            "errors": [],
+        }
+
+    observation = seed_freshness.begin_startup_seed_freshness_observation()
+    report = _bootstrap_canonical_concept_summary_fields(
+        asset_path=asset_path,
+        freshness_context={
+            "source_digest": source_digest,
+            "observation": observation,
+        },
+    )
+    report["freshness_receipt_check"] = public_check
+    report["duration_ms"] = int((time.perf_counter() - started_at) * 1000)
+    return report
 
 
 __all__ = [
     "SUMMARY_FIELD_SEED_SCHEMA_VERSION",
+    "SUMMARY_FIELD_STARTUP_FAMILY_ID",
+    "SUMMARY_FIELD_STARTUP_PRODUCER_SCHEMA_VERSION",
     "SUMMARY_FIELD_TYPE_ID",
     "bootstrap_canonical_concept_summary_fields",
+    "ensure_concept_summary_fields_current_for_startup",
 ]

--- a/src/backend/services/publication_scope_profile_vontology_service.py
+++ b/src/backend/services/publication_scope_profile_vontology_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from . import concept_service
+from . import startup_seed_freshness_service as seed_freshness
 from .publication_scope_profile_service import (
     PUBLICATION_SCOPE_PROFILE_LINK_PREDICATE,
     PUBLICATION_SCOPE_PROFILE_SCHEMA_VERSION,
@@ -30,6 +31,10 @@ PUBLICATION_SCOPE_PROFILE_SEED_SCHEMA_VERSION = (
     "publication_scope_profile_seed_bundle.v1"
 )
 PUBLICATION_SCOPE_PROFILE_TYPE_ID = "#V#publication_scope_profile"
+PUBLICATION_SCOPE_PROFILE_STARTUP_FAMILY_ID = "publication_scope_profiles"
+PUBLICATION_SCOPE_PROFILE_STARTUP_PRODUCER_SCHEMA_VERSION = (
+    "publication_scope_profile_startup_materialisation.v1"
+)
 
 _SEED_ASSET_PATH = (
     Path(__file__).resolve().parents[1]
@@ -74,6 +79,60 @@ def _load_seed_bundle(asset_path: str | Path | None = None) -> dict[str, Any]:
     ):
         raise ValueError("publication_scope_profile_seed_bundle_schema_unsupported")
     return {**dict(payload), "asset_path": str(path)}
+
+
+def _startup_freshness_scope(bundle: Mapping[str, Any]) -> dict[str, list[str]]:
+    concept_ids = _strings(
+        [
+            *[
+                _text(spec.get("concept_id"))
+                for spec in bundle.get("concepts") or ()
+                if isinstance(spec, Mapping)
+            ],
+            *[
+                _text(spec.get("profile_concept_id"))
+                for spec in bundle.get("profiles") or ()
+                if isinstance(spec, Mapping)
+            ],
+            *[
+                _text(spec.get("subject_concept_id"))
+                for spec in bundle.get("relationships") or ()
+                if isinstance(spec, Mapping)
+            ],
+            *[
+                subject_id
+                for spec in bundle.get("profiles") or ()
+                if isinstance(spec, Mapping)
+                for subject_id in _profile_subject_ids(spec)
+            ],
+        ]
+    )
+    profile_ids = _strings(
+        [
+            _text(spec.get("profile_concept_id"))
+            for spec in bundle.get("profiles") or ()
+            if isinstance(spec, Mapping)
+        ]
+    )
+    return {
+        "concept_ids": concept_ids,
+        "text_relation_subject_ids": profile_ids,
+        "text_relation_predicates": list(_PROFILE_TEXT_PREDICATE_ALIASES),
+    }
+
+
+def _startup_source_digest(bundle: Mapping[str, Any]) -> str:
+    return seed_freshness.build_startup_seed_source_digest(
+        asset_path=_text(bundle.get("asset_path")),
+        producer_paths=[Path(__file__), Path(seed_freshness.__file__)],
+        material_configuration={
+            "seed_schema_version": PUBLICATION_SCOPE_PROFILE_SEED_SCHEMA_VERSION,
+            "profile_schema_version": PUBLICATION_SCOPE_PROFILE_SCHEMA_VERSION,
+            "producer_schema_version": (
+                PUBLICATION_SCOPE_PROFILE_STARTUP_PRODUCER_SCHEMA_VERSION
+            ),
+        },
+    )
 
 
 def _get_concept(concept_id: str) -> Mapping[str, Any] | None:
@@ -185,10 +244,11 @@ def _profile_subject_ids(spec: Mapping[str, Any]) -> list[str]:
     )
 
 
-def bootstrap_canonical_publication_scope_profiles(
+def _bootstrap_canonical_publication_scope_profiles(
     *,
     asset_path: str | Path | None = None,
     force_profile_seed: bool = False,
+    freshness_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Materialise missing represented profiles and read them back exactly."""
 
@@ -377,7 +437,7 @@ def bootstrap_canonical_publication_scope_profiles(
                 }
             )
 
-    return {
+    report: dict[str, Any] = {
         "success": not errors,
         "schema_version": bundle.get("schema_version"),
         "seed_version": bundle.get("seed_version"),
@@ -409,10 +469,144 @@ def bootstrap_canonical_publication_scope_profiles(
             "errors": len(errors),
         },
     }
+    if freshness_context is not None:
+        canonical_read_complete = not bool(
+            profile_query_metadata.get("relation_query_truncated")
+        )
+        if report["success"] and not report["changed"] and canonical_read_complete:
+            scope = _startup_freshness_scope(bundle)
+            tracked_concept_document_ids = [
+                concept.get("_id") or concept.get("id")
+                for concept in concepts_by_id.values()
+                if isinstance(concept, Mapping)
+                and (concept.get("_id") is not None or concept.get("id") is not None)
+            ]
+            tracked_text_relation_document_ids = [
+                row.get("relation_id")
+                for rows in profile_rows_by_id.values()
+                for row in rows
+                if isinstance(row, Mapping) and row.get("relation_id") is not None
+            ]
+            tracked_text_value_document_ids = [
+                row.get("text_value_id")
+                for rows in profile_rows_by_id.values()
+                for row in rows
+                if isinstance(row, Mapping) and row.get("text_value_id") is not None
+            ]
+            receipt_result = seed_freshness.record_startup_seed_freshness(
+                family_id=PUBLICATION_SCOPE_PROFILE_STARTUP_FAMILY_ID,
+                source_digest=_text(freshness_context.get("source_digest")),
+                producer_schema_version=(
+                    PUBLICATION_SCOPE_PROFILE_STARTUP_PRODUCER_SCHEMA_VERSION
+                ),
+                concept_ids=scope["concept_ids"],
+                text_relation_subject_ids=scope["text_relation_subject_ids"],
+                text_relation_predicates=scope["text_relation_predicates"],
+                tracked_concept_document_ids=tracked_concept_document_ids,
+                tracked_text_relation_document_ids=(tracked_text_relation_document_ids),
+                tracked_text_value_document_ids=tracked_text_value_document_ids,
+                observation=(freshness_context.get("observation") or {}),
+                metadata={
+                    "schema_version": report.get("schema_version"),
+                    "seed_version": report.get("seed_version"),
+                    "source_tag": report.get("source_tag"),
+                    "managed_by": report.get("managed_by"),
+                    "counts": report.get("counts"),
+                },
+            )
+        else:
+            receipt_result = {
+                "persisted": False,
+                "reason": (
+                    "canonical_verification_failed"
+                    if not report["success"]
+                    else (
+                        "canonical_read_truncated"
+                        if not canonical_read_complete
+                        else "canonical_state_changed"
+                    )
+                ),
+            }
+        report["freshness_receipt"] = (
+            seed_freshness.public_startup_seed_freshness_result(receipt_result)
+        )
+    return report
+
+
+def bootstrap_canonical_publication_scope_profiles(
+    *,
+    asset_path: str | Path | None = None,
+    force_profile_seed: bool = False,
+) -> dict[str, Any]:
+    """Materialise canonical publication profiles without cache shortcuts."""
+
+    return _bootstrap_canonical_publication_scope_profiles(
+        asset_path=asset_path,
+        force_profile_seed=force_profile_seed,
+    )
+
+
+def ensure_publication_scope_profiles_current_for_startup(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Use a complete dependency receipt before canonical startup verification."""
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    scope = _startup_freshness_scope(bundle)
+    source_digest = _startup_source_digest(bundle)
+    freshness_check = seed_freshness.check_startup_seed_freshness(
+        family_id=PUBLICATION_SCOPE_PROFILE_STARTUP_FAMILY_ID,
+        source_digest=source_digest,
+        producer_schema_version=(
+            PUBLICATION_SCOPE_PROFILE_STARTUP_PRODUCER_SCHEMA_VERSION
+        ),
+        concept_ids=scope["concept_ids"],
+        text_relation_subject_ids=scope["text_relation_subject_ids"],
+        text_relation_predicates=scope["text_relation_predicates"],
+    )
+    public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    if freshness_check.get("fresh"):
+        metadata = freshness_check.get("metadata")
+        metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+        return {
+            "success": True,
+            "skipped": True,
+            "reason": "dependency_receipt_current",
+            "changed": False,
+            "asset_path": bundle.get("asset_path"),
+            "schema_version": bundle.get("schema_version"),
+            "seed_version": bundle.get("seed_version"),
+            "source_tag": metadata.get("source_tag") or bundle.get("source_tag"),
+            "managed_by": metadata.get("managed_by") or bundle.get("managed_by"),
+            "read_strategy": "dependency_receipt",
+            "read_phases": 1,
+            "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+            "freshness_receipt": public_check,
+            "counts": dict(metadata.get("counts") or {}),
+            "errors": [],
+        }
+
+    observation = seed_freshness.begin_startup_seed_freshness_observation()
+    report = _bootstrap_canonical_publication_scope_profiles(
+        asset_path=asset_path,
+        freshness_context={
+            "source_digest": source_digest,
+            "observation": observation,
+        },
+    )
+    report["freshness_receipt_check"] = public_check
+    report["duration_ms"] = int((time.perf_counter() - started_at) * 1000)
+    return report
 
 
 __all__ = [
     "PUBLICATION_SCOPE_PROFILE_SEED_SCHEMA_VERSION",
+    "PUBLICATION_SCOPE_PROFILE_STARTUP_FAMILY_ID",
+    "PUBLICATION_SCOPE_PROFILE_STARTUP_PRODUCER_SCHEMA_VERSION",
     "PUBLICATION_SCOPE_PROFILE_TYPE_ID",
     "bootstrap_canonical_publication_scope_profiles",
+    "ensure_publication_scope_profiles_current_for_startup",
 ]

--- a/src/backend/services/startup_seed_freshness_service.py
+++ b/src/backend/services/startup_seed_freshness_service.py
@@ -1,0 +1,737 @@
+"""Change-aware freshness receipts for bounded startup seed materialisations.
+
+The receipts in this module are derived support state.  They never replace
+Vontology as authority: a missing, incompatible, or unresumable receipt is a
+cache miss and callers retain their canonical verification path.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, unquote, urlsplit
+
+from bson import BSON
+
+STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION = "startup_seed_freshness_receipt.v1"
+_RECEIPT_FILE_SCHEMA_VERSION = "startup_seed_freshness_receipts.v1"
+_DEFAULT_RECEIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "data"
+    / "startup_seed_cache"
+    / "freshness_receipts.json"
+)
+_RECEIPT_LOCK = threading.Lock()
+_WATCHED_COLLECTIONS = ("concepts", "text_relations", "text_values")
+_DDL_OPERATION_TYPES = frozenset({"drop", "rename", "dropDatabase", "invalidate"})
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalised_strings(values: Sequence[Any] | None) -> list[str]:
+    return sorted({_text(value) for value in values or () if _text(value)})
+
+
+def _receipt_path() -> Path:
+    override = os.getenv("VON_STARTUP_SEED_FRESHNESS_RECEIPT_PATH")
+    if isinstance(override, str) and override.strip():
+        return Path(override.strip())
+    return _DEFAULT_RECEIPT_PATH
+
+
+def _receipts_enabled() -> bool:
+    if os.getenv("PYTEST_CURRENT_TEST") and not os.getenv(
+        "VON_STARTUP_SEED_FRESHNESS_RECEIPT_PATH"
+    ):
+        return False
+    return os.getenv(
+        "VON_STARTUP_SEED_FRESHNESS_RECEIPTS_ENABLED", "1"
+    ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _max_await_time_ms() -> int:
+    try:
+        configured = int(
+            os.getenv("VON_STARTUP_SEED_CHANGE_STREAM_MAX_AWAIT_MS", "100")
+        )
+    except (TypeError, ValueError):
+        configured = 100
+    return max(10, min(configured, 5_000))
+
+
+def _max_events() -> int:
+    try:
+        configured = int(
+            os.getenv("VON_STARTUP_SEED_CHANGE_STREAM_MAX_EVENTS", "10000")
+        )
+    except (TypeError, ValueError):
+        configured = 10_000
+    return max(1, min(configured, 1_000_000))
+
+
+def _dependency_scope(
+    *,
+    concept_ids: Sequence[str],
+    text_relation_subject_ids: Sequence[str],
+    text_relation_predicates: Sequence[str],
+) -> dict[str, list[str]]:
+    return {
+        "concept_ids": _normalised_strings(concept_ids),
+        "text_relation_subject_ids": _normalised_strings(text_relation_subject_ids),
+        "text_relation_predicates": _normalised_strings(text_relation_predicates),
+    }
+
+
+def build_startup_seed_source_digest(
+    *,
+    asset_path: str | Path,
+    producer_paths: Sequence[str | Path],
+    material_configuration: Mapping[str, Any] | None = None,
+) -> str:
+    """Digest the exact seed, producer code, and material configuration."""
+
+    digest = hashlib.sha256()
+    paths = [Path(asset_path), *[Path(path) for path in producer_paths]]
+    for path in paths:
+        resolved = path.resolve()
+        digest.update(resolved.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(resolved.read_bytes())
+        digest.update(b"\0")
+    encoded_configuration = json.dumps(
+        dict(material_configuration or {}),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    digest.update(encoded_configuration)
+    return digest.hexdigest()
+
+
+def _mongo_principal_fingerprint(uri: str) -> str | None:
+    try:
+        parsed = urlsplit(uri)
+        query_options = {
+            _text(key).lower(): _text(value)
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        }
+        identity = {
+            "username": unquote(parsed.username or "").strip(),
+            "auth_source": query_options.get("authsource", ""),
+            "auth_mechanism": query_options.get("authmechanism", ""),
+        }
+        if not any(identity.values()):
+            return None
+        return hashlib.sha256(
+            json.dumps(
+                identity,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+    except Exception:  # noqa: BLE001 - an unavailable identity is a cache miss
+        return None
+
+
+def _current_authority_fingerprint(db: Any) -> str:
+    """Return a secret-free identity for the represented read authority."""
+
+    from ..db.mongo_client import (
+        MONGO_URI,
+        get_effective_mongo_uri,
+        get_mongo_fallback_policy_state,
+        is_using_fallback_uri,
+    )
+    from ..db.mongo_uri_redaction import build_safe_mongo_connection_location
+
+    effective_uri = get_effective_mongo_uri()
+    fallback_policy = get_mongo_fallback_policy_state()
+    identity = {
+        "database_name": _text(getattr(db, "name", "")),
+        "mongo_location": build_safe_mongo_connection_location(
+            effective_uri,
+            using_fallback=is_using_fallback_uri(),
+            fallback_kind=fallback_policy.get("active_fallback_kind"),
+            fallback_target_uri=MONGO_URI,
+        ),
+        "mongo_principal_fingerprint": _mongo_principal_fingerprint(effective_uri),
+        "namespace": _text(os.getenv("VON_DEFAULT_NAMESPACE")),
+    }
+    return hashlib.sha256(
+        json.dumps(
+            identity,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _get_db() -> Any:
+    from ..db.mongo_client import get_db
+
+    return get_db()
+
+
+def _encode_resume_token(token: Mapping[str, Any]) -> str:
+    return base64.b64encode(BSON.encode({"resume_token": dict(token)})).decode("ascii")
+
+
+def _decode_resume_token(encoded: Any) -> Mapping[str, Any] | None:
+    if not isinstance(encoded, str) or not encoded.strip():
+        return None
+    try:
+        payload = BSON(base64.b64decode(encoded.encode("ascii"))).decode()
+    except Exception:  # noqa: BLE001 - malformed opaque tokens are cache misses
+        return None
+    token = payload.get("resume_token")
+    return token if isinstance(token, Mapping) else None
+
+
+def _read_receipt_entries(path: Path) -> dict[str, Mapping[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 - corrupt/missing receipts are cache misses
+        return {}
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != _RECEIPT_FILE_SCHEMA_VERSION
+        or not isinstance(payload.get("entries"), Mapping)
+    ):
+        return {}
+    return {
+        _text(key): dict(value)
+        for key, value in payload["entries"].items()
+        if _text(key) and isinstance(value, Mapping)
+    }
+
+
+def _persist_receipt_entry(family_id: str, entry: Mapping[str, Any]) -> None:
+    path = _receipt_path()
+    temp_path: str | None = None
+    with _RECEIPT_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entries = _read_receipt_entries(path)
+        entries[family_id] = dict(entry)
+        payload = {
+            "schema_version": _RECEIPT_FILE_SCHEMA_VERSION,
+            "entries": entries,
+        }
+        handle, temp_path = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=str(path.parent),
+        )
+        try:
+            with os.fdopen(handle, "w", encoding="utf-8") as stream:
+                json.dump(
+                    payload,
+                    stream,
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temp_path, 0o600)
+            os.replace(temp_path, path)
+            temp_path = None
+        finally:
+            if temp_path:
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+
+
+def _public_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        _text(key): value
+        for key, value in result.items()
+        if not _text(key).startswith("_")
+    }
+
+
+def public_startup_seed_freshness_result(
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Remove opaque checkpoint values before exposing startup telemetry."""
+
+    return _public_result(result)
+
+
+def _normalised_tracked_ids(values: Sequence[Any] | None) -> list[str]:
+    return _normalised_strings(values)
+
+
+def _event_relevance(
+    event: Mapping[str, Any],
+    *,
+    scope: Mapping[str, Sequence[str]],
+    tracked_ids: Mapping[str, Sequence[str]],
+) -> tuple[bool, bool]:
+    """Return ``(relevant, determinate)`` for one database change event."""
+
+    operation_type = _text(event.get("operationType"))
+    if operation_type in _DDL_OPERATION_TYPES:
+        return True, True
+
+    namespace = event.get("ns")
+    collection_name = (
+        _text(namespace.get("coll")) if isinstance(namespace, Mapping) else ""
+    )
+    if collection_name not in _WATCHED_COLLECTIONS:
+        return False, True
+
+    document_key = event.get("documentKey")
+    raw_document_id = (
+        document_key.get("_id") if isinstance(document_key, Mapping) else None
+    )
+    document_id = _text(raw_document_id)
+    full_document = event.get("fullDocument")
+    document = full_document if isinstance(full_document, Mapping) else {}
+
+    if collection_name == "concepts":
+        if document_id and document_id in set(
+            tracked_ids.get("concept_document_ids") or ()
+        ):
+            return True, True
+        concept_id = _text(document.get("concept_id"))
+        if concept_id:
+            return concept_id in set(scope.get("concept_ids") or ()), True
+    elif collection_name == "text_relations":
+        if document_id and document_id in set(
+            tracked_ids.get("text_relation_document_ids") or ()
+        ):
+            return True, True
+        subject_id = _text(document.get("subject_concept_id"))
+        predicate = _text(document.get("predicate"))
+        if subject_id or predicate:
+            return (
+                subject_id in set(scope.get("text_relation_subject_ids") or ())
+                and predicate in set(scope.get("text_relation_predicates") or ())
+            ), True
+    elif collection_name == "text_values":
+        if document_id:
+            return (
+                document_id in set(tracked_ids.get("text_value_document_ids") or ()),
+                True,
+            )
+
+    if operation_type == "delete" and document_id:
+        # An untracked deletion cannot affect the exact verified dependency set.
+        return False, True
+    return False, False
+
+
+def _watch_pipeline() -> list[dict[str, Any]]:
+    return [
+        {
+            "$match": {
+                "$or": [
+                    {"ns.coll": {"$in": list(_WATCHED_COLLECTIONS)}},
+                    {"operationType": {"$in": sorted(_DDL_OPERATION_TYPES)}},
+                ]
+            }
+        }
+    ]
+
+
+def _drain_changes(
+    *,
+    db: Any,
+    observation: Mapping[str, Any],
+    scope: Mapping[str, Sequence[str]],
+    tracked_ids: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    watch_options: dict[str, Any] = {
+        "full_document": "updateLookup",
+        "max_await_time_ms": _max_await_time_ms(),
+    }
+    resume_token = observation.get("_resume_token")
+    start_at_operation_time = observation.get("_start_at_operation_time")
+    if isinstance(resume_token, Mapping):
+        watch_options["resume_after"] = dict(resume_token)
+    elif start_at_operation_time is not None:
+        watch_options["start_at_operation_time"] = start_at_operation_time
+    else:
+        return {
+            "success": False,
+            "reason": "change_stream_observation_missing",
+            "events_examined": 0,
+            "relevant_events": 0,
+        }
+
+    events_examined = 0
+    relevant_events = 0
+    indeterminate_events = 0
+    stream = None
+    try:
+        stream = db.watch(_watch_pipeline(), **watch_options)
+        while True:
+            event = stream.try_next()
+            if event is None:
+                break
+            events_examined += 1
+            relevant, determinate = _event_relevance(
+                event,
+                scope=scope,
+                tracked_ids=tracked_ids,
+            )
+            if relevant:
+                relevant_events += 1
+                break
+            if not determinate:
+                indeterminate_events += 1
+                break
+            if events_examined >= _max_events():
+                return {
+                    "success": False,
+                    "reason": "change_stream_event_limit_reached",
+                    "events_examined": events_examined,
+                    "relevant_events": relevant_events,
+                    "indeterminate_events": indeterminate_events,
+                }
+        current_token = getattr(stream, "resume_token", None)
+        if relevant_events:
+            return {
+                "success": True,
+                "fresh": False,
+                "reason": "relevant_dependency_change_observed",
+                "events_examined": events_examined,
+                "relevant_events": relevant_events,
+                "indeterminate_events": indeterminate_events,
+            }
+        if indeterminate_events:
+            return {
+                "success": False,
+                "fresh": False,
+                "reason": "change_stream_event_indeterminate",
+                "events_examined": events_examined,
+                "relevant_events": 0,
+                "indeterminate_events": indeterminate_events,
+            }
+        if not isinstance(current_token, Mapping):
+            return {
+                "success": False,
+                "fresh": False,
+                "reason": "change_stream_resume_token_missing",
+                "events_examined": events_examined,
+                "relevant_events": 0,
+                "indeterminate_events": 0,
+            }
+        return {
+            "success": True,
+            "fresh": True,
+            "reason": "no_relevant_dependency_change",
+            "events_examined": events_examined,
+            "relevant_events": 0,
+            "indeterminate_events": 0,
+            "_resume_token": dict(current_token),
+        }
+    except Exception as exc:  # noqa: BLE001 - any driver failure must fail closed
+        return {
+            "success": False,
+            "fresh": False,
+            "reason": "change_stream_unavailable_or_unresumable",
+            "error_type": type(exc).__name__,
+            "events_examined": events_examined,
+            "relevant_events": relevant_events,
+            "indeterminate_events": indeterminate_events,
+        }
+    finally:
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:  # noqa: BLE001,S110 - close is best-effort only
+                pass
+
+
+def begin_startup_seed_freshness_observation() -> dict[str, Any]:
+    """Capture a server operation time before canonical verification begins."""
+
+    if not _receipts_enabled():
+        return {"success": False, "reason": "freshness_receipts_disabled"}
+    try:
+        db = _get_db()
+        hello = db.command("hello")
+        operation_time = hello.get("operationTime")
+        if operation_time is None:
+            return {
+                "success": False,
+                "reason": "mongo_operation_time_unavailable",
+            }
+        return {
+            "success": True,
+            "reason": "mongo_operation_time_captured",
+            "_start_at_operation_time": operation_time,
+        }
+    except Exception as exc:  # noqa: BLE001 - unavailable observation is typed
+        return {
+            "success": False,
+            "reason": "mongo_operation_time_capture_failed",
+            "error_type": type(exc).__name__,
+        }
+
+
+def check_startup_seed_freshness(
+    *,
+    family_id: str,
+    source_digest: str,
+    producer_schema_version: str,
+    concept_ids: Sequence[str],
+    text_relation_subject_ids: Sequence[str],
+    text_relation_predicates: Sequence[str],
+) -> dict[str, Any]:
+    """Validate a receipt and drain its checkpoint to the current high-water mark."""
+
+    started_at = time.perf_counter()
+    base_result: dict[str, Any] = {
+        "fresh": False,
+        "family_id": family_id,
+        "receipt_schema_version": STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION,
+    }
+    if not _receipts_enabled():
+        return {
+            **base_result,
+            "reason": "freshness_receipts_disabled",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    scope = _dependency_scope(
+        concept_ids=concept_ids,
+        text_relation_subject_ids=text_relation_subject_ids,
+        text_relation_predicates=text_relation_predicates,
+    )
+    entry = _read_receipt_entries(_receipt_path()).get(family_id)
+    if not isinstance(entry, Mapping):
+        return {
+            **base_result,
+            "reason": "receipt_missing",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("schema_version") != STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION:
+        return {
+            **base_result,
+            "reason": "receipt_schema_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("source_digest") != source_digest:
+        return {
+            **base_result,
+            "reason": "source_digest_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("producer_schema_version") != producer_schema_version:
+        return {
+            **base_result,
+            "reason": "producer_schema_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("dependency_scope") != scope:
+        return {
+            **base_result,
+            "reason": "dependency_scope_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    tracked_ids = entry.get("tracked_ids")
+    if not isinstance(tracked_ids, Mapping):
+        return {
+            **base_result,
+            "reason": "tracked_dependency_ids_missing",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    token = _decode_resume_token(entry.get("resume_token_bson_base64"))
+    if token is None:
+        return {
+            **base_result,
+            "reason": "resume_token_invalid",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    try:
+        db = _get_db()
+        authority_fingerprint = _current_authority_fingerprint(db)
+    except Exception as exc:  # noqa: BLE001 - authority uncertainty is a miss
+        return {
+            **base_result,
+            "reason": "authority_fingerprint_unavailable",
+            "error_type": type(exc).__name__,
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("authority_fingerprint") != authority_fingerprint:
+        return {
+            **base_result,
+            "reason": "authority_fingerprint_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    drained = _drain_changes(
+        db=db,
+        observation={"_resume_token": token},
+        scope=scope,
+        tracked_ids=tracked_ids,
+    )
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    if not drained.get("fresh"):
+        return {
+            **base_result,
+            **_public_result(drained),
+            "duration_ms": duration_ms,
+        }
+
+    current_token = drained.get("_resume_token")
+    if not isinstance(current_token, Mapping):
+        return {
+            **base_result,
+            "reason": "change_stream_resume_token_missing",
+            "duration_ms": duration_ms,
+        }
+    refreshed_entry = {
+        **dict(entry),
+        "resume_token_bson_base64": _encode_resume_token(current_token),
+        "last_checked_at_epoch_seconds": time.time(),
+    }
+    try:
+        _persist_receipt_entry(family_id, refreshed_entry)
+    except Exception as exc:  # noqa: BLE001 - persistence failure is a miss
+        return {
+            **base_result,
+            "reason": "receipt_checkpoint_persist_failed",
+            "error_type": type(exc).__name__,
+            "events_examined": drained.get("events_examined", 0),
+            "duration_ms": duration_ms,
+        }
+    return {
+        **base_result,
+        "fresh": True,
+        "reason": "dependency_receipt_current",
+        "events_examined": drained.get("events_examined", 0),
+        "relevant_events": 0,
+        "indeterminate_events": 0,
+        "verified_at_epoch_seconds": entry.get("verified_at_epoch_seconds"),
+        "metadata": dict(entry.get("metadata") or {}),
+        "duration_ms": duration_ms,
+    }
+
+
+def record_startup_seed_freshness(
+    *,
+    family_id: str,
+    source_digest: str,
+    producer_schema_version: str,
+    concept_ids: Sequence[str],
+    text_relation_subject_ids: Sequence[str],
+    text_relation_predicates: Sequence[str],
+    tracked_concept_document_ids: Sequence[Any],
+    tracked_text_relation_document_ids: Sequence[Any],
+    tracked_text_value_document_ids: Sequence[Any],
+    observation: Mapping[str, Any],
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Publish a receipt only if canonical verification had a quiet change window."""
+
+    started_at = time.perf_counter()
+    base_result: dict[str, Any] = {"family_id": family_id, "persisted": False}
+    if not observation.get("success"):
+        return {
+            **base_result,
+            "reason": _text(observation.get("reason"))
+            or "freshness_observation_unavailable",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    scope = _dependency_scope(
+        concept_ids=concept_ids,
+        text_relation_subject_ids=text_relation_subject_ids,
+        text_relation_predicates=text_relation_predicates,
+    )
+    tracked_ids = {
+        "concept_document_ids": _normalised_tracked_ids(tracked_concept_document_ids),
+        "text_relation_document_ids": _normalised_tracked_ids(
+            tracked_text_relation_document_ids
+        ),
+        "text_value_document_ids": _normalised_tracked_ids(
+            tracked_text_value_document_ids
+        ),
+    }
+    try:
+        db = _get_db()
+        authority_fingerprint = _current_authority_fingerprint(db)
+    except Exception as exc:  # noqa: BLE001 - authority uncertainty is a miss
+        return {
+            **base_result,
+            "reason": "authority_fingerprint_unavailable",
+            "error_type": type(exc).__name__,
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    drained = _drain_changes(
+        db=db,
+        observation=observation,
+        scope=scope,
+        tracked_ids=tracked_ids,
+    )
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    current_token = drained.get("_resume_token")
+    if not drained.get("fresh") or not isinstance(current_token, Mapping):
+        return {
+            **base_result,
+            **_public_result(drained),
+            "duration_ms": duration_ms,
+        }
+    now = time.time()
+    entry = {
+        "schema_version": STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION,
+        "family_id": family_id,
+        "source_digest": source_digest,
+        "producer_schema_version": producer_schema_version,
+        "authority_fingerprint": authority_fingerprint,
+        "dependency_scope": scope,
+        "tracked_ids": tracked_ids,
+        "resume_token_bson_base64": _encode_resume_token(current_token),
+        "verified_at_epoch_seconds": now,
+        "last_checked_at_epoch_seconds": now,
+        "metadata": dict(metadata or {}),
+    }
+    try:
+        _persist_receipt_entry(family_id, entry)
+    except Exception as exc:  # noqa: BLE001 - persistence failure is non-current
+        return {
+            **base_result,
+            "reason": "receipt_persist_failed",
+            "error_type": type(exc).__name__,
+            "events_examined": drained.get("events_examined", 0),
+            "duration_ms": duration_ms,
+        }
+    return {
+        **base_result,
+        "persisted": True,
+        "reason": "dependency_receipt_persisted",
+        "events_examined": drained.get("events_examined", 0),
+        "relevant_events": 0,
+        "indeterminate_events": 0,
+        "tracked_dependency_counts": {
+            key: len(value) for key, value in tracked_ids.items()
+        },
+        "duration_ms": duration_ms,
+    }
+
+
+__all__ = [
+    "STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION",
+    "begin_startup_seed_freshness_observation",
+    "build_startup_seed_source_digest",
+    "check_startup_seed_freshness",
+    "public_startup_seed_freshness_result",
+    "record_startup_seed_freshness",
+]

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -9,6 +9,7 @@ import src.backend.services.concept_summary_field_vontology_service as summary_s
 from src.backend.services import concept_service
 from src.backend.services.concept_summary_field_vontology_service import (
     bootstrap_canonical_concept_summary_fields,
+    ensure_concept_summary_fields_current_for_startup,
 )
 
 
@@ -226,3 +227,84 @@ def test_summary_field_bootstrap_uses_batched_noop_fast_path(
     assert second["counts"]["type_bindings_changed"] == 0
     assert concept_reads == 1
     assert text_reads == 1
+
+
+def test_summary_field_startup_receipt_hit_performs_no_canonical_scan(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        summary_seed_module.seed_freshness,
+        "check_startup_seed_freshness",
+        lambda **_kwargs: {
+            "fresh": True,
+            "reason": "dependency_receipt_current",
+            "events_examined": 0,
+            "metadata": {"counts": {"fields_seen": 17}},
+        },
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt hit must not scan canonical concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        summary_seed_module,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt hit must not scan canonical text")
+        ),
+    )
+
+    report = ensure_concept_summary_fields_current_for_startup()
+
+    assert report["success"] is True
+    assert report["skipped"] is True
+    assert report["read_strategy"] == "dependency_receipt"
+    assert report["canonical_read_batches"] == {
+        "concepts": 0,
+        "text_assertions": 0,
+    }
+
+
+def test_summary_field_startup_miss_records_only_quiet_unchanged_state(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = bootstrap_canonical_concept_summary_fields()
+    assert first["success"] is True
+    recorded: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        summary_seed_module.seed_freshness,
+        "check_startup_seed_freshness",
+        lambda **_kwargs: {"fresh": False, "reason": "receipt_missing"},
+    )
+    monkeypatch.setattr(
+        summary_seed_module.seed_freshness,
+        "begin_startup_seed_freshness_observation",
+        lambda: {"success": True, "_start_at_operation_time": "before-scan"},
+    )
+
+    def _record(**kwargs):
+        recorded.update(kwargs)
+        return {"persisted": True, "reason": "dependency_receipt_persisted"}
+
+    monkeypatch.setattr(
+        summary_seed_module.seed_freshness,
+        "record_startup_seed_freshness",
+        _record,
+    )
+
+    report = ensure_concept_summary_fields_current_for_startup()
+
+    assert report["success"] is True
+    assert report["changed"] is False
+    assert report["read_strategy"] == "batched_canonical_state"
+    assert report["freshness_receipt"]["persisted"] is True
+    assert recorded["observation"]["_start_at_operation_time"] == "before-scan"
+    assert recorded["tracked_concept_document_ids"]
+    assert recorded["tracked_text_relation_document_ids"]
+    assert recorded["tracked_text_value_document_ids"]

--- a/tests/backend/test_publication_scope_profile_service.py
+++ b/tests/backend/test_publication_scope_profile_service.py
@@ -15,6 +15,7 @@ from src.backend.services.publication_scope_profile_service import (
 )
 from src.backend.services.publication_scope_profile_vontology_service import (
     bootstrap_canonical_publication_scope_profiles,
+    ensure_publication_scope_profiles_current_for_startup,
 )
 from src.backend.services.text_value_service import upsert_singleton_text_relation
 
@@ -584,3 +585,43 @@ def test_bootstrap_is_idempotent_when_profiles_are_unchanged(
     assert second["counts"]["relationships_changed"] == 0
     assert concept_reads == 1
     assert text_reads == 1
+
+
+def test_publication_profile_startup_receipt_hit_performs_no_canonical_scan(
+    publication_profile_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        publication_seed_module.seed_freshness,
+        "check_startup_seed_freshness",
+        lambda **_kwargs: {
+            "fresh": True,
+            "reason": "dependency_receipt_current",
+            "events_examined": 0,
+            "metadata": {"counts": {"profiles_preserved": 19}},
+        },
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt hit must not scan canonical concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        publication_seed_module,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt hit must not scan canonical text")
+        ),
+    )
+
+    report = ensure_publication_scope_profiles_current_for_startup()
+
+    assert report["success"] is True
+    assert report["skipped"] is True
+    assert report["read_strategy"] == "dependency_receipt"
+    assert report["canonical_read_batches"] == {
+        "concepts": 0,
+        "text_assertions": 0,
+    }

--- a/tests/backend/test_startup_seed_freshness_service.py
+++ b/tests/backend/test_startup_seed_freshness_service.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.backend.services import startup_seed_freshness_service as freshness
+
+
+class _FakeChangeStream:
+    def __init__(
+        self,
+        *,
+        events: list[Mapping[str, Any]] | None = None,
+        resume_token: Mapping[str, Any] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._events = list(events or [])
+        self.resume_token = dict(resume_token or {"_data": "current"})
+        self._error = error
+        self.closed = False
+
+    def try_next(self):
+        if self._error is not None:
+            raise self._error
+        if self._events:
+            return self._events.pop(0)
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeDatabase:
+    name = "von_db"
+
+    def __init__(self, streams: list[_FakeChangeStream]) -> None:
+        self._streams = list(streams)
+        self.watch_calls: list[dict[str, Any]] = []
+
+    def command(self, name: str) -> dict[str, Any]:
+        assert name == "hello"
+        return {"operationTime": "operation-time"}
+
+    def watch(self, pipeline, **kwargs):
+        self.watch_calls.append({"pipeline": pipeline, "kwargs": kwargs})
+        if not self._streams:
+            raise AssertionError("unexpected change-stream call")
+        return self._streams.pop(0)
+
+
+@pytest.fixture
+def receipt_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    receipt_path = tmp_path / "freshness_receipts.json"
+    monkeypatch.setenv("VON_STARTUP_SEED_FRESHNESS_RECEIPT_PATH", str(receipt_path))
+    monkeypatch.setenv("VON_STARTUP_SEED_FRESHNESS_RECEIPTS_ENABLED", "1")
+    monkeypatch.setattr(
+        freshness,
+        "_current_authority_fingerprint",
+        lambda _db: "authority-fingerprint",
+    )
+    return receipt_path
+
+
+def _record(
+    monkeypatch: pytest.MonkeyPatch,
+    db: _FakeDatabase,
+) -> dict[str, Any]:
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+    observation = freshness.begin_startup_seed_freshness_observation()
+    assert observation["success"] is True
+    return freshness.record_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+        tracked_concept_document_ids=["concept-document"],
+        tracked_text_relation_document_ids=["relation-document"],
+        tracked_text_value_document_ids=["text-document"],
+        observation=observation,
+        metadata={"counts": {"items": 1}},
+    )
+
+
+def _check(monkeypatch: pytest.MonkeyPatch, db: _FakeDatabase) -> dict[str, Any]:
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+    return freshness.check_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+
+
+def test_receipt_round_trip_skips_unrelated_changes(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(resume_token={"_data": "recorded"}),
+            _FakeChangeStream(
+                events=[
+                    {
+                        "operationType": "update",
+                        "ns": {"coll": "concepts"},
+                        "documentKey": {"_id": "unrelated-document"},
+                        "fullDocument": {"concept_id": "#V#unrelated"},
+                    }
+                ],
+                resume_token={"_data": "advanced"},
+            ),
+        ]
+    )
+
+    recorded = _record(monkeypatch, db)
+    checked = _check(monkeypatch, db)
+
+    assert recorded["persisted"] is True
+    assert checked["fresh"] is True
+    assert checked["reason"] == "dependency_receipt_current"
+    assert checked["events_examined"] == 1
+    assert checked["metadata"] == {"counts": {"items": 1}}
+    assert receipt_environment.exists()
+    assert "resume_token" not in str(checked)
+    assert db.watch_calls[0]["kwargs"]["start_at_operation_time"] == ("operation-time")
+    assert "resume_after" in db.watch_calls[1]["kwargs"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "operationType": "update",
+            "ns": {"coll": "concepts"},
+            "documentKey": {"_id": "other"},
+            "fullDocument": {"concept_id": "#V#subject"},
+        },
+        {
+            "operationType": "delete",
+            "ns": {"coll": "concepts"},
+            "documentKey": {"_id": "concept-document"},
+        },
+        {
+            "operationType": "insert",
+            "ns": {"coll": "text_relations"},
+            "documentKey": {"_id": "new-relation"},
+            "fullDocument": {
+                "subject_concept_id": "#V#subject",
+                "predicate": "#V#has_config",
+            },
+        },
+        {
+            "operationType": "delete",
+            "ns": {"coll": "text_relations"},
+            "documentKey": {"_id": "relation-document"},
+        },
+        {
+            "operationType": "delete",
+            "ns": {"coll": "text_values"},
+            "documentKey": {"_id": "text-document"},
+        },
+        {
+            "operationType": "drop",
+            "ns": {"coll": "concepts"},
+        },
+    ],
+)
+def test_relevant_change_or_deletion_invalidates_receipt(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    event: Mapping[str, Any],
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(resume_token={"_data": "recorded"}),
+            _FakeChangeStream(
+                events=[event],
+                resume_token={"_data": "changed"},
+            ),
+        ]
+    )
+
+    assert _record(monkeypatch, db)["persisted"] is True
+    checked = _check(monkeypatch, db)
+
+    assert checked["fresh"] is False
+    assert checked["reason"] == "relevant_dependency_change_observed"
+    assert checked["relevant_events"] == 1
+
+
+def test_indeterminate_event_falls_back_instead_of_claiming_fresh(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(resume_token={"_data": "recorded"}),
+            _FakeChangeStream(
+                events=[
+                    {
+                        "operationType": "update",
+                        "ns": {"coll": "text_relations"},
+                        "documentKey": {"_id": "unknown"},
+                        "fullDocument": None,
+                    }
+                ],
+                resume_token={"_data": "indeterminate"},
+            ),
+        ]
+    )
+
+    assert _record(monkeypatch, db)["persisted"] is True
+    checked = _check(monkeypatch, db)
+
+    assert checked["fresh"] is False
+    assert checked["reason"] == "change_stream_event_indeterminate"
+    assert checked["indeterminate_events"] == 1
+
+
+def test_unresumable_stream_falls_back(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(resume_token={"_data": "recorded"}),
+            _FakeChangeStream(error=RuntimeError("expired token")),
+        ]
+    )
+
+    assert _record(monkeypatch, db)["persisted"] is True
+    checked = _check(monkeypatch, db)
+
+    assert checked["fresh"] is False
+    assert checked["reason"] == "change_stream_unavailable_or_unresumable"
+    assert checked["error_type"] == "RuntimeError"
+
+
+def test_receipt_is_not_published_when_dependency_changes_during_verification(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(
+                events=[
+                    {
+                        "operationType": "delete",
+                        "ns": {"coll": "concepts"},
+                        "documentKey": {"_id": "concept-document"},
+                    }
+                ],
+                resume_token={"_data": "changed-during-scan"},
+            )
+        ]
+    )
+
+    recorded = _record(monkeypatch, db)
+
+    assert recorded["persisted"] is False
+    assert recorded["reason"] == "relevant_dependency_change_observed"
+    assert not receipt_environment.exists()
+
+
+def test_source_change_invalidates_without_consuming_old_checkpoint(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase([_FakeChangeStream(resume_token={"_data": "recorded"})])
+    assert _record(monkeypatch, db)["persisted"] is True
+
+    changed = freshness.check_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="changed-source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+
+    assert changed["fresh"] is False
+    assert changed["reason"] == "source_digest_mismatch"
+    assert len(db.watch_calls) == 1
+
+
+def test_public_result_never_exposes_opaque_checkpoint_values() -> None:
+    public = freshness.public_startup_seed_freshness_result(
+        {
+            "fresh": True,
+            "reason": "current",
+            "_resume_token": {"_data": "opaque"},
+            "_start_at_operation_time": "opaque-time",
+        }
+    )
+
+    assert public == {"fresh": True, "reason": "current"}

--- a/tests/backend/test_utils_flask_orchestrator_startup.py
+++ b/tests/backend/test_utils_flask_orchestrator_startup.py
@@ -417,7 +417,7 @@ def test_publication_scope_profile_startup_records_bootstrap_report(
     expected = {"success": True, "seed_version": "test"}
     monkeypatch.setattr(
         publication_scope_profile_vontology_service,
-        "bootstrap_canonical_publication_scope_profiles",
+        "ensure_publication_scope_profiles_current_for_startup",
         lambda: expected,
     )
     app = types.SimpleNamespace(


### PR DESCRIPTION
## Outcome

Eliminates unchanged-startup canonical scans for the concept-summary and publication-scope-profile seed families when a dependency-complete Mongo change-stream receipt proves the materialisation current.

## Correctness boundary

- Vontology remains authoritative; direct and release bootstrap callers retain unconditional canonical verification.
- Receipts bind seed and producer-code digests, schema/configuration, DB/namespace/principal identity, exact dependency scope, tracked document ids, and a resumable high-water token.
- Relevant changes/deletions invalidate. Missing, corrupt, unresumable, indeterminate, truncated, or authority-mismatched state falls back conservatively.
- JVNAUTOSCI-2390 remains the owner of workflow-scoped dirty marking and incremental capability indexing.

## Evidence

- 45 targeted receipt/startup/publication tests passed.
- 74 downstream paper-representation tests passed; 2 skipped.
- Python 3.11 syntax compatibility passed for 1,338 files.
- Read-only Atlas validation with all Vontology writes disabled established both receipts; three later zero-scan hits completed both families in 2,146 ms, 2,465 ms, and 2,147 ms total.

No deployment, runtime restart, live Vontology mutation, or model request was performed.

Jira: JVNAUTOSCI-2681