### PR TITLE
Fix represented summary description read

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/paper_matching_profile_maintenance_prompt_seed.md
+++ b/src/backend/workflows/repo_seed_bundles/paper_matching_profile_maintenance_prompt_seed.md
@@ -22,8 +22,11 @@ Use the returned publication recommendation to choose
 `global_general`, `user`, or `organisation`; never publish private or
 actor-specific evidence globally.
 
-When `source_artifact_concept_id` is present but `source_text` is absent, read
-that exact source artefact's `hasDescription` text before judging the evidence.
+When `source_artifact_concept_id` is present but `source_text` is absent, call
+`get_text_relations` for that exact source artefact without a predicate filter,
+then use the row whose predicate is `hasDescription` (or the equivalent
+`#V#hasDescription` alias) before judging the evidence. Do not assume the
+canonical base predicate is written with a `#V#` prefix.
 For a research-summary relationship event, the profile subject is the relation
 source and the represented summary artefact is the relation target. Do not
 mistake the summary artefact for the student. For an `#V#authored_by`

--- a/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_recommendation_workflow_seed_bundle",
   "managed_by": "paper_recommendation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "3",
+  "seed_version": "4",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#paper_recommendation_evaluation_workflow": {
       "1": [

--- a/tests/backend/test_paper_recommendation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_recommendation_workflow_vontology_service.py
@@ -144,7 +144,10 @@ def test_paper_recommendation_prompt_support_seeds_content_from_repo_asset(
     assert "Never pass `user` or `organisation` as `selected_scope_mode`" in (
         normalised_maintenance_text
     )
-    assert "read that exact source artefact's `hasDescription` text" in (
+    assert "call `get_text_relations` for that exact source artefact without a predicate filter" in (
+        normalised_maintenance_text
+    )
+    assert "Do not assume the canonical base predicate is written with a `#V#` prefix" in (
         normalised_maintenance_text
     )
 


### PR DESCRIPTION
## Outcome

Automatic profile maintenance now reads the exact represented summary artefact without assuming the base hasDescription predicate carries a #V# prefix.

## Reliability-ratchet review

This remains represented semantic behaviour: no student/profile-specific Python and no new orchestration layer. The repository changes are only the versioned prompt seed, bundle version, and its contract test.

## Evidence

- Live Timothy replay exposed the discriminating gap: the automatic relationship event completed only because an existing profile was present, while its evidence reported no source description.
- Canonical actor-effective read showed the source row is stored under hasDescription.
- Six tests passed in tests/backend/test_paper_recommendation_workflow_vontology_service.py.

Jira: JVNAUTOSCI-2687