### PR TITLE
JVNAUTOSCI-2688: Normalise structural predicate extent filters

### DIFF
--- a/src/backend/server/routes/predicate_routes.py
+++ b/src/backend/server/routes/predicate_routes.py
@@ -6,12 +6,15 @@ following a knowledge-driven approach where predicate properties are stored
 as facts in the Vontology itself rather than in hard-coded schemas.
 """
 
+from bson import ObjectId
 from flask import Blueprint, jsonify, request, current_app
 from typing import Dict, List, Any, Optional
-from bson import ObjectId
 
 from ...db.mongo_client import get_text_relations_collection, get_concepts_collection
 from ...db.repositories.text_value_repository import TextValuesRepository
+from ...services.concept_predicate_metadata_service import (
+    resolve_structural_predicate_storage_key,
+)
 from ...services.relationship_extent_index_service import (
     query_relationship_extent_index,
 )
@@ -373,6 +376,9 @@ def _query_structured_relations_extent(
         concepts_coll = get_concepts_collection()
         if concepts_coll is None:
             return [], 0
+        predicate_storage_key = resolve_structural_predicate_storage_key(
+            predicate_concept_id
+        )
 
         object_ids: Optional[set[str]] = None
         if object_type:
@@ -382,7 +388,8 @@ def _query_structured_relations_extent(
 
         if subject_type is None:
             indexed_items, indexed_count = _query_structured_relations_extent_index(
-                predicate_concept_id=predicate_concept_id,
+                predicate_concept_id=predicate_storage_key,
+                response_predicate_id=predicate_concept_id,
                 object_ids=object_ids,
                 limit=limit,
                 offset=offset,
@@ -395,11 +402,11 @@ def _query_structured_relations_extent(
         # Build query to find concepts with this predicate in their relationships
         # Note: This queries for the predicate as a key in the relationships object
         query_filter: Dict[str, Any] = {
-            f"relationships.{predicate_concept_id}": {"$exists": True, "$ne": None}
+            f"relationships.{predicate_storage_key}": {"$exists": True, "$ne": None}
         }
 
         if object_type:
-            query_filter[f"relationships.{predicate_concept_id}"] = {
+            query_filter[f"relationships.{predicate_storage_key}"] = {
                 "$in": list(object_ids)
             }
 
@@ -416,7 +423,7 @@ def _query_structured_relations_extent(
         object_name_ids = []
         for concept in concepts:
             relationships = concept.get("relationships", {})
-            object_values = relationships.get(predicate_concept_id)
+            object_values = relationships.get(predicate_storage_key)
             if not isinstance(object_values, list):
                 object_values = [object_values] if object_values else []
             object_name_ids.extend(
@@ -431,7 +438,7 @@ def _query_structured_relations_extent(
 
             # Get the object(s) for this predicate
             relationships = concept.get("relationships", {})
-            object_values = relationships.get(predicate_concept_id)
+            object_values = relationships.get(predicate_storage_key)
 
             # Handle both single values and arrays
             if not isinstance(object_values, list):
@@ -541,9 +548,12 @@ def _sample_structured_relations_extent(
         concepts_coll = get_concepts_collection()
         if concepts_coll is None:
             return [], 0
+        predicate_storage_key = resolve_structural_predicate_storage_key(
+            predicate_concept_id
+        )
 
         query_filter: Dict[str, Any] = {
-            f"relationships.{predicate_concept_id}": {"$exists": True, "$ne": None}
+            f"relationships.{predicate_storage_key}": {"$exists": True, "$ne": None}
         }
 
         object_ids: Optional[set[str]] = None
@@ -551,7 +561,7 @@ def _sample_structured_relations_extent(
             object_ids = _resolve_object_type_ids(object_type, concepts_coll)
             if not object_ids:
                 return [], 0
-            query_filter[f"relationships.{predicate_concept_id}"] = {
+            query_filter[f"relationships.{predicate_storage_key}"] = {
                 "$in": list(object_ids)
             }
         if subject_type:
@@ -568,7 +578,7 @@ def _sample_structured_relations_extent(
         object_name_ids = []
         for concept in concepts:
             relationships = concept.get("relationships", {})
-            object_values = relationships.get(predicate_concept_id)
+            object_values = relationships.get(predicate_storage_key)
             if not isinstance(object_values, list):
                 object_values = [object_values] if object_values else []
             object_name_ids.extend(
@@ -582,7 +592,7 @@ def _sample_structured_relations_extent(
             subject_name = concept.get("name") or subject_id
 
             relationships = concept.get("relationships", {})
-            object_values = relationships.get(predicate_concept_id)
+            object_values = relationships.get(predicate_storage_key)
             if not isinstance(object_values, list):
                 object_values = [object_values] if object_values else []
 
@@ -693,6 +703,7 @@ def _relationship_index_sort(sort_by: str, sort_order: str) -> List[tuple[str, i
 def _query_structured_relations_extent_index(
     *,
     predicate_concept_id: str,
+    response_predicate_id: str,
     object_ids: Optional[set[str]],
     limit: int,
     offset: int,
@@ -726,7 +737,7 @@ def _query_structured_relations_extent_index(
             {
                 "subject": subject_id,
                 "subject_name": concept_names.get(subject_id) or subject_id,
-                "predicate": predicate_concept_id,
+                "predicate": response_predicate_id,
                 "object": obj_value,
                 "object_name": concept_names.get(obj_value)
                 if isinstance(obj_value, str)

--- a/src/backend/server/routes/vontology_routes.py
+++ b/src/backend/server/routes/vontology_routes.py
@@ -44,7 +44,10 @@ from ...vontology.utils_vontology import (
     build_pure_instance_query,
 )
 from ...db.repositories.concepts_repository import ConceptsRepository
-from ...services.concept_predicate_metadata_service import get_relationship_kinds_set
+from ...services.concept_predicate_metadata_service import (
+    get_relationship_kinds_set,
+    resolve_structural_predicate_storage_key,
+)
 from ...services.concept_service import (
     get_concept_by_id,
     ConceptNotFoundError,
@@ -232,7 +235,8 @@ def _canonicalise_relationship_predicate(raw_predicate: Any) -> str | None:
     predicate = raw_predicate.strip()
     if not predicate:
         return None
-    return _RELATIONSHIP_ALIAS_TO_CANONICAL.get(predicate, predicate)
+    predicate = _RELATIONSHIP_ALIAS_TO_CANONICAL.get(predicate, predicate)
+    return resolve_structural_predicate_storage_key(predicate)
 
 
 def _coerce_relationship_extent_limit(raw_value: Any) -> int:

--- a/src/backend/services/concept_predicate_metadata_service.py
+++ b/src/backend/services/concept_predicate_metadata_service.py
@@ -218,6 +218,19 @@ def get_structural_predicate_aliases() -> Dict[str, str]:
     return dict(_ensure_cache()["structural_predicate_aliases"])
 
 
+def resolve_structural_predicate_storage_key(predicate: str) -> str:
+    """Resolve a structural predicate concept ID to its stored relationship key.
+
+    Non-structural predicates are returned unchanged so callers can safely use
+    this at read boundaries without stripping ordinary namespaced predicate IDs.
+    """
+
+    if not isinstance(predicate, str):
+        return predicate
+    cleaned = predicate.strip()
+    return get_structural_predicate_aliases().get(cleaned, cleaned)
+
+
 def get_structural_inverse_map() -> Dict[str, str]:
     """Return mapping of structural field names to their inverse field names.
 

--- a/src/backend/services/concept_relation_service.py
+++ b/src/backend/services/concept_relation_service.py
@@ -36,7 +36,10 @@ from ..vontology.utils_vontology import (
     is_predicate,
     is_type,
 )
-from .concept_predicate_metadata_service import get_relationship_kinds_set
+from .concept_predicate_metadata_service import (
+    get_relationship_kinds_set,
+    resolve_structural_predicate_storage_key,
+)
 from .relationship_extent_index_service import (
     incoming_dynamic_extent_rows_page_for_target,
     query_relationship_extent_index,
@@ -177,7 +180,11 @@ def build_concept_relations_payload(
     if not concept_id:
         return _empty_payload(limit=limit, offset=offset)
 
-    predicate_allow_list = set(predicate_filter or [])
+    predicate_allow_list = {
+        resolve_structural_predicate_storage_key(predicate)
+        for predicate in (predicate_filter or [])
+        if isinstance(predicate, str) and predicate.strip()
+    }
     structural_predicates = set(get_relationship_kinds_set())
     if predicate_allow_list:
         structural_predicates.update(
@@ -210,7 +217,10 @@ def build_concept_relations_payload(
             return True
         if candidate is None:
             return False
-        return candidate in predicate_allow_list
+        return (
+            resolve_structural_predicate_storage_key(candidate)
+            in predicate_allow_list
+        )
 
     def _record(entry: RelationValue) -> None:
         nonlocal total_matches
@@ -4063,7 +4073,10 @@ def _iter_predicate_filter_tokens(
 def _normalise_predicate_terms(
     predicate_filter: Optional[Sequence[str]],
 ) -> List[str]:
-    return [token.lower() for token in _iter_predicate_filter_tokens(predicate_filter)]
+    return [
+        resolve_structural_predicate_storage_key(token).lower()
+        for token in _iter_predicate_filter_tokens(predicate_filter)
+    ]
 
 
 def _normalise_predicate_display_terms(
@@ -4078,12 +4091,21 @@ def _canonical_exact_predicate_filter_ids(
     """Return exact safe field IDs only when the whole filter is canonical."""
 
     tokens = _iter_predicate_filter_tokens(predicate_filter)
-    if not tokens or any(
-        not token.startswith("#V#") or "." in token or "$" in token or "\x00" in token
-        for token in tokens
-    ):
+    if not tokens:
         return []
-    return list(dict.fromkeys(tokens))
+    structural_predicates = get_relationship_kinds_set()
+    resolved_tokens: List[str] = []
+    for token in tokens:
+        resolved = resolve_structural_predicate_storage_key(token)
+        if (
+            (not token.startswith("#V#") and resolved not in structural_predicates)
+            or "." in resolved
+            or "$" in resolved
+            or "\x00" in resolved
+        ):
+            return []
+        resolved_tokens.append(resolved)
+    return list(dict.fromkeys(resolved_tokens))
 
 
 def _predicate_matches_terms(predicate_id: Any, terms: Sequence[str]) -> bool:

--- a/src/backend/services/relationship_extent_index_service.py
+++ b/src/backend/services/relationship_extent_index_service.py
@@ -29,7 +29,10 @@ from ..db.mongo_client import (
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..security.access_control import bypass_access_control, can_access_concept
 from ..security.access_control import filter_accessible_concept_ids
-from .concept_predicate_metadata_service import get_relationship_kinds_set
+from .concept_predicate_metadata_service import (
+    get_relationship_kinds_set,
+    resolve_structural_predicate_storage_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -930,12 +933,12 @@ def _build_relationship_extent_index_query(
         dict.fromkeys(
             [
                 *(
-                    [predicate_id.strip()]
+                    [resolve_structural_predicate_storage_key(predicate_id)]
                     if isinstance(predicate_id, str) and predicate_id.strip()
                     else []
                 ),
                 *(
-                    item.strip()
+                    resolve_structural_predicate_storage_key(item)
                     for item in raw_predicate_ids
                     if isinstance(item, str) and item.strip()
                 ),

--- a/src/backend/services/relationship_write_service.py
+++ b/src/backend/services/relationship_write_service.py
@@ -32,6 +32,7 @@ from .concept_predicate_metadata_service import (
     get_relationship_kinds_set,
     get_structural_predicate_aliases,
     get_structural_inverse_map,
+    resolve_structural_predicate_storage_key,
 )
 from .feature_flags import (
     get_event_workflow_integration_enabled,
@@ -256,9 +257,7 @@ def normalise_structural_predicate(predicate: str) -> str:
     predicate = predicate.strip()
 
     # Check #V# prefixed structural aliases first (Vontology-backed)
-    aliases = get_structural_predicate_aliases()
-    if predicate in aliases:
-        return aliases[predicate]
+    predicate = resolve_structural_predicate_storage_key(predicate)
 
     # Check common name aliases
     if predicate in PREDICATE_NAME_ALIASES:

--- a/tests/backend/test_concept_relation_service_extent_index.py
+++ b/tests/backend/test_concept_relation_service_extent_index.py
@@ -370,6 +370,94 @@ def test_relation_hits_include_source_previews_for_both_directions(
     ]
 
 
+def test_structural_predicate_concept_ids_match_storage_keys_in_both_directions(
+    monkeypatch,
+) -> None:
+    from src.backend.services import concept_relation_service as service
+
+    focal_id = "#V#zhenyun_deng"
+    index_queries: list[dict[str, Any]] = []
+    aliases = {
+        "#V#has_instance": "has_instance",
+        "#V#is_an_instance_of": "is_an_instance_of",
+    }
+    monkeypatch.setattr(
+        service,
+        "resolve_structural_predicate_storage_key",
+        lambda predicate: aliases.get(predicate, predicate),
+    )
+    monkeypatch.setattr(
+        service,
+        "get_relationship_kinds_set",
+        lambda: frozenset({"has_instance", "is_an_instance_of"}),
+    )
+    monkeypatch.setattr(
+        service,
+        "_load_accessible_relation_subject_document",
+        lambda *_args, **_kwargs: {
+            "concept_id": focal_id,
+            "relationships": {
+                "is_an_instance_of": ["#V#person", "#V#student"],
+            },
+        },
+    )
+
+    def query_index(**kwargs: Any):
+        index_queries.append(kwargs)
+        return (
+            [
+                {
+                    "source_concept_id": "#V#person",
+                    "predicate_id": "has_instance",
+                    "target_value": focal_id,
+                    "target_index": 0,
+                    "source_updated_at": None,
+                }
+            ],
+            1,
+        )
+
+    monkeypatch.setattr(service, "query_relationship_extent_index", query_index)
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+
+    def relation_tuples(predicate_filter: list[str]) -> list[tuple[str, str, str]]:
+        payload = service.find_relations_with_argument(
+            focal_id,
+            argument_index="any",
+            predicate_filter=predicate_filter,
+            relation_kind="binary",
+            include_concept_preview=False,
+            limit=10,
+        )
+        return sorted(
+            (
+                hit["source_concept_id"],
+                hit["predicate_concept_id"],
+                hit["target_value"],
+            )
+            for hit in payload["hits"]
+        )
+
+    namespaced = relation_tuples(
+        ["#V#has_instance", "#V#is_an_instance_of"]
+    )
+    storage_keys = relation_tuples(["has_instance", "is_an_instance_of"])
+
+    assert namespaced == storage_keys == [
+        ("#V#person", "has_instance", focal_id),
+        (focal_id, "is_an_instance_of", "#V#person"),
+        (focal_id, "is_an_instance_of", "#V#student"),
+    ]
+    assert [query["predicate_ids"] for query in index_queries] == [
+        ["has_instance", "is_an_instance_of"],
+        ["has_instance", "is_an_instance_of"],
+    ]
+
+
 def test_outgoing_relation_previews_batch_uncached_targets(monkeypatch) -> None:
     from src.backend.services import concept_relation_service as service
 

--- a/tests/backend/test_relationship_extent_index_service.py
+++ b/tests/backend/test_relationship_extent_index_service.py
@@ -155,20 +155,58 @@ def test_relationship_extent_readiness_requires_explicit_complete_state(
     assert service.relationship_extent_index_ready() is True
 
 
-def test_relationship_extent_query_batches_exact_predicates() -> None:
+def test_relationship_extent_query_batches_exact_predicates(monkeypatch) -> None:
     from src.backend.services import relationship_extent_index_service as service
 
+    monkeypatch.setattr(
+        service,
+        "resolve_structural_predicate_storage_key",
+        lambda predicate: {
+            "#V#is_an_instance_of": "is_an_instance_of",
+        }.get(predicate, predicate),
+    )
     query, should_query = service._build_relationship_extent_index_query(
-        predicate_ids=["#V#supervises", "#V#co_supervises", "#V#supervises"],
+        predicate_ids=[
+            "#V#is_an_instance_of",
+            "#V#supervises",
+            "#V#is_an_instance_of",
+        ],
         target_value="#V#person",
     )
 
     assert should_query is True
     assert query == {
         "schema_version": service.RELATIONSHIP_EXTENT_INDEX_SCHEMA_VERSION,
-        "predicate_id": {"$in": ["#V#supervises", "#V#co_supervises"]},
+        "predicate_id": {"$in": ["is_an_instance_of", "#V#supervises"]},
         "target_value": "#V#person",
     }
+
+
+def test_structural_predicate_storage_key_resolution_preserves_other_predicates(
+    monkeypatch,
+) -> None:
+    from src.backend.services import concept_predicate_metadata_service as service
+
+    monkeypatch.setattr(
+        service,
+        "get_structural_predicate_aliases",
+        lambda: {"#V#is_an_instance_of": "is_an_instance_of"},
+    )
+
+    assert (
+        service.resolve_structural_predicate_storage_key(
+            "#V#is_an_instance_of"
+        )
+        == "is_an_instance_of"
+    )
+    assert (
+        service.resolve_structural_predicate_storage_key("is_an_instance_of")
+        == "is_an_instance_of"
+    )
+    assert (
+        service.resolve_structural_predicate_storage_key("#V#attended_event")
+        == "#V#attended_event"
+    )
 
 
 def test_relationship_extent_rebuild_enforces_batch_size_for_dense_source(
@@ -905,10 +943,11 @@ def test_predicate_structured_extent_uses_relationship_extent_index(monkeypatch)
     )
 
     monkeypatch.setattr(predicate_routes, "get_concepts_collection", lambda: concepts)
-    monkeypatch.setattr(
-        predicate_routes,
-        "query_relationship_extent_index",
-        lambda **kwargs: (
+    index_queries: list[dict] = []
+
+    def query_index(**kwargs):
+        index_queries.append(kwargs)
+        return (
             [
                 {
                     "source_concept_id": "#V#source",
@@ -918,7 +957,12 @@ def test_predicate_structured_extent_uses_relationship_extent_index(monkeypatch)
                 }
             ],
             1,
-        ),
+        )
+
+    monkeypatch.setattr(
+        predicate_routes,
+        "query_relationship_extent_index",
+        query_index,
     )
 
     items, total = predicate_routes._query_structured_relations_extent(
@@ -932,6 +976,7 @@ def test_predicate_structured_extent_uses_relationship_extent_index(monkeypatch)
     )
 
     assert total == 1
+    assert index_queries[0]["predicate_id"] == "#V#attended_event"
     assert items == [
         {
             "subject": "#V#source",
@@ -942,4 +987,63 @@ def test_predicate_structured_extent_uses_relationship_extent_index(monkeypatch)
             "source": "structured",
             "updated_at": None,
         }
+    ]
+
+
+def test_predicate_extent_route_accepts_structural_predicate_concept_id(
+    monkeypatch,
+):
+    from src.backend.server.routes import predicate_routes
+
+    client = mongomock.MongoClient()
+    concepts = client.db.concepts
+    concepts.insert_many(
+        [
+            {"concept_id": "#V#source", "name": "Source concept"},
+            {"concept_id": "#V#target", "name": "Target concept"},
+        ]
+    )
+    index_predicates: list[str | None] = []
+
+    def query_index(**kwargs):
+        index_predicates.append(kwargs.get("predicate_id"))
+        if kwargs.get("predicate_id") != "is_an_instance_of":
+            return [], 0
+        return (
+            [
+                {
+                    "source_concept_id": "#V#source",
+                    "predicate_id": "is_an_instance_of",
+                    "target_value": "#V#target",
+                    "target_index": 0,
+                }
+            ],
+            1,
+        )
+
+    monkeypatch.setattr(predicate_routes, "get_concepts_collection", lambda: concepts)
+    monkeypatch.setattr(predicate_routes, "query_relationship_extent_index", query_index)
+
+    app = Flask(__name__)
+    app.register_blueprint(predicate_routes.predicate_bp)
+    client_app = app.test_client()
+    responses = [
+        client_app.get(
+            f"/api/predicates/{predicate}/extent?source=structured&limit=20"
+        )
+        for predicate in ("%23V%23is_an_instance_of", "is_an_instance_of")
+    ]
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert index_predicates == ["is_an_instance_of", "is_an_instance_of"]
+    assert [response.get_json()["total_count"] for response in responses] == [1, 1]
+    assert [
+        [
+            (item["subject"], item["object"])
+            for item in response.get_json()["extent"]
+        ]
+        for response in responses
+    ] == [
+        [("#V#source", "#V#target")],
+        [("#V#source", "#V#target")],
     ]

--- a/tests/backend/test_virtual_code_predicate_concepts.py
+++ b/tests/backend/test_virtual_code_predicate_concepts.py
@@ -512,6 +512,73 @@ def test_relationship_extent_route_includes_incoming_dynamic_arg2_rows(
     assert rows[0]["arg2_value"] == "#V#focus"
 
 
+def test_relationship_extent_route_accepts_structural_predicate_concept_id(
+    app_client, monkeypatch
+):
+    _, client = app_client
+    requested_predicates: list[str | None] = []
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.ConceptsRepository.find_one",
+        lambda *a, **k: {"concept_id": "#V#focus", "relationships": {}},
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.relationship_extent_index_ready",
+        lambda: True,
+    )
+
+    def page_rows(*_args, requested_predicate=None, **_kwargs):
+        requested_predicates.append(requested_predicate)
+        return (
+            [
+                {
+                    "relation_id": "struct::#V#person::has_instance::incoming::0",
+                    "source": "structured",
+                    "relation_kind": "binary",
+                    "role": "arg2",
+                    "predicate_id": "has_instance",
+                    "arg1_value": "#V#person",
+                    "arg1_is_concept": True,
+                    "arg2_value": "#V#focus",
+                    "arg2_is_concept": True,
+                    "arg2_index": 2,
+                    "source_concept_id": "#V#person",
+                    "target_value": "#V#focus",
+                    "is_asserted": True,
+                    "relation_state": "asserted",
+                }
+            ],
+            True,
+            {
+                "used_extent_index": True,
+                "complete": True,
+                "bounded": False,
+                "has_more": False,
+            },
+        )
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.vontology_routes.incoming_dynamic_extent_rows_page_for_target",
+        page_rows,
+    )
+
+    responses = [
+        client.get(
+            "/vontology/api/vontology/relationships/extent?"
+            "concept_id=%23V%23focus&role=arg2&source=structured&"
+            f"predicate={predicate}&limit=20"
+        )
+        for predicate in ("%23V%23has_instance", "has_instance")
+    ]
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert requested_predicates == ["has_instance", "has_instance"]
+    assert [
+        [row["predicate_id"] for row in response.get_json()["rows"]]
+        for response in responses
+    ] == [["has_instance"], ["has_instance"]]
+
+
 def test_relationship_extent_route_dedupes_visibility_alias_rows(
     app_client, monkeypatch
 ):


### PR DESCRIPTION
## Outcome

Structural predicate concept IDs such as `#V#is_an_instance_of` now resolve to the canonical relationship storage key before predicate-extent reads. Namespaced and bare structural filters therefore return the same relationship set, while ordinary namespaced predicates remain unchanged.

## Scope

- add one Vontology-backed structural predicate storage-key resolver
- apply it at the shared extent-index boundary and both predicate/concept relationship routes
- retain requested predicate IDs in predicate-route response presentation
- cover the motivating Zhenyun-style incoming and outgoing relationship case

## Validation

- `69 passed, 3 deselected` across the four affected backend test modules
- the three deselected unrelated route tests fail identically on untouched `origin/main`
- six narrow regressions passed before the broader run
- changed modules compile
- `ruff check --select F,E9` passes
- `git diff --check` passes

No deployment or live-service restart is included.