### PR TITLE
Fix profile summary event contract

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/paper_matching_profile_maintenance_prompt_seed.md
+++ b/src/backend/workflows/repo_seed_bundles/paper_matching_profile_maintenance_prompt_seed.md
@@ -11,9 +11,24 @@ intended profile assertion with `plane` set to `assertion`,
 `predicate_concept_id` set to `#V#has_paper_matching_profile_json`, and
 `source_kind` set to `represented_profile_maintenance`. If you supply its
 optional `source_context`, it must be a JSON object; omit it instead of sending
-a string. Use the returned publication recommendation to choose
+a string. The resolver's optional `selected_scope_mode` uses publication-profile
+codes, not the profile output labels: use `user_only_default` for output scope
+`user`, `organisation_general` for output scope `organisation`, and
+`global_general` for output scope `global_general`. Never pass `user` or
+`organisation` as `selected_scope_mode`. When supplied context already makes a
+scope choice clear, include that code and a concise `selection_reason` in the
+resolver call so an absent represented profile can be resolved explicitly.
+Use the returned publication recommendation to choose
 `global_general`, `user`, or `organisation`; never publish private or
 actor-specific evidence globally.
+
+When `source_artifact_concept_id` is present but `source_text` is absent, read
+that exact source artefact's `hasDescription` text before judging the evidence.
+For a research-summary relationship event, the profile subject is the relation
+source and the represented summary artefact is the relation target. Do not
+mistake the summary artefact for the student. For an `#V#authored_by`
+relationship event, the publication artefact is the relation source and the
+profile subject is the author target.
 
 Preserve explicit preferences. In particular, do not remove, weaken, or infer
 away `stated_interest_terms`, explicit exclusions, delivery preferences, or

--- a/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_recommendation_workflow_seed_bundle",
   "managed_by": "paper_recommendation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "2",
+  "seed_version": "3",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#paper_recommendation_evaluation_workflow": {
       "1": [
@@ -436,16 +436,16 @@
         {
           "event_type": "relationship.added",
           "input_mapping": {
-            "subject_concept_id": "event.target_id",
-            "source_artifact_concept_id": "event.source_id",
             "source_predicate": "event.predicate",
-            "source_fingerprint": "event.mutation_id",
-            "evidence_kind": "new_publication"
+            "source_fingerprint": "event.mutation_id"
           },
           "condition": {
-            "kind": "context_value_equals",
+            "kind": "context_value_in",
             "key": "event.predicate",
-            "value": "#V#authored_by"
+            "values": [
+              "#V#has_research_description",
+              "#V#authored_by"
+            ]
           },
           "enabled": true
         }

--- a/tests/backend/test_paper_recommendation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_recommendation_workflow_vontology_service.py
@@ -140,6 +140,13 @@ def test_paper_recommendation_prompt_support_seeds_content_from_repo_asset(
         maintenance_text
     )
     assert "omit it instead of sending a string" in normalised_maintenance_text
+    assert "use `user_only_default` for output scope" in normalised_maintenance_text
+    assert "Never pass `user` or `organisation` as `selected_scope_mode`" in (
+        normalised_maintenance_text
+    )
+    assert "read that exact source artefact's `hasDescription` text" in (
+        normalised_maintenance_text
+    )
 
 
 def test_forced_profile_prompt_seed_refreshes_existing_content(
@@ -219,17 +226,33 @@ def test_paper_recommendation_event_bindings_are_conditioned_by_policy(
         EVENT_TYPE_SCOPED_ASSERTION_UPSERTED
     ]["condition"]
 
-    maintenance_bindings = {
+    maintenance_bindings = represented[
+        PAPER_MATCHING_PROFILE_MAINTENANCE_WORKFLOW_ID
+    ]
+    maintenance_bindings_by_event = {
         item["event_type"]: item
-        for item in represented[PAPER_MATCHING_PROFILE_MAINTENANCE_WORKFLOW_ID]
+        for item in maintenance_bindings
+        if item["event_type"] != EVENT_TYPE_RELATIONSHIP_ADDED
     }
-    assert maintenance_bindings[EVENT_TYPE_TEXT_RELATION_UPSERTED]["input_mapping"][
-        "evidence_kind"
-    ] == "research_summary"
-    assert maintenance_bindings[EVENT_TYPE_RELATIONSHIP_ADDED]["condition"] == {
-        "kind": "context_value_equals",
+    assert (
+        maintenance_bindings_by_event[EVENT_TYPE_TEXT_RELATION_UPSERTED][
+            "input_mapping"
+        ]["evidence_kind"]
+        == "research_summary"
+    )
+    relationship_binding = next(
+        item
+        for item in maintenance_bindings
+        if item["event_type"] == EVENT_TYPE_RELATIONSHIP_ADDED
+    )
+    assert relationship_binding["input_mapping"] == {
+        "source_predicate": "event.predicate",
+        "source_fingerprint": "event.mutation_id",
+    }
+    assert relationship_binding["condition"] == {
+        "kind": "context_value_in",
         "key": "event.predicate",
-        "value": "#V#authored_by",
+        "values": ["#V#has_research_description", "#V#authored_by"],
     }
 
 


### PR DESCRIPTION
## Outcome
Makes the represented profile-maintenance workflow handle the canonical student-to-summary relationship representation and supplies the exact publication-scope resolver enum contract exposed by Timothy's live run.

## Design
- one existing represented relationship.added binding now covers both #V#has_research_description and #V#authored_by
- the represented prompt resolves relation direction by predicate and reads an exact source artefact when event text is absent
- the prompt maps workflow output scopes to resolver codes user_only_default, organisation_general, and global_general, and requires a reasoned explicit selection when appropriate
- no student-specific or profile-semantic Python

## Evidence
- 6 focused bundle/materialisation tests passed
- 76 broader profile, event, and paper-representation tests passed; 2 skipped
- JSON, import/F lint, and diff checks passed

## Live acceptance pending
Force-publish the merged represented assets, rerun Timothy's exact summary, read back the scoped profile, and replay the canonical relationship event/idempotency path.

Jira: JVNAUTOSCI-2687