### PR TITLE
JVNAUTOSCI-2686: govern Gmail visible disclosure

### DIFF
--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -75,14 +75,6 @@ MESSAGE_LIST_VISIBILITY_VALUES: set[str] = {
 
 PROFILES_ENV_VAR = "VON_GMAIL_PROFILES"
 MAX_GMAIL_ATTACHMENT_MIME_PARTS = 256
-AI_AGENT_DISCLOSURE_TEXT = (
-    "AI-agent notice: This email was composed and sent by Von, an AI agent."
-)
-AI_AGENT_DISCLOSURE_HTML = (
-    '<p data-von-ai-agent-disclosure="true">'
-    f"{AI_AGENT_DISCLOSURE_TEXT}"
-    "</p>"
-)
 AI_AGENT_MACHINE_HEADER = "X-Von-AI-Agent"
 AI_AGENT_SENDER_DISPLAY_NAME = "Von AI Agent"
 DELIVERY_FINGERPRINT_HEADER = "X-Von-Delivery-Fingerprint"
@@ -1278,25 +1270,8 @@ def _build_raw_message(
     body_html: str | None = None,
     delivery_fingerprint: str | None = None,
     sender_email: str | None = None,
+    visible_disclosure_mode: str = "off",
 ) -> str:
-    disclosed_body_text = (
-        f"{body_text.rstrip()}\n\n{AI_AGENT_DISCLOSURE_TEXT}"
-    )
-    disclosed_body_html: str | None = None
-    if isinstance(body_html, str) and body_html.strip():
-        stripped_html = body_html.rstrip()
-        closing_body_index = stripped_html.lower().rfind("</body>")
-        if closing_body_index >= 0:
-            disclosed_body_html = (
-                f"{stripped_html[:closing_body_index]}"
-                f"{AI_AGENT_DISCLOSURE_HTML}\n"
-                f"{stripped_html[closing_body_index:]}"
-            )
-        else:
-            disclosed_body_html = (
-                f"{stripped_html}\n{AI_AGENT_DISCLOSURE_HTML}"
-            )
-
     message = EmailMessage()
     if isinstance(sender_email, str) and sender_email.strip():
         message["From"] = formataddr(
@@ -1304,7 +1279,7 @@ def _build_raw_message(
         )
     message["To"] = ", ".join(to)
     message["Subject"] = subject
-    message[AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    message[AI_AGENT_MACHINE_HEADER] = f"Von; disclosure={visible_disclosure_mode}"
     if delivery_fingerprint:
         message[DELIVERY_FINGERPRINT_HEADER] = delivery_fingerprint
         message["Message-ID"] = _delivery_rfc822_message_id(delivery_fingerprint)
@@ -1315,9 +1290,9 @@ def _build_raw_message(
     if reply_to:
         message["Reply-To"] = ", ".join(reply_to)
 
-    message.set_content(disclosed_body_text)
-    if disclosed_body_html is not None:
-        message.add_alternative(disclosed_body_html, subtype="html")
+    message.set_content(body_text)
+    if isinstance(body_html, str) and body_html.strip():
+        message.add_alternative(body_html, subtype="html")
 
     return base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
 
@@ -1364,6 +1339,9 @@ def _read_back_sent_message(
     expected_subject: str,
     expected_html: bool,
     expected_delivery_fingerprint: str,
+    expected_plain_body_sha256: str,
+    expected_disclosure_mode: str,
+    expected_disclosure_text: str | None,
 ) -> dict[str, Any]:
     """Read back one sent message and return a body-free verification receipt."""
 
@@ -1427,20 +1405,28 @@ def _read_back_sent_message(
         and observed_bcc == expected_bcc_addresses
     )
     subject_verified = observed_subject == expected_subject
+    body_sha256_verified = isinstance(plain_body, str) and (
+        _sha256_json(plain_body) == expected_plain_body_sha256
+    )
+    visible_disclosure_count = (
+        plain_body.count(expected_disclosure_text)
+        if isinstance(plain_body, str)
+        and isinstance(expected_disclosure_text, str)
+        and expected_disclosure_text
+        else 0
+    )
     text_disclosure_verified = (
-        isinstance(plain_body, str) and AI_AGENT_DISCLOSURE_TEXT in plain_body
+        visible_disclosure_count == 1
+        if expected_disclosure_mode == "required"
+        else True
     )
-    html_disclosure_verified = (
-        not expected_html
-        or (
-            isinstance(html_body, str)
-            and AI_AGENT_DISCLOSURE_TEXT in html_body
-        )
+    html_disclosure_verified = not expected_html and html_body is None
+    disclosure_verified = all(
+        (body_sha256_verified, text_disclosure_verified, html_disclosure_verified)
     )
-    disclosure_verified = (
-        text_disclosure_verified and html_disclosure_verified
+    machine_disclosure_verified = observed_agent_header == (
+        f"Von; disclosure={expected_disclosure_mode}"
     )
-    machine_disclosure_verified = observed_agent_header.startswith("Von;")
     delivery_fingerprint_verified = (
         observed_delivery_fingerprint == expected_delivery_fingerprint
     )
@@ -1468,10 +1454,14 @@ def _read_back_sent_message(
         "message_id_verified": message_id_verified,
         "sender": observed_sender,
         "sender_address": (
-            observed_sender_addresses[0] if len(observed_sender_addresses) == 1 else None
+            observed_sender_addresses[0]
+            if len(observed_sender_addresses) == 1
+            else None
         ),
         "authorised_sender_address": (
-            expected_sender_addresses[0] if len(expected_sender_addresses) == 1 else None
+            expected_sender_addresses[0]
+            if len(expected_sender_addresses) == 1
+            else None
         ),
         "sender_verified": sender_verified,
         "to": observed_to,
@@ -1481,6 +1471,9 @@ def _read_back_sent_message(
         "recipients_verified": recipients_verified,
         "subject": observed_subject,
         "subject_verified": subject_verified,
+        "resolved_disclosure_mode": expected_disclosure_mode,
+        "visible_disclosure_count": visible_disclosure_count,
+        "body_sha256_verified": body_sha256_verified,
         "text_disclosure_verified": text_disclosure_verified,
         "html_disclosure_verified": html_disclosure_verified,
         "disclosure_verified": disclosure_verified,
@@ -1503,6 +1496,9 @@ def _reconcile_sent_delivery(
     expected_bcc: list[str],
     expected_subject: str,
     expected_html: bool,
+    expected_plain_body_sha256: str,
+    expected_disclosure_mode: str,
+    expected_disclosure_text: str | None,
     search_anchor: datetime | str | None = None,
 ) -> dict[str, Any]:
     """Find one fingerprinted Sent message and verify its canonical MIME.
@@ -1531,9 +1527,7 @@ def _reconcile_sent_delivery(
             anchor = anchor.astimezone(UTC)
         now = datetime.now(UTC)
         search_start = (anchor - timedelta(days=1)).strftime("%Y/%m/%d")
-        search_end = (max(anchor, now) + timedelta(days=2)).strftime(
-            "%Y/%m/%d"
-        )
+        search_end = (max(anchor, now) + timedelta(days=2)).strftime("%Y/%m/%d")
         query_parts = [
             "in:sent",
             f"after:{search_start}",
@@ -1592,9 +1586,7 @@ def _reconcile_sent_delivery(
         if len(matching_candidates) != 1:
             return {
                 "schema_version": "gmail_sent_delivery_reconciliation.v1",
-                "status": (
-                    "not_found" if not matching_candidates else "ambiguous"
-                ),
+                "status": ("not_found" if not matching_candidates else "ambiguous"),
                 "verified": False,
                 "body_included": False,
                 "candidate_count": len(matching_candidates),
@@ -1611,12 +1603,13 @@ def _reconcile_sent_delivery(
             expected_subject=expected_subject,
             expected_html=expected_html,
             expected_delivery_fingerprint=delivery_fingerprint,
+            expected_plain_body_sha256=expected_plain_body_sha256,
+            expected_disclosure_mode=expected_disclosure_mode,
+            expected_disclosure_text=expected_disclosure_text,
         )
         return {
             "schema_version": "gmail_sent_delivery_reconciliation.v1",
-            "status": (
-                "verified" if canonical.get("verified") is True else "mismatch"
-            ),
+            "status": ("verified" if canonical.get("verified") is True else "mismatch"),
             "verified": canonical.get("verified") is True,
             "body_included": False,
             "candidate_count": 1,
@@ -1645,6 +1638,17 @@ def _sha256_json(value: Any) -> str:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _mime_plain_body_sha256(body_text: str) -> str:
+    """Hash the canonical MIME text representation without exposing its body."""
+
+    message = EmailMessage()
+    message.set_content(body_text)
+    canonical_text = _message_part_text(message, "text/plain")
+    if not isinstance(canonical_text, str):  # pragma: no cover - stdlib invariant
+        raise ValueError("Could not construct canonical plain-text MIME body")
+    return _sha256_json(canonical_text)
 
 
 def _outbound_delivery_identity(
@@ -1719,6 +1723,9 @@ def _safe_canonical_readback(value: Any) -> dict[str, Any] | None:
                 "recipient_count",
                 "recipients_verified",
                 "subject_verified",
+                "resolved_disclosure_mode",
+                "visible_disclosure_count",
+                "body_sha256_verified",
                 "text_disclosure_verified",
                 "html_disclosure_verified",
                 "disclosure_verified",
@@ -1755,6 +1762,9 @@ def _safe_delivery_ledger_receipt(payload: Mapping[str, Any]) -> dict[str, Any]:
     safe_canonical = _safe_canonical_readback(payload.get("canonical_readback"))
     if safe_canonical is not None:
         receipt["canonical_readback"] = safe_canonical
+    disclosure = payload.get("ai_agent_disclosure")
+    if isinstance(disclosure, Mapping):
+        receipt["ai_agent_disclosure"] = dict(disclosure)
     reconciliation = payload.get("delivery_reconciliation")
     if isinstance(reconciliation, Mapping):
         safe_reconciliation = {
@@ -1825,6 +1835,8 @@ def send_message(
     request_id: str | None = None,
     acting_user_concept_id: str | None = None,
     organisation_concept_id: str | None = None,
+    body_language: str | None = None,
+    body_authorship: str | None = None,
     outbound_rate_limit_settings: Any = None,
     outbound_quota_collection: Any = _DEFAULT_OUTBOUND_COLLECTION,
     outbound_delivery_collection: Any = _DEFAULT_OUTBOUND_COLLECTION,
@@ -1836,12 +1848,12 @@ def send_message(
     Gmail scope accepted by ``users.messages.send`` before invoking the API.
     The trusted caller must also provide the represented profile resource and a
     stable request id. Before provider dispatch this boundary durably claims the
-    idempotency key and atomically reserves mailbox-wide quota. A human-visible
-    AI-agent disclosure is injected into every MIME alternative. After Gmail
-    accepts the message, the helper reads it back and returns a body-free
-    verification receipt. A completed send with unavailable or mismatched
-    read-back is reported as indeterminate, rather than encouraging a blind
-    retry.
+    idempotency key and atomically reserves mailbox-wide quota. A visible
+    AI-agent disclosure is absent by default and is added only when a trusted
+    actor, organisation, or mailbox policy requires one. After Gmail accepts
+    the message, the helper reads it back and returns a body-free verification
+    receipt. A completed send with unavailable or mismatched read-back is
+    reported as indeterminate, rather than encouraging a blind retry.
     """
 
     if not allow_send:
@@ -1852,8 +1864,8 @@ def send_message(
         raise ValueError("body_text is required")
     if body_html is not None:
         raise ValueError(
-            "body_html is not supported for AI-agent outbound email; use the "
-            "plain-text body so the required disclosure cannot be visually hidden"
+            "body_html is not supported for AI-agent outbound email; use a "
+            "plain-text body so canonical delivery read-back remains exact"
         )
 
     to_addresses = _normalise_address_list(to, "to")
@@ -1883,6 +1895,53 @@ def send_message(
     if len(trusted_request_id) > 512:
         raise ValueError("request_id is too long")
 
+    from ...services.gmail_visible_disclosure_policy_service import (
+        GmailVisibleDisclosurePolicyError,
+        apply_gmail_visible_disclosure,
+        resolve_gmail_visible_disclosure_policy,
+    )
+
+    try:
+        disclosure_resolution = resolve_gmail_visible_disclosure_policy(
+            profile_resource_concept_id=resource_id,
+            acting_user_concept_id=acting_user_concept_id,
+            organisation_concept_id=organisation_concept_id,
+            body_language=body_language,
+            body_authorship=body_authorship,
+        )
+        rendered_body_text = apply_gmail_visible_disclosure(
+            body_text,
+            disclosure_resolution,
+        )
+    except GmailVisibleDisclosurePolicyError as exc:
+        return _outbound_not_started_payload(
+            error_code=exc.reason_code,
+            message=str(exc),
+        )
+
+    disclosure_receipt = disclosure_resolution.as_receipt()
+    expected_plain_body_sha256 = _mime_plain_body_sha256(rendered_body_text)
+    disclosure_audit_context = dict(audit_context or {})
+    disclosure_audit_context.update(
+        {
+            "visible_disclosure_mode": disclosure_resolution.mode,
+            "visible_disclosure_policy_id": disclosure_resolution.policy_id,
+            "visible_disclosure_policy_version": (disclosure_resolution.policy_version),
+            "visible_disclosure_authority_scope": (
+                disclosure_resolution.authority_scope
+            ),
+            "visible_disclosure_authority_concept_id": (
+                disclosure_resolution.authority_concept_id
+            ),
+            "visible_disclosure_resolved_language": (
+                disclosure_resolution.resolved_language
+            ),
+            "visible_disclosure_body_authorship": (
+                disclosure_resolution.body_authorship
+            ),
+        }
+    )
+
     recipient_count = len(to_addresses) + len(cc_addresses) + len(bcc_addresses)
     try:
         from ...services.gmail_outbound_mailbox_identity_service import (
@@ -1902,7 +1961,7 @@ def send_message(
         _log_gmail_audit(
             "send_message_canonical_mailbox_preflight_failed",
             profile_id=profile.profile_id,
-            audit_context=audit_context,
+            audit_context=disclosure_audit_context,
             allow_mutation=allow_send,
             recipient_count=recipient_count,
         )
@@ -1914,6 +1973,7 @@ def send_message(
             ),
         )
         payload["exception_type"] = type(exc).__name__
+        payload["ai_agent_disclosure"] = disclosure_receipt
         return payload
 
     (
@@ -1935,7 +1995,7 @@ def send_message(
     _log_gmail_audit(
         "send_message",
         profile_id=profile.profile_id,
-        audit_context=audit_context,
+        audit_context=disclosure_audit_context,
         allow_mutation=allow_send,
         recipient_count=recipient_count,
         delivery_fingerprint=delivery_fingerprint,
@@ -1969,7 +2029,7 @@ def send_message(
     try:
         delivery_claim = claim_gmail_outbound_delivery(**claim_kwargs)
     except GmailOutboundDeliveryConflict:
-        return _outbound_not_started_payload(
+        payload = _outbound_not_started_payload(
             error_code="gmail_outbound_idempotency_conflict",
             message=(
                 "Outbound email was not sent because this request id was already "
@@ -1977,8 +2037,10 @@ def send_message(
             ),
             delivery_fingerprint=delivery_fingerprint,
         )
+        payload["ai_agent_disclosure"] = disclosure_receipt
+        return payload
     except GmailOutboundDeliveryLedgerUnavailable:
-        return _outbound_not_started_payload(
+        payload = _outbound_not_started_payload(
             error_code="gmail_outbound_delivery_ledger_unavailable",
             message=(
                 "Outbound email was not sent because its durable delivery claim "
@@ -1986,6 +2048,8 @@ def send_message(
             ),
             delivery_fingerprint=delivery_fingerprint,
         )
+        payload["ai_agent_disclosure"] = disclosure_receipt
+        return payload
 
     def _persist_delivery(status: str, payload: dict[str, Any]) -> None:
         result_kwargs: dict[str, Any] = {
@@ -2011,11 +2075,7 @@ def send_message(
     if delivery_claim.duplicate:
         stored_projection = delivery_claim.receipt or {}
         stored_receipt = stored_projection.get("receipt")
-        payload = (
-            dict(stored_receipt)
-            if isinstance(stored_receipt, Mapping)
-            else {}
-        )
+        payload = dict(stored_receipt) if isinstance(stored_receipt, Mapping) else {}
         payload.update(
             {
                 "delivery_fingerprint": delivery_fingerprint,
@@ -2061,6 +2121,9 @@ def send_message(
                     expected_html=(
                         isinstance(body_html, str) and bool(body_html.strip())
                     ),
+                    expected_plain_body_sha256=expected_plain_body_sha256,
+                    expected_disclosure_mode=disclosure_resolution.mode,
+                    expected_disclosure_text=disclosure_resolution.visible_text,
                     search_anchor=stored_projection.get("created_at"),
                 )
             except Exception as exc:  # noqa: BLE001 - still never re-dispatch
@@ -2070,9 +2133,7 @@ def send_message(
                     "verified": False,
                     "body_included": False,
                     "delivery_fingerprint": delivery_fingerprint,
-                    "error_code": (
-                        "gmail_sent_delivery_reconciliation_unavailable"
-                    ),
+                    "error_code": ("gmail_sent_delivery_reconciliation_unavailable"),
                     "exception_type": type(exc).__name__,
                 }
             canonical = reconciliation.get("canonical_readback")
@@ -2112,6 +2173,7 @@ def send_message(
                         "Retry this same request only to re-run Gmail Sent reconciliation; Von will not re-dispatch it."
                     ],
                 )
+        payload.setdefault("ai_agent_disclosure", disclosure_receipt)
         return payload
 
     quota_kwargs: dict[str, Any] = {
@@ -2132,6 +2194,7 @@ def send_message(
             delivery_fingerprint=delivery_fingerprint,
             quota=quota_receipt,
         )
+        payload["ai_agent_disclosure"] = disclosure_receipt
         _persist_delivery("not_started", payload)
         return payload
 
@@ -2142,10 +2205,11 @@ def send_message(
             bcc=bcc_addresses,
             reply_to=reply_to_addresses,
             subject=subject.strip(),
-            body_text=body_text,
+            body_text=rendered_body_text,
             body_html=body_html,
             delivery_fingerprint=delivery_fingerprint,
             sender_email=sender_email,
+            visible_disclosure_mode=disclosure_resolution.mode,
         )
         messages_resource = service.users().messages()
         send_request = messages_resource.send(
@@ -2163,6 +2227,7 @@ def send_message(
             quota=quota_receipt,
         )
         payload["exception_type"] = type(exc).__name__
+        payload["ai_agent_disclosure"] = disclosure_receipt
         _persist_delivery("not_started", payload)
         return payload
 
@@ -2177,14 +2242,13 @@ def send_message(
             expected_cc=cc_addresses,
             expected_bcc=bcc_addresses,
             expected_subject=subject.strip(),
-            expected_html=(
-                isinstance(body_html, str) and bool(body_html.strip())
-            ),
+            expected_html=(isinstance(body_html, str) and bool(body_html.strip())),
+            expected_plain_body_sha256=expected_plain_body_sha256,
+            expected_disclosure_mode=disclosure_resolution.mode,
+            expected_disclosure_text=disclosure_resolution.visible_text,
         )
         canonical = reconciliation.get("canonical_readback")
-        if reconciliation.get("verified") is True and isinstance(
-            canonical, Mapping
-        ):
+        if reconciliation.get("verified") is True and isinstance(canonical, Mapping):
             payload = {
                 "success": True,
                 "message_id": canonical.get("message_id"),
@@ -2202,6 +2266,7 @@ def send_message(
                 "outcome_finality": "gmail_sent_reconciled_after_provider_error",
                 "provider_dispatch_attempted": True,
                 "changed": True,
+                "ai_agent_disclosure": disclosure_receipt,
             }
             _persist_delivery("succeeded", payload)
             return payload
@@ -2224,6 +2289,7 @@ def send_message(
             "recovery_affordances": [
                 "Reconcile the delivery fingerprint against Gmail Sent before any new send request."
             ],
+            "ai_agent_disclosure": disclosure_receipt,
         }
         _persist_delivery("indeterminate", payload)
         return payload
@@ -2257,13 +2323,7 @@ def send_message(
     payload.setdefault("quota", quota_receipt)
     payload.setdefault(
         "ai_agent_disclosure",
-        {
-            "schema_version": "gmail_ai_agent_disclosure.v1",
-            "visible_text": AI_AGENT_DISCLOSURE_TEXT,
-            "plain_text_part": True,
-            "html_part": isinstance(body_html, str) and bool(body_html.strip()),
-            "machine_header": AI_AGENT_MACHINE_HEADER,
-        },
+        disclosure_receipt,
     )
 
     canonical_readback: dict[str, Any]
@@ -2279,6 +2339,9 @@ def send_message(
                 expected_subject=subject.strip(),
                 expected_html=isinstance(body_html, str) and bool(body_html.strip()),
                 expected_delivery_fingerprint=delivery_fingerprint,
+                expected_plain_body_sha256=expected_plain_body_sha256,
+                expected_disclosure_mode=disclosure_resolution.mode,
+                expected_disclosure_text=disclosure_resolution.visible_text,
             )
         except Exception as exc:  # noqa: BLE001 - send already completed
             canonical_readback = {
@@ -2301,16 +2364,10 @@ def send_message(
     send_state_verified = canonical_readback.get("verified") is True
     payload["canonical_readback"] = canonical_readback
     payload["success"] = send_state_verified
-    payload["status"] = (
-        "succeeded" if send_state_verified else "indeterminate"
-    )
+    payload["status"] = "succeeded" if send_state_verified else "indeterminate"
     payload["gmail_send_state_verified"] = send_state_verified
-    payload["effect_status"] = (
-        "succeeded" if send_state_verified else "indeterminate"
-    )
-    payload["mutation_outcome"] = (
-        "completed" if send_state_verified else "unknown"
-    )
+    payload["effect_status"] = "succeeded" if send_state_verified else "indeterminate"
+    payload["mutation_outcome"] = "completed" if send_state_verified else "unknown"
     payload["outcome_finality"] = (
         "canonical_durable_readback"
         if send_state_verified

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -28694,6 +28694,8 @@ def _gmail_send_message(**kwargs):
             cc=kwargs.get("cc"),
             bcc=kwargs.get("bcc"),
             reply_to=kwargs.get("reply_to"),
+            body_language=kwargs.get("body_language"),
+            body_authorship=kwargs.get("body_authorship"),
             allow_send=allow_send,
             profile_resource_concept_id=profile_resource_id,
             request_id=request_id_value,
@@ -39192,6 +39194,8 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "cc": (str, list),
             "bcc": (str, list),
             "reply_to": (str, list),
+            "body_language": str,
+            "body_authorship": str,
             "namespace": (str, type(None)),
             "acting_user_concept_id": (str, type(None)),
             "organisation_concept_id": (str, type(None)),
@@ -39200,7 +39204,12 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
         description=(
             "Send an email through a configured Gmail profile. Requires "
             "allow_send=true after explicit user or workflow authorisation, "
-            "and a profile with a Gmail send-capable OAuth scope."
+            "and a profile with a Gmail send-capable OAuth scope. Do not add "
+            "an AI-agent notice to body_text: the Gmail boundary resolves any "
+            "required visible disclosure from trusted policy and adds it "
+            "exactly once. Supply body_language when known and classify "
+            "body_authorship as von_drafted or user_supplied; omit it when "
+            "provenance is uncertain."
         ),
         aliases={
             "profile_id": "profile",
@@ -39213,6 +39222,9 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "allow_mutation": "allow_send",
         },
         batch_propagated_fields=("profile", "allow_send"),
+        enum_values={
+            "body_authorship": ("von_drafted", "user_supplied", "unspecified"),
+        },
     )
     gmail_get_attachment_input_schema = Schema(
         required={"profile": str, "message_id": str, "attachment_id": str},
@@ -39917,9 +39929,12 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
                 "draft, read, or label-change capability. Required model "
                 "inputs are to, subject, and body_text; profile is selected "
                 "only from server-supplied authorised resources. Optional cc, "
-                "bcc, and reply_to are supported. HTML bodies are deliberately "
-                "unsupported so the mandatory AI-agent disclosure cannot be "
-                "visually hidden. The profile must have a "
+                "bcc, reply_to, body_language, and body_authorship are supported. "
+                "Do not put an AI-agent notice in body_text: the Gmail boundary "
+                "resolves a trusted actor, organisation, or mailbox policy and "
+                "adds policy-owned text exactly once only when required. HTML "
+                "bodies are deliberately unsupported so canonical delivery "
+                "read-back remains exact. The profile must have a "
                 "send-capable Gmail OAuth scope such as gmail.send, "
                 "gmail.compose, gmail.modify, or mail.google.com. The tool "
                 "returns Gmail send metadata and does not return the sent body."

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -3303,7 +3303,7 @@
         },
         {
             "name": "gmail_send_message",
-            "description": "Send an outbound Gmail message from an actor-authorised profile. Use only when the current user request, or bounded recent request context, explicitly asks Von to send email; the ordinary-turn runtime verifies that request evidence before dispatch and supplies allow_send=true. This is not a draft, read, or label-change capability. Required model inputs are to, subject, and body_text; profile is selected only from server-supplied authorised resources. Optional cc, bcc, and reply_to are supported. HTML bodies are deliberately unsupported so the mandatory AI-agent disclosure cannot be visually hidden. The profile must have a send-capable Gmail OAuth scope such as gmail.send, gmail.compose, gmail.modify, or mail.google.com. The tool returns Gmail send metadata and does not return the sent body.",
+            "description": "Send an outbound Gmail message from an actor-authorised profile. Use only when the current user request, or bounded recent request context, explicitly asks Von to send email; the ordinary-turn runtime verifies that request evidence before dispatch and supplies allow_send=true. This is not a draft, read, or label-change capability. Required model inputs are to, subject, and body_text; profile is selected only from server-supplied authorised resources. Optional cc, bcc, reply_to, body_language, and body_authorship are supported. Do not put an AI-agent notice in body_text: the Gmail boundary resolves a trusted actor, organisation, or mailbox policy and adds policy-owned text exactly once only when required. HTML bodies are deliberately unsupported so canonical delivery read-back remains exact. The profile must have a send-capable Gmail OAuth scope such as gmail.send, gmail.compose, gmail.modify, or mail.google.com. The tool returns Gmail send metadata and does not return the sent body.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3350,6 +3350,17 @@
                         ],
                         "items": {}
                     },
+                    "body_language": {
+                        "type": "string"
+                    },
+                    "body_authorship": {
+                        "type": "string",
+                        "enum": [
+                            "von_drafted",
+                            "user_supplied",
+                            "unspecified"
+                        ]
+                    },
                     "namespace": {
                         "type": [
                             "string",
@@ -3378,7 +3389,7 @@
                     "request_id"
                 ],
                 "additionalProperties": false,
-                "description": "Send an email through a configured Gmail profile. Requires allow_send=true after explicit user or workflow authorisation, and a profile with a Gmail send-capable OAuth scope.",
+                "description": "Send an email through a configured Gmail profile. Requires allow_send=true after explicit user or workflow authorisation, and a profile with a Gmail send-capable OAuth scope. Do not add an AI-agent notice to body_text: the Gmail boundary resolves any required visible disclosure from trusted policy and adds it exactly once. Supply body_language when known and classify body_authorship as von_drafted or user_supplied; omit it when provenance is uncertain.",
                 "x-von-argument-aliases": {
                     "profile_id": "profile",
                     "identity": "profile",

--- a/src/backend/services/gmail_visible_disclosure_policy_service.py
+++ b/src/backend/services/gmail_visible_disclosure_policy_service.py
@@ -1,0 +1,548 @@
+"""Resolve governed visible-disclosure policy for outbound Gmail messages.
+
+Visible text in a recipient's message is semantic policy, not an unavoidable
+transport property.  The policy therefore lives as a versioned attribute on a
+trusted actor, organisation, or represented mailbox concept.  This module owns
+only the small deterministic boundary needed to validate, resolve, render, and
+report that policy.
+
+The attribute name is :data:`GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE`.  Its
+value has this shape::
+
+    {
+        "schema_version": "gmail_visible_ai_agent_disclosure_policy.v1",
+        "policy_id": "organisation-mail-disclosure",
+        "policy_version": "2026-08-26",
+        "mode": "required",  # or "off"
+        "binding": true,
+        "default_language": "en",
+        "templates": {
+            "en": {
+                "von_sent": "Sent by Von, an AI agent.",
+                "von_drafted_and_sent": "Drafted and sent by Von, an AI agent.",
+                "user_authored_von_sent": "Sent by Von, an AI agent, using text supplied by the user."
+            }
+        }
+    }
+
+``templates`` are required only for ``required`` policies.  The transport has
+no built-in English disclosure or language-specific semantic matcher.  An
+explicit message language must have an exact or primary-language template; it
+never silently falls back to another language.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from . import concept_service
+
+GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE = "gmail_visible_ai_agent_disclosure_policy"
+GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION = (
+    "gmail_visible_ai_agent_disclosure_policy.v1"
+)
+GMAIL_VISIBLE_DISCLOSURE_RECEIPT_SCHEMA_VERSION = "gmail_visible_ai_agent_disclosure.v2"
+
+DISCLOSURE_MODE_OFF = "off"
+DISCLOSURE_MODE_REQUIRED = "required"
+DISCLOSURE_MODES = frozenset({DISCLOSURE_MODE_OFF, DISCLOSURE_MODE_REQUIRED})
+
+BODY_AUTHORSHIP_VON_DRAFTED = "von_drafted"
+BODY_AUTHORSHIP_USER_SUPPLIED = "user_supplied"
+BODY_AUTHORSHIP_UNSPECIFIED = "unspecified"
+BODY_AUTHORSHIP_VALUES = frozenset(
+    {
+        BODY_AUTHORSHIP_VON_DRAFTED,
+        BODY_AUTHORSHIP_USER_SUPPLIED,
+        BODY_AUTHORSHIP_UNSPECIFIED,
+    }
+)
+_AUTHORSHIP_TEMPLATE_ROLE = {
+    BODY_AUTHORSHIP_VON_DRAFTED: "von_drafted_and_sent",
+    BODY_AUTHORSHIP_USER_SUPPLIED: "user_authored_von_sent",
+    BODY_AUTHORSHIP_UNSPECIFIED: "von_sent",
+}
+_REQUIRED_TEMPLATE_ROLES = frozenset(_AUTHORSHIP_TEMPLATE_ROLE.values())
+
+_LANGUAGE_TAG = re.compile(r"^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*$")
+_MAX_POLICY_IDENTIFIER_CHARS = 256
+_MAX_TEMPLATE_CHARS = 4_000
+
+
+class GmailVisibleDisclosurePolicyError(ValueError):
+    """A represented visible-disclosure policy cannot be applied safely."""
+
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def load_concepts(concept_ids: list[str]) -> Mapping[str, Mapping[str, Any]]:
+    """Batch-read policy authorities without conflating absence and failure."""
+
+    try:
+        return concept_service.get_concepts_by_concept_ids_exact(concept_ids)
+    except Exception as exc:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_resolution_unavailable",
+            (
+                "Outbound email was not sent because governed visible-disclosure "
+                "policy could not be resolved."
+            ),
+        ) from exc
+
+
+@dataclass(frozen=True)
+class _PolicyCandidate:
+    mode: str
+    policy_id: str
+    policy_version: str
+    authority_scope: str
+    authority_concept_id: str
+    binding: bool
+    default_language: str | None
+    templates: Mapping[str, Mapping[str, str]]
+
+    def projection(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "authority_scope": self.authority_scope,
+            "authority_concept_id": self.authority_concept_id,
+            "binding": self.binding,
+        }
+
+
+@dataclass(frozen=True)
+class GmailVisibleDisclosureResolution:
+    """Body-free resolution used by MIME construction, audit, and receipts."""
+
+    mode: str
+    policy_id: str
+    policy_version: str
+    authority_scope: str
+    authority_concept_id: str | None
+    binding: bool
+    selection_reason: str
+    requested_language: str | None
+    resolved_language: str | None
+    body_authorship: str
+    template_role: str | None
+    visible_text: str | None
+    considered_policies: tuple[Mapping[str, Any], ...]
+
+    def as_receipt(self) -> dict[str, Any]:
+        """Return inspectable policy provenance without the message body."""
+
+        return {
+            "schema_version": GMAIL_VISIBLE_DISCLOSURE_RECEIPT_SCHEMA_VERSION,
+            "requested_policies": [dict(item) for item in self.considered_policies],
+            "resolved_mode": self.mode,
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "authority_scope": self.authority_scope,
+            "authority_concept_id": self.authority_concept_id,
+            "binding": self.binding,
+            "selection_reason": self.selection_reason,
+            "requested_language": self.requested_language,
+            "resolved_language": self.resolved_language,
+            "body_authorship": self.body_authorship,
+            "template_role": self.template_role,
+            "visible_text": self.visible_text,
+            "plain_text_part": self.mode == DISCLOSURE_MODE_REQUIRED,
+            "html_part": False,
+            "machine_header": "X-Von-AI-Agent",
+        }
+
+
+def _clean_identifier(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            f"{field_name} must be a non-empty string",
+        )
+    cleaned = value.strip()
+    if len(cleaned) > _MAX_POLICY_IDENTIFIER_CHARS:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            f"{field_name} is too long",
+        )
+    return cleaned
+
+
+def _normalise_language_tag(value: Any, *, field_name: str) -> str:
+    cleaned = _clean_identifier(value, field_name=field_name)
+    if not _LANGUAGE_TAG.fullmatch(cleaned):
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            f"{field_name} must be a BCP-47-style language tag",
+        )
+    return cleaned.lower()
+
+
+def _parse_templates(value: Any) -> dict[str, dict[str, str]]:
+    if not isinstance(value, Mapping) or not value:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "required disclosure policy templates must be a non-empty object",
+        )
+    templates: dict[str, dict[str, str]] = {}
+    for raw_language, raw_roles in value.items():
+        language = _normalise_language_tag(
+            raw_language,
+            field_name="templates language",
+        )
+        if language in templates:
+            raise GmailVisibleDisclosurePolicyError(
+                "gmail_visible_disclosure_policy_invalid",
+                f"duplicate disclosure template language {language!r}",
+            )
+        if not isinstance(raw_roles, Mapping):
+            raise GmailVisibleDisclosurePolicyError(
+                "gmail_visible_disclosure_policy_invalid",
+                f"templates.{language} must be an object",
+            )
+        unknown_roles = sorted(set(raw_roles) - _REQUIRED_TEMPLATE_ROLES)
+        missing_roles = sorted(_REQUIRED_TEMPLATE_ROLES - set(raw_roles))
+        if unknown_roles or missing_roles:
+            details: list[str] = []
+            if missing_roles:
+                details.append("missing " + ", ".join(missing_roles))
+            if unknown_roles:
+                details.append("unknown " + ", ".join(unknown_roles))
+            raise GmailVisibleDisclosurePolicyError(
+                "gmail_visible_disclosure_policy_invalid",
+                f"templates.{language} has " + "; ".join(details),
+            )
+        roles: dict[str, str] = {}
+        for role in _REQUIRED_TEMPLATE_ROLES:
+            text = raw_roles.get(role)
+            if not isinstance(text, str) or not text.strip():
+                raise GmailVisibleDisclosurePolicyError(
+                    "gmail_visible_disclosure_policy_invalid",
+                    f"templates.{language}.{role} must be non-empty text",
+                )
+            if len(text) > _MAX_TEMPLATE_CHARS:
+                raise GmailVisibleDisclosurePolicyError(
+                    "gmail_visible_disclosure_policy_invalid",
+                    f"templates.{language}.{role} is too long",
+                )
+            roles[role] = text
+        templates[language] = roles
+    return templates
+
+
+def _parse_candidate(
+    raw_policy: Any,
+    *,
+    authority_scope: str,
+    authority_concept_id: str,
+) -> _PolicyCandidate:
+    if not isinstance(raw_policy, Mapping):
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            (
+                f"{GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE} on "
+                f"{authority_concept_id} must be an object"
+            ),
+        )
+    supplied_schema = raw_policy.get("schema_version")
+    if supplied_schema != GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            (
+                "visible disclosure policy schema_version must be "
+                f"{GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION!r}"
+            ),
+        )
+    mode = str(raw_policy.get("mode") or "").strip().lower()
+    if mode not in DISCLOSURE_MODES:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "visible disclosure policy mode must be 'off' or 'required'",
+        )
+    policy_id = _clean_identifier(raw_policy.get("policy_id"), field_name="policy_id")
+    policy_version = _clean_identifier(
+        raw_policy.get("policy_version"),
+        field_name="policy_version",
+    )
+    binding = raw_policy.get("binding", False)
+    if not isinstance(binding, bool):
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "visible disclosure policy binding must be a boolean",
+        )
+    if binding and authority_scope == "actor":
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "an actor preference cannot declare itself binding",
+        )
+    if binding and mode != DISCLOSURE_MODE_REQUIRED:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "only a required disclosure policy may be binding",
+        )
+
+    default_language: str | None = None
+    templates: dict[str, dict[str, str]] = {}
+    if mode == DISCLOSURE_MODE_REQUIRED:
+        default_language = _normalise_language_tag(
+            raw_policy.get("default_language"),
+            field_name="default_language",
+        )
+        templates = _parse_templates(raw_policy.get("templates"))
+        if default_language not in templates:
+            raise GmailVisibleDisclosurePolicyError(
+                "gmail_visible_disclosure_policy_invalid",
+                "default_language must name an available disclosure template",
+            )
+
+    return _PolicyCandidate(
+        mode=mode,
+        policy_id=policy_id,
+        policy_version=policy_version,
+        authority_scope=authority_scope,
+        authority_concept_id=authority_concept_id,
+        binding=binding,
+        default_language=default_language,
+        templates=templates,
+    )
+
+
+def _load_candidate(
+    concept_id: str | None,
+    *,
+    authority_scope: str,
+    concept_loader: Callable[[str], Mapping[str, Any] | None],
+) -> _PolicyCandidate | None:
+    cleaned_id = str(concept_id or "").strip()
+    if not cleaned_id:
+        return None
+    concept = concept_loader(cleaned_id)
+    if not isinstance(concept, Mapping):
+        return None
+    attributes = concept.get("attributes")
+    if not isinstance(attributes, Mapping):
+        return None
+    raw_policy = attributes.get(GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE)
+    if raw_policy is None:
+        return None
+    return _parse_candidate(
+        raw_policy,
+        authority_scope=authority_scope,
+        authority_concept_id=cleaned_id,
+    )
+
+
+def _select_candidate(
+    candidates: Mapping[str, _PolicyCandidate],
+) -> tuple[_PolicyCandidate | None, str]:
+    # A binding organisation or mailbox requirement is a trusted ceiling on
+    # actor preference.  Organisation wins if both bind because it is the
+    # broader governing authority; both necessarily resolve to ``required``.
+    for scope in ("organisation", "mailbox"):
+        candidate = candidates.get(scope)
+        if candidate is not None and candidate.binding:
+            return candidate, "binding_required"
+
+    # In the absence of a binding requirement, the actor's explicit preference
+    # is most specific, followed by the mailbox and then organisation default.
+    for scope, reason in (
+        ("actor", "actor_preference"),
+        ("mailbox", "mailbox_policy"),
+        ("organisation", "organisation_policy"),
+    ):
+        candidate = candidates.get(scope)
+        if candidate is not None:
+            return candidate, reason
+    return None, "default_absence"
+
+
+def _resolve_template_language(
+    *,
+    candidate: _PolicyCandidate,
+    requested_language: str | None,
+) -> str:
+    if requested_language is None:
+        assert candidate.default_language is not None
+        return candidate.default_language
+    normalised = _normalise_language_tag(
+        requested_language,
+        field_name="body_language",
+    )
+    if normalised in candidate.templates:
+        return normalised
+    primary = normalised.split("-", 1)[0]
+    if primary in candidate.templates:
+        return primary
+    raise GmailVisibleDisclosurePolicyError(
+        "gmail_visible_disclosure_language_unavailable",
+        (
+            f"required visible disclosure policy {candidate.policy_id!r} has no "
+            f"template for message language {normalised!r}"
+        ),
+    )
+
+
+def resolve_gmail_visible_disclosure_policy(
+    *,
+    profile_resource_concept_id: str,
+    acting_user_concept_id: str | None,
+    organisation_concept_id: str | None,
+    body_language: str | None = None,
+    body_authorship: str | None = None,
+    concept_loader: Callable[[str], Mapping[str, Any] | None] | None = None,
+) -> GmailVisibleDisclosureResolution:
+    """Resolve one trusted policy and render its role/language-specific text."""
+
+    scoped_concept_ids = (
+        ("organisation", organisation_concept_id),
+        ("mailbox", profile_resource_concept_id),
+        ("actor", acting_user_concept_id),
+    )
+    if concept_loader is None:
+        policy_concept_ids = [
+            str(concept_id).strip()
+            for _scope, concept_id in scoped_concept_ids
+            if isinstance(concept_id, str) and concept_id.strip()
+        ]
+        loaded_concepts = load_concepts(policy_concept_ids)
+        loader = loaded_concepts.get
+    else:
+        loader = concept_loader
+    candidates: dict[str, _PolicyCandidate] = {}
+    for scope, concept_id in scoped_concept_ids:
+        candidate = _load_candidate(
+            concept_id,
+            authority_scope=scope,
+            concept_loader=loader,
+        )
+        if candidate is not None:
+            candidates[scope] = candidate
+
+    selected, selection_reason = _select_candidate(candidates)
+    considered = tuple(
+        candidates[scope].projection()
+        for scope in ("organisation", "mailbox", "actor")
+        if scope in candidates
+    )
+    requested_language = (
+        str(body_language).strip()
+        if isinstance(body_language, str) and body_language.strip()
+        else None
+    )
+    authorship = str(body_authorship or BODY_AUTHORSHIP_UNSPECIFIED).strip().lower()
+    if authorship not in BODY_AUTHORSHIP_VALUES:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_authorship_invalid",
+            (
+                "body_authorship must be 'von_drafted', 'user_supplied', or "
+                "'unspecified'"
+            ),
+        )
+
+    if selected is None:
+        return GmailVisibleDisclosureResolution(
+            mode=DISCLOSURE_MODE_OFF,
+            policy_id="von-default-no-visible-disclosure",
+            policy_version="1",
+            authority_scope="default",
+            authority_concept_id=None,
+            binding=False,
+            selection_reason=selection_reason,
+            requested_language=requested_language,
+            resolved_language=None,
+            body_authorship=authorship,
+            template_role=None,
+            visible_text=None,
+            considered_policies=considered,
+        )
+
+    if selected.mode == DISCLOSURE_MODE_OFF:
+        return GmailVisibleDisclosureResolution(
+            mode=selected.mode,
+            policy_id=selected.policy_id,
+            policy_version=selected.policy_version,
+            authority_scope=selected.authority_scope,
+            authority_concept_id=selected.authority_concept_id,
+            binding=selected.binding,
+            selection_reason=selection_reason,
+            requested_language=requested_language,
+            resolved_language=None,
+            body_authorship=authorship,
+            template_role=None,
+            visible_text=None,
+            considered_policies=considered,
+        )
+
+    resolved_language = _resolve_template_language(
+        candidate=selected,
+        requested_language=requested_language,
+    )
+    template_role = _AUTHORSHIP_TEMPLATE_ROLE[authorship]
+    visible_text = selected.templates[resolved_language][template_role]
+    return GmailVisibleDisclosureResolution(
+        mode=selected.mode,
+        policy_id=selected.policy_id,
+        policy_version=selected.policy_version,
+        authority_scope=selected.authority_scope,
+        authority_concept_id=selected.authority_concept_id,
+        binding=selected.binding,
+        selection_reason=selection_reason,
+        requested_language=requested_language,
+        resolved_language=resolved_language,
+        body_authorship=authorship,
+        template_role=template_role,
+        visible_text=visible_text,
+        considered_policies=considered,
+    )
+
+
+def apply_gmail_visible_disclosure(
+    body_text: str,
+    resolution: GmailVisibleDisclosureResolution,
+) -> str:
+    """Return the exact outbound body, adding a required block exactly once.
+
+    ``off`` is a byte-preserving pass-through.  Under ``required``, an existing
+    canonical block is retained rather than duplicated.  Multiple exact copies
+    are collapsed to the first; no language-specific heuristic or regex decides
+    what counts as the policy-owned block.
+    """
+
+    if resolution.mode == DISCLOSURE_MODE_OFF:
+        return body_text
+    visible_text = resolution.visible_text
+    if not isinstance(visible_text, str) or not visible_text:
+        raise GmailVisibleDisclosurePolicyError(
+            "gmail_visible_disclosure_policy_invalid",
+            "required visible disclosure resolution has no rendered text",
+        )
+    occurrences = body_text.count(visible_text)
+    if occurrences == 0:
+        return f"{body_text}\n\n{visible_text}"
+    if occurrences == 1:
+        return body_text
+
+    first, *remaining = body_text.split(visible_text)
+    return visible_text.join((first, "".join(remaining)))
+
+
+__all__ = [
+    "BODY_AUTHORSHIP_UNSPECIFIED",
+    "BODY_AUTHORSHIP_USER_SUPPLIED",
+    "BODY_AUTHORSHIP_VALUES",
+    "BODY_AUTHORSHIP_VON_DRAFTED",
+    "DISCLOSURE_MODE_OFF",
+    "DISCLOSURE_MODE_REQUIRED",
+    "GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE",
+    "GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION",
+    "GmailVisibleDisclosurePolicyError",
+    "GmailVisibleDisclosureResolution",
+    "apply_gmail_visible_disclosure",
+    "resolve_gmail_visible_disclosure_policy",
+]

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -13,10 +13,20 @@ import mongomock
 import pytest
 
 from src.backend.integrations.google import gmail_service as gs
+from src.backend.services import gmail_visible_disclosure_policy_service
 from src.backend.services.gmail_outbound_mailbox_identity_service import (
     derive_canonical_gmail_mailbox_key,
 )
 from src.backend.services.settings_service import GmailOutboundRateLimitSettings
+
+
+@pytest.fixture(autouse=True)
+def _default_test_disclosure_policy_off(monkeypatch):
+    monkeypatch.setattr(
+        gmail_visible_disclosure_policy_service,
+        "load_concepts",
+        lambda _concept_ids: {},
+    )
 
 
 def _outbound_test_collections():
@@ -679,9 +689,7 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     quota_collection, delivery_collection = _outbound_test_collections()
     request_id = "turn-verified-1"
     expected_fingerprint = gs._outbound_delivery_identity(
-        canonical_mailbox_key=derive_canonical_gmail_mailbox_key(
-            "zhan@example.test"
-        ),
+        canonical_mailbox_key=derive_canonical_gmail_mailbox_key("zhan@example.test"),
         request_id=request_id,
         to=["recipient@example.test"],
         cc=["copy@example.test"],
@@ -697,17 +705,13 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     canonical_message["Cc"] = "copy@example.test"
     canonical_message["Bcc"] = "blind-copy@example.test"
     canonical_message["Subject"] = "Agent message"
-    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=off"
     canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
-    canonical_message["Message-ID"] = (
-        "<provider-rewritten-message-id@example.test>"
+    canonical_message["Message-ID"] = "<provider-rewritten-message-id@example.test>"
+    canonical_message.set_content("Private research summary.")
+    canonical_raw = base64.urlsafe_b64encode(canonical_message.as_bytes()).decode(
+        "ascii"
     )
-    canonical_message.set_content(
-        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
-    )
-    canonical_raw = base64.urlsafe_b64encode(
-        canonical_message.as_bytes()
-    ).decode("ascii")
 
     class _Request:
         def __init__(self, payload):
@@ -784,13 +788,11 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     )
 
     sent_message = BytesParser(policy=default_email_policy).parsebytes(
-        base64.urlsafe_b64decode(
-            captured["send_kwargs"]["body"]["raw"].encode("ascii")
-        )
+        base64.urlsafe_b64decode(captured["send_kwargs"]["body"]["raw"].encode("ascii"))
     )
-    assert gs.AI_AGENT_DISCLOSURE_TEXT in sent_message.get_body(
-        preferencelist=("plain",)
-    ).get_content()
+    assert sent_message.get_body(preferencelist=("plain",)).get_content() == (
+        "Private research summary.\n"
+    )
     assert sent_message.get_body(preferencelist=("html",)) is None
     assert sent_message["From"] == "Von AI Agent <zhan@example.test>"
     assert captured["profile_kwargs"] == {"userId": "me"}
@@ -817,10 +819,15 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     assert readback["bcc_count"] == 1
     assert readback["recipients_verified"] is True
     assert readback["subject_verified"] is True
+    assert readback["resolved_disclosure_mode"] == "off"
+    assert readback["visible_disclosure_count"] == 0
+    assert readback["body_sha256_verified"] is True
     assert readback["disclosure_verified"] is True
     assert readback["machine_disclosure_verified"] is True
     assert readback["delivery_fingerprint_verified"] is True
     assert result["delivery_ledger_status"] == "succeeded"
+    assert result["ai_agent_disclosure"]["resolved_mode"] == "off"
+    assert result["ai_agent_disclosure"]["visible_text"] is None
     assert result["quota"]["allowed"] is True
     assert "Private research summary." not in json.dumps(readback)
     assert "raw" not in readback
@@ -850,6 +857,144 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     assert replay["outcome_finality"] == "durable_idempotent_replay"
 
 
+def test_send_message_required_policy_is_localised_exact_once_and_read_back(
+    monkeypatch,
+):
+    captured: dict = {}
+    quota_collection, delivery_collection = _outbound_test_collections()
+    profile_resource_id = "#V#gmail_profile_zhan_gmail"
+    notice = "由 Von 这个人工智能助理发送（文本由用户提供）。"
+    represented_policy = {
+        "schema_version": (
+            gmail_visible_disclosure_policy_service.GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION
+        ),
+        "policy_id": "mailbox-required-zh",
+        "policy_version": "2026-08-26",
+        "mode": "required",
+        "binding": True,
+        "default_language": "zh-Hans",
+        "templates": {
+            "zh-Hans": {
+                "von_sent": "由 Von 这个人工智能助理发送。",
+                "von_drafted_and_sent": "由 Von 这个人工智能助理起草并发送。",
+                "user_authored_von_sent": notice,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        gmail_visible_disclosure_policy_service,
+        "load_concepts",
+        lambda _concept_ids: {
+            profile_resource_id: {
+                "attributes": {
+                    gmail_visible_disclosure_policy_service.GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE: represented_policy
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+
+    class _Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class _Messages:
+        def send(self, **kwargs):
+            captured["raw"] = kwargs["body"]["raw"]
+            captured["send_count"] = captured.get("send_count", 0) + 1
+            return _Request({"id": "sent-required-1", "threadId": "thread-1"})
+
+        def get(self, **_kwargs):
+            return _Request(
+                {
+                    "id": "sent-required-1",
+                    "threadId": "thread-1",
+                    "labelIds": ["SENT"],
+                    "raw": captured["raw"],
+                }
+            )
+
+    class _Users:
+        def messages(self):
+            return _Messages()
+
+        def getProfile(self, **_kwargs):
+            return _Request({"emailAddress": "zhan@example.test"})
+
+    class _Service:
+        def users(self):
+            return _Users()
+
+    profiles = {
+        "zhan-gmail": gs.GmailProfile(
+            profile_id="zhan-gmail",
+            token_path="/tmp/fake-token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+    body_text = f"研究摘要。\n\n{notice}"
+
+    result = gs.send_message(
+        profile_id="zhan-gmail",
+        to="recipient@example.test",
+        subject="研究摘要",
+        body_text=body_text,
+        body_language="zh-Hans",
+        body_authorship="user_supplied",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id="turn-required-zh-1",
+            profile_resource_concept_id=profile_resource_id,
+        ),
+    )
+
+    sent_message = BytesParser(policy=default_email_policy).parsebytes(
+        base64.urlsafe_b64decode(captured["raw"].encode("ascii"))
+    )
+    sent_body = sent_message.get_body(preferencelist=("plain",)).get_content()
+    assert sent_body.count(notice) == 1
+    assert sent_message[gs.AI_AGENT_MACHINE_HEADER] == "Von; disclosure=required"
+    assert result["success"] is True
+    assert result["canonical_readback"]["visible_disclosure_count"] == 1
+    assert result["canonical_readback"]["body_sha256_verified"] is True
+    assert result["ai_agent_disclosure"] == {
+        "schema_version": "gmail_visible_ai_agent_disclosure.v2",
+        "requested_policies": [
+            {
+                "mode": "required",
+                "policy_id": "mailbox-required-zh",
+                "policy_version": "2026-08-26",
+                "authority_scope": "mailbox",
+                "authority_concept_id": profile_resource_id,
+                "binding": True,
+            }
+        ],
+        "resolved_mode": "required",
+        "policy_id": "mailbox-required-zh",
+        "policy_version": "2026-08-26",
+        "authority_scope": "mailbox",
+        "authority_concept_id": profile_resource_id,
+        "binding": True,
+        "selection_reason": "binding_required",
+        "requested_language": "zh-Hans",
+        "resolved_language": "zh-hans",
+        "body_authorship": "user_supplied",
+        "template_role": "user_authored_von_sent",
+        "visible_text": notice,
+        "plain_text_part": True,
+        "html_part": False,
+        "machine_header": "X-Von-AI-Agent",
+    }
+    assert "研究摘要。" not in json.dumps(result, ensure_ascii=False)
+
+
 def test_send_message_aliases_share_mailbox_delivery_and_quota_identity(monkeypatch):
     """Two authorised aliases for one Gmail mailbox cannot bypass controls."""
 
@@ -873,17 +1018,13 @@ def test_send_message_aliases_share_mailbox_delivery_and_quota_identity(monkeypa
     canonical_message["From"] = f"Von AI Agent <{canonical_address}>"
     canonical_message["To"] = "recipient@example.test"
     canonical_message["Subject"] = "Alias-safe agent message"
-    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=off"
     canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
-    canonical_message["Message-ID"] = (
-        "<provider-rewritten-message-id@example.test>"
+    canonical_message["Message-ID"] = "<provider-rewritten-message-id@example.test>"
+    canonical_message.set_content("Private research summary.")
+    canonical_raw = base64.urlsafe_b64encode(canonical_message.as_bytes()).decode(
+        "ascii"
     )
-    canonical_message.set_content(
-        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
-    )
-    canonical_raw = base64.urlsafe_b64encode(
-        canonical_message.as_bytes()
-    ).decode("ascii")
     captured = {"send_count": 0, "messages_calls": 0, "profile_reads": 0}
 
     class _Request:
@@ -1151,9 +1292,7 @@ def test_send_message_reconciles_lost_provider_response_without_redispatch(
     monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
     request_id = "turn-provider-response-lost-1"
     expected_fingerprint = gs._outbound_delivery_identity(
-        canonical_mailbox_key=derive_canonical_gmail_mailbox_key(
-            "zhan@example.test"
-        ),
+        canonical_mailbox_key=derive_canonical_gmail_mailbox_key("zhan@example.test"),
         request_id=request_id,
         to=["recipient@example.test"],
         cc=[],
@@ -1167,17 +1306,13 @@ def test_send_message_reconciles_lost_provider_response_without_redispatch(
     canonical_message["From"] = "Von AI Agent <zhan@example.test>"
     canonical_message["To"] = "recipient@example.test"
     canonical_message["Subject"] = "Reconciled agent message"
-    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=body"
+    canonical_message[gs.AI_AGENT_MACHINE_HEADER] = "Von; disclosure=off"
     canonical_message[gs.DELIVERY_FINGERPRINT_HEADER] = expected_fingerprint
-    canonical_message["Message-ID"] = (
-        "<provider-rewritten-message-id@example.test>"
+    canonical_message["Message-ID"] = "<provider-rewritten-message-id@example.test>"
+    canonical_message.set_content("Private research summary.")
+    canonical_raw = base64.urlsafe_b64encode(canonical_message.as_bytes()).decode(
+        "ascii"
     )
-    canonical_message.set_content(
-        "Private research summary.\n\n" + gs.AI_AGENT_DISCLOSURE_TEXT
-    )
-    canonical_raw = base64.urlsafe_b64encode(
-        canonical_message.as_bytes()
-    ).decode("ascii")
     captured = {"send_count": 0, "list_count": 0, "metadata_get_count": 0}
 
     class _Request:

--- a/tests/backend/test_gmail_visible_disclosure_policy_service.py
+++ b/tests/backend/test_gmail_visible_disclosure_policy_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backend.services import gmail_visible_disclosure_policy_service as policy
+
+
+def _concept(raw_policy=None):
+    attributes = {}
+    if raw_policy is not None:
+        attributes[policy.GMAIL_VISIBLE_DISCLOSURE_POLICY_ATTRIBUTE] = raw_policy
+    return {"attributes": attributes}
+
+
+def _policy(
+    *,
+    mode="required",
+    policy_id="policy-1",
+    policy_version="1",
+    binding=False,
+    default_language="en",
+    templates=None,
+):
+    value = {
+        "schema_version": policy.GMAIL_VISIBLE_DISCLOSURE_POLICY_SCHEMA_VERSION,
+        "policy_id": policy_id,
+        "policy_version": policy_version,
+        "mode": mode,
+        "binding": binding,
+    }
+    if mode == "required":
+        value["default_language"] = default_language
+        value["templates"] = templates or {
+            "en": {
+                "von_sent": "Sent by the assistant.",
+                "von_drafted_and_sent": "Drafted and sent by the assistant.",
+                "user_authored_von_sent": (
+                    "Sent by the assistant using user-supplied text."
+                ),
+            }
+        }
+    return value
+
+
+def _resolve(concepts, **kwargs):
+    return policy.resolve_gmail_visible_disclosure_policy(
+        profile_resource_concept_id="#V#mailbox",
+        acting_user_concept_id="#V#actor",
+        organisation_concept_id="#V#organisation",
+        concept_loader=concepts.get,
+        **kwargs,
+    )
+
+
+def test_absent_policy_defaults_to_no_visible_disclosure_and_preserves_body():
+    resolution = _resolve({})
+
+    assert resolution.mode == policy.DISCLOSURE_MODE_OFF
+    assert resolution.selection_reason == "default_absence"
+    assert resolution.authority_scope == "default"
+    assert resolution.visible_text is None
+    assert policy.apply_gmail_visible_disclosure("Body.\n", resolution) == "Body.\n"
+
+
+def test_actor_preference_can_disable_only_non_binding_policy():
+    concepts = {
+        "#V#organisation": _concept(
+            _policy(policy_id="organisation-default", binding=False)
+        ),
+        "#V#actor": _concept(_policy(mode="off", policy_id="actor-off")),
+    }
+
+    resolution = _resolve(concepts)
+
+    assert resolution.mode == policy.DISCLOSURE_MODE_OFF
+    assert resolution.policy_id == "actor-off"
+    assert resolution.selection_reason == "actor_preference"
+    assert [item["policy_id"] for item in resolution.considered_policies] == [
+        "organisation-default",
+        "actor-off",
+    ]
+
+
+def test_binding_organisation_requirement_cannot_be_disabled_by_actor():
+    concepts = {
+        "#V#organisation": _concept(
+            _policy(policy_id="binding-organisation", binding=True)
+        ),
+        "#V#actor": _concept(_policy(mode="off", policy_id="actor-off")),
+    }
+
+    resolution = _resolve(
+        concepts,
+        body_language="en-NZ",
+        body_authorship=policy.BODY_AUTHORSHIP_USER_SUPPLIED,
+    )
+
+    assert resolution.mode == policy.DISCLOSURE_MODE_REQUIRED
+    assert resolution.policy_id == "binding-organisation"
+    assert resolution.authority_scope == "organisation"
+    assert resolution.binding is True
+    assert resolution.selection_reason == "binding_required"
+    assert resolution.resolved_language == "en"
+    assert resolution.template_role == "user_authored_von_sent"
+    assert resolution.visible_text == "Sent by the assistant using user-supplied text."
+
+
+def test_required_policy_adds_exactly_one_role_specific_block():
+    concepts = {"#V#mailbox": _concept(_policy(policy_id="mailbox-required"))}
+    resolution = _resolve(
+        concepts,
+        body_authorship=policy.BODY_AUTHORSHIP_VON_DRAFTED,
+    )
+    disclosure = "Drafted and sent by the assistant."
+
+    added = policy.apply_gmail_visible_disclosure("Body.", resolution)
+    already_present = policy.apply_gmail_visible_disclosure(added, resolution)
+    duplicated = policy.apply_gmail_visible_disclosure(
+        f"Body.\n\n{disclosure}\n\n{disclosure}",
+        resolution,
+    )
+
+    assert added == f"Body.\n\n{disclosure}"
+    assert already_present == added
+    assert duplicated.count(disclosure) == 1
+
+
+@pytest.mark.parametrize(
+    ("language", "notice"),
+    [
+        ("es", "Enviado por el asistente."),
+        ("mi", "I tukuna e te kaiāwhina."),
+        ("zh-Hans", "由助理发送。"),
+    ],
+)
+def test_required_policy_uses_configured_non_english_language_templates(
+    language,
+    notice,
+):
+    templates = {
+        language: {
+            "von_sent": notice,
+            "von_drafted_and_sent": f"{notice}（草拟并发送）",
+            "user_authored_von_sent": f"{notice}（用户提供文本）",
+        }
+    }
+    concepts = {
+        "#V#mailbox": _concept(
+            _policy(
+                policy_id=f"required-{language}",
+                default_language=language,
+                templates=templates,
+            )
+        )
+    }
+
+    resolution = _resolve(concepts, body_language=language)
+
+    assert resolution.resolved_language == language.lower()
+    assert resolution.visible_text == notice
+    assert policy.apply_gmail_visible_disclosure("正文。", resolution).endswith(notice)
+
+
+def test_required_policy_does_not_fall_back_to_another_message_language():
+    concepts = {"#V#mailbox": _concept(_policy())}
+
+    with pytest.raises(
+        policy.GmailVisibleDisclosurePolicyError,
+        match="has no template for message language 'zh-hans'",
+    ):
+        _resolve(concepts, body_language="zh-Hans")
+
+
+def test_malformed_binding_off_policy_fails_closed():
+    concepts = {
+        "#V#organisation": _concept(
+            _policy(mode="off", policy_id="invalid-binding-off", binding=True)
+        )
+    }
+
+    with pytest.raises(
+        policy.GmailVisibleDisclosurePolicyError,
+        match="only a required disclosure policy may be binding",
+    ):
+        _resolve(concepts)
+
+
+def test_policy_store_failure_is_not_treated_as_absent(monkeypatch):
+    monkeypatch.setattr(
+        policy.concept_service,
+        "get_concepts_by_concept_ids_exact",
+        lambda _concept_ids: (_ for _ in ()).throw(RuntimeError("store unavailable")),
+    )
+
+    with pytest.raises(
+        policy.GmailVisibleDisclosurePolicyError,
+        match="policy could not be resolved",
+    ) as error:
+        policy.resolve_gmail_visible_disclosure_policy(
+            profile_resource_concept_id="#V#mailbox",
+            acting_user_concept_id="#V#actor",
+            organisation_concept_id="#V#organisation",
+        )
+
+    assert (
+        error.value.reason_code
+        == "gmail_visible_disclosure_policy_resolution_unavailable"
+    )

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -1961,6 +1961,8 @@ def test_gmail_send_message_registered_and_gateway_invokes(
             "recipient": "witbrock@gmail.com",
             "subject": "Hi From Von",
             "body": "An interesting body.",
+            "body_language": "en-NZ",
+            "body_authorship": "von_drafted",
             "allow_send": True,
             "request_id": "turn-send-1",
         },
@@ -1970,6 +1972,8 @@ def test_gmail_send_message_registered_and_gateway_invokes(
     assert captured["profile_id"] == "zhan-gmail"
     assert captured["to"] == ["witbrock@gmail.com"]
     assert captured["body_text"] == "An interesting body."
+    assert captured["body_language"] == "en-NZ"
+    assert captured["body_authorship"] == "von_drafted"
     assert captured["allow_send"] is True
     assert captured["request_id"] == "turn-send-1"
     assert (
@@ -2173,6 +2177,7 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     import pytest
 
     from src.backend.integrations.google import gmail_service as gs
+    from src.backend.services import gmail_visible_disclosure_policy_service
     from src.backend.services.settings_service import (
         GmailOutboundRateLimitSettings,
     )
@@ -2226,6 +2231,11 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
 
     monkeypatch.setattr(gs, "get_service", lambda *_a, **_kw: _FakeService())
     monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    monkeypatch.setattr(
+        gmail_visible_disclosure_policy_service,
+        "load_concepts",
+        lambda _concept_ids: {},
+    )
     test_database = mongomock.MongoClient().von_test
     delivery_collection = test_database.gmail_outbound_deliveries
     delivery_collection.create_index("delivery_fingerprint", unique=True)
@@ -2254,10 +2264,11 @@ def test_gmail_service_send_message_builds_raw_mime_and_checks_scope(monkeypatch
     assert message["To"] == "witbrock@gmail.com"
     assert message["Subject"] == "Hi From Von"
     assert message["From"] == "Von AI Agent <zhan@example.test>"
-    assert message.get_body(preferencelist=("plain",)).get_content().strip() == (
-        "Here is a small interesting thought.\n\n"
-        f"{gs.AI_AGENT_DISCLOSURE_TEXT}"
+    assert message.get_body(preferencelist=("plain",)).get_content() == (
+        "Here is a small interesting thought.\n"
     )
+    assert message[gs.AI_AGENT_MACHINE_HEADER] == "Von; disclosure=off"
+    assert payload["ai_agent_disclosure"]["resolved_mode"] == "off"
 
     with pytest.raises(ValueError, match="allow_send"):
         gs.send_message(


### PR DESCRIPTION
## Outcome

Replace the unconditional fixed-English Gmail footer with governed visible-disclosure policy.

- default to no visible body disclosure while retaining From and X-Von-AI-Agent attribution
- resolve versioned actor, organisation, and mailbox policies from Vontology in one bounded read
- prevent actor preferences from overriding a binding organisation or mailbox requirement
- render policy-owned language and authorship-role templates without a built-in English notice
- add required text exactly once and verify the resolved body through canonical Gmail read-back
- preserve delivery fingerprinting, quota, ledger receipts, and replay behaviour
- tell the model not to add an AI notice to body_text; accept optional body_language and body_authorship

## Validation

- 56 Gmail, visible-policy, and profile-authority tests passed
- 20 focused Gmail tool-contract and delivery tests passed
- 14 post-review focused tests passed after batching Vontology policy reads
- policy tests cover default off, binding precedence, malformed/store-unavailable failure, Spanish, Maori, and Chinese templates
- controlled MIME/read-back tests cover default off and Chinese required exact-once delivery
- Gmail manifest entry matches the code-authoritative catalogue contract

## Known unrelated baseline issue

The broad manifest suite also reports existing create_concepts registry/manifest drift on origin/main. It is unrelated to the Gmail candidate and is not included here.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2686