### PR TITLE
JVNAUTOSCI-2687: allow empty prior profile assertion ID

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
@@ -551,12 +551,14 @@
             },
             "validation_policy": {
               "output_format": "json_value",
+              "json_field_defaults": {
+                "prior_scoped_assertion_id": ""
+              },
               "required_json_fields": [
                 "decision",
                 "subject_concept_id",
                 "scope_mode",
                 "profile",
-                "prior_scoped_assertion_id",
                 "evidence",
                 "reason"
               ]

--- a/tests/backend/test_paper_recommendation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_recommendation_workflow_vontology_service.py
@@ -258,6 +258,12 @@ def test_profile_maintenance_workflow_definition_is_executable_and_separates_wri
         "resolve_publication_scope_profile",
     ]
     assert "upsert_scoped_assertion" not in plan_action.llm_policy["allowed_tools"]
+    assert plan_action.validation_policy["json_field_defaults"] == {
+        "prior_scoped_assertion_id": ""
+    }
+    assert "prior_scoped_assertion_id" not in plan_action.validation_policy[
+        "required_json_fields"
+    ]
     assert definition.states["write_global_profile"].actions[0].action_id == (
         "workflow_mcp.invoke_tool"
     )


### PR DESCRIPTION
The post-repair live run completed all semantic reads and produced a complete update_profile result, but the represented validator treated the intentionally empty prior_scoped_assertion_id as missing.

This PR changes only the represented workflow contract:
- supplies an empty-string JSON default for prior_scoped_assertion_id;
- removes that empty-allowed field from the non-empty required list;
- retains the prompt field and deterministic output mapping;
- adds focused authority coverage.

No Python policy or orchestration is added.

Validation:
- 6 focused tests passed;
- seed JSON parses;
- git diff --check passed.

Live acceptance after merge: deploy exact main, force-publish the bundle, run a fresh fenced Bin mutation, read back the scoped assertion, and replay unchanged evidence to verify no duplicate revision.