### PR TITLE
Fix event workflow suppression scope

### DIFF
--- a/src/backend/services/feature_flags.py
+++ b/src/backend/services/feature_flags.py
@@ -1,8 +1,43 @@
 import os
-
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 _TRUTHY = {"1", "true", "yes", "y", "on"}
 _FALSY = {"0", "false", "no", "n", "off"}
+
+_EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS: ContextVar[tuple[str, ...]] = ContextVar(
+    "event_workflow_launch_suppression_reasons",
+    default=(),
+)
+
+
+def current_event_workflow_launch_suppression_reason() -> str | None:
+    """Return the innermost request-local event-launch suppression reason."""
+
+    reasons = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get()
+    return reasons[-1] if reasons else None
+
+
+def event_workflow_launches_suppressed() -> bool:
+    """Return whether event-driven workflow launch is suppressed in this context."""
+
+    return bool(_EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get())
+
+
+@contextmanager
+def suppress_event_workflow_launches(reason: str) -> Iterator[None]:
+    """Suppress event-workflow fan-out within one nested execution context."""
+
+    cleaned_reason = str(reason or "").strip() or "unspecified"
+    current_reasons = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get()
+    token = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.set(
+        (*current_reasons, cleaned_reason)
+    )
+    try:
+        yield
+    finally:
+        _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.reset(token)
 
 
 def _read_env_flag(name: str, *, default: bool) -> bool:
@@ -40,6 +75,8 @@ def get_durable_workflows_enabled(*, default: bool = False) -> bool:
 def get_event_workflow_integration_enabled(*, default: bool = True) -> bool:
     """Return whether event -> workflow integration is enabled."""
 
+    if event_workflow_launches_suppressed():
+        return False
     return _read_env_flag("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", default=default)
 
 
@@ -54,15 +91,8 @@ def get_workflow_discovery_cache_invalidation_enabled(
     avoid coupling ordinary feature-flag reads to workflow service start-up.
     """
 
-    try:
-        from .workflow_event_integration_service import (
-            event_workflow_launches_suppressed,
-        )
-
-        if event_workflow_launches_suppressed():
-            return False
-    except ImportError:
-        pass
+    if event_workflow_launches_suppressed():
+        return False
 
     return _read_env_flag(
         "VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE",

--- a/src/backend/services/workflow_event_integration_service.py
+++ b/src/backend/services/workflow_event_integration_service.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-from contextlib import contextmanager
-from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 from time import perf_counter
-from typing import Any, Iterator, Mapping
+from typing import Any, Mapping
 
 from ..workflows.durable.models import EventWorkflowBinding
 from ..workflows.durable.startup import get_instance_manager
@@ -35,8 +33,12 @@ from .episode_evaluation_workflow_contracts import (
     EVENT_TYPE_WORKFLOW_INSTANCE_TERMINAL,
 )
 from .feature_flags import (
+    current_event_workflow_launch_suppression_reason,
     get_durable_workflows_enabled,
     get_event_workflow_integration_enabled,
+)
+from .feature_flags import (
+    suppress_event_workflow_launches as suppress_event_workflow_launches,
 )
 from .namespace_service import (
     coerce_namespace,
@@ -72,43 +74,6 @@ FILE_COPY_UPLOAD_EVENT_BINDING_MANAGED_BY = (
 )
 
 _DEFAULT_BINDINGS_ENSURED = False
-_EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS: ContextVar[tuple[str, ...]] = ContextVar(
-    "event_workflow_launch_suppression_reasons",
-    default=(),
-)
-
-
-def current_event_workflow_launch_suppression_reason() -> str | None:
-    """Return the innermost request-local event-launch suppression reason."""
-
-    reasons = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get()
-    return reasons[-1] if reasons else None
-
-
-def event_workflow_launches_suppressed() -> bool:
-    """Return whether event-driven workflow launch is suppressed in this context."""
-
-    return bool(_EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get())
-
-
-@contextmanager
-def suppress_event_workflow_launches(reason: str) -> Iterator[None]:
-    """Suppress event-workflow fan-out within one nested execution context.
-
-    The context is copied into internal MCP handler workers by the bounded
-    transport, while independent threads retain their own default. Resetting
-    the token preserves an outer suppression reason when scopes are nested.
-    """
-
-    cleaned_reason = str(reason or "").strip() or "unspecified"
-    current_reasons = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.get()
-    token = _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.set(
-        (*current_reasons, cleaned_reason)
-    )
-    try:
-        yield
-    finally:
-        _EVENT_WORKFLOW_LAUNCH_SUPPRESSION_REASONS.reset(token)
 
 
 def _clean_text(value: Any) -> str | None:

--- a/src/backend/services/workflow_vontology_materialisation_helpers.py
+++ b/src/backend/services/workflow_vontology_materialisation_helpers.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import re
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from collections.abc import Mapping, Sequence
-from collections.abc import Iterator
 from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..utils.concept_id_utils import canonicalise_vontology_concept_id
 from . import concept_service
+from .feature_flags import suppress_event_workflow_launches
 
 _WORKFLOW_PARENT_ID_SANITISER = re.compile(r"[^a-z0-9]+")
 
@@ -131,30 +130,15 @@ def suspend_event_workflow_integration() -> Iterator[None]:
     authoritative invalidation after publication completes.
     """
 
-    prior_event = os.environ.get("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE")
-    prior_discovery = os.environ.get(
-        "VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE"
+    from .relationship_extent_index_service import (
+        defer_relationship_extent_index_sync,
     )
-    os.environ["VON_EVENT_WORKFLOW_INTEGRATION_ENABLE"] = "0"
-    os.environ["VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE"] = "0"
-    try:
-        from .relationship_extent_index_service import (
-            defer_relationship_extent_index_sync,
-        )
 
-        with defer_relationship_extent_index_sync():
-            yield
-    finally:
-        if prior_event is None:
-            os.environ.pop("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", None)
-        else:
-            os.environ["VON_EVENT_WORKFLOW_INTEGRATION_ENABLE"] = prior_event
-        if prior_discovery is None:
-            os.environ.pop("VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE", None)
-        else:
-            os.environ["VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE"] = (
-                prior_discovery
-            )
+    with (
+        suppress_event_workflow_launches("workflow_vontology_materialisation"),
+        defer_relationship_extent_index_sync(),
+    ):
+        yield
 
 
 __all__ = [

--- a/tests/backend/test_concept_service_bulk_materialisation_guards.py
+++ b/tests/backend/test_concept_service_bulk_materialisation_guards.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import builtins
+import os
 from typing import Any
 
 import pytest
 
 from src.backend.db.mongo_client import close_connection, get_db
 from src.backend.services import concept_service
+from src.backend.services.feature_flags import (
+    get_event_workflow_integration_enabled,
+    get_workflow_discovery_cache_invalidation_enabled,
+)
 from src.backend.services.workflow_vontology_materialisation_helpers import (
     suspend_event_workflow_integration,
 )
@@ -81,3 +86,27 @@ def test_bulk_materialisation_skips_event_and_discovery_imports(
     assert created["concept_id"] == "#V#bulk_materialisation_guard_concept"
     assert (updated.get("attributes") or {}).get("guard_checked") is True
     assert blocked_attempts == []
+
+
+def test_bulk_materialisation_suppression_is_context_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VON_EVENT_WORKFLOW_INTEGRATION_ENABLE", raising=False)
+    monkeypatch.delenv(
+        "VON_WORKFLOW_DISCOVERY_CACHE_INVALIDATION_ENABLE",
+        raising=False,
+    )
+    before = dict(os.environ)
+
+    assert get_event_workflow_integration_enabled(default=True) is True
+    assert get_workflow_discovery_cache_invalidation_enabled(default=True) is True
+    with suspend_event_workflow_integration():
+        assert get_event_workflow_integration_enabled(default=True) is False
+        assert get_workflow_discovery_cache_invalidation_enabled(default=True) is False
+        with suspend_event_workflow_integration():
+            assert get_event_workflow_integration_enabled(default=True) is False
+        assert get_event_workflow_integration_enabled(default=True) is False
+
+    assert get_event_workflow_integration_enabled(default=True) is True
+    assert get_workflow_discovery_cache_invalidation_enabled(default=True) is True
+    assert dict(os.environ) == before


### PR DESCRIPTION
## Outcome\nPrevents workflow/Vontology materialisation from leaving event-driven workflow integration disabled process-wide after overlapping suppression scopes.\n\n## Design\nReuses the existing ContextVar suppression boundary and makes event/discovery feature-flag reads honour it. No profile-specific semantic policy is added to Python.\n\n## Evidence\n- 30 focused suppression/event-integration tests passed\n- 76 broader profile/event tests passed, 2 skipped\n- compileall, import/F lint, formatting on changed support modules, and diff checks passed\n\n## Live acceptance pending\nAfter merge and exact-build deployment, emit a fresh scoped-assertion mutation event and verify the represented binding launches with canonical read-back.\n\nJira: JVNAUTOSCI-2687