### PR TITLE
JVNAUTOSCI-2681 separate startup from release seed reconciliation

### DIFF
--- a/docs/engineering/operational_engineering_guide.md
+++ b/docs/engineering/operational_engineering_guide.md
@@ -74,12 +74,16 @@ checkout on `main`:
 
 This is the canonical local deployment operation. It fetches `origin/main`,
 fast-forwards a clean primary `main`, checks out the exact commit detached in
-the dedicated sibling `Von-runtime-main` worktree, restarts that runtime, and
-verifies the running commit, clean-build marker, durable workflow services,
-and both background indexing workers. It refuses a dirty, divergent, wrong-
-branch, or unrelated runtime checkout. Set `VON_RUNTIME_WORKTREE` or pass
-`-RuntimeWorktree <path>` only when the runtime worktree intentionally lives
-elsewhere.
+the dedicated sibling `Von-runtime-main` worktree, runs that release's explicit
+startup-seed reconciliation from the runtime checkout, restarts the runtime,
+and verifies the running commit, clean-build marker, startup-seed receipts,
+durable workflow services, and both background indexing workers. The
+reconciliation is a trusted local operator action that may write canonical
+Vontology state; ordinary Flask startup only checks its derived receipts. The
+deployment refuses a dirty, divergent, wrong-branch, unrelated runtime
+checkout, failed reconciliation, or unavailable startup materialisation. Set
+`VON_RUNTIME_WORKTREE` or pass `-RuntimeWorktree <path>` only when the runtime
+worktree intentionally lives elsewhere.
 
 The primary checkout owns the local `main` branch. The runtime worktree is
 deliberately detached at the deployed commit; it must not maintain a second
@@ -111,6 +115,21 @@ Isolated agent-test restart:
 
 Agent-test replay tools normally target `http://127.0.0.1:5010` and should
 verify that `/health` reports `agent_test_instance=true`.
+
+To reconcile the same release inputs explicitly without deploying or starting
+a server, run this from the checkout whose derived receipt path the eventual
+runtime will use:
+
+```sh
+.venv/bin/python scripts/reconcile_startup_seed_materialisations.py
+```
+
+Use `--family concept-summary-fields` or
+`--family publication-scope-profiles` for a bounded repair. A zero exit status
+means the command applied any missing canonical state, performed a subsequent
+unchanged verification when needed, and published a current dependency
+receipt. This command is not a startup workaround and must not be scheduled on
+every restart.
 
 ### 3.3 Clean up repeated local helpers
 

--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -13,9 +13,10 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 import psutil
 
@@ -208,6 +209,42 @@ def _prepare_runtime(
         raise DeploymentError("Runtime checkout must be detached, but it is on a branch")
 
 
+def _reconcile_startup_seed_materialisations(
+    runtime_root: Path,
+) -> dict[str, Any]:
+    """Run the target release's explicit canonical seed reconciliation."""
+
+    script = runtime_root / "scripts" / "reconcile_startup_seed_materialisations.py"
+    if not script.is_file():
+        raise DeploymentError(
+            f"Startup seed reconciliation command missing after checkout: {script}"
+        )
+    result = _run(
+        [sys.executable, script, "--machine-readable"],
+        cwd=runtime_root,
+    )
+    receipt_prefix = "VON_STARTUP_SEED_RECONCILIATION_RECEIPT="
+    receipt_line = next(
+        (
+            line.removeprefix(receipt_prefix)
+            for line in reversed(result.stdout.splitlines())
+            if line.startswith(receipt_prefix)
+        ),
+        "",
+    )
+    try:
+        payload = json.loads(receipt_line)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError(
+            "Startup seed reconciliation did not return a JSON receipt"
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        raise DeploymentError(
+            f"Startup seed reconciliation was not ready: {payload!r}"
+        )
+    return payload
+
+
 def _read_health(url: str) -> dict[str, Any]:
     try:
         with urllib.request.urlopen(url, timeout=5) as response:
@@ -344,6 +381,21 @@ def _health_error(payload: dict[str, Any], target_commit: str) -> str | None:
     missing = [name for name in required if durable.get(name) is not True]
     if missing:
         return f"durable workflow readiness false: {', '.join(missing)}"
+    startup_materialisations = (
+        authority.get("startup_seed_materialisations")
+        if isinstance(authority, dict)
+        else None
+    )
+    if not isinstance(startup_materialisations, dict):
+        return "startup seed materialisation health missing"
+    if (
+        startup_materialisations.get("ready") is not True
+        or startup_materialisations.get("state") != "ready"
+    ):
+        return (
+            "startup seed materialisation readiness false: "
+            f"{startup_materialisations.get('state')!r}"
+        )
     return None
 
 
@@ -447,6 +499,7 @@ def deploy(
     launcher = runtime_root / "run.sh"
     if not launcher.is_file():
         raise DeploymentError(f"Runtime launcher missing after checkout: {launcher}")
+    _reconcile_startup_seed_materialisations(runtime_root)
     _run(
         [
             "bash",

--- a/scripts/reconcile_startup_seed_materialisations.py
+++ b/scripts/reconcile_startup_seed_materialisations.py
@@ -1,0 +1,103 @@
+"""Explicitly reconcile startup seed materialisations for a release.
+
+This command may write canonical Vontology state.  It is intentionally separate
+from Flask construction so an ordinary process start can remain a cheap,
+read-only freshness check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_summary_service = importlib.import_module(
+    "src.backend.services.concept_summary_field_vontology_service"
+)
+_publication_service = importlib.import_module(
+    "src.backend.services.publication_scope_profile_vontology_service"
+)
+reconcile_canonical_concept_summary_fields = (
+    _summary_service.reconcile_canonical_concept_summary_fields
+)
+reconcile_canonical_publication_scope_profiles = (
+    _publication_service.reconcile_canonical_publication_scope_profiles
+)
+
+CONCEPT_SUMMARY_FIELDS = "concept-summary-fields"
+PUBLICATION_SCOPE_PROFILES = "publication-scope-profiles"
+ALL_FAMILIES = "all"
+MACHINE_RECEIPT_PREFIX = "VON_STARTUP_SEED_RECONCILIATION_RECEIPT="
+
+_RECONCILERS: dict[str, Callable[[], dict[str, Any]]] = {
+    CONCEPT_SUMMARY_FIELDS: reconcile_canonical_concept_summary_fields,
+    PUBLICATION_SCOPE_PROFILES: reconcile_canonical_publication_scope_profiles,
+}
+
+
+def reconcile_startup_seed_materialisations(
+    families: Sequence[str],
+) -> dict[str, Any]:
+    """Run the selected canonical repairs and return one release receipt."""
+
+    selected = list(_RECONCILERS) if ALL_FAMILIES in families else list(families)
+    results: dict[str, dict[str, Any]] = {}
+    for family in selected:
+        results[family] = _RECONCILERS[family]()
+    success = bool(results) and all(
+        bool(result.get("ready")) for result in results.values()
+    )
+    return {
+        "schema_version": "startup_seed_release_reconciliation.v1",
+        "success": success,
+        "state": "ready" if success else "unavailable",
+        "families": results,
+    }
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Apply and canonically verify selected startup seed families, then "
+            "publish dependency freshness receipts. This is a state-changing "
+            "release/maintenance command, not an ordinary startup step."
+        )
+    )
+    parser.add_argument(
+        "--family",
+        action="append",
+        choices=[ALL_FAMILIES, *_RECONCILERS],
+        default=None,
+        help="Seed family to reconcile; repeat to select more than one (default: all).",
+    )
+    parser.add_argument(
+        "--machine-readable",
+        action="store_true",
+        help="Emit one prefixed compact JSON receipt for deployment automation.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    report = reconcile_startup_seed_materialisations(args.family or [ALL_FAMILIES])
+    if args.machine_readable:
+        print(
+            MACHINE_RECEIPT_PREFIX
+            + json.dumps(report, ensure_ascii=True, sort_keys=True)
+        )
+    else:
+        print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -8,7 +8,8 @@ import os
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from flask import Flask, g, jsonify, redirect, request, url_for
@@ -3223,6 +3224,79 @@ def _build_health_runtime_authority_projection(app: Flask) -> dict[str, object]:
         "mongo": mongo,
         "durable_workflows": durable,
         "model_registry": model_registry,
+        "startup_seed_materialisations": (
+            _build_startup_seed_materialisations_projection(app)
+        ),
+    }
+
+
+def _build_startup_seed_materialisations_projection(
+    app: Flask,
+) -> dict[str, object]:
+    """Expose bounded startup seed readiness without canonical re-reads."""
+
+    family_configs = {
+        "concept_summary_fields": "CONCEPT_SUMMARY_FIELD_BOOTSTRAP_REPORT",
+        "publication_scope_profiles": (
+            "PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"
+        ),
+    }
+    families: dict[str, dict[str, object]] = {}
+    for family, config_key in family_configs.items():
+        raw_report = app.config.get(config_key)
+        report = raw_report if isinstance(raw_report, Mapping) else {}
+        reason = str(report.get("reason") or "").strip() or None
+        state = str(report.get("state") or "").strip() or None
+        ready_value = report.get("ready")
+        if not state and reason == "agent_test_instance":
+            state = "skipped"
+        elif not state and report:
+            state = "ready" if report.get("success") else "unavailable"
+        elif not state:
+            state = "not_checked"
+        ready = ready_value if isinstance(ready_value, bool) else state == "ready"
+        freshness_receipt = report.get("freshness_receipt")
+        receipt_reason = (
+            str(freshness_receipt.get("reason") or "").strip() or None
+            if isinstance(freshness_receipt, Mapping)
+            else None
+        )
+        families[family] = {
+            "ready": ready,
+            "state": state,
+            "reason": reason,
+            "reconciliation_required": bool(
+                report.get("reconciliation_required", False)
+            ),
+            "receipt_reason": receipt_reason,
+            "duration_ms": (
+                report.get("duration_ms")
+                if isinstance(report.get("duration_ms"), int)
+                else None
+            ),
+        }
+
+    active_states = {
+        str(family.get("state"))
+        for family in families.values()
+        if family.get("state") not in {"skipped", "not_checked"}
+    }
+    if "unavailable" in active_states:
+        state = "unavailable"
+    elif "initialising" in active_states:
+        state = "initialising"
+    elif active_states and active_states == {"ready"}:
+        state = "ready"
+    elif all(family.get("state") == "skipped" for family in families.values()):
+        state = "skipped"
+    else:
+        state = "not_checked"
+
+    return {
+        "schema_version": "startup_seed_materialisation_status.v1",
+        "ready": state == "ready",
+        "state": state,
+        "families": families,
     }
 
 

--- a/src/backend/services/concept_summary_field_vontology_service.py
+++ b/src/backend/services/concept_summary_field_vontology_service.py
@@ -420,11 +420,87 @@ def bootstrap_canonical_concept_summary_fields(
     return _bootstrap_canonical_concept_summary_fields(asset_path=asset_path)
 
 
+def reconcile_canonical_concept_summary_fields(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Apply and verify this release seed, then publish a freshness receipt.
+
+    This is an explicit release/maintenance operation.  Ordinary process
+    startup must use :func:`ensure_concept_summary_fields_current_for_startup`
+    and must never call this mutating reconciliation path implicitly.
+    """
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    source_digest = _startup_source_digest(bundle)
+    passes: list[dict[str, Any]] = []
+
+    def run_canonical_pass() -> dict[str, Any]:
+        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        report = _bootstrap_canonical_concept_summary_fields(
+            asset_path=asset_path,
+            freshness_context={
+                "source_digest": source_digest,
+                "observation": observation,
+            },
+        )
+        passes.append(report)
+        return report
+
+    final_report = run_canonical_pass()
+    final_receipt = final_report.get("freshness_receipt")
+    receipt_persisted = bool(
+        isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+    )
+    if final_report.get("success") and (
+        final_report.get("changed") or not receipt_persisted
+    ):
+        # A pass that changed canonical state cannot prove its own quiet window.
+        # Re-read once from a new high-water mark so the release result is a
+        # canonical verification plus a dependency-complete receipt.
+        final_report = run_canonical_pass()
+        final_receipt = final_report.get("freshness_receipt")
+        receipt_persisted = bool(
+            isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+        )
+
+    ready = bool(
+        final_report.get("success")
+        and not final_report.get("changed")
+        and receipt_persisted
+    )
+    receipt_reason = (
+        str(final_receipt.get("reason") or "").strip()
+        if isinstance(final_receipt, Mapping)
+        else ""
+    )
+    return {
+        "schema_version": "startup_seed_reconciliation.v1",
+        "family_id": SUMMARY_FIELD_STARTUP_FAMILY_ID,
+        "success": ready,
+        "ready": ready,
+        "state": "ready" if ready else "unavailable",
+        "reason": (
+            "canonical_reconciliation_verified"
+            if ready
+            else receipt_reason or "canonical_reconciliation_unverified"
+        ),
+        "changed": any(bool(report.get("changed")) for report in passes),
+        "reconciliation_pass_count": len(passes),
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": (
+            dict(final_receipt) if isinstance(final_receipt, Mapping) else {}
+        ),
+        "passes": passes,
+    }
+
+
 def ensure_concept_summary_fields_current_for_startup(
     *,
     asset_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Use a complete dependency receipt before canonical startup verification."""
+    """Check the dependency receipt without running release reconciliation."""
 
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
@@ -444,8 +520,11 @@ def ensure_concept_summary_fields_current_for_startup(
         metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
         return {
             "success": True,
+            "ready": True,
+            "state": "ready",
             "skipped": True,
             "reason": "dependency_receipt_current",
+            "reconciliation_required": False,
             "changed": False,
             "asset_path": bundle.get("asset_path"),
             "schema_version": bundle.get("schema_version"),
@@ -461,17 +540,23 @@ def ensure_concept_summary_fields_current_for_startup(
             "errors": [],
         }
 
-    observation = seed_freshness.begin_startup_seed_freshness_observation()
-    report = _bootstrap_canonical_concept_summary_fields(
-        asset_path=asset_path,
-        freshness_context={
-            "source_digest": source_digest,
-            "observation": observation,
-        },
-    )
-    report["freshness_receipt_check"] = public_check
-    report["duration_ms"] = int((time.perf_counter() - started_at) * 1000)
-    return report
+    return {
+        "success": False,
+        "ready": False,
+        "state": "unavailable",
+        "skipped": True,
+        "reason": "startup_seed_reconciliation_required",
+        "reconciliation_required": True,
+        "asset_path": bundle.get("asset_path"),
+        "schema_version": bundle.get("schema_version"),
+        "seed_version": bundle.get("seed_version"),
+        "read_strategy": "dependency_receipt",
+        "read_phases": 1,
+        "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": public_check,
+        "errors": [],
+    }
 
 
 __all__ = [
@@ -481,4 +566,5 @@ __all__ = [
     "SUMMARY_FIELD_TYPE_ID",
     "bootstrap_canonical_concept_summary_fields",
     "ensure_concept_summary_fields_current_for_startup",
+    "reconcile_canonical_concept_summary_fields",
 ]

--- a/src/backend/services/publication_scope_profile_vontology_service.py
+++ b/src/backend/services/publication_scope_profile_vontology_service.py
@@ -546,11 +546,84 @@ def bootstrap_canonical_publication_scope_profiles(
     )
 
 
+def reconcile_canonical_publication_scope_profiles(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Apply and verify this release seed, then publish a freshness receipt.
+
+    The maintenance path deliberately preserves represented profile payloads
+    that already exist.  Ordinary process startup only checks the resulting
+    receipt and never invokes this mutating operation implicitly.
+    """
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    source_digest = _startup_source_digest(bundle)
+    passes: list[dict[str, Any]] = []
+
+    def run_canonical_pass() -> dict[str, Any]:
+        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        report = _bootstrap_canonical_publication_scope_profiles(
+            asset_path=asset_path,
+            freshness_context={
+                "source_digest": source_digest,
+                "observation": observation,
+            },
+        )
+        passes.append(report)
+        return report
+
+    final_report = run_canonical_pass()
+    final_receipt = final_report.get("freshness_receipt")
+    receipt_persisted = bool(
+        isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+    )
+    if final_report.get("success") and (
+        final_report.get("changed") or not receipt_persisted
+    ):
+        final_report = run_canonical_pass()
+        final_receipt = final_report.get("freshness_receipt")
+        receipt_persisted = bool(
+            isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+        )
+
+    ready = bool(
+        final_report.get("success")
+        and not final_report.get("changed")
+        and receipt_persisted
+    )
+    receipt_reason = (
+        str(final_receipt.get("reason") or "").strip()
+        if isinstance(final_receipt, Mapping)
+        else ""
+    )
+    return {
+        "schema_version": "startup_seed_reconciliation.v1",
+        "family_id": PUBLICATION_SCOPE_PROFILE_STARTUP_FAMILY_ID,
+        "success": ready,
+        "ready": ready,
+        "state": "ready" if ready else "unavailable",
+        "reason": (
+            "canonical_reconciliation_verified"
+            if ready
+            else receipt_reason or "canonical_reconciliation_unverified"
+        ),
+        "changed": any(bool(report.get("changed")) for report in passes),
+        "reconciliation_pass_count": len(passes),
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": (
+            dict(final_receipt) if isinstance(final_receipt, Mapping) else {}
+        ),
+        "passes": passes,
+    }
+
+
 def ensure_publication_scope_profiles_current_for_startup(
     *,
     asset_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Use a complete dependency receipt before canonical startup verification."""
+    """Check the dependency receipt without running release reconciliation."""
 
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
@@ -572,8 +645,11 @@ def ensure_publication_scope_profiles_current_for_startup(
         metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
         return {
             "success": True,
+            "ready": True,
+            "state": "ready",
             "skipped": True,
             "reason": "dependency_receipt_current",
+            "reconciliation_required": False,
             "changed": False,
             "asset_path": bundle.get("asset_path"),
             "schema_version": bundle.get("schema_version"),
@@ -589,17 +665,23 @@ def ensure_publication_scope_profiles_current_for_startup(
             "errors": [],
         }
 
-    observation = seed_freshness.begin_startup_seed_freshness_observation()
-    report = _bootstrap_canonical_publication_scope_profiles(
-        asset_path=asset_path,
-        freshness_context={
-            "source_digest": source_digest,
-            "observation": observation,
-        },
-    )
-    report["freshness_receipt_check"] = public_check
-    report["duration_ms"] = int((time.perf_counter() - started_at) * 1000)
-    return report
+    return {
+        "success": False,
+        "ready": False,
+        "state": "unavailable",
+        "skipped": True,
+        "reason": "startup_seed_reconciliation_required",
+        "reconciliation_required": True,
+        "asset_path": bundle.get("asset_path"),
+        "schema_version": bundle.get("schema_version"),
+        "seed_version": bundle.get("seed_version"),
+        "read_strategy": "dependency_receipt",
+        "read_phases": 1,
+        "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": public_check,
+        "errors": [],
+    }
 
 
 __all__ = [
@@ -609,4 +691,5 @@ __all__ = [
     "PUBLICATION_SCOPE_PROFILE_TYPE_ID",
     "bootstrap_canonical_publication_scope_profiles",
     "ensure_publication_scope_profiles_current_for_startup",
+    "reconcile_canonical_publication_scope_profiles",
 ]

--- a/src/backend/services/startup_seed_freshness_service.py
+++ b/src/backend/services/startup_seed_freshness_service.py
@@ -1,8 +1,11 @@
 """Change-aware freshness receipts for bounded startup seed materialisations.
 
 The receipts in this module are derived support state.  They never replace
-Vontology as authority: a missing, incompatible, or unresumable receipt is a
-cache miss and callers retain their canonical verification path.
+Vontology as authority: a missing, incompatible, or unresumable receipt makes
+the affected startup subsystem unavailable until an explicit release or
+maintenance reconciliation verifies canonical state and publishes a new
+receipt.  Ordinary process startup never turns that miss into hidden canonical
+reads or writes.
 """
 
 from __future__ import annotations

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -10,6 +10,7 @@ from src.backend.services import concept_service
 from src.backend.services.concept_summary_field_vontology_service import (
     bootstrap_canonical_concept_summary_fields,
     ensure_concept_summary_fields_current_for_startup,
+    reconcile_canonical_concept_summary_fields,
 )
 
 
@@ -269,42 +270,105 @@ def test_summary_field_startup_receipt_hit_performs_no_canonical_scan(
     }
 
 
-def test_summary_field_startup_miss_records_only_quiet_unchanged_state(
+def test_summary_field_startup_miss_requires_explicit_reconciliation_without_scan(
     _reset_mock_db: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    first = bootstrap_canonical_concept_summary_fields()
-    assert first["success"] is True
-    recorded: dict[str, Any] = {}
-
     monkeypatch.setattr(
         summary_seed_module.seed_freshness,
         "check_startup_seed_freshness",
         lambda **_kwargs: {"fresh": False, "reason": "receipt_missing"},
     )
     monkeypatch.setattr(
-        summary_seed_module.seed_freshness,
-        "begin_startup_seed_freshness_observation",
-        lambda: {"success": True, "_start_at_operation_time": "before-scan"},
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not scan canonical concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        summary_seed_module,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not scan canonical text")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "create_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not create concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "update_concept",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not update concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        summary_seed_module,
+        "upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not write text relations")
+        ),
     )
 
+    report = ensure_concept_summary_fields_current_for_startup()
+
+    assert report["success"] is False
+    assert report["ready"] is False
+    assert report["state"] == "unavailable"
+    assert report["reason"] == "startup_seed_reconciliation_required"
+    assert report["reconciliation_required"] is True
+    assert report["canonical_read_batches"] == {
+        "concepts": 0,
+        "text_assertions": 0,
+    }
+    assert report["freshness_receipt"]["reason"] == "receipt_missing"
+
+
+def test_summary_field_explicit_reconciliation_verifies_after_write(
+    _reset_mock_db: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations: list[dict[str, Any]] = []
+    recorded: list[dict[str, Any]] = []
+
+    def _observe() -> dict[str, Any]:
+        observation = {
+            "success": True,
+            "_start_at_operation_time": f"before-pass-{len(observations) + 1}",
+        }
+        observations.append(observation)
+        return observation
+
     def _record(**kwargs):
-        recorded.update(kwargs)
+        recorded.append(kwargs)
         return {"persisted": True, "reason": "dependency_receipt_persisted"}
 
+    monkeypatch.setattr(
+        summary_seed_module.seed_freshness,
+        "begin_startup_seed_freshness_observation",
+        _observe,
+    )
     monkeypatch.setattr(
         summary_seed_module.seed_freshness,
         "record_startup_seed_freshness",
         _record,
     )
 
-    report = ensure_concept_summary_fields_current_for_startup()
+    report = reconcile_canonical_concept_summary_fields()
 
     assert report["success"] is True
-    assert report["changed"] is False
-    assert report["read_strategy"] == "batched_canonical_state"
+    assert report["ready"] is True
+    assert report["state"] == "ready"
+    assert report["changed"] is True
+    assert report["reconciliation_pass_count"] == 2
+    assert report["passes"][0]["changed"] is True
+    assert report["passes"][1]["changed"] is False
     assert report["freshness_receipt"]["persisted"] is True
-    assert recorded["observation"]["_start_at_operation_time"] == "before-scan"
-    assert recorded["tracked_concept_document_ids"]
-    assert recorded["tracked_text_relation_document_ids"]
-    assert recorded["tracked_text_value_document_ids"]
+    assert recorded[0]["observation"]["_start_at_operation_time"] == (
+        "before-pass-2"
+    )

--- a/tests/backend/test_publication_scope_profile_service.py
+++ b/tests/backend/test_publication_scope_profile_service.py
@@ -16,6 +16,7 @@ from src.backend.services.publication_scope_profile_service import (
 from src.backend.services.publication_scope_profile_vontology_service import (
     bootstrap_canonical_publication_scope_profiles,
     ensure_publication_scope_profiles_current_for_startup,
+    reconcile_canonical_publication_scope_profiles,
 )
 from src.backend.services.text_value_service import upsert_singleton_text_relation
 
@@ -625,3 +626,106 @@ def test_publication_profile_startup_receipt_hit_performs_no_canonical_scan(
         "concepts": 0,
         "text_assertions": 0,
     }
+
+
+def test_publication_profile_startup_miss_requires_explicit_reconciliation_without_scan(
+    publication_profile_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        publication_seed_module.seed_freshness,
+        "check_startup_seed_freshness",
+        lambda **_kwargs: {"fresh": False, "reason": "source_digest_mismatch"},
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_concepts_by_concept_ids_exact",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not scan canonical concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        publication_seed_module,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not scan canonical text")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "create_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not create concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "update_concept",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not update concepts")
+        ),
+    )
+    monkeypatch.setattr(
+        publication_seed_module,
+        "upsert_singleton_text_relation",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("startup receipt miss must not write text relations")
+        ),
+    )
+
+    report = ensure_publication_scope_profiles_current_for_startup()
+
+    assert report["success"] is False
+    assert report["ready"] is False
+    assert report["state"] == "unavailable"
+    assert report["reason"] == "startup_seed_reconciliation_required"
+    assert report["reconciliation_required"] is True
+    assert report["canonical_read_batches"] == {
+        "concepts": 0,
+        "text_assertions": 0,
+    }
+    assert report["freshness_receipt"]["reason"] == "source_digest_mismatch"
+
+
+def test_publication_profile_explicit_reconciliation_publishes_current_receipt(
+    publication_profile_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations: list[dict[str, Any]] = []
+    recorded: list[dict[str, Any]] = []
+
+    def _observe() -> dict[str, Any]:
+        observation = {
+            "success": True,
+            "_start_at_operation_time": f"before-pass-{len(observations) + 1}",
+        }
+        observations.append(observation)
+        return observation
+
+    def _record(**kwargs):
+        recorded.append(kwargs)
+        return {"persisted": True, "reason": "dependency_receipt_persisted"}
+
+    monkeypatch.setattr(
+        publication_seed_module.seed_freshness,
+        "begin_startup_seed_freshness_observation",
+        _observe,
+    )
+    monkeypatch.setattr(
+        publication_seed_module.seed_freshness,
+        "record_startup_seed_freshness",
+        _record,
+    )
+
+    report = reconcile_canonical_publication_scope_profiles()
+
+    assert report["success"] is True
+    assert report["ready"] is True
+    assert report["state"] == "ready"
+    assert report["changed"] is False
+    assert report["reconciliation_pass_count"] == 1
+    assert report["passes"][0]["changed"] is False
+    assert report["freshness_receipt"]["persisted"] is True
+    assert recorded[0]["observation"]["_start_at_operation_time"] == (
+        "before-pass-1"
+    )

--- a/tests/backend/test_reconcile_startup_seed_materialisations_script.py
+++ b/tests/backend/test_reconcile_startup_seed_materialisations_script.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+
+from scripts import reconcile_startup_seed_materialisations as script
+
+
+def test_release_reconciliation_runs_selected_families(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        script,
+        "_RECONCILERS",
+        {
+            script.CONCEPT_SUMMARY_FIELDS: lambda: (
+                calls.append("summary") or {"ready": True}
+            ),
+            script.PUBLICATION_SCOPE_PROFILES: lambda: (
+                calls.append("publication") or {"ready": True}
+            ),
+        },
+    )
+
+    report = script.reconcile_startup_seed_materialisations([script.ALL_FAMILIES])
+
+    assert report["success"] is True
+    assert report["state"] == "ready"
+    assert calls == ["summary", "publication"]
+
+
+def test_release_reconciliation_returns_nonzero_when_a_family_is_unavailable(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        script,
+        "_RECONCILERS",
+        {
+            script.CONCEPT_SUMMARY_FIELDS: lambda: {"ready": True},
+            script.PUBLICATION_SCOPE_PROFILES: lambda: {
+                "ready": False,
+                "reason": "receipt_persist_failed",
+            },
+        },
+    )
+
+    exit_code = script.main(["--family", script.ALL_FAMILIES])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["state"] == "unavailable"
+
+
+def test_release_reconciliation_emits_prefixed_machine_receipt(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        script,
+        "_RECONCILERS",
+        {script.CONCEPT_SUMMARY_FIELDS: lambda: {"ready": True}},
+    )
+
+    assert script.main(["--machine-readable"]) == 0
+    output = capsys.readouterr().out.strip()
+
+    assert output.startswith(script.MACHINE_RECEIPT_PREFIX)
+    payload = json.loads(output.removeprefix(script.MACHINE_RECEIPT_PREFIX))
+    assert payload["success"] is True

--- a/tests/backend/test_utils_flask_health_agent_test_marker.py
+++ b/tests/backend/test_utils_flask_health_agent_test_marker.py
@@ -85,6 +85,9 @@ def test_health_response_exposes_agent_test_instance_marker(monkeypatch) -> None
         "effective_database_name_sha256": hashlib.sha256(b"von").hexdigest(),
     }
     assert runtime_authority["durable_workflows"]["worker_running"] is False
+    assert runtime_authority["startup_seed_materialisations"]["state"] == (
+        "not_checked"
+    )
     assert "secret-user" not in json.dumps(payload)
     assert "secret-password" not in json.dumps(payload)
     assert network_calls == {"socket": 0, "urlopen": 0}
@@ -257,3 +260,59 @@ def test_health_runtime_authority_uses_count_free_durable_status(monkeypatch) ->
         "last_refresh_succeeded": True,
     }
     assert "worker_id" not in json.dumps(payload)
+
+
+def test_health_projects_startup_seed_family_readiness_without_raw_report() -> None:
+    import src.backend.server.utils_flask as utils_flask
+
+    app = Flask(__name__)
+    app.config["CONCEPT_SUMMARY_FIELD_BOOTSTRAP_REPORT"] = {
+        "success": True,
+        "ready": True,
+        "state": "ready",
+        "reason": "dependency_receipt_current",
+        "duration_ms": 12,
+        "freshness_receipt": {
+            "reason": "dependency_receipt_current",
+            "private_checkpoint": "must-not-be-public",
+        },
+    }
+    app.config["PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"] = {
+        "success": False,
+        "ready": False,
+        "state": "unavailable",
+        "reason": "startup_seed_reconciliation_required",
+        "reconciliation_required": True,
+        "duration_ms": 8,
+        "freshness_receipt": {
+            "reason": "source_digest_mismatch",
+            "private_checkpoint": "must-not-be-public",
+        },
+    }
+
+    payload = utils_flask._build_startup_seed_materialisations_projection(app)
+
+    assert payload == {
+        "schema_version": "startup_seed_materialisation_status.v1",
+        "ready": False,
+        "state": "unavailable",
+        "families": {
+            "concept_summary_fields": {
+                "ready": True,
+                "state": "ready",
+                "reason": "dependency_receipt_current",
+                "reconciliation_required": False,
+                "receipt_reason": "dependency_receipt_current",
+                "duration_ms": 12,
+            },
+            "publication_scope_profiles": {
+                "ready": False,
+                "state": "unavailable",
+                "reason": "startup_seed_reconciliation_required",
+                "reconciliation_required": True,
+                "receipt_reason": "source_digest_mismatch",
+                "duration_ms": 8,
+            },
+        },
+    }
+    assert "private_checkpoint" not in json.dumps(payload)

--- a/tests/test_deploy_local_main.py
+++ b/tests/test_deploy_local_main.py
@@ -13,7 +13,9 @@ from scripts.deploy_local_main import (
     _matching_von_process_root,
     _prepare_primary,
     _prepare_runtime,
+    _reconcile_startup_seed_materialisations,
     _stop_verified_predecessor,
+    deploy,
 )
 
 
@@ -145,7 +147,11 @@ def test_health_verification_requires_exact_clean_durable_build() -> None:
                 "database_connected": True,
                 "worker_running": True,
                 "scheduler_running": True,
-            }
+            },
+            "startup_seed_materialisations": {
+                "ready": True,
+                "state": "ready",
+            },
         },
     }
     assert _health_error(payload, commit) is None
@@ -165,6 +171,105 @@ def test_health_verification_requires_exact_clean_durable_build() -> None:
     assert _health_error(no_scheduler, commit) == (
         "durable workflow readiness false: scheduler_running"
     )
+
+    stale_seed = json.loads(json.dumps(payload))
+    stale_seed["runtime_authority"]["startup_seed_materialisations"] = {
+        "ready": False,
+        "state": "unavailable",
+    }
+    assert _health_error(stale_seed, commit) == (
+        "startup seed materialisation readiness false: 'unavailable'"
+    )
+
+
+def test_runtime_reconciliation_uses_target_checkout_and_reads_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "Von-runtime-main"
+    script = runtime / "scripts" / "reconcile_startup_seed_materialisations.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# target release command\n", encoding="utf-8")
+    calls: list[dict[str, object]] = []
+
+    def _record_run(args, **kwargs):
+        calls.append({"args": list(args), **kwargs})
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            "diagnostic output\n"
+            "VON_STARTUP_SEED_RECONCILIATION_RECEIPT="
+            + json.dumps({"success": True, "state": "ready"}),
+            "",
+        )
+
+    monkeypatch.setattr("scripts.deploy_local_main._run", _record_run)
+
+    report = _reconcile_startup_seed_materialisations(runtime)
+
+    assert report == {"success": True, "state": "ready"}
+    assert calls[0]["args"][1] == script
+    assert calls[0]["args"][2] == "--machine-readable"
+    assert calls[0]["cwd"] == runtime
+
+
+def test_deploy_reconciles_target_runtime_before_server_start(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    primary = (tmp_path / "Von").resolve()
+    runtime = (tmp_path / "Von-runtime-main").resolve()
+    primary.mkdir()
+    runtime.mkdir()
+    (primary / "run.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (runtime / "run.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    commit = "a" * 40
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._prepare_primary",
+        lambda *_args, **_kwargs: commit,
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._validate_runtime",
+        lambda *_args, **_kwargs: events.append("validate"),
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._stop_verified_predecessor",
+        lambda **_kwargs: events.append("stop_predecessor"),
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._prepare_runtime",
+        lambda *_args, **_kwargs: events.append("prepare_runtime"),
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._reconcile_startup_seed_materialisations",
+        lambda *_args, **_kwargs: events.append("reconcile")
+        or {"success": True},
+    )
+
+    def _record_run(args, **_kwargs):
+        if "start" in args:
+            events.append("start")
+        elif "stop" in args:
+            events.append("stop_runtime")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr("scripts.deploy_local_main._run", _record_run)
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._wait_for_verified_health",
+        lambda *_args, **_kwargs: {"pid": 1234},
+    )
+    monkeypatch.setattr(
+        "scripts.deploy_local_main._verify_workers",
+        lambda *_args, **_kwargs: (2345, 3456),
+    )
+
+    result = deploy(primary_root=primary, runtime_root=runtime)
+
+    assert result.commit == commit
+    assert events.index("prepare_runtime") < events.index("reconcile")
+    assert events.index("reconcile") < events.index("start")
 
 
 def test_matching_von_process_root_accepts_only_exact_checkout_and_port(


### PR DESCRIPTION
Merge decision: ready — ordinary startup is receipt-only, while explicit target-release reconciliation owns canonical repair and verified receipt publication.

## User outcome

Ordinary Von startup no longer turns a stale or missing startup-seed receipt into synchronous canonical scans and writes. It binds with a truthful family-specific unavailable state until a trusted release or maintenance reconciliation succeeds.

## Material changes

- Receipt hits and misses remain read-only with respect to canonical Vontology; misses expose startup_seed_reconciliation_required.
- A bounded maintenance command applies both seed families, verifies a quiet canonical pass after any change, and publishes dependency receipts.
- deploy-main runs that command from the selected detached runtime checkout before server start and rejects non-ready seed health.
- Health exposes only bounded secret-safe family readiness.
- The operational guide documents the trusted state-changing boundary.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2681

## Evidence

- 146 affected and neighbouring tests passed; 2 skipped.
- Focused deployment and runner recheck: 15 passed.
- Python 3.11 grammar check passed for 1,340 files.
- Focused fatal Ruff checks and git diff --check passed.
- No live reconciliation, deployment, restart, Vontology mutation, or model request was performed.

## Ship boundary

- **Minimum ship criteria:** startup receipt misses perform no canonical reads or writes; explicit reconciliation produces verified current receipts; deploy-main invokes it from the target runtime and verifies ready health.
- **Stop-ship conditions:** hidden canonical startup work, ready health for a stale family, unverified post-write receipt publication, or target-runtime deployment bypass.
- **Non-blocking observations:** deployed start-to-listen timing remains required before the overall Jira can close.
- **Non-goals:** model-registry content generations, live deployment, and JVNAUTOSCI-2390 workflow indexing.