### PR TITLE
Remove conflicting profile-read default

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_recommendation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_recommendation_workflow_seed_bundle",
   "managed_by": "paper_recommendation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "4",
+  "seed_version": "5",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#paper_recommendation_evaluation_workflow": {
       "1": [
@@ -495,7 +495,6 @@
               "max_tool_invocations": 8,
               "tool_argument_defaults": {
                 "get_text_relations": {
-                  "predicate": "#V#has_paper_matching_profile_json",
                   "limit": 8
                 },
                 "resolve_publication_scope_profile": {

--- a/tests/backend/test_paper_recommendation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_recommendation_workflow_vontology_service.py
@@ -151,6 +151,22 @@ def test_paper_recommendation_prompt_support_seeds_content_from_repo_asset(
         normalised_maintenance_text
     )
 
+    bundle = json.loads(_REPO_SEED_ASSET_PATH.read_text(encoding="utf-8"))
+    profile_workflow = next(
+        workflow
+        for workflow in bundle["workflows"]
+        if workflow["workflow_id"] == PAPER_MATCHING_PROFILE_MAINTENANCE_WORKFLOW_ID
+    )
+    maintenance_step = next(
+        step
+        for step in profile_workflow["publication_spec"]["steps"]
+        if step["state_id"] == "plan_profile_maintenance"
+    )
+    text_relation_defaults = maintenance_step["llm_policy"]["tool_argument_defaults"][
+        "get_text_relations"
+    ]
+    assert text_relation_defaults == {"limit": 8}
+
 
 def test_forced_profile_prompt_seed_refreshes_existing_content(
     _reset_mock_db: Any,


### PR DESCRIPTION
## Outcome

Profile maintenance can now use get_text_relations both for an explicitly profile-filtered subject read and for an intentionally unfiltered source-artefact read.

## Reliability-ratchet review

The fix stays on the represented workflow surface. It removes one conflicting tool-argument default; it does not add student/profile-specific Python or another orchestration stage.

## Evidence

- Seed-v4 live telemetry proved the model omitted predicate for the artefact read, but represented tool defaults injected the paper-profile predicate.
- Seed v5 removes only that default while retaining the bounded default limit.
- Six focused workflow-authority tests pass.

Jira: JVNAUTOSCI-2687