### PR TITLE
JVNAUTOSCI-2690: Make direct-message sends prompt and idempotent

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -1735,6 +1735,23 @@ def _ensure_concepts_collection_indexes(concepts_coll: Collection) -> None:
             [("embedding_status", ASCENDING), ("updated_at", DESCENDING)],
             name="embedding_status_updated_at_desc",
         )
+    if "direct_message_idempotency_scope_unique" not in existing_indexes:
+        concepts_coll.create_index(
+            [
+                (
+                    "concept_data.metadata.delivery_idempotency_scope",
+                    ASCENDING,
+                )
+            ],
+            name="direct_message_idempotency_scope_unique",
+            unique=True,
+            partialFilterExpression={
+                "concept_data.metadata.delivery_idempotency_scope": {
+                    "$exists": True,
+                    "$type": "string",
+                }
+            },
+        )
     if "updated_at_-1" not in existing_indexes:
         concepts_coll.create_index([("updated_at", DESCENDING)], name="updated_at_-1")
 

--- a/src/backend/server/routes/message_routes.py
+++ b/src/backend/server/routes/message_routes.py
@@ -12,16 +12,20 @@ from flask import Blueprint, jsonify, request, session
 from flask.typing import ResponseReturnValue
 
 from ...services.message_service import (
+    DirectMessageIdempotencyConflict,
     authorise_direct_message_participants,
     create_message,
-    get_message_for_user,
-    get_messages_for_user,
+    create_message_idempotently,
+    delete_message,
     get_conversation_between_users,
+    get_message_for_user,
+    get_message_threads_for_user,
+    get_messages_for_user,
     get_unread_count,
     mark_message_read,
     mark_messages_read_bulk,
-    delete_message,
-    get_message_threads_for_user,
+    normalise_direct_message_delivery_idempotency_key,
+    sanitise_direct_message_delivery_metadata,
     search_messages,
 )
 from ...services.paper_recommendation_review_service import (
@@ -29,6 +33,11 @@ from ...services.paper_recommendation_review_service import (
 )
 from ...services.paper_recommendation_vontology_service import (
     record_paper_recommendation_feedback,
+)
+from ...services.window_session_context_service import (
+    WindowSessionContextRecoveryUnavailable,
+    WindowSessionContextUnavailable,
+    get_effective_context,
 )
 
 _log = logging.getLogger(__name__)
@@ -98,23 +107,46 @@ def _get_current_user_concept_id() -> Optional[str]:
     return None
 
 
-def _get_current_org_concept_id(user_concept_id: Optional[str]) -> Optional[str]:
-    """Get the current organisation's concept ID from effective window/session context."""
+def _get_current_org_concept_id(
+    user_concept_id: Optional[str],
+    *,
+    require_known_window: bool = False,
+) -> Optional[str]:
+    """Get the organisation from the actor-bound window or legacy session context.
+
+    A supplied window selector must never silently degrade to the browser-wide
+    Flask session for an organisation-scoped mutation.  Callers opt into that
+    boundary with ``require_known_window`` while no-window clients retain the
+    legacy session fallback.
+    """
+    window_session_id = request.headers.get("X-Von-Window-Session")
+    strict_window = bool(
+        require_known_window
+        and isinstance(window_session_id, str)
+        and window_session_id.strip()
+    )
     if isinstance(user_concept_id, str) and user_concept_id.strip():
         try:
-            from ...services.window_session_context_service import get_effective_context
-
-            window_session_id = request.headers.get("X-Von-Window-Session")
             effective = get_effective_context(
                 window_session_id,
                 dict(session),
                 user_concept_id.strip(),
+                require_known_window=strict_window,
             )
             org_id = _normalise_concept_id(effective.get("organisation_id"))
-            if org_id:
+            if org_id or strict_window:
                 return org_id
-        except Exception:
-            pass
+        except (
+            WindowSessionContextRecoveryUnavailable,
+            WindowSessionContextUnavailable,
+        ):
+            if strict_window:
+                raise
+        except Exception as exc:
+            if strict_window:
+                raise WindowSessionContextRecoveryUnavailable(
+                    "window_session_context_recovery_unavailable"
+                ) from exc
 
     return _normalise_concept_id(session.get("organisation_concept_id"))
 
@@ -286,6 +318,7 @@ def send_message() -> ResponseReturnValue:
         "thread_id": "Optional thread concept ID",
         "reply_to_id": "Optional message ID being replied to",
         "organisation_concept_id": "Optional explicit send scope",
+        "delivery_idempotency_key": "Optional stable key for one UI send",
         "metadata": {}
     }
     """
@@ -301,7 +334,33 @@ def send_message() -> ResponseReturnValue:
     explicit_org_id = _normalise_concept_id(
         data.get("organisation_concept_id") or data.get("org_id")
     )
-    org_id = explicit_org_id or _get_current_org_concept_id(sender_id)
+    try:
+        org_id = explicit_org_id or _get_current_org_concept_id(
+            sender_id,
+            require_known_window=True,
+        )
+    except WindowSessionContextRecoveryUnavailable:
+        return (
+            jsonify(
+                {
+                    "error": "Window organisation context could not be recovered",
+                    "error_code": "window_context_recovery_unavailable",
+                    "retryable": True,
+                }
+            ),
+            503,
+        )
+    except WindowSessionContextUnavailable:
+        return (
+            jsonify(
+                {
+                    "error": "Window organisation context must be rebound",
+                    "error_code": "window_context_unavailable",
+                    "retryable": True,
+                }
+            ),
+            409,
+        )
     if not isinstance(org_id, str) or not org_id:
         return jsonify({"error": "No organisation context"}), 400
 
@@ -312,6 +371,62 @@ def send_message() -> ResponseReturnValue:
         return jsonify({"error": "At least one recipient is required"}), 400
     if not content:
         return jsonify({"error": "Message content is required"}), 400
+    if "idempotency_key" in data:
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "Use delivery_idempotency_key for direct-message retries"
+                    ),
+                    "error_code": "unsupported_idempotency_key_field",
+                }
+            ),
+            400,
+        )
+
+    try:
+        body_idempotency_key = (
+            normalise_direct_message_delivery_idempotency_key(
+                data.get("delivery_idempotency_key")
+            )
+            if "delivery_idempotency_key" in data
+            else None
+        )
+        header_idempotency_key = (
+            normalise_direct_message_delivery_idempotency_key(
+                request.headers.get("Idempotency-Key")
+            )
+            if request.headers.get("Idempotency-Key") is not None
+            else None
+        )
+    except ValueError as exc:
+        return (
+            jsonify(
+                {
+                    "error": str(exc),
+                    "error_code": "invalid_idempotency_key",
+                }
+            ),
+            400,
+        )
+    if (
+        body_idempotency_key
+        and header_idempotency_key
+        and body_idempotency_key != header_idempotency_key
+    ):
+        return (
+            jsonify(
+                {
+                    "error": (
+                        "Body delivery_idempotency_key and Idempotency-Key "
+                        "header must match"
+                    ),
+                    "error_code": "idempotency_key_mismatch",
+                }
+            ),
+            400,
+        )
+    idempotency_key = body_idempotency_key or header_idempotency_key
 
     try:
         is_authorised, invalid_ids = _authorise_sender_and_recipients_for_org(
@@ -341,9 +456,9 @@ def send_message() -> ResponseReturnValue:
                 403,
             )
 
-        metadata = data.get("metadata")
-        metadata_payload = metadata if isinstance(metadata, dict) else {}
-        metadata_payload = dict(metadata_payload)
+        metadata_payload = sanitise_direct_message_delivery_metadata(
+            data.get("metadata") if isinstance(data.get("metadata"), dict) else None
+        )
         metadata_payload.setdefault("delivery_channel", "interuser_message")
         metadata_payload.setdefault("intent", "info")
         metadata_payload.setdefault(
@@ -351,46 +466,82 @@ def send_message() -> ResponseReturnValue:
             f"Sent by Von on behalf of {sender_id}",
         )
 
-        message = create_message(
-            sender_id=sender_id,
-            recipient_ids=recipient_ids,
-            content=content,
-            subject=data.get("subject"),
-            thread_id=data.get("thread_id"),
-            reply_to_id=data.get("reply_to_id"),
-            org_id=org_id,
-            metadata=metadata_payload,
-        )
+        reused = False
+        if idempotency_key:
+            create_receipt = create_message_idempotently(
+                delivery_idempotency_key=idempotency_key,
+                sender_id=sender_id,
+                recipient_ids=recipient_ids,
+                content=content,
+                subject=data.get("subject"),
+                thread_id=data.get("thread_id"),
+                reply_to_id=data.get("reply_to_id"),
+                organisation_concept_id=org_id,
+                metadata=metadata_payload,
+            )
+            message = create_receipt.message
+            reused = create_receipt.reused
+        else:
+            message = create_message(
+                sender_id=sender_id,
+                recipient_ids=recipient_ids,
+                content=content,
+                subject=data.get("subject"),
+                thread_id=data.get("thread_id"),
+                reply_to_id=data.get("reply_to_id"),
+                org_id=org_id,
+                metadata=metadata_payload,
+            )
 
-        from ...services.episode_logging_service import log_episode
+        if not reused:
+            from ...services.episode_logging_service import log_episode
 
-        log_episode(
-            episode_type="interuser_message_sent",
-            actor_user_id=sender_id,
-            organisation_concept_id=org_id,
-            payload={
-                "message_id": message.get("concept_id"),
-                "recipient_ids": recipient_ids,
-                "intent": metadata_payload.get("intent"),
-                "thread_id": data.get("thread_id"),
-                "reply_to_id": data.get("reply_to_id"),
-            },
-            status="sent",
-        )
+            log_episode(
+                episode_type="interuser_message_sent",
+                actor_user_id=sender_id,
+                organisation_concept_id=org_id,
+                payload={
+                    "message_id": message.get("concept_id"),
+                    "recipient_ids": recipient_ids,
+                    "intent": metadata_payload.get("intent"),
+                    "thread_id": data.get("thread_id"),
+                    "reply_to_id": data.get("reply_to_id"),
+                },
+                status="sent",
+            )
 
         # Return sanitised response
+        delivery_status = "reused" if reused else "created"
         return (
             jsonify(
                 {
                     "success": True,
+                    "effect_status": "succeeded",
+                    "changed": not reused,
+                    "reused": reused,
+                    "idempotent_replay": reused,
+                    "delivery_status": delivery_status,
                     "message_id": message.get("concept_id"),
                     "sent_at": message.get("concept_data", {}).get("sent_at"),
-                    "attribution": metadata_payload.get("attribution"),
+                    "attribution": message.get("concept_data", {}).get(
+                        "attribution",
+                        metadata_payload.get("attribution"),
+                    ),
                 }
             ),
-            201,
+            200 if reused else 201,
         )
 
+    except DirectMessageIdempotencyConflict as exc:
+        return (
+            jsonify(
+                {
+                    "error": str(exc),
+                    "error_code": "idempotency_key_reused_with_different_payload",
+                }
+            ),
+            409,
+        )
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
     except Exception as e:

--- a/src/backend/services/message_service.py
+++ b/src/backend/services/message_service.py
@@ -8,21 +8,26 @@ JVNAUTOSCI-1071
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from pymongo.errors import DuplicateKeyError
+
 from ..db.mongo_client import get_concepts_collection
 from ..db.repositories.concepts_repository import ConceptsRepository
-from ..services.text_value_service import upsert_text_for_concept
-from .workflow_event_integration_service import (
-    maybe_launch_direct_message_workflow,
-)
 from ..security.access_control import (
     apply_concept_query_filter,
 )
 from ..security.visibility_predicates import (
     set_specific_to_user_values,
+)
+from ..services.text_value_service import upsert_text_for_concept
+from .workflow_event_integration_service import (
+    maybe_launch_direct_message_workflow,
 )
 
 _log = logging.getLogger(__name__)
@@ -40,6 +45,48 @@ PREDICATE_REPLY_TO = "#V#is_reply_to"  # For reply chains
 MESSAGE_STATUS_SENT = "sent"
 MESSAGE_STATUS_DELIVERED = "delivered"
 MESSAGE_STATUS_READ = "read"
+
+DIRECT_MESSAGE_IDEMPOTENCY_SCHEMA_VERSION = "direct_message_idempotency.v1"
+DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD = "delivery_idempotency_scope"
+DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD = "delivery_payload_fingerprint"
+DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD = "delivery_fingerprint"
+DIRECT_MESSAGE_IDEMPOTENCY_KEY_HASH_FIELD = "delivery_idempotency_key_hash"
+MAX_DIRECT_MESSAGE_IDEMPOTENCY_KEY_LENGTH = 512
+DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX = "direct_message_idempotency_v1:"
+
+_DIRECT_MESSAGE_RESERVED_DELIVERY_METADATA_FIELDS = frozenset(
+    {
+        DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD,
+        DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD,
+        DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD,
+        DIRECT_MESSAGE_IDEMPOTENCY_KEY_HASH_FIELD,
+        "delivery_idempotency_schema_version",
+    }
+)
+
+
+class DirectMessageIdempotencyConflict(ValueError):
+    """The same scoped idempotency key names a different message intent."""
+
+
+@dataclass(frozen=True)
+class DirectMessageDeliveryIdentity:
+    """Opaque hashes used to reconcile one actor-scoped delivery request."""
+
+    idempotency_scope: str
+    payload_fingerprint: str
+    delivery_fingerprint: str
+    idempotency_key_hash: str
+    document_id: str
+
+
+@dataclass(frozen=True)
+class DirectMessageCreateReceipt:
+    """Result of an idempotent direct-message create or replay."""
+
+    message: Dict[str, Any]
+    reused: bool
+    delivery_identity: DirectMessageDeliveryIdentity
 
 
 def _normalise_concept_id(value: Any) -> Optional[str]:
@@ -68,6 +115,154 @@ def normalise_message_recipient_ids(value: Any) -> List[str]:
         seen.add(fingerprint)
         recipients.append(concept_id)
     return recipients
+
+
+def normalise_direct_message_delivery_idempotency_key(value: Any) -> Optional[str]:
+    """Validate an optional client retry key without treating it as authority."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("delivery_idempotency_key must be a string")
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("delivery_idempotency_key must not be empty")
+    if len(cleaned) > MAX_DIRECT_MESSAGE_IDEMPOTENCY_KEY_LENGTH:
+        raise ValueError(
+            "delivery_idempotency_key must be at most "
+            f"{MAX_DIRECT_MESSAGE_IDEMPOTENCY_KEY_LENGTH} characters"
+        )
+    return cleaned
+
+
+def _normalise_optional_message_text(value: Any, *, field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value.strip() or None
+
+
+def _canonical_json_sha256(payload: Dict[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Direct-message metadata must be valid JSON") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _material_delivery_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(metadata, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in metadata.items()
+        if isinstance(key, str)
+        and key not in _DIRECT_MESSAGE_RESERVED_DELIVERY_METADATA_FIELDS
+    }
+
+
+def sanitise_direct_message_delivery_metadata(
+    metadata: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Remove server-owned delivery identity fields from client metadata."""
+
+    return _material_delivery_metadata(metadata)
+
+
+def build_direct_message_delivery_identity(
+    *,
+    delivery_idempotency_key: str,
+    sender_id: str,
+    organisation_concept_id: str,
+    recipient_ids: List[str],
+    content: str,
+    subject: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    reply_to_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> DirectMessageDeliveryIdentity:
+    """Build a scoped retry identity and a separately comparable payload hash.
+
+    The client key is never an authority carrier. Its unique claim is bound to
+    the trusted sender, so the same key remains isolated between actors. The
+    separate payload hash binds the authorised organisation and canonical
+    recipient set along with visible message content; changing any of those
+    fields is therefore conflicting key reuse rather than a second delivery.
+    """
+
+    normalised_key = normalise_direct_message_delivery_idempotency_key(
+        delivery_idempotency_key
+    )
+    normalised_sender = _normalise_concept_id(sender_id)
+    normalised_org = _normalise_concept_id(organisation_concept_id)
+    normalised_recipients = normalise_message_recipient_ids(recipient_ids)
+    if normalised_key is None:
+        raise ValueError("delivery_idempotency_key is required")
+    if normalised_sender is None:
+        raise ValueError("sender_id is required")
+    if normalised_org is None:
+        raise ValueError("organisation_concept_id is required")
+    if not normalised_recipients:
+        raise ValueError("At least one recipient is required")
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("Message content cannot be empty")
+
+    canonical_recipients = sorted(
+        normalised_recipients,
+        key=lambda item: item.casefold(),
+    )
+    idempotency_key_hash = hashlib.sha256(normalised_key.encode("utf-8")).hexdigest()
+    idempotency_scope = _canonical_json_sha256(
+        {
+            "schema_version": DIRECT_MESSAGE_IDEMPOTENCY_SCHEMA_VERSION,
+            "delivery_idempotency_key": normalised_key,
+            "sender_id": normalised_sender,
+        }
+    )
+    payload_fingerprint = _canonical_json_sha256(
+        {
+            "schema_version": DIRECT_MESSAGE_IDEMPOTENCY_SCHEMA_VERSION,
+            "organisation_concept_id": normalised_org,
+            "recipient_ids": canonical_recipients,
+            "content": content.strip(),
+            "subject": _normalise_optional_message_text(
+                subject,
+                field_name="subject",
+            ),
+            "thread_id": _normalise_optional_message_text(
+                thread_id,
+                field_name="thread_id",
+            ),
+            "reply_to_id": _normalise_optional_message_text(
+                reply_to_id,
+                field_name="reply_to_id",
+            ),
+            "metadata": _material_delivery_metadata(metadata),
+        }
+    )
+    delivery_fingerprint = _canonical_json_sha256(
+        {
+            "schema_version": DIRECT_MESSAGE_IDEMPOTENCY_SCHEMA_VERSION,
+            "idempotency_scope": idempotency_scope,
+            "payload_fingerprint": payload_fingerprint,
+        }
+    )
+    return DirectMessageDeliveryIdentity(
+        idempotency_scope=idempotency_scope,
+        payload_fingerprint=payload_fingerprint,
+        delivery_fingerprint=delivery_fingerprint,
+        idempotency_key_hash=idempotency_key_hash,
+        document_id=(
+            f"{DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX}{idempotency_scope}"
+        ),
+    )
 
 
 def authorise_direct_message_participants(
@@ -179,6 +374,7 @@ def create_message(
     reply_to_id: Optional[str] = None,
     org_id: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    _server_owned_document_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a new direct message.
 
@@ -191,6 +387,8 @@ def create_message(
         reply_to_id: Optional message ID this is replying to.
         org_id: Optional organisation context for org-scoped messages.
         metadata: Optional additional metadata.
+        _server_owned_document_id: Internal deterministic Mongo identity for an
+            already server-derived idempotency scope. REST clients cannot set it.
 
     Returns:
         The created message document.
@@ -257,6 +455,22 @@ def create_message(
         "created_at": timestamp,
         "updated_at": timestamp,
     }
+    if _server_owned_document_id is not None:
+        document_id = str(_server_owned_document_id).strip()
+        scope_hash = document_id.removeprefix(
+            DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX
+        )
+        persisted_scope = str(
+            metadata_payload.get(DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD) or ""
+        ).strip()
+        if (
+            not document_id.startswith(DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX)
+            or len(scope_hash) != 64
+            or any(character not in "0123456789abcdef" for character in scope_hash)
+            or persisted_scope != scope_hash
+        ):
+            raise ValueError("Invalid server-owned direct-message document identity")
+        concept_doc["_id"] = document_id
 
     # Add optional subject
     if subject:
@@ -372,6 +586,156 @@ def get_message_for_delivery_fingerprint(
         "concept_data.metadata.delivery_fingerprint": delivery_fingerprint.strip(),
     }
     return coll.find_one(apply_concept_query_filter(base_filter))
+
+
+def get_message_for_delivery_idempotency_scope(
+    *,
+    sender_id: str,
+    idempotency_scope: str,
+) -> Optional[Dict[str, Any]]:
+    """Read the trusted sender's message through Mongo's built-in unique key."""
+
+    normalised_sender = _normalise_concept_id(sender_id)
+    scope = str(idempotency_scope or "").strip()
+    if normalised_sender is None or not scope:
+        return None
+    coll = get_concepts_collection()
+    if coll is None:
+        return None
+    base_filter: Dict[str, Any] = {
+        "_id": f"{DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX}{scope}",
+        "relationships.is_an_instance_of": MESSAGE_TYPE_CONCEPT_ID,
+        f"relationships.{PREDICATE_SENDER}": normalised_sender,
+    }
+    message = coll.find_one(apply_concept_query_filter(base_filter))
+    return message if isinstance(message, dict) else None
+
+
+def _require_matching_delivery_identity(
+    message: Dict[str, Any],
+    expected: DirectMessageDeliveryIdentity,
+) -> None:
+    concept_data = message.get("concept_data")
+    concept_data = concept_data if isinstance(concept_data, dict) else {}
+    metadata = concept_data.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    if (
+        metadata.get(DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD)
+        != expected.idempotency_scope
+        or metadata.get(DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD)
+        != expected.payload_fingerprint
+        or metadata.get(DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD)
+        != expected.delivery_fingerprint
+    ):
+        raise DirectMessageIdempotencyConflict(
+            "delivery_idempotency_key was already used for a different message payload"
+        )
+
+
+def create_message_idempotently(
+    *,
+    delivery_idempotency_key: str,
+    sender_id: str,
+    recipient_ids: List[str],
+    content: str,
+    organisation_concept_id: str,
+    subject: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    reply_to_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> DirectMessageCreateReceipt:
+    """Create once, or reconcile a concurrent/retried REST delivery request.
+
+    A deterministic, server-owned Mongo ``_id`` derived from the opaque sender
+    scope is the atomic claim. The pre-read is the fast replay path; built-in
+    ``_id`` uniqueness and ``DuplicateKeyError`` recovery make simultaneous
+    requests converge even when optional index bootstrap fails open.
+    """
+
+    normalised_recipients = normalise_message_recipient_ids(recipient_ids)
+    normalised_subject = _normalise_optional_message_text(
+        subject,
+        field_name="subject",
+    )
+    normalised_thread_id = _normalise_optional_message_text(
+        thread_id,
+        field_name="thread_id",
+    )
+    normalised_reply_to_id = _normalise_optional_message_text(
+        reply_to_id,
+        field_name="reply_to_id",
+    )
+    material_metadata = _material_delivery_metadata(metadata)
+    identity = build_direct_message_delivery_identity(
+        delivery_idempotency_key=delivery_idempotency_key,
+        sender_id=sender_id,
+        organisation_concept_id=organisation_concept_id,
+        recipient_ids=normalised_recipients,
+        content=content,
+        subject=normalised_subject,
+        thread_id=normalised_thread_id,
+        reply_to_id=normalised_reply_to_id,
+        metadata=material_metadata,
+    )
+
+    def find_prior() -> Optional[Dict[str, Any]]:
+        return get_message_for_delivery_idempotency_scope(
+            sender_id=sender_id,
+            idempotency_scope=identity.idempotency_scope,
+        )
+
+    prior_message = find_prior()
+    if isinstance(prior_message, dict):
+        _require_matching_delivery_identity(prior_message, identity)
+        return DirectMessageCreateReceipt(
+            message=prior_message,
+            reused=True,
+            delivery_identity=identity,
+        )
+
+    persistence_metadata = dict(material_metadata)
+    persistence_metadata.update(
+        {
+            "delivery_idempotency_schema_version": (
+                DIRECT_MESSAGE_IDEMPOTENCY_SCHEMA_VERSION
+            ),
+            DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD: identity.idempotency_scope,
+            DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD: identity.payload_fingerprint,
+            DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD: identity.delivery_fingerprint,
+            DIRECT_MESSAGE_IDEMPOTENCY_KEY_HASH_FIELD: identity.idempotency_key_hash,
+        }
+    )
+
+    try:
+        message = create_message(
+            sender_id=sender_id,
+            recipient_ids=normalised_recipients,
+            content=content.strip(),
+            subject=normalised_subject,
+            thread_id=normalised_thread_id,
+            reply_to_id=normalised_reply_to_id,
+            org_id=organisation_concept_id,
+            metadata=persistence_metadata,
+            _server_owned_document_id=identity.document_id,
+        )
+    except DuplicateKeyError as exc:
+        winner = find_prior()
+        if not isinstance(winner, dict):
+            raise RuntimeError(
+                "Direct-message idempotency race could not be reconciled"
+            ) from exc
+        _require_matching_delivery_identity(winner, identity)
+        return DirectMessageCreateReceipt(
+            message=winner,
+            reused=True,
+            delivery_identity=identity,
+        )
+
+    return DirectMessageCreateReceipt(
+        message=message,
+        reused=False,
+        delivery_identity=identity,
+    )
 
 
 def get_messages_for_user(

--- a/src/backend/services/workflow_capability_service.py
+++ b/src/backend/services/workflow_capability_service.py
@@ -440,9 +440,15 @@ def is_authoritative_workflow_concept_id(concept_id: str) -> bool:
     on unrelated concepts (e.g. task or episode-critique concepts produced by
     background workflows) must not invalidate the workflow routing index.
 
-    Fails open (returns True) when the registry cannot be resolved, so a lookup
-    failure degrades to the prior always-invalidate behaviour rather than
-    silently skipping a legitimate workflow update.
+    This check is used on every routing-relevant text write, including ordinary
+    ``hasDescription`` writes.  It must therefore never construct the shared
+    workflow registry on the caller's latency-sensitive path.  Prefer an
+    already-built registry, then use the same represented ``hasInitialStep``
+    criterion as workflow discovery for an exact concept lookup.
+
+    Fails open (returns True) when represented authority cannot be read, so a
+    lookup failure degrades to the prior always-invalidate behaviour rather
+    than silently skipping a legitimate workflow update.
     """
 
     cleaned = str(concept_id or "").strip()
@@ -450,14 +456,30 @@ def is_authoritative_workflow_concept_id(concept_id: str) -> bool:
         return False
     try:
         from ..workflows.durable.registry_factory import (
-            get_shared_workflow_registry_read_only,
+            get_cached_shared_workflow_registry_read_only,
         )
 
-        registry = get_shared_workflow_registry_read_only(defer_parity_work=True)
-        authoritative_ids = set(_authoritative_registry_workflow_ids(registry))
+        registry = get_cached_shared_workflow_registry_read_only()
+        if registry is not None and registry.has(cleaned):
+            return True
+
+        from ..db.repositories.concepts_repository import ConceptsRepository
+        from ..workflows.vontology_loader import WORKFLOW_GRAPH_PREDICATE_ALIASES
+
+        initial_step_query = [
+            {f"relationships.{predicate}": {"$exists": True}}
+            for predicate in WORKFLOW_GRAPH_PREDICATE_ALIASES["hasInitialStep"]
+        ]
+        represented_workflow = ConceptsRepository.find_one(
+            {
+                "concept_id": cleaned,
+                "$or": initial_step_query,
+            },
+            {"concept_id": 1},
+        )
     except Exception:
         return True
-    return cleaned in authoritative_ids
+    return represented_workflow is not None
 
 
 def _authoritative_registry_fingerprint_rows(

--- a/src/frontend/web/von_interface/static/js/components/messagePanel.js
+++ b/src/frontend/web/von_interface/static/js/components/messagePanel.js
@@ -6,6 +6,7 @@
  */
 
 import { getJson, postJson, postJsonDetailed } from '../apiService.js';
+import { getSessionScopedOrgId } from '../utils/sessionScopedStorage.js';
 import { hydrateConceptCartouchesInRoot } from '../utils/selectConceptByIdHandler.js';
 import { cartouchifyElementText } from '../utils/textDecorator.js';
 import { showToast } from '../utils/toast.js';
@@ -25,9 +26,19 @@ let _isLoading = false;
 let _unreadCount = 0;
 let _replySendFailureState = null;
 let _newMessageSendFailureState = null;
+let _replySendPending = false;
+let _newMessageSendPending = false;
+let _replyDeliveryAttempt = null;
+let _newMessageDeliveryAttempt = null;
+let _deliveryKeySequence = 0;
 
 const COMPOSE_SCOPE_REPLY = 'reply';
 const COMPOSE_SCOPE_NEW_MESSAGE = 'newMessage';
+const REPLY_DELIVERY_ATTEMPT_STORAGE_KEY = 'von_message_reply_delivery_attempt_v1';
+const REPLY_DELIVERY_ATTEMPT_SCHEMA_VERSION = 'direct_message_reply_delivery_attempt.v2';
+const NEW_MESSAGE_DELIVERY_ATTEMPT_STORAGE_KEY = 'von_message_new_delivery_attempt_v1';
+const NEW_MESSAGE_DELIVERY_ATTEMPT_SCHEMA_VERSION = 'direct_message_new_delivery_attempt.v2';
+const MESSAGE_THREAD_PREDICATE_ID = '#V#is_part_of_thread';
 
 const MESSAGE_PANEL_ICONS = Object.freeze({
     chat: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M21 12a8 8 0 0 1-8 8H7l-4 3v-6.2A7.8 7.8 0 0 1 5 4.8 8 8 0 0 1 13 4a8 8 0 0 1 8 8Z"/><path d="M8 10h8"/><path d="M8 14h5"/></svg>',
@@ -101,6 +112,9 @@ function resetMessagesViewportPosition() {
 function renderMessagesTabContent() {
     if (!_messagesContainer) return;
 
+    syncVisibleReplyDeliveryAttempt();
+    syncVisibleNewMessageDeliveryAttempt();
+
     _messagesContainer.innerHTML = `
         <div class="messages-layout">
             <div class="messages-sidebar">
@@ -143,7 +157,7 @@ function renderMessagesTabContent() {
                     </div>
                     <div class="message-compose-row">
                         <textarea id="messageInput" class="message-input" placeholder="Type your message..." rows="3"></textarea>
-                        <button id="sendMessageBtn" class="send-message-btn">Send</button>
+                        <button id="sendMessageBtn" class="send-message-btn" type="button" aria-busy="false">Send</button>
                     </div>
                 </div>
             </div>
@@ -172,7 +186,7 @@ function renderMessagesTabContent() {
                 </div>
                 <div class="message-modal-footer">
                     <button id="cancelNewMessage" class="modal-cancel-btn">Cancel</button>
-                    <button id="sendNewMessage" class="modal-send-btn">Send</button>
+                    <button id="sendNewMessage" class="modal-send-btn" type="button" aria-busy="false">Send</button>
                 </div>
             </div>
         </div>
@@ -183,6 +197,9 @@ function renderMessagesTabContent() {
 
     // Attach event listeners
     attachMessagesEventListeners();
+    restoreNewMessageDeliveryAttemptForCurrentScope();
+    renderComposePendingUi(COMPOSE_SCOPE_REPLY);
+    renderComposePendingUi(COMPOSE_SCOPE_NEW_MESSAGE);
 }
 
 /**
@@ -222,24 +239,26 @@ function attachMessagesEventListeners() {
                 handleSendReply();
             }
         });
+        msgInput.addEventListener('input', syncVisibleReplyDeliveryAttempt);
     }
 
     const replyRecoverySelect = _messagesContainer.querySelector('#messageComposeRecoverySelect');
     if (replyRecoverySelect) {
         replyRecoverySelect.addEventListener('change', (event) => {
             updateComposeRecoverySelection(COMPOSE_SCOPE_REPLY, event.target?.value || '');
+            syncVisibleReplyDeliveryAttempt();
         });
     }
 
     // New message modal
     const closeModalBtn = _messagesContainer.querySelector('#closeNewMessageModal');
     if (closeModalBtn) {
-        closeModalBtn.addEventListener('click', hideNewMessageModal);
+        closeModalBtn.addEventListener('click', () => hideNewMessageModal());
     }
 
     const cancelBtn = _messagesContainer.querySelector('#cancelNewMessage');
     if (cancelBtn) {
-        cancelBtn.addEventListener('click', hideNewMessageModal);
+        cancelBtn.addEventListener('click', () => hideNewMessageModal());
     }
 
     const sendNewBtn = _messagesContainer.querySelector('#sendNewMessage');
@@ -251,6 +270,7 @@ function attachMessagesEventListeners() {
     if (newMessageRecoverySelect) {
         newMessageRecoverySelect.addEventListener('change', (event) => {
             updateComposeRecoverySelection(COMPOSE_SCOPE_NEW_MESSAGE, event.target?.value || '');
+            syncVisibleNewMessageDeliveryAttempt();
         });
     }
 
@@ -258,7 +278,13 @@ function attachMessagesEventListeners() {
     if (recipientInput) {
         recipientInput.addEventListener('input', () => {
             resetComposeFailureUi(COMPOSE_SCOPE_NEW_MESSAGE);
+            syncVisibleNewMessageDeliveryAttempt();
         });
+    }
+
+    const newMessageContent = _messagesContainer.querySelector('#newMessageContent');
+    if (newMessageContent) {
+        newMessageContent.addEventListener('input', syncVisibleNewMessageDeliveryAttempt);
     }
 }
 
@@ -280,7 +306,8 @@ async function loadMessageThreads() {
         const response = await getJson('/api/messages/threads?limit=20');
         _threads = response.threads || [];
         renderThreadList();
-        autoOpenUserId = resolveAutoOpenThreadUserId();
+        autoOpenUserId = resolveStoredReplyAttemptAutoOpenUserId()
+            || resolveAutoOpenThreadUserId();
 
     } catch (err) {
         console.error('[messagePanel] Failed to load threads:', err);
@@ -397,6 +424,21 @@ function renderThreadList() {
  * Select a conversation to view.
  */
 async function selectConversation(userId) {
+    const renderedSelection = _messagesContainer?.querySelector(
+        '.message-thread-item.selected',
+    );
+    if (renderedSelection) {
+        syncVisibleReplyDeliveryAttempt();
+    }
+    const replyInput = _messagesContainer?.querySelector('#messageInput');
+    if (replyInput) {
+        replyInput.value = '';
+    }
+    // Detach the in-memory attempt while changing scope without deleting the
+    // session record. A matching recipient can bind it again after actor/thread
+    // context has been read from the server.
+    _replyDeliveryAttempt = null;
+    _currentMessages = [];
     _currentConversationUserId = userId;
     resetComposeFailureUi(COMPOSE_SCOPE_REPLY);
 
@@ -439,6 +481,7 @@ async function loadConversation(userId) {
         _currentMessages = response.messages || [];
         _currentUserId = response.current_user_id || null;
         await renderMessages();
+        restoreReplyDeliveryAttemptForCurrentScope();
 
         // Mark messages as read
         const unreadIds = _currentMessages
@@ -795,6 +838,51 @@ async function renderMessages() {
     contentEl.scrollTop = contentEl.scrollHeight;
 }
 
+function isComposePending(scope) {
+    if (scope === COMPOSE_SCOPE_REPLY) {
+        return _replySendPending;
+    }
+    if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        return _newMessageSendPending;
+    }
+    return false;
+}
+
+function renderComposePendingUi(scope) {
+    if (!_messagesContainer) return;
+
+    const button = scope === COMPOSE_SCOPE_REPLY
+        ? _messagesContainer.querySelector('#sendMessageBtn')
+        : _messagesContainer.querySelector('#sendNewMessage');
+    if (!button) return;
+
+    const pending = isComposePending(scope);
+    button.disabled = pending;
+    button.textContent = pending ? 'Sending…' : 'Send';
+    button.setAttribute('aria-busy', pending ? 'true' : 'false');
+
+    if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        const recipientInput = _messagesContainer.querySelector('#newMessageRecipient');
+        const contentInput = _messagesContainer.querySelector('#newMessageContent');
+        const closeButton = _messagesContainer.querySelector('#closeNewMessageModal');
+        const cancelButton = _messagesContainer.querySelector('#cancelNewMessage');
+        if (recipientInput) recipientInput.disabled = pending;
+        if (contentInput) contentInput.disabled = pending;
+        if (closeButton) closeButton.disabled = pending;
+        if (cancelButton) cancelButton.disabled = pending;
+    }
+}
+
+function setComposePending(scope, pending) {
+    const nextPending = Boolean(pending);
+    if (scope === COMPOSE_SCOPE_REPLY) {
+        _replySendPending = nextPending;
+    } else if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        _newMessageSendPending = nextPending;
+    }
+    renderComposePendingUi(scope);
+}
+
 function getComposeFailureState(scope) {
     if (scope === COMPOSE_SCOPE_REPLY) {
         return _replySendFailureState;
@@ -803,6 +891,644 @@ function getComposeFailureState(scope) {
         return _newMessageSendFailureState;
     }
     return null;
+}
+
+function getDeliveryAttempt(scope) {
+    if (scope === COMPOSE_SCOPE_REPLY) {
+        return _replyDeliveryAttempt;
+    }
+    if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        return _newMessageDeliveryAttempt;
+    }
+    return null;
+}
+
+function setDeliveryAttempt(scope, attempt) {
+    if (scope === COMPOSE_SCOPE_REPLY) {
+        _replyDeliveryAttempt = attempt;
+        if (attempt) {
+            persistReplyDeliveryAttempt(attempt);
+        } else {
+            clearPersistedReplyDeliveryAttempt();
+        }
+    } else if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        _newMessageDeliveryAttempt = attempt;
+        if (attempt) {
+            persistNewMessageDeliveryAttempt(attempt);
+        } else {
+            clearPersistedNewMessageDeliveryAttempt();
+        }
+    }
+}
+
+function normaliseDeliveryConceptId(value) {
+    const cleaned = String(value || '').trim();
+    if (!cleaned) return '';
+    return cleaned.startsWith('#V#') ? cleaned : `#V#${cleaned}`;
+}
+
+function createDeliveryIdempotencyKey() {
+    try {
+        if (typeof globalThis.crypto?.randomUUID === 'function') {
+            return globalThis.crypto.randomUUID();
+        }
+    } catch (_) {
+        // Fall back to a process-local, time-based key in older browser shells.
+    }
+
+    _deliveryKeySequence += 1;
+    const randomPart = Math.random().toString(36).slice(2, 12);
+    return `dm-${Date.now().toString(36)}-${_deliveryKeySequence.toString(36)}-${randomPart}`;
+}
+
+function resolveDeliveryOrganisationId(explicitOrganisationConceptId) {
+    return normaliseDeliveryConceptId(
+        explicitOrganisationConceptId || getSessionScopedOrgId() || '',
+    );
+}
+
+function readSessionActorConceptId() {
+    try {
+        const raw = sessionStorage.getItem('von_current_user');
+        if (!raw) return '';
+        let storedUser = raw;
+        try {
+            storedUser = JSON.parse(raw);
+        } catch (_) {
+            // Legacy storage may contain the concept ID directly.
+        }
+        if (typeof storedUser === 'string') {
+            return normaliseDeliveryConceptId(storedUser);
+        }
+        return normaliseDeliveryConceptId(
+            storedUser?.concept_id || storedUser?.id || '',
+        );
+    } catch (_) {
+        return '';
+    }
+}
+
+function resolveCurrentReplyActorId() {
+    return normaliseDeliveryConceptId(_currentUserId || readSessionActorConceptId());
+}
+
+function resolveCurrentReplyThreadId() {
+    const threadIds = new Set();
+    _currentMessages.forEach((message) => {
+        const values = message?.relationships?.[MESSAGE_THREAD_PREDICATE_ID];
+        if (!Array.isArray(values)) return;
+        values.forEach((value) => {
+            const conceptId = normaliseDeliveryConceptId(value);
+            if (conceptId) threadIds.add(conceptId);
+        });
+    });
+    return threadIds.size === 1 ? Array.from(threadIds)[0] : '';
+}
+
+function buildDeliveryScope({
+    recipientIds,
+    organisationConceptId,
+    actorUserId,
+    threadId,
+}) {
+    const normalisedRecipients = recipientIds
+        .map(normaliseDeliveryConceptId)
+        .filter(Boolean)
+        .sort((left, right) => left.localeCompare(right));
+    return {
+        actor_user_id: normaliseDeliveryConceptId(
+            actorUserId || resolveCurrentReplyActorId(),
+        ),
+        organisation_concept_id: resolveDeliveryOrganisationId(organisationConceptId),
+        recipient_ids: normalisedRecipients,
+        thread_id: normaliseDeliveryConceptId(threadId || ''),
+    };
+}
+
+function buildDeliveryFingerprintFromScope(deliveryScope, content) {
+    return JSON.stringify({
+        scope: deliveryScope,
+        content: String(content || '').trim(),
+    });
+}
+
+function deliveryScopesMatch(left, right) {
+    return JSON.stringify(left || null) === JSON.stringify(right || null);
+}
+
+function buildCurrentComposeSessionScope() {
+    return {
+        actor_user_id: readSessionActorConceptId(),
+        organisation_concept_id: resolveDeliveryOrganisationId(''),
+    };
+}
+
+function composeSessionScopesEqual(left, right) {
+    return JSON.stringify(left || null) === JSON.stringify(right || null);
+}
+
+function isBoundComposeSessionScope(scope) {
+    return Boolean(
+        scope?.actor_user_id
+        && scope?.organisation_concept_id
+    );
+}
+
+function clearPersistedReplyDeliveryAttempt() {
+    try {
+        sessionStorage.removeItem(REPLY_DELIVERY_ATTEMPT_STORAGE_KEY);
+    } catch (_) {
+        // Storage can be unavailable in restricted browser contexts.
+    }
+}
+
+function persistReplyDeliveryAttempt(attempt) {
+    if (
+        !attempt?.key
+        || !attempt?.fingerprint
+        || !String(attempt?.draft || '').trim()
+        || !isBoundComposeSessionScope(attempt?.sessionScope)
+    ) {
+        clearPersistedReplyDeliveryAttempt();
+        return;
+    }
+    try {
+        sessionStorage.setItem(REPLY_DELIVERY_ATTEMPT_STORAGE_KEY, JSON.stringify({
+            schema_version: REPLY_DELIVERY_ATTEMPT_SCHEMA_VERSION,
+            key: attempt.key,
+            fingerprint: attempt.fingerprint,
+            draft: attempt.draft,
+            scope: attempt.scope,
+            session_scope: attempt.sessionScope,
+            recovery_state: attempt.recoveryState || null,
+        }));
+    } catch (_) {
+        // The in-memory attempt still protects the current rendered tab.
+    }
+}
+
+function readPersistedReplyDeliveryAttempt() {
+    let stored;
+    try {
+        stored = JSON.parse(
+            sessionStorage.getItem(REPLY_DELIVERY_ATTEMPT_STORAGE_KEY) || 'null',
+        );
+    } catch (_) {
+        clearPersistedReplyDeliveryAttempt();
+        return null;
+    }
+
+    const draft = typeof stored?.draft === 'string' ? stored.draft : '';
+    const key = typeof stored?.key === 'string' ? stored.key.trim() : '';
+    const fingerprint = typeof stored?.fingerprint === 'string'
+        ? stored.fingerprint
+        : '';
+    const scope = stored?.scope;
+    const recipientIds = Array.isArray(scope?.recipient_ids)
+        ? scope.recipient_ids.map(normaliseDeliveryConceptId).filter(Boolean)
+        : [];
+    const normalisedScope = {
+        actor_user_id: normaliseDeliveryConceptId(scope?.actor_user_id || ''),
+        organisation_concept_id: normaliseDeliveryConceptId(
+            scope?.organisation_concept_id || '',
+        ),
+        recipient_ids: recipientIds.sort((left, right) => left.localeCompare(right)),
+        thread_id: normaliseDeliveryConceptId(scope?.thread_id || ''),
+    };
+    const expectedFingerprint = buildDeliveryFingerprintFromScope(normalisedScope, draft);
+    const rawSessionScope = stored?.session_scope;
+    const sessionScope = {
+        actor_user_id: normaliseDeliveryConceptId(rawSessionScope?.actor_user_id || ''),
+        organisation_concept_id: normaliseDeliveryConceptId(
+            rawSessionScope?.organisation_concept_id || '',
+        ),
+    };
+    const recoveryState = normaliseComposeFailureState(stored?.recovery_state);
+    const requiresExplicitRecoveryOrganisation = Boolean(
+        normalisedScope.organisation_concept_id
+        && normalisedScope.organisation_concept_id
+            !== sessionScope.organisation_concept_id
+    );
+
+    if (
+        stored?.schema_version !== REPLY_DELIVERY_ATTEMPT_SCHEMA_VERSION
+        || !key
+        || !draft.trim()
+        || !normalisedScope.actor_user_id
+        || normalisedScope.recipient_ids.length === 0
+        || !isBoundComposeSessionScope(sessionScope)
+        || (
+            requiresExplicitRecoveryOrganisation
+            && recoveryState?.selectedOrganisationConceptId
+                !== normalisedScope.organisation_concept_id
+        )
+        || fingerprint !== expectedFingerprint
+    ) {
+        clearPersistedReplyDeliveryAttempt();
+        return null;
+    }
+
+    return {
+        key,
+        fingerprint,
+        draft,
+        scope: normalisedScope,
+        sessionScope,
+        recoveryState,
+    };
+}
+
+function clearPersistedNewMessageDeliveryAttempt() {
+    try {
+        sessionStorage.removeItem(NEW_MESSAGE_DELIVERY_ATTEMPT_STORAGE_KEY);
+    } catch (_) {
+        // Storage can be unavailable in restricted browser contexts.
+    }
+}
+
+function persistNewMessageDeliveryAttempt(attempt) {
+    const recipient = typeof attempt?.recipient === 'string' ? attempt.recipient : '';
+    const draft = typeof attempt?.draft === 'string' ? attempt.draft : '';
+    const sessionScope = attempt?.sessionScope;
+    if (
+        !attempt?.key
+        || !attempt?.fingerprint
+        || !recipient.trim()
+        || !draft.trim()
+        || !sessionScope?.actor_user_id
+        || !sessionScope?.organisation_concept_id
+    ) {
+        clearPersistedNewMessageDeliveryAttempt();
+        return;
+    }
+
+    try {
+        sessionStorage.setItem(NEW_MESSAGE_DELIVERY_ATTEMPT_STORAGE_KEY, JSON.stringify({
+            schema_version: NEW_MESSAGE_DELIVERY_ATTEMPT_SCHEMA_VERSION,
+            key: attempt.key,
+            fingerprint: attempt.fingerprint,
+            recipient,
+            draft,
+            scope: sessionScope,
+            delivery_scope: attempt.scope,
+            recovery_state: attempt.recoveryState || null,
+        }));
+    } catch (_) {
+        // The in-memory attempt still protects the current rendered tab.
+    }
+}
+
+function readPersistedNewMessageDeliveryAttempt() {
+    let stored;
+    try {
+        stored = JSON.parse(
+            sessionStorage.getItem(NEW_MESSAGE_DELIVERY_ATTEMPT_STORAGE_KEY) || 'null',
+        );
+    } catch (_) {
+        clearPersistedNewMessageDeliveryAttempt();
+        return null;
+    }
+
+    const recipient = typeof stored?.recipient === 'string' ? stored.recipient : '';
+    const draft = typeof stored?.draft === 'string' ? stored.draft : '';
+    const key = typeof stored?.key === 'string' ? stored.key.trim() : '';
+    const fingerprint = typeof stored?.fingerprint === 'string'
+        ? stored.fingerprint
+        : '';
+    const sessionScope = {
+        actor_user_id: normaliseDeliveryConceptId(stored?.scope?.actor_user_id || ''),
+        organisation_concept_id: normaliseDeliveryConceptId(
+            stored?.scope?.organisation_concept_id || '',
+        ),
+    };
+    const rawDeliveryScope = stored?.delivery_scope;
+    const recipientIds = Array.isArray(rawDeliveryScope?.recipient_ids)
+        ? rawDeliveryScope.recipient_ids
+            .map(normaliseDeliveryConceptId)
+            .filter(Boolean)
+            .sort((left, right) => left.localeCompare(right))
+        : [];
+    const deliveryScope = {
+        actor_user_id: normaliseDeliveryConceptId(rawDeliveryScope?.actor_user_id || ''),
+        organisation_concept_id: normaliseDeliveryConceptId(
+            rawDeliveryScope?.organisation_concept_id || '',
+        ),
+        recipient_ids: recipientIds,
+        thread_id: normaliseDeliveryConceptId(rawDeliveryScope?.thread_id || ''),
+    };
+    const expectedFingerprint = buildDeliveryFingerprintFromScope(deliveryScope, draft);
+    const recoveryState = normaliseComposeFailureState(stored?.recovery_state);
+    const requiresExplicitRecoveryOrganisation = Boolean(
+        deliveryScope.organisation_concept_id
+        && deliveryScope.organisation_concept_id
+            !== sessionScope.organisation_concept_id
+    );
+
+    if (
+        stored?.schema_version !== NEW_MESSAGE_DELIVERY_ATTEMPT_SCHEMA_VERSION
+        || !key
+        || !recipient.trim()
+        || !draft.trim()
+        || !sessionScope.actor_user_id
+        || !sessionScope.organisation_concept_id
+        || deliveryScope.recipient_ids.length !== 1
+        || (
+            requiresExplicitRecoveryOrganisation
+            && recoveryState?.selectedOrganisationConceptId
+                !== deliveryScope.organisation_concept_id
+        )
+        || normaliseDeliveryConceptId(recipient) !== deliveryScope.recipient_ids[0]
+        || fingerprint !== expectedFingerprint
+    ) {
+        clearPersistedNewMessageDeliveryAttempt();
+        return null;
+    }
+
+    return {
+        key,
+        fingerprint,
+        recipient,
+        draft,
+        scope: deliveryScope,
+        sessionScope,
+        recoveryState,
+    };
+}
+
+function buildCurrentReplyDeliveryScope(organisationConceptId) {
+    if (!_currentConversationUserId) return null;
+    const selectedOrganisationConceptId = organisationConceptId === undefined
+        ? getSelectedRecoveryOrganisationConceptId(COMPOSE_SCOPE_REPLY)
+        : organisationConceptId;
+    return buildDeliveryScope({
+        recipientIds: [_currentConversationUserId],
+        organisationConceptId: selectedOrganisationConceptId,
+        actorUserId: _currentUserId,
+        threadId: resolveCurrentReplyThreadId(),
+    });
+}
+
+function replaceVisibleDeliveryAttempt(scope, {
+    deliveryScope,
+    draft,
+    recipient = '',
+    sessionScope,
+}) {
+    const fingerprint = buildDeliveryFingerprintFromScope(deliveryScope, draft);
+    setDeliveryAttempt(scope, {
+        fingerprint,
+        key: createDeliveryIdempotencyKey(),
+        draft,
+        scope: deliveryScope,
+        sessionScope,
+        recoveryState: getPersistableComposeRecoveryState(scope),
+        ...(scope === COMPOSE_SCOPE_NEW_MESSAGE ? { recipient } : {}),
+    });
+}
+
+function syncVisibleReplyDeliveryAttempt() {
+    const replyInput = _messagesContainer?.querySelector('#messageInput');
+    if (!replyInput) return;
+
+    const draft = replyInput.value;
+    const currentAttempt = getDeliveryAttempt(COMPOSE_SCOPE_REPLY);
+    if (!currentAttempt) {
+        // A newly typed visible draft supersedes any off-screen attempt from a
+        // different conversation. Do not retain its invisible key.
+        if (draft.trim()) {
+            clearPersistedReplyDeliveryAttempt();
+        }
+        return;
+    }
+
+    if (!draft.trim()) {
+        setDeliveryAttempt(COMPOSE_SCOPE_REPLY, null);
+        return;
+    }
+
+    const deliveryScope = buildCurrentReplyDeliveryScope();
+    const fingerprint = deliveryScope
+        ? buildDeliveryFingerprintFromScope(deliveryScope, draft)
+        : '';
+    const sessionScope = buildCurrentComposeSessionScope();
+    if (!composeSessionScopesEqual(sessionScope, currentAttempt.sessionScope)) {
+        setDeliveryAttempt(COMPOSE_SCOPE_REPLY, null);
+        return;
+    }
+    if (
+        !deliveryScope
+        || fingerprint !== currentAttempt.fingerprint
+        || !deliveryScopesMatch(deliveryScope, currentAttempt.scope)
+    ) {
+        if (!deliveryScope) {
+            setDeliveryAttempt(COMPOSE_SCOPE_REPLY, null);
+            return;
+        }
+        replaceVisibleDeliveryAttempt(COMPOSE_SCOPE_REPLY, {
+            deliveryScope,
+            draft,
+            sessionScope,
+        });
+        return;
+    }
+
+    setDeliveryAttempt(COMPOSE_SCOPE_REPLY, {
+        ...currentAttempt,
+        draft,
+        scope: deliveryScope,
+        sessionScope,
+        recoveryState: getPersistableComposeRecoveryState(COMPOSE_SCOPE_REPLY),
+    });
+}
+
+function syncVisibleNewMessageDeliveryAttempt() {
+    const recipientInput = _messagesContainer?.querySelector('#newMessageRecipient');
+    const contentInput = _messagesContainer?.querySelector('#newMessageContent');
+    if (!recipientInput || !contentInput) return;
+
+    const recipient = recipientInput.value;
+    const draft = contentInput.value;
+    const currentAttempt = getDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE);
+    if (!currentAttempt) {
+        if (recipient.trim() || draft.trim()) {
+            clearPersistedNewMessageDeliveryAttempt();
+        }
+        return;
+    }
+
+    if (!recipient.trim() || !draft.trim()) {
+        setDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, null);
+        return;
+    }
+
+    const failureState = getComposeFailureState(COMPOSE_SCOPE_NEW_MESSAGE);
+    const selectedOrganisationConceptId = String(
+        failureState?.selectedOrganisationConceptId || '',
+    ).trim();
+    const deliveryScope = buildDeliveryScope({
+        recipientIds: [recipient],
+        organisationConceptId: selectedOrganisationConceptId,
+    });
+    const fingerprint = buildDeliveryFingerprintFromScope(deliveryScope, draft);
+    const sessionScope = buildCurrentComposeSessionScope();
+    if (!composeSessionScopesEqual(sessionScope, currentAttempt.sessionScope)) {
+        setDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, null);
+        return;
+    }
+    if (
+        fingerprint !== currentAttempt.fingerprint
+        || !deliveryScopesMatch(deliveryScope, currentAttempt.scope)
+    ) {
+        replaceVisibleDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, {
+            deliveryScope,
+            recipient,
+            draft,
+            sessionScope,
+        });
+        return;
+    }
+
+    setDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, {
+        ...currentAttempt,
+        recipient,
+        draft,
+        scope: deliveryScope,
+        sessionScope,
+        recoveryState: getPersistableComposeRecoveryState(COMPOSE_SCOPE_NEW_MESSAGE),
+    });
+}
+
+function restoreNewMessageDeliveryAttemptForCurrentScope() {
+    const persistedAttempt = readPersistedNewMessageDeliveryAttempt();
+    const sessionScope = buildCurrentComposeSessionScope();
+    if (
+        !persistedAttempt
+        || !isBoundComposeSessionScope(sessionScope)
+        || !composeSessionScopesEqual(persistedAttempt.sessionScope, sessionScope)
+    ) {
+        _newMessageDeliveryAttempt = null;
+        return false;
+    }
+
+    const modal = _messagesContainer?.querySelector('#newMessageModal');
+    const recipientInput = modal?.querySelector('#newMessageRecipient');
+    const contentInput = modal?.querySelector('#newMessageContent');
+    if (!modal || !recipientInput || !contentInput) {
+        _newMessageDeliveryAttempt = null;
+        return false;
+    }
+
+    _newMessageDeliveryAttempt = persistedAttempt;
+    recipientInput.value = persistedAttempt.recipient;
+    contentInput.value = persistedAttempt.draft;
+    modal.classList.remove('hidden');
+    setComposeFailureState(COMPOSE_SCOPE_NEW_MESSAGE, persistedAttempt.recoveryState);
+    return true;
+}
+
+function restoreReplyDeliveryAttemptForCurrentScope() {
+    const replyInput = _messagesContainer?.querySelector('#messageInput');
+    if (!replyInput) return false;
+
+    const persistedAttempt = readPersistedReplyDeliveryAttempt();
+    const sessionScope = buildCurrentComposeSessionScope();
+    const deliveryScope = persistedAttempt
+        ? buildCurrentReplyDeliveryScope(
+            persistedAttempt.scope.organisation_concept_id,
+        )
+        : null;
+    if (
+        !persistedAttempt
+        || !isBoundComposeSessionScope(sessionScope)
+        || !composeSessionScopesEqual(persistedAttempt.sessionScope, sessionScope)
+        || !deliveryScope
+        || !deliveryScopesMatch(persistedAttempt.scope, deliveryScope)
+        || persistedAttempt.fingerprint
+            !== buildDeliveryFingerprintFromScope(deliveryScope, persistedAttempt.draft)
+    ) {
+        _replyDeliveryAttempt = null;
+        return false;
+    }
+
+    _replyDeliveryAttempt = persistedAttempt;
+    replyInput.value = persistedAttempt.draft;
+    setComposeFailureState(COMPOSE_SCOPE_REPLY, persistedAttempt.recoveryState);
+    return true;
+}
+
+function resolveStoredReplyAttemptAutoOpenUserId() {
+    const persistedAttempt = readPersistedReplyDeliveryAttempt();
+    if (!persistedAttempt) return null;
+
+    const sessionScope = buildCurrentComposeSessionScope();
+    if (
+        !isBoundComposeSessionScope(sessionScope)
+        || !composeSessionScopesEqual(persistedAttempt.sessionScope, sessionScope)
+        || persistedAttempt.scope.recipient_ids.length !== 1
+    ) {
+        return null;
+    }
+
+    const recipientId = persistedAttempt.scope.recipient_ids[0];
+    const matchingThread = _threads.some(
+        (thread) => normaliseDeliveryConceptId(getThreadUserId(thread)) === recipientId,
+    );
+    return matchingThread ? recipientId : null;
+}
+
+function getOrCreateDeliveryIdempotencyKey({
+    scope,
+    recipientIds,
+    content,
+    visibleDraft,
+    visibleRecipient,
+    organisationConceptId,
+    actorUserId,
+    threadId,
+}) {
+    const deliveryScope = buildDeliveryScope({
+        recipientIds,
+        organisationConceptId,
+        actorUserId,
+        threadId,
+    });
+    const fingerprint = buildDeliveryFingerprintFromScope(deliveryScope, content);
+    const draft = String(visibleDraft ?? content ?? '');
+    const recipient = String(visibleRecipient ?? recipientIds[0] ?? '');
+    const sessionScope = buildCurrentComposeSessionScope();
+    const recoveryState = getPersistableComposeRecoveryState(scope);
+    const currentAttempt = getDeliveryAttempt(scope);
+    const sameSessionScope = composeSessionScopesEqual(
+        sessionScope,
+        currentAttempt?.sessionScope,
+    );
+    if (
+        currentAttempt?.fingerprint === fingerprint
+        && currentAttempt?.key
+        && sameSessionScope
+    ) {
+        setDeliveryAttempt(scope, {
+            ...currentAttempt,
+            draft,
+            sessionScope,
+            recoveryState,
+            ...(scope === COMPOSE_SCOPE_NEW_MESSAGE ? { recipient } : {}),
+            scope: deliveryScope,
+        });
+        return currentAttempt.key;
+    }
+
+    const key = createDeliveryIdempotencyKey();
+    setDeliveryAttempt(scope, {
+        fingerprint,
+        key,
+        draft,
+        sessionScope,
+        recoveryState,
+        ...(scope === COMPOSE_SCOPE_NEW_MESSAGE ? { recipient } : {}),
+        scope: deliveryScope,
+    });
+    return key;
 }
 
 function getComposeUiElements(scope) {
@@ -836,7 +1562,9 @@ function normaliseRecoveryOrganisationOption(option) {
         return null;
     }
 
-    const conceptId = String(option.concept_id || option.conceptId || '').trim();
+    const conceptId = normaliseDeliveryConceptId(
+        option.concept_id || option.conceptId || '',
+    );
     if (!conceptId) {
         return null;
     }
@@ -869,6 +1597,83 @@ function buildMessageSendFailureState(err) {
             ? organisationOptions[0].conceptId
             : '',
     };
+}
+
+function normaliseComposeFailureState(nextState) {
+    if (!nextState || typeof nextState !== 'object') {
+        return null;
+    }
+
+    const organisationOptions = Array.isArray(nextState.organisationOptions)
+        ? nextState.organisationOptions
+            .map(normaliseRecoveryOrganisationOption)
+            .filter(Boolean)
+        : [];
+    const selectedOrganisationConceptId = normaliseDeliveryConceptId(
+        nextState.selectedOrganisationConceptId || '',
+    );
+    const knownOrganisationIds = new Set(
+        organisationOptions.map((option) => option.conceptId),
+    );
+
+    return {
+        errorMessage: String(nextState.errorMessage || '').trim() || 'Failed to send message',
+        organisationOptions,
+        selectedOrganisationConceptId: organisationOptions.length === 1
+            ? organisationOptions[0].conceptId
+            : (knownOrganisationIds.has(selectedOrganisationConceptId)
+                ? selectedOrganisationConceptId
+                : ''),
+    };
+}
+
+function getPersistableComposeRecoveryState(scope) {
+    const failureState = normaliseComposeFailureState(getComposeFailureState(scope));
+    if (
+        !failureState?.selectedOrganisationConceptId
+        || failureState.organisationOptions.length === 0
+    ) {
+        return null;
+    }
+    return failureState;
+}
+
+function getSelectedRecoveryOrganisationConceptId(scope) {
+    return normaliseDeliveryConceptId(
+        getComposeFailureState(scope)?.selectedOrganisationConceptId || '',
+    );
+}
+
+function buildMessageSendFailureStatePreservingRecovery(scope, err) {
+    const nextState = buildMessageSendFailureState(err);
+    if (nextState.organisationOptions.length > 0) {
+        return nextState;
+    }
+
+    const retainedRecoveryState = getPersistableComposeRecoveryState(scope)
+        || normaliseComposeFailureState(getDeliveryAttempt(scope)?.recoveryState);
+    if (!retainedRecoveryState?.selectedOrganisationConceptId) {
+        return nextState;
+    }
+
+    return {
+        ...nextState,
+        organisationOptions: retainedRecoveryState.organisationOptions,
+        selectedOrganisationConceptId:
+            retainedRecoveryState.selectedOrganisationConceptId,
+    };
+}
+
+function recordComposeSendFailure(scope, err) {
+    setComposeFailureState(
+        scope,
+        buildMessageSendFailureStatePreservingRecovery(scope, err),
+    );
+    if (scope === COMPOSE_SCOPE_REPLY) {
+        syncVisibleReplyDeliveryAttempt();
+    } else if (scope === COMPOSE_SCOPE_NEW_MESSAGE) {
+        syncVisibleNewMessageDeliveryAttempt();
+    }
 }
 
 function renderComposeFailureUi(scope) {
@@ -939,25 +1744,7 @@ function renderComposeFailureUi(scope) {
 }
 
 function setComposeFailureState(scope, nextState) {
-    let normalisedState = null;
-
-    if (nextState && typeof nextState === 'object') {
-        const organisationOptions = Array.isArray(nextState.organisationOptions)
-            ? nextState.organisationOptions.filter(Boolean)
-            : [];
-        const selectedOrganisationConceptId = String(nextState.selectedOrganisationConceptId || '').trim();
-        const knownOrganisationIds = new Set(
-            organisationOptions.map((option) => String(option.conceptId || '').trim()).filter(Boolean),
-        );
-
-        normalisedState = {
-            errorMessage: String(nextState.errorMessage || '').trim() || 'Failed to send message',
-            organisationOptions,
-            selectedOrganisationConceptId: organisationOptions.length === 1
-                ? organisationOptions[0].conceptId
-                : (knownOrganisationIds.has(selectedOrganisationConceptId) ? selectedOrganisationConceptId : ''),
-        };
-    }
+    const normalisedState = normaliseComposeFailureState(nextState);
 
     if (scope === COMPOSE_SCOPE_REPLY) {
         _replySendFailureState = normalisedState;
@@ -984,7 +1771,14 @@ function updateComposeRecoverySelection(scope, organisationConceptId) {
     });
 }
 
-function buildSendPayload({ scope, recipientIds, content }) {
+function buildSendPayload({
+    scope,
+    recipientIds,
+    content,
+    visibleDraft = content,
+    visibleRecipient,
+    threadId = '',
+}) {
     const failureState = getComposeFailureState(scope);
     const organisationOptions = Array.isArray(failureState?.organisationOptions)
         ? failureState.organisationOptions
@@ -1002,9 +1796,20 @@ function buildSendPayload({ scope, recipientIds, content }) {
         return null;
     }
 
+    const deliveryIdempotencyKey = getOrCreateDeliveryIdempotencyKey({
+        scope,
+        recipientIds,
+        content,
+        visibleDraft,
+        visibleRecipient,
+        organisationConceptId: selectedOrganisationConceptId,
+        threadId,
+    });
+
     return {
         recipient_ids: recipientIds,
         content,
+        delivery_idempotency_key: deliveryIdempotencyKey,
         ...(selectedOrganisationConceptId
             ? { organisation_concept_id: selectedOrganisationConceptId }
             : {}),
@@ -1015,6 +1820,10 @@ function buildSendPayload({ scope, recipientIds, content }) {
  * Handle sending a reply in the current conversation.
  */
 async function handleSendReply() {
+    if (isComposePending(COMPOSE_SCOPE_REPLY)) {
+        return;
+    }
+
     if (!_currentConversationUserId) {
         showToast('No conversation selected', 'warning');
         return;
@@ -1023,7 +1832,8 @@ async function handleSendReply() {
     const msgInput = _messagesContainer?.querySelector('#messageInput');
     if (!msgInput) return;
 
-    const content = msgInput.value.trim();
+    const visibleDraft = msgInput.value;
+    const content = visibleDraft.trim();
     if (!content) {
         showToast('Please enter a message', 'warning');
         return;
@@ -1033,16 +1843,27 @@ async function handleSendReply() {
         scope: COMPOSE_SCOPE_REPLY,
         recipientIds: [_currentConversationUserId],
         content,
+        visibleDraft,
+        threadId: resolveCurrentReplyThreadId(),
     });
     if (!payload) {
         return;
     }
 
+    const submittedConversationUserId = _currentConversationUserId;
+    setComposePending(COMPOSE_SCOPE_REPLY, true);
     try {
         await postJsonDetailed('/api/messages/', payload);
 
         resetComposeFailureUi(COMPOSE_SCOPE_REPLY);
-        msgInput.value = '';
+        setDeliveryAttempt(COMPOSE_SCOPE_REPLY, null);
+        const activeReplyInput = _messagesContainer?.querySelector('#messageInput');
+        if (
+            _currentConversationUserId === submittedConversationUserId
+            && activeReplyInput?.value.trim() === content
+        ) {
+            activeReplyInput.value = '';
+        }
         showToast('Message sent', 'success');
 
         // Reload conversation
@@ -1050,7 +1871,9 @@ async function handleSendReply() {
 
     } catch (err) {
         console.error('[messagePanel] Failed to send message:', err);
-        setComposeFailureState(COMPOSE_SCOPE_REPLY, buildMessageSendFailureState(err));
+        recordComposeSendFailure(COMPOSE_SCOPE_REPLY, err);
+    } finally {
+        setComposePending(COMPOSE_SCOPE_REPLY, false);
     }
 }
 
@@ -1072,7 +1895,11 @@ function showNewMessageModal() {
 /**
  * Hide the new message modal.
  */
-function hideNewMessageModal() {
+function hideNewMessageModal({ force = false } = {}) {
+    if (_newMessageSendPending && !force) {
+        return;
+    }
+
     const modal = _messagesContainer?.querySelector('#newMessageModal');
     if (modal) {
         modal.classList.add('hidden');
@@ -1082,6 +1909,9 @@ function hideNewMessageModal() {
         const contentInput = modal.querySelector('#newMessageContent');
         if (recipientInput) recipientInput.value = '';
         if (contentInput) contentInput.value = '';
+        if (_newMessageDeliveryAttempt) {
+            setDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, null);
+        }
     }
 }
 
@@ -1089,13 +1919,19 @@ function hideNewMessageModal() {
  * Handle sending a new message from the modal.
  */
 async function handleSendNewMessage() {
+    if (isComposePending(COMPOSE_SCOPE_NEW_MESSAGE)) {
+        return;
+    }
+
     const recipientInput = _messagesContainer?.querySelector('#newMessageRecipient');
     const contentInput = _messagesContainer?.querySelector('#newMessageContent');
 
     if (!recipientInput || !contentInput) return;
 
-    const recipient = recipientInput.value.trim();
-    const content = contentInput.value.trim();
+    const visibleRecipient = recipientInput.value;
+    const visibleDraft = contentInput.value;
+    const recipient = visibleRecipient.trim();
+    const content = visibleDraft.trim();
 
     if (!recipient) {
         showToast('Please enter a recipient', 'warning');
@@ -1115,17 +1951,21 @@ async function handleSendNewMessage() {
         scope: COMPOSE_SCOPE_NEW_MESSAGE,
         recipientIds: [recipientId],
         content,
+        visibleDraft,
+        visibleRecipient,
     });
     if (!payload) {
         return;
     }
 
+    setComposePending(COMPOSE_SCOPE_NEW_MESSAGE, true);
     try {
         await postJsonDetailed('/api/messages/', payload);
 
         resetComposeFailureUi(COMPOSE_SCOPE_NEW_MESSAGE);
+        setDeliveryAttempt(COMPOSE_SCOPE_NEW_MESSAGE, null);
         showToast('Message sent', 'success');
-        hideNewMessageModal();
+        hideNewMessageModal({ force: true });
 
         // Reload threads and select the new conversation
         await loadMessageThreads();
@@ -1133,7 +1973,9 @@ async function handleSendNewMessage() {
 
     } catch (err) {
         console.error('[messagePanel] Failed to send new message:', err);
-        setComposeFailureState(COMPOSE_SCOPE_NEW_MESSAGE, buildMessageSendFailureState(err));
+        recordComposeSendFailure(COMPOSE_SCOPE_NEW_MESSAGE, err);
+    } finally {
+        setComposePending(COMPOSE_SCOPE_NEW_MESSAGE, false);
     }
 }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -4911,6 +4911,13 @@ body[data-active-tab="messagesTab"] .tab-content-area {
     box-shadow: 0 8px 16px rgba(33, 95, 141, 0.18);
 }
 
+.send-message-btn:disabled,
+.modal-send-btn:disabled {
+    cursor: wait;
+    opacity: 0.72;
+    box-shadow: none;
+}
+
 .message-modal {
     background: rgba(15, 23, 42, 0.42);
     backdrop-filter: blur(3px);

--- a/tests/backend/test_message_routes.py
+++ b/tests/backend/test_message_routes.py
@@ -2,10 +2,30 @@
 
 from __future__ import annotations
 
-from flask import Flask
+from types import SimpleNamespace
+
 import pytest
+from flask import Flask
 
 import src.backend.server.routes.message_routes as message_routes
+
+
+def _authorise_test_direct_message(monkeypatch) -> None:
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#user_alice",
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_org_concept_id",
+        lambda _user_id, **_kwargs: "#V#org_test",
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "_authorise_sender_and_recipients_for_org",
+        lambda **_kwargs: (True, []),
+    )
 
 
 @pytest.fixture
@@ -30,6 +50,140 @@ def test_send_message_requires_authentication(monkeypatch, app_client):
 
     assert response.status_code == 401
     assert response.get_json()["error"] == "Authentication required"
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "expected_status", "expected_code"),
+    [
+        (
+            message_routes.WindowSessionContextUnavailable,
+            409,
+            "window_context_unavailable",
+        ),
+        (
+            message_routes.WindowSessionContextRecoveryUnavailable,
+            503,
+            "window_context_recovery_unavailable",
+        ),
+    ],
+)
+def test_send_message_rejects_unavailable_selected_window_without_org_fallback(
+    monkeypatch,
+    app_client,
+    exception_type,
+    expected_status,
+    expected_code,
+):
+    _, client = app_client
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#user_alice",
+    )
+    effective_context_calls: list[dict[str, object]] = []
+
+    def _unavailable_context(
+        window_session_id,
+        flask_session_snapshot,
+        user_concept_id,
+        *,
+        require_known_window=False,
+    ):
+        effective_context_calls.append(
+            {
+                "window_session_id": window_session_id,
+                "flask_session_snapshot": flask_session_snapshot,
+                "user_concept_id": user_concept_id,
+                "require_known_window": require_known_window,
+            }
+        )
+        raise exception_type("window context unavailable")
+
+    monkeypatch.setattr(message_routes, "get_effective_context", _unavailable_context)
+    monkeypatch.setattr(
+        message_routes,
+        "create_message",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("create_message should not be called")
+        ),
+    )
+    with client.session_transaction() as browser_session:
+        browser_session["organisation_concept_id"] = "#V#wrong_browser_org"
+
+    response = client.post(
+        "/api/messages/",
+        headers={"X-Von-Window-Session": "tab-selected-org"},
+        json={"recipient_ids": ["#V#user_bob"], "content": "Kia ora"},
+    )
+
+    assert response.status_code == expected_status
+    payload = response.get_json()
+    assert payload["error_code"] == expected_code
+    assert payload["retryable"] is True
+    assert effective_context_calls == [
+        {
+            "window_session_id": "tab-selected-org",
+            "flask_session_snapshot": {
+                "organisation_concept_id": "#V#wrong_browser_org"
+            },
+            "user_concept_id": "#V#user_alice",
+            "require_known_window": True,
+        }
+    ]
+
+
+def test_send_message_without_window_selector_keeps_legacy_org_fallback(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    monkeypatch.setattr(
+        message_routes,
+        "_get_current_user_concept_id",
+        lambda: "#V#user_alice",
+    )
+    seen_require_known_window: list[bool] = []
+
+    def _legacy_context(
+        _window_session_id,
+        flask_session_snapshot,
+        _user_concept_id,
+        *,
+        require_known_window=False,
+    ):
+        seen_require_known_window.append(require_known_window)
+        return {
+            "organisation_id": flask_session_snapshot.get("organisation_concept_id")
+        }
+
+    monkeypatch.setattr(message_routes, "get_effective_context", _legacy_context)
+    monkeypatch.setattr(
+        message_routes,
+        "_authorise_sender_and_recipients_for_org",
+        lambda **_kwargs: (True, []),
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "create_message",
+        lambda **_kwargs: {
+            "concept_id": "#V#message_legacy_client",
+            "concept_data": {"sent_at": "2026-08-28T12:00:00+00:00"},
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.services.episode_logging_service.log_episode",
+        lambda **_kwargs: "episode-legacy-client",
+    )
+    with client.session_transaction() as browser_session:
+        browser_session["organisation_concept_id"] = "#V#legacy_org"
+
+    response = client.post(
+        "/api/messages/",
+        json={"recipient_ids": ["#V#user_bob"], "content": "Kia ora"},
+    )
+
+    assert response.status_code == 201
+    assert seen_require_known_window == [False]
 
 
 def test_get_single_message_requires_actor_participation(monkeypatch, app_client):
@@ -67,7 +221,7 @@ def test_send_message_rejects_recipient_outside_organisation(monkeypatch, app_cl
     monkeypatch.setattr(
         message_routes,
         "_get_current_org_concept_id",
-        lambda _user_id: "#V#org_test",
+        lambda _user_id, **_kwargs: "#V#org_test",
     )
 
     import src.backend.services.organisation_membership_service as membership_service
@@ -155,7 +309,11 @@ def test_send_message_accepts_explicit_send_organisation_context(
     monkeypatch.setattr(
         message_routes,
         "_get_current_org_concept_id",
-        lambda _user_id: "#V#org_current",
+        lambda _user_id, **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "explicit authorised organisation recovery must not read a stale window"
+            )
+        ),
     )
 
     import src.backend.services.organisation_membership_service as membership_service
@@ -202,6 +360,7 @@ def test_send_message_accepts_explicit_send_organisation_context(
 
     response = client.post(
         "/api/messages/",
+        headers={"X-Von-Window-Session": "stale-tab-selector"},
         json={
             "recipient_ids": ["#V#user_bob"],
             "content": "Switch to our shared lab organisation for this message.",
@@ -229,7 +388,7 @@ def test_send_message_success_logs_episode_and_returns_attribution(
     monkeypatch.setattr(
         message_routes,
         "_get_current_org_concept_id",
-        lambda _user_id: "#V#org_test",
+        lambda _user_id, **_kwargs: "#V#org_test",
     )
 
     import src.backend.services.organisation_membership_service as membership_service
@@ -295,3 +454,165 @@ def test_send_message_success_logs_episode_and_returns_attribution(
     assert episode_calls[0]["actor_user_id"] == "#V#user_alice"
     assert episode_calls[0]["organisation_concept_id"] == "#V#org_test"
     assert episode_calls[0]["payload"]["message_id"] == "#V#message_test_1"
+
+
+def test_send_message_returns_explicit_reused_receipt_without_duplicate_episode(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    _authorise_test_direct_message(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def _fake_create_idempotently(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            reused=True,
+            message={
+                "concept_id": "#V#message_existing",
+                "concept_data": {
+                    "sent_at": "2026-08-28T05:00:00+00:00",
+                    "attribution": "Sent by Von on behalf of #V#user_alice",
+                },
+            },
+        )
+
+    monkeypatch.setattr(
+        message_routes,
+        "create_message_idempotently",
+        _fake_create_idempotently,
+    )
+    monkeypatch.setattr(
+        message_routes,
+        "create_message",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy create should not run for an idempotent request")
+        ),
+    )
+
+    import src.backend.services.episode_logging_service as episode_logging_service
+
+    episode_calls: list[dict] = []
+    monkeypatch.setattr(
+        episode_logging_service,
+        "log_episode",
+        lambda **kwargs: episode_calls.append(dict(kwargs)),
+    )
+
+    response = client.post(
+        "/api/messages/",
+        headers={"Idempotency-Key": "browser-send-1"},
+        json={
+            "_id": "client-controlled-document-id",
+            "recipient_ids": ["#V#user_bob"],
+            "content": "Please review the update.",
+            "delivery_idempotency_key": "browser-send-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "effect_status": "succeeded",
+        "changed": False,
+        "reused": True,
+        "idempotent_replay": True,
+        "delivery_status": "reused",
+        "message_id": "#V#message_existing",
+        "sent_at": "2026-08-28T05:00:00+00:00",
+        "attribution": "Sent by Von on behalf of #V#user_alice",
+    }
+    assert captured["delivery_idempotency_key"] == "browser-send-1"
+    assert captured["sender_id"] == "#V#user_alice"
+    assert captured["organisation_concept_id"] == "#V#org_test"
+    assert captured["recipient_ids"] == ["#V#user_bob"]
+    assert "_id" not in captured
+    assert "_server_owned_document_id" not in captured
+    assert episode_calls == []
+
+
+def test_send_message_maps_changed_payload_for_same_key_to_conflict(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    _authorise_test_direct_message(monkeypatch)
+
+    def _raise_conflict(**_kwargs):
+        raise message_routes.DirectMessageIdempotencyConflict(
+            "delivery_idempotency_key was already used for a different message payload"
+        )
+
+    monkeypatch.setattr(
+        message_routes,
+        "create_message_idempotently",
+        _raise_conflict,
+    )
+
+    response = client.post(
+        "/api/messages/",
+        json={
+            "recipient_ids": ["#V#user_bob"],
+            "content": "Changed payload",
+            "delivery_idempotency_key": "browser-send-1",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "error": (
+            "delivery_idempotency_key was already used for a different message payload"
+        ),
+        "error_code": "idempotency_key_reused_with_different_payload",
+    }
+
+
+def test_send_message_requires_matching_body_and_header_delivery_keys(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    _authorise_test_direct_message(monkeypatch)
+    monkeypatch.setattr(
+        message_routes,
+        "create_message_idempotently",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("mismatched keys must fail before persistence")
+        ),
+    )
+
+    response = client.post(
+        "/api/messages/",
+        headers={"Idempotency-Key": "header-key"},
+        json={
+            "recipient_ids": ["#V#user_bob"],
+            "content": "Please review the update.",
+            "delivery_idempotency_key": "body-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error_code"] == "idempotency_key_mismatch"
+
+
+def test_send_message_rejects_ambiguous_legacy_idempotency_field(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    _authorise_test_direct_message(monkeypatch)
+
+    response = client.post(
+        "/api/messages/",
+        json={
+            "recipient_ids": ["#V#user_bob"],
+            "content": "Please review the update.",
+            "idempotency_key": "ambiguous-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Use delivery_idempotency_key for direct-message retries",
+        "error_code": "unsupported_idempotency_key_field",
+    }

--- a/tests/backend/test_message_service.py
+++ b/tests/backend/test_message_service.py
@@ -8,24 +8,32 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pymongo.errors import DuplicateKeyError
 
+from src.backend.security.visibility_predicates import (
+    CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
+    CANONICAL_SPECIFIC_TO_USER_PREDICATE,
+)
 from src.backend.services.message_service import (
-    MESSAGE_TYPE_CONCEPT_ID,
-    MESSAGE_STATUS_SENT,
+    DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD,
+    DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX,
+    DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD,
+    DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD,
     MESSAGE_STATUS_READ,
-    PREDICATE_SENDER,
+    MESSAGE_STATUS_SENT,
+    MESSAGE_TYPE_CONCEPT_ID,
     PREDICATE_RECIPIENT,
+    PREDICATE_SENDER,
+    DirectMessageIdempotencyConflict,
+    build_direct_message_delivery_identity,
     create_message,
+    create_message_idempotently,
+    delete_message,
     get_message,
     get_message_for_user,
     get_messages_for_user,
     get_unread_count,
     mark_message_read,
-    delete_message,
-)
-from src.backend.security.visibility_predicates import (
-    CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
-    CANONICAL_SPECIFIC_TO_USER_PREDICATE,
 )
 
 
@@ -222,6 +230,357 @@ class TestCreateMessage:
                 content="   ",
             )
 
+    def test_create_message_rejects_unbound_server_document_identity(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="Invalid server-owned direct-message document identity",
+        ):
+            create_message(
+                sender_id="#V#user_alice",
+                recipient_ids=["#V#user_bob"],
+                content="Hello",
+                metadata={DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD: "a" * 64},
+                _server_owned_document_id=(
+                    DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX + ("b" * 64)
+                ),
+            )
+
+
+class TestIdempotentMessageCreate:
+    """Tests for sender-scoped REST delivery retry reconciliation."""
+
+    @staticmethod
+    def _identity(**overrides):
+        arguments = {
+            "delivery_idempotency_key": "browser-send-1",
+            "sender_id": "#V#user_alice",
+            "organisation_concept_id": "#V#org_test",
+            "recipient_ids": ["#V#user_bob", "#V#user_charlie"],
+            "content": "Please review this.",
+            "subject": "Review",
+        }
+        arguments.update(overrides)
+        return build_direct_message_delivery_identity(**arguments)
+
+    @staticmethod
+    def _message_for_identity(identity):
+        return {
+            "_id": identity.document_id,
+            "concept_id": "#V#message_winner",
+            "relationships": {
+                "is_an_instance_of": [MESSAGE_TYPE_CONCEPT_ID],
+                PREDICATE_SENDER: ["#V#user_alice"],
+                PREDICATE_RECIPIENT: ["#V#user_bob", "#V#user_charlie"],
+            },
+            "concept_data": {
+                "organisation_concept_id": "#V#org_test",
+                "sent_at": "2026-08-28T05:00:00+00:00",
+                "metadata": {
+                    DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD: (
+                        identity.idempotency_scope
+                    ),
+                    DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD: (
+                        identity.payload_fingerprint
+                    ),
+                    DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD: (
+                        identity.delivery_fingerprint
+                    ),
+                },
+            },
+        }
+
+    def test_identity_is_sender_scoped_and_payload_binds_org_recipients_content(
+        self,
+    ) -> None:
+        baseline = self._identity()
+        reordered_recipients = self._identity(
+            recipient_ids=["#V#user_charlie", "#V#user_bob"]
+        )
+        changed_sender = self._identity(sender_id="#V#user_dana")
+        changed_org = self._identity(organisation_concept_id="#V#org_other")
+        changed_recipients = self._identity(recipient_ids=["#V#user_bob"])
+        changed_content = self._identity(content="A materially different message")
+        changed_metadata = self._identity(metadata={"intent": "action_required"})
+
+        assert reordered_recipients == baseline
+        assert changed_sender.idempotency_scope != baseline.idempotency_scope
+        assert changed_org.idempotency_scope == baseline.idempotency_scope
+        assert changed_recipients.idempotency_scope == baseline.idempotency_scope
+        assert changed_content.idempotency_scope == baseline.idempotency_scope
+        assert changed_metadata.idempotency_scope == baseline.idempotency_scope
+        assert changed_org.payload_fingerprint != baseline.payload_fingerprint
+        assert changed_recipients.payload_fingerprint != baseline.payload_fingerprint
+        assert changed_content.payload_fingerprint != baseline.payload_fingerprint
+        assert changed_metadata.payload_fingerprint != baseline.payload_fingerprint
+
+    @patch("src.backend.services.message_service.create_message")
+    @patch(
+        "src.backend.services.message_service."
+        "get_message_for_delivery_idempotency_scope"
+    )
+    def test_first_delivery_persists_server_owned_fingerprints(
+        self,
+        mock_get_prior: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        mock_get_prior.return_value = None
+        mock_create.side_effect = lambda **kwargs: {
+            "concept_id": "#V#message_created",
+            "concept_data": {"metadata": kwargs["metadata"]},
+        }
+
+        receipt = create_message_idempotently(
+            delivery_idempotency_key="browser-send-1",
+            sender_id="#V#user_alice",
+            organisation_concept_id="#V#org_test",
+            recipient_ids=["#V#user_bob", "#V#user_charlie"],
+            content="Please review this.",
+            subject="Review",
+            metadata={
+                "intent": "review_request",
+                DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD: "client-spoofed",
+            },
+        )
+
+        assert receipt.reused is False
+        persisted_metadata = mock_create.call_args.kwargs["metadata"]
+        assert persisted_metadata["intent"] == "review_request"
+        assert persisted_metadata[DIRECT_MESSAGE_IDEMPOTENCY_SCOPE_FIELD] == (
+            receipt.delivery_identity.idempotency_scope
+        )
+        assert persisted_metadata[DIRECT_MESSAGE_PAYLOAD_FINGERPRINT_FIELD] == (
+            receipt.delivery_identity.payload_fingerprint
+        )
+        assert persisted_metadata[DIRECT_MESSAGE_DELIVERY_FINGERPRINT_FIELD] == (
+            receipt.delivery_identity.delivery_fingerprint
+        )
+        assert mock_create.call_args.kwargs["_server_owned_document_id"] == (
+            receipt.delivery_identity.document_id
+        )
+
+    @patch("src.backend.services.message_service.create_message")
+    @patch(
+        "src.backend.services.message_service."
+        "get_message_for_delivery_idempotency_scope"
+    )
+    def test_duplicate_key_race_reuses_atomic_winner(
+        self,
+        mock_get_prior: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        identity = self._identity()
+        winner = self._message_for_identity(identity)
+        mock_get_prior.side_effect = [None, winner]
+        mock_create.side_effect = DuplicateKeyError("duplicate retry scope")
+
+        receipt = create_message_idempotently(
+            delivery_idempotency_key="browser-send-1",
+            sender_id="#V#user_alice",
+            organisation_concept_id="#V#org_test",
+            recipient_ids=["#V#user_bob", "#V#user_charlie"],
+            content="Please review this.",
+            subject="Review",
+        )
+
+        assert receipt.reused is True
+        assert receipt.message["concept_id"] == "#V#message_winner"
+        assert mock_get_prior.call_count == 2
+        assert mock_create.call_args.kwargs["_server_owned_document_id"] == (
+            identity.document_id
+        )
+
+    @patch("src.backend.services.message_service.create_message")
+    @patch(
+        "src.backend.services.message_service."
+        "get_message_for_delivery_idempotency_scope"
+    )
+    def test_duplicate_document_id_race_with_changed_payload_conflicts(
+        self,
+        mock_get_prior: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        winning_identity = self._identity(content="Winning payload")
+        winner = self._message_for_identity(winning_identity)
+        mock_get_prior.side_effect = [None, winner]
+        mock_create.side_effect = DuplicateKeyError("duplicate built-in _id")
+
+        with pytest.raises(
+            DirectMessageIdempotencyConflict,
+            match="different message payload",
+        ):
+            create_message_idempotently(
+                delivery_idempotency_key="browser-send-1",
+                sender_id="#V#user_alice",
+                organisation_concept_id="#V#org_test",
+                recipient_ids=["#V#user_bob", "#V#user_charlie"],
+                content="Losing changed payload",
+                subject="Review",
+            )
+
+        losing_identity = self._identity(content="Losing changed payload")
+        assert mock_create.call_args.kwargs["_server_owned_document_id"] == (
+            losing_identity.document_id
+        )
+        assert losing_identity.document_id == winning_identity.document_id
+
+    @patch("src.backend.services.message_service.create_message")
+    @patch(
+        "src.backend.services.message_service."
+        "get_message_for_delivery_idempotency_scope"
+    )
+    def test_same_sender_key_with_changed_material_payload_is_rejected(
+        self,
+        mock_get_prior: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        existing_identity = self._identity()
+        mock_get_prior.return_value = self._message_for_identity(existing_identity)
+        baseline_arguments = {
+            "delivery_idempotency_key": "browser-send-1",
+            "sender_id": "#V#user_alice",
+            "organisation_concept_id": "#V#org_test",
+            "recipient_ids": ["#V#user_bob", "#V#user_charlie"],
+            "content": "Please review this.",
+            "subject": "Review",
+        }
+
+        for changed_fields in (
+            {"organisation_concept_id": "#V#org_other"},
+            {"recipient_ids": ["#V#user_bob"]},
+            {"content": "Changed message"},
+            {"metadata": {"intent": "action_required"}},
+        ):
+            arguments = {**baseline_arguments, **changed_fields}
+            with pytest.raises(
+                DirectMessageIdempotencyConflict,
+                match="different message payload",
+            ):
+                create_message_idempotently(
+                    **arguments,
+                )
+
+        mock_create.assert_not_called()
+
+    @patch("src.backend.services.message_service.create_message")
+    @patch(
+        "src.backend.services.message_service."
+        "get_message_for_delivery_idempotency_scope"
+    )
+    def test_same_client_key_is_isolated_between_trusted_senders(
+        self,
+        mock_get_prior: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        mock_get_prior.return_value = None
+        mock_create.side_effect = lambda **kwargs: {
+            "concept_id": "#V#message_dana",
+            "concept_data": {"metadata": kwargs["metadata"]},
+        }
+
+        receipt = create_message_idempotently(
+            delivery_idempotency_key="browser-send-1",
+            sender_id="#V#user_dana",
+            organisation_concept_id="#V#org_test",
+            recipient_ids=["#V#user_bob", "#V#user_charlie"],
+            content="Please review this.",
+            subject="Review",
+        )
+
+        assert receipt.reused is False
+        assert mock_get_prior.call_args.kwargs["sender_id"] == "#V#user_dana"
+        assert receipt.delivery_identity.idempotency_scope != (
+            self._identity().idempotency_scope
+        )
+
+    def test_builtin_document_id_concurrent_race_works_without_custom_index(
+        self,
+        monkeypatch,
+    ) -> None:
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        import mongomock
+
+        from src.backend.services import message_service as message_service_module
+
+        collection = mongomock.MongoClient().von_test.concepts
+        assert "direct_message_idempotency_scope_unique" not in (
+            collection.index_information()
+        )
+        monkeypatch.setattr(
+            message_service_module,
+            "get_concepts_collection",
+            lambda: collection,
+        )
+        monkeypatch.setattr(
+            message_service_module,
+            "apply_concept_query_filter",
+            lambda query: query,
+        )
+        monkeypatch.setattr(
+            message_service_module.ConceptsRepository,
+            "insert_one",
+            lambda document: collection.insert_one(dict(document)),
+        )
+        monkeypatch.setattr(
+            message_service_module,
+            "upsert_text_for_concept",
+            lambda **_kwargs: {},
+        )
+        monkeypatch.setattr(
+            message_service_module,
+            "maybe_launch_direct_message_workflow",
+            lambda **_kwargs: {"triggered": False},
+        )
+        original_get = message_service_module.get_message_for_delivery_idempotency_scope
+        first_reads_lock = threading.Lock()
+        first_reads_barrier = threading.Barrier(2)
+        first_read_count = 0
+
+        def force_both_concurrent_pre_reads_to_miss(**kwargs):
+            nonlocal first_read_count
+            with first_reads_lock:
+                is_initial_read = first_read_count < 2
+                if is_initial_read:
+                    first_read_count += 1
+            if is_initial_read:
+                first_reads_barrier.wait(timeout=2)
+                return None
+            return original_get(**kwargs)
+
+        monkeypatch.setattr(
+            message_service_module,
+            "get_message_for_delivery_idempotency_scope",
+            force_both_concurrent_pre_reads_to_miss,
+        )
+
+        arguments = {
+            "delivery_idempotency_key": "browser-send-no-custom-index",
+            "sender_id": "#V#user_alice",
+            "organisation_concept_id": "#V#org_test",
+            "recipient_ids": ["#V#user_bob"],
+            "content": "One durable message",
+            "metadata": {"intent": "info"},
+        }
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            receipts = list(
+                executor.map(
+                    lambda _index: create_message_idempotently(**arguments),
+                    range(2),
+                )
+            )
+
+        assert sorted(receipt.reused for receipt in receipts) == [False, True]
+        assert len({receipt.message["concept_id"] for receipt in receipts}) == 1
+        assert receipts[0].message["concept_id"].startswith("#V#message_user_alice_")
+        assert collection.count_documents({}) == 1
+        assert "direct_message_idempotency_scope_unique" not in (
+            collection.index_information()
+        )
+        stored = collection.find_one({})
+        assert stored is not None
+        assert stored["_id"] == receipts[0].delivery_identity.document_id
+
 
 class TestGetMessage:
     """Tests for get_message function."""
@@ -297,6 +656,35 @@ class TestGetMessage:
             {f"relationships.{PREDICATE_SENDER}": "#V#user_charlie"},
             {f"relationships.{PREDICATE_RECIPIENT}": "#V#user_charlie"},
         ]
+
+    @patch("src.backend.services.message_service.get_concepts_collection")
+    @patch("src.backend.services.message_service.apply_concept_query_filter")
+    def test_idempotency_lookup_uses_builtin_document_id_not_custom_index(
+        self,
+        mock_filter: MagicMock,
+        mock_get_coll: MagicMock,
+    ) -> None:
+        from src.backend.services.message_service import (
+            get_message_for_delivery_idempotency_scope,
+        )
+
+        collection = MagicMock()
+        mock_get_coll.return_value = collection
+        mock_filter.side_effect = lambda query: query
+        collection.find_one.return_value = None
+
+        result = get_message_for_delivery_idempotency_scope(
+            sender_id="#V#user_alice",
+            idempotency_scope="a" * 64,
+        )
+
+        assert result is None
+        query = collection.find_one.call_args.args[0]
+        assert query["_id"] == (
+            f"{DIRECT_MESSAGE_IDEMPOTENCY_DOCUMENT_ID_PREFIX}{'a' * 64}"
+        )
+        assert query[f"relationships.{PREDICATE_SENDER}"] == "#V#user_alice"
+        assert "concept_data.metadata.delivery_idempotency_scope" not in query
 
 
 class TestGetMessagesForUser:

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -294,6 +294,7 @@ def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
         "relationships_has_initial_step_1",
         "relationships_v_evidence_view_applies_to_tool_1",
         "episode_critique_remediation_external_instance_lookup",
+        "direct_message_idempotency_scope_unique",
         "embedding_status_updated_at_desc",
         "legacy_name_exact_1",
         "updated_at_-1",
@@ -315,6 +316,26 @@ def test_concepts_indexes_are_guarded_per_database_key(monkeypatch):
     ]
     assert concept_indexes_by_name["embedding_status_updated_at_desc"]["kwargs"] == {
         "name": "embedding_status_updated_at_desc"
+    }
+    assert concept_indexes_by_name["direct_message_idempotency_scope_unique"][
+        "keys"
+    ] == [
+        (
+            "concept_data.metadata.delivery_idempotency_scope",
+            mc.ASCENDING,
+        )
+    ]
+    assert concept_indexes_by_name["direct_message_idempotency_scope_unique"][
+        "kwargs"
+    ] == {
+        "name": "direct_message_idempotency_scope_unique",
+        "unique": True,
+        "partialFilterExpression": {
+            "concept_data.metadata.delivery_idempotency_scope": {
+                "$exists": True,
+                "$type": "string",
+            }
+        },
     }
 
 

--- a/tests/backend/test_workflow_capability_service.py
+++ b/tests/backend/test_workflow_capability_service.py
@@ -2298,10 +2298,16 @@ def test_process_invalidation_does_not_clobber_completed_current_generation_buil
 def test_workflow_routing_text_relation_change_invalidates_projection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
     from src.backend.services import text_value_service
+    from src.backend.workflows.durable import registry_factory
 
     invalidations: list[dict[str, object]] = []
     discovery_cache_clears: list[bool] = []
+
+    class _CachedRegistry:
+        def has(self, workflow_id: str) -> bool:
+            return workflow_id == "#V#workflow_repair_or_create_workflow"
 
     monkeypatch.setattr(
         "src.backend.services.workflow_capability_service.invalidate_workflow_capability_index",
@@ -2312,8 +2318,14 @@ def test_workflow_routing_text_relation_change_invalidates_projection(
         lambda: discovery_cache_clears.append(True),
     )
     monkeypatch.setattr(
-        "src.backend.services.workflow_capability_service.is_authoritative_workflow_concept_id",
-        lambda concept_id: concept_id == "#V#workflow_repair_or_create_workflow",
+        registry_factory,
+        "get_cached_shared_workflow_registry_read_only",
+        lambda: _CachedRegistry(),
+    )
+    monkeypatch.setattr(
+        ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: None,
     )
 
     text_value_service._invalidate_workflow_routing_projection_for_text_relation_change(
@@ -2341,7 +2353,9 @@ def test_workflow_routing_text_relation_change_skips_non_workflow_subject(
     on task/episode concepts; those writes previously invalidated the routing
     index and starved live workflow discovery of a ready index."""
 
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
     from src.backend.services import text_value_service
+    from src.backend.workflows.durable import registry_factory
 
     invalidations: list[str | None] = []
     discovery_cache_clears: list[bool] = []
@@ -2357,8 +2371,21 @@ def test_workflow_routing_text_relation_change_skips_non_workflow_subject(
         lambda: discovery_cache_clears.append(True),
     )
     monkeypatch.setattr(
-        "src.backend.services.workflow_capability_service.is_authoritative_workflow_concept_id",
-        lambda concept_id: False,
+        registry_factory,
+        "get_cached_shared_workflow_registry_read_only",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        registry_factory,
+        "get_shared_workflow_registry_read_only",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("ordinary description write must not build the registry")
+        ),
+    )
+    monkeypatch.setattr(
+        ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: None,
     )
 
     text_value_service._invalidate_workflow_routing_projection_for_text_relation_change(
@@ -2377,37 +2404,111 @@ def test_is_authoritative_workflow_concept_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import src.backend.services.workflow_capability_service as capability_service
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.workflows.durable import registry_factory
+
+    registry_checks: list[str] = []
+    represented_queries: list[tuple[dict[str, object], dict[str, object]]] = []
+
+    class _CachedRegistry:
+        def has(self, workflow_id: str) -> bool:
+            registry_checks.append(workflow_id)
+            return workflow_id == "#V#a_workflow"
 
     monkeypatch.setattr(
-        "src.backend.workflows.durable.registry_factory.get_shared_workflow_registry_read_only",
-        lambda **kwargs: object(),
+        registry_factory,
+        "get_cached_shared_workflow_registry_read_only",
+        lambda: _CachedRegistry(),
     )
     monkeypatch.setattr(
-        capability_service,
-        "_authoritative_registry_workflow_ids",
-        lambda registry: ("#V#a_workflow", "#V#b_workflow"),
+        registry_factory,
+        "get_shared_workflow_registry_read_only",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "latency-sensitive identity check must not build the registry"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        ConceptsRepository,
+        "find_one",
+        lambda query, projection=None: (
+            represented_queries.append((dict(query), dict(projection or {}))) or None
+        ),
     )
 
     assert capability_service.is_authoritative_workflow_concept_id("#V#a_workflow")
     assert not capability_service.is_authoritative_workflow_concept_id("#V#task_x")
     assert not capability_service.is_authoritative_workflow_concept_id("")
     assert not capability_service.is_authoritative_workflow_concept_id(None)  # type: ignore[arg-type]
+    assert registry_checks == ["#V#a_workflow", "#V#task_x"]
+    assert represented_queries == [
+        (
+            {
+                "concept_id": "#V#task_x",
+                "$or": [
+                    {"relationships.#V#hasInitialStep": {"$exists": True}},
+                    {"relationships.hasInitialStep": {"$exists": True}},
+                    {"relationships.#V#has_initial_step": {"$exists": True}},
+                    {"relationships.has_initial_step": {"$exists": True}},
+                ],
+            },
+            {"concept_id": 1},
+        )
+    ]
+
+
+def test_is_authoritative_workflow_concept_id_uses_exact_represented_graph_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.backend.services.workflow_capability_service as capability_service
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.workflows.durable import registry_factory
+
+    monkeypatch.setattr(
+        registry_factory,
+        "get_cached_shared_workflow_registry_read_only",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        ConceptsRepository,
+        "find_one",
+        lambda query, projection=None: (
+            {"concept_id": "#V#represented_workflow"}
+            if query.get("concept_id") == "#V#represented_workflow"
+            else None
+        ),
+    )
+
+    assert capability_service.is_authoritative_workflow_concept_id(
+        "#V#represented_workflow"
+    )
+    assert not capability_service.is_authoritative_workflow_concept_id(
+        "#V#ordinary_message"
+    )
 
 
 def test_is_authoritative_workflow_concept_id_fails_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import src.backend.services.workflow_capability_service as capability_service
-
-    def _raise(**kwargs: object) -> object:
-        raise RuntimeError("registry unavailable")
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.workflows.durable import registry_factory
 
     monkeypatch.setattr(
-        "src.backend.workflows.durable.registry_factory.get_shared_workflow_registry_read_only",
-        _raise,
+        registry_factory,
+        "get_cached_shared_workflow_registry_read_only",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("represented workflow authority unavailable")
+        ),
     )
 
-    # Registry lookup failure must degrade to the prior always-invalidate
+    # Represented-authority lookup failure must degrade to the prior always-invalidate
     # behaviour rather than silently skipping a legitimate workflow update.
     assert capability_service.is_authoritative_workflow_concept_id("#V#task_x")
 

--- a/tests/frontend/messagePanelSendFailure.test.js
+++ b/tests/frontend/messagePanelSendFailure.test.js
@@ -11,6 +11,8 @@ jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () =>
 }));
 
 const modulePath = '../../src/frontend/web/von_interface/static/js/components/messagePanel.js';
+const replyAttemptStorageKey = 'von_message_reply_delivery_attempt_v1';
+const newMessageAttemptStorageKey = 'von_message_new_delivery_attempt_v1';
 
 function renderFixture() {
     document.body.innerHTML = `
@@ -23,6 +25,16 @@ function flushUi() {
     return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function createDeferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
 function buildSendError({ status = 403, payload = null, message = null } = {}) {
     const err = new Error(message || payload?.error || `HTTP ${status}`);
     err.status = status;
@@ -30,8 +42,78 @@ function buildSendError({ status = 403, payload = null, message = null } = {}) {
     return err;
 }
 
+function setMessageSessionScope({ actorId, organisationId }) {
+    sessionStorage.setItem('von_current_user', JSON.stringify({ concept_id: actorId }));
+    sessionStorage.setItem('von_current_org', JSON.stringify({ concept_id: organisationId }));
+}
+
+function mockReplyReads(getJson, {
+    actorId = '#V#user_alice',
+    recipientIds = ['#V#user_bob'],
+    threadIdByRecipient = {},
+} = {}) {
+    getJson.mockImplementation(async (url) => {
+        if (url === '/api/messages/threads?limit=20') {
+            return {
+                threads: recipientIds.map((recipientId) => ({
+                    _id: [recipientId],
+                    last_message: {
+                        concept_data: { content_fallback: 'Earlier message' },
+                    },
+                    message_count: 1,
+                })),
+            };
+        }
+        if (url === '/api/messages/unread/count') {
+            return { unread_count: 0 };
+        }
+        const conversationMatch = url.match(
+            /^\/api\/messages\/conversation\/(.+)\?limit=50$/u,
+        );
+        if (conversationMatch) {
+            const recipientId = decodeURIComponent(conversationMatch[1]);
+            const threadId = threadIdByRecipient[recipientId] || '';
+            return {
+                messages: [{
+                    concept_id: `#V#message_for_${recipientId.replace(/^#V#/u, '')}`,
+                    relationships: {
+                        '#V#has_sender': [actorId],
+                        '#V#has_recipient': [recipientId],
+                        ...(threadId ? { '#V#is_part_of_thread': [threadId] } : {}),
+                    },
+                    concept_data: {
+                        content_fallback: 'Earlier message',
+                        read_by: [],
+                    },
+                    created_at: '2026-08-28T00:00:00Z',
+                }],
+                current_user_id: actorId,
+            };
+        }
+        throw new Error(`Unexpected getJson call: ${url}`);
+    });
+}
+
+function mockNewMessageReads(getJson) {
+    getJson.mockImplementation(async (url) => {
+        if (url === '/api/messages/threads?limit=20') {
+            return { threads: [] };
+        }
+        if (url === '/api/messages/unread/count') {
+            return { unread_count: 0 };
+        }
+        if (url === '/api/messages/conversation/%23V%23user_bob?limit=50') {
+            return { messages: [], current_user_id: '#V#user_alice' };
+        }
+        throw new Error(`Unexpected getJson call: ${url}`);
+    });
+}
+
 describe('message panel send failure recovery', () => {
     beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        window.scrollTo = jest.fn();
         renderFixture();
     });
 
@@ -126,8 +208,12 @@ describe('message panel send failure recovery', () => {
         expect(postJsonDetailed).toHaveBeenNthCalledWith(2, '/api/messages/', {
             recipient_ids: ['#V#user_bob'],
             content: 'Please review the draft.',
+            delivery_idempotency_key: expect.any(String),
             organisation_concept_id: '#V#org_shared',
         });
+        const firstDeliveryKey = postJsonDetailed.mock.calls[0][1].delivery_idempotency_key;
+        const retryDeliveryKey = postJsonDetailed.mock.calls[1][1].delivery_idempotency_key;
+        expect(retryDeliveryKey).not.toBe(firstDeliveryKey);
         expect(showToast).toHaveBeenCalledWith('Message sent', 'success');
         expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
     });
@@ -251,5 +337,891 @@ describe('message panel send failure recovery', () => {
         expect(replyInput.value).toBe('Need a reply from the correct organisation.');
         expect(document.getElementById('messageComposeRecovery').classList.contains('hidden')).toBe(true);
         expect(showToast).not.toHaveBeenCalledWith('Failed to send message', 'error');
+    });
+
+    test('reply send is single-flight and a same-draft retry reuses its delivery key', async () => {
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        const firstSend = createDeferred();
+        const retrySend = createDeferred();
+
+        postJson.mockResolvedValue({});
+        postJsonDetailed
+            .mockImplementationOnce(() => firstSend.promise)
+            .mockImplementationOnce(() => retrySend.promise);
+        getJson.mockImplementation(async (url) => {
+            if (url === '/api/messages/threads?limit=20') {
+                return {
+                    threads: [{
+                        _id: ['#V#user_bob'],
+                        last_message: {
+                            concept_data: { content_fallback: 'Earlier message' },
+                        },
+                        message_count: 1,
+                    }],
+                };
+            }
+            if (url === '/api/messages/unread/count') {
+                return { unread_count: 0 };
+            }
+            if (url === '/api/messages/conversation/%23V%23user_bob?limit=50') {
+                return { messages: [], current_user_id: '#V#user_alice' };
+            }
+            throw new Error(`Unexpected getJson call: ${url}`);
+        });
+
+        initializeMessagePanel();
+        await showMessagesTab();
+        await flushUi();
+
+        const replyInput = document.getElementById('messageInput');
+        const sendButton = document.getElementById('sendMessageBtn');
+        replyInput.value = 'Please review this once.';
+        sendButton.click();
+
+        expect(postJsonDetailed).toHaveBeenCalledTimes(1);
+        expect(sendButton.disabled).toBe(true);
+        expect(sendButton.textContent).toBe('Sending…');
+        expect(sendButton.getAttribute('aria-busy')).toBe('true');
+        expect(replyInput.value).toBe('Please review this once.');
+
+        sendButton.click();
+        replyInput.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true,
+        }));
+        expect(postJsonDetailed).toHaveBeenCalledTimes(1);
+
+        firstSend.reject(new Error('Temporary delivery failure'));
+        await flushUi();
+        await flushUi();
+
+        expect(sendButton.disabled).toBe(false);
+        expect(sendButton.textContent).toBe('Send');
+        expect(sendButton.getAttribute('aria-busy')).toBe('false');
+        expect(replyInput.value).toBe('Please review this once.');
+
+        sendButton.click();
+        expect(postJsonDetailed).toHaveBeenCalledTimes(2);
+        expect(postJsonDetailed.mock.calls[1][1].delivery_idempotency_key).toBe(
+            postJsonDetailed.mock.calls[0][1].delivery_idempotency_key,
+        );
+
+        retrySend.resolve({
+            data: { success: true, message_id: '#V#message_sent' },
+            status: 201,
+            headers: { get: () => null },
+        });
+        await flushUi();
+        await flushUi();
+
+        expect(replyInput.value).toBe('');
+        expect(sendButton.disabled).toBe(false);
+        expect(sendButton.textContent).toBe('Send');
+    });
+
+    test('new-message retries get new delivery keys after recipient or content changes', async () => {
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        const firstSend = createDeferred();
+
+        postJson.mockResolvedValue({});
+        postJsonDetailed
+            .mockImplementationOnce(() => firstSend.promise)
+            .mockRejectedValueOnce(new Error('Second temporary failure'))
+            .mockRejectedValueOnce(new Error('Third temporary failure'));
+        getJson.mockImplementation(async (url) => {
+            if (url === '/api/messages/threads?limit=20') {
+                return { threads: [] };
+            }
+            if (url === '/api/messages/unread/count') {
+                return { unread_count: 0 };
+            }
+            throw new Error(`Unexpected getJson call: ${url}`);
+        });
+
+        initializeMessagePanel();
+        await showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+
+        const recipientInput = document.getElementById('newMessageRecipient');
+        const contentInput = document.getElementById('newMessageContent');
+        const sendButton = document.getElementById('sendNewMessage');
+        recipientInput.value = 'user_bob';
+        contentInput.value = 'Original draft';
+        sendButton.click();
+
+        expect(postJsonDetailed).toHaveBeenCalledTimes(1);
+        expect(sendButton.disabled).toBe(true);
+        expect(sendButton.textContent).toBe('Sending…');
+        expect(recipientInput.disabled).toBe(true);
+        expect(contentInput.disabled).toBe(true);
+        sendButton.click();
+        expect(postJsonDetailed).toHaveBeenCalledTimes(1);
+
+        firstSend.reject(new Error('First temporary failure'));
+        await flushUi();
+        await flushUi();
+        expect(recipientInput.value).toBe('user_bob');
+        expect(contentInput.value).toBe('Original draft');
+        expect(recipientInput.disabled).toBe(false);
+        expect(contentInput.disabled).toBe(false);
+        const firstKey = postJsonDetailed.mock.calls[0][1].delivery_idempotency_key;
+
+        recipientInput.value = 'user_alice';
+        recipientInput.dispatchEvent(new Event('input', { bubbles: true }));
+        sendButton.click();
+        await flushUi();
+        await flushUi();
+        const recipientChangedKey = postJsonDetailed.mock.calls[1][1].delivery_idempotency_key;
+        expect(recipientChangedKey).not.toBe(firstKey);
+        expect(recipientInput.value).toBe('user_alice');
+        expect(contentInput.value).toBe('Original draft');
+
+        contentInput.value = 'Changed draft';
+        sendButton.click();
+        await flushUi();
+        await flushUi();
+        const contentChangedKey = postJsonDetailed.mock.calls[2][1].delivery_idempotency_key;
+        expect(contentChangedKey).not.toBe(recipientChangedKey);
+        expect(recipientInput.value).toBe('user_alice');
+        expect(contentInput.value).toBe('Changed draft');
+        expect(sendButton.disabled).toBe(false);
+        expect(sendButton.textContent).toBe('Send');
+    });
+
+    test('new-message retry restores its exact recipient, draft, and key across render and module reload', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const firstApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        firstApi.postJson.mockResolvedValue({});
+        firstApi.postJsonDetailed.mockRejectedValueOnce(
+            new Error('Unknown delivery outcome'),
+        );
+        mockNewMessageReads(firstApi.getJson);
+
+        const firstPanel = require(modulePath);
+        firstPanel.initializeMessagePanel();
+        await firstPanel.showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+
+        const exactRecipient = '  user_bob  ';
+        const exactDraft = '  Retry this exact new-message draft.  ';
+        document.getElementById('newMessageRecipient').value = exactRecipient;
+        document.getElementById('newMessageContent').value = exactDraft;
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+
+        const originalDeliveryKey = firstApi.postJsonDetailed.mock.calls[0][1]
+            .delivery_idempotency_key;
+        expect(JSON.parse(sessionStorage.getItem(newMessageAttemptStorageKey))).toMatchObject({
+            key: originalDeliveryKey,
+            recipient: exactRecipient,
+            draft: exactDraft,
+            scope: {
+                actor_user_id: '#V#user_alice',
+                organisation_concept_id: '#V#org_alpha',
+            },
+            delivery_scope: {
+                recipient_ids: ['#V#user_bob'],
+            },
+        });
+
+        await firstPanel.showMessagesTab();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('newMessageRecipient').value).toBe(exactRecipient);
+        expect(document.getElementById('newMessageContent').value).toBe(exactDraft);
+
+        jest.resetModules();
+        jest.clearAllMocks();
+        renderFixture();
+        const reloadedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        reloadedApi.postJson.mockResolvedValue({});
+        reloadedApi.postJsonDetailed.mockResolvedValueOnce({
+            data: { success: true, message_id: '#V#message_reconciled' },
+            status: 200,
+            headers: { get: () => null },
+        });
+        mockNewMessageReads(reloadedApi.getJson);
+
+        const reloadedPanel = require(modulePath);
+        reloadedPanel.initializeMessagePanel();
+        await reloadedPanel.showMessagesTab();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('newMessageRecipient').value).toBe(exactRecipient);
+        expect(document.getElementById('newMessageContent').value).toBe(exactDraft);
+
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+
+        expect(reloadedApi.postJsonDetailed.mock.calls[0][1]).toMatchObject({
+            recipient_ids: ['#V#user_bob'],
+            content: 'Retry this exact new-message draft.',
+            delivery_idempotency_key: originalDeliveryKey,
+        });
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBeNull();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
+    });
+
+    test.each([
+        {
+            label: 'actor',
+            actorId: '#V#user_eve',
+            organisationId: '#V#org_alpha',
+        },
+        {
+            label: 'organisation',
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_beta',
+        },
+    ])('new-message retry stays isolated from a changed $label scope', async ({
+        actorId,
+        organisationId,
+    }) => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const seedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        seedApi.postJson.mockResolvedValue({});
+        seedApi.postJsonDetailed.mockRejectedValueOnce(
+            new Error('Unknown delivery outcome'),
+        );
+        mockNewMessageReads(seedApi.getJson);
+        const seedPanel = require(modulePath);
+        seedPanel.initializeMessagePanel();
+        await seedPanel.showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+        document.getElementById('newMessageRecipient').value = 'user_bob';
+        document.getElementById('newMessageContent').value = 'Scope-bound draft';
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+
+        const originalAttemptRaw = sessionStorage.getItem(newMessageAttemptStorageKey);
+        const originalKey = JSON.parse(originalAttemptRaw).key;
+
+        jest.resetModules();
+        jest.clearAllMocks();
+        renderFixture();
+        setMessageSessionScope({ actorId, organisationId });
+        sessionStorage.setItem(newMessageAttemptStorageKey, originalAttemptRaw);
+        const scopedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        scopedApi.postJson.mockResolvedValue({});
+        scopedApi.postJsonDetailed.mockRejectedValueOnce(new Error('Scoped retry failed'));
+        mockNewMessageReads(scopedApi.getJson);
+        const scopedPanel = require(modulePath);
+        scopedPanel.initializeMessagePanel();
+        await scopedPanel.showMessagesTab();
+
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('newMessageRecipient').value).toBe('');
+        expect(document.getElementById('newMessageContent').value).toBe('');
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBe(originalAttemptRaw);
+
+        document.getElementById('newMessageBtn').click();
+        const recipientInput = document.getElementById('newMessageRecipient');
+        const contentInput = document.getElementById('newMessageContent');
+        recipientInput.value = 'user_bob';
+        recipientInput.dispatchEvent(new Event('input', { bubbles: true }));
+        contentInput.value = 'Scope-bound draft';
+        contentInput.dispatchEvent(new Event('input', { bubbles: true }));
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+
+        expect(scopedApi.postJsonDetailed.mock.calls[0][1].delivery_idempotency_key).not.toBe(
+            originalKey,
+        );
+    });
+
+    test('cancelling a restored new-message attempt abandons its persisted key', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        postJson.mockResolvedValue({});
+        postJsonDetailed.mockRejectedValueOnce(new Error('Unknown delivery outcome'));
+        mockNewMessageReads(getJson);
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        initializeMessagePanel();
+        await showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+        document.getElementById('newMessageRecipient').value = 'user_bob';
+        document.getElementById('newMessageContent').value = 'Abandon this retry';
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).not.toBeNull();
+        document.getElementById('cancelNewMessage').click();
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBeNull();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
+
+        await showMessagesTab();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
+    });
+
+    test('confirmed new-message success clears the persisted attempt', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const send = createDeferred();
+        postJson.mockResolvedValue({});
+        postJsonDetailed.mockImplementationOnce(() => send.promise);
+        mockNewMessageReads(getJson);
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        initializeMessagePanel();
+        await showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+        document.getElementById('newMessageRecipient').value = 'user_bob';
+        document.getElementById('newMessageContent').value = 'Clear after success';
+        document.getElementById('sendNewMessage').click();
+
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).not.toBeNull();
+        send.resolve({
+            data: { success: true, message_id: '#V#message_sent' },
+            status: 201,
+            headers: { get: () => null },
+        });
+        await flushUi();
+        await flushUi();
+
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBeNull();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
+    });
+
+    test('conversation refresh preserves an ordinary unsent reply draft', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const { getJson, postJson } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        postJson.mockResolvedValue({});
+        mockReplyReads(getJson);
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        initializeMessagePanel();
+        await showMessagesTab();
+
+        const replyInput = document.getElementById('messageInput');
+        replyInput.value = 'Do not erase this unsent draft.';
+        document.getElementById('refreshMessagesBtn').click();
+        await flushUi();
+        await flushUi();
+
+        expect(replyInput.value).toBe('Do not erase this unsent draft.');
+        expect(sessionStorage.getItem(replyAttemptStorageKey)).toBeNull();
+    });
+
+    test('reply retry restores its exact visible draft and delivery key across render and module reload', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const firstApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        firstApi.postJson.mockResolvedValue({});
+        firstApi.postJsonDetailed.mockRejectedValueOnce(new Error('Unknown delivery outcome'));
+        mockReplyReads(firstApi.getJson, {
+            recipientIds: ['#V#user_bob', '#V#user_carol'],
+            threadIdByRecipient: {
+                '#V#user_bob': '#V#thread_bob',
+                '#V#user_carol': '#V#thread_carol',
+            },
+        });
+
+        const firstPanel = require(modulePath);
+        firstPanel.initializeMessagePanel();
+        await firstPanel.showMessagesTab();
+        document.querySelector(
+            '.message-thread-item[data-user-id="#V#user_bob"]',
+        ).click();
+        await flushUi();
+        await flushUi();
+
+        const exactDraft = '  Retry this exact visible draft.  ';
+        const firstInput = document.getElementById('messageInput');
+        firstInput.value = exactDraft;
+        firstInput.dispatchEvent(new Event('input', { bubbles: true }));
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+
+        const storedAfterFailure = JSON.parse(
+            sessionStorage.getItem(replyAttemptStorageKey),
+        );
+        const originalDeliveryKey = firstApi.postJsonDetailed.mock.calls[0][1]
+            .delivery_idempotency_key;
+        expect(storedAfterFailure).toMatchObject({
+            key: originalDeliveryKey,
+            draft: exactDraft,
+            scope: {
+                actor_user_id: '#V#user_alice',
+                organisation_concept_id: '#V#org_alpha',
+                recipient_ids: ['#V#user_bob'],
+                thread_id: '#V#thread_bob',
+            },
+        });
+
+        await firstPanel.showMessagesTab();
+        expect(document.querySelector('.message-thread-item.selected')?.dataset.userId).toBe(
+            '#V#user_bob',
+        );
+        expect(document.getElementById('messageInput').value).toBe(exactDraft);
+
+        jest.resetModules();
+        jest.clearAllMocks();
+        renderFixture();
+        const reloadedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        reloadedApi.postJson.mockResolvedValue({});
+        reloadedApi.postJsonDetailed.mockResolvedValueOnce({
+            data: { success: true, message_id: '#V#message_reconciled' },
+            status: 200,
+            headers: { get: () => null },
+        });
+        mockReplyReads(reloadedApi.getJson, {
+            recipientIds: ['#V#user_bob', '#V#user_carol'],
+            threadIdByRecipient: {
+                '#V#user_bob': '#V#thread_bob',
+                '#V#user_carol': '#V#thread_carol',
+            },
+        });
+
+        const reloadedPanel = require(modulePath);
+        reloadedPanel.initializeMessagePanel();
+        await reloadedPanel.showMessagesTab();
+        expect(document.querySelector('.message-thread-item.selected')?.dataset.userId).toBe(
+            '#V#user_bob',
+        );
+        expect(document.getElementById('messageInput').value).toBe(exactDraft);
+
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+
+        expect(reloadedApi.postJsonDetailed.mock.calls[0][1].delivery_idempotency_key).toBe(
+            originalDeliveryKey,
+        );
+        expect(document.getElementById('messageInput').value).toBe('');
+        expect(sessionStorage.getItem(replyAttemptStorageKey)).toBeNull();
+    });
+
+    test('reply retry does not restore across actor, organisation, recipient, or thread scope changes', async () => {
+        const exactDraft = 'Retry only in the original reply scope.';
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const seedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        seedApi.postJson.mockResolvedValue({});
+        seedApi.postJsonDetailed.mockRejectedValueOnce(new Error('Unknown delivery outcome'));
+        mockReplyReads(seedApi.getJson, {
+            threadIdByRecipient: { '#V#user_bob': '#V#thread_one' },
+        });
+        const seedPanel = require(modulePath);
+        seedPanel.initializeMessagePanel();
+        await seedPanel.showMessagesTab();
+        const seedInput = document.getElementById('messageInput');
+        seedInput.value = exactDraft;
+        seedInput.dispatchEvent(new Event('input', { bubbles: true }));
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+
+        const originalAttemptRaw = sessionStorage.getItem(replyAttemptStorageKey);
+        const originalAttempt = JSON.parse(originalAttemptRaw);
+        const mismatchCases = [
+            {
+                label: 'actor',
+                actorId: '#V#user_eve',
+                organisationId: '#V#org_alpha',
+                selectedRecipientId: '#V#user_bob',
+                recipientIds: ['#V#user_bob'],
+                threadId: '#V#thread_one',
+            },
+            {
+                label: 'organisation',
+                actorId: '#V#user_alice',
+                organisationId: '#V#org_beta',
+                selectedRecipientId: '#V#user_bob',
+                recipientIds: ['#V#user_bob'],
+                threadId: '#V#thread_one',
+            },
+            {
+                label: 'recipient',
+                actorId: '#V#user_alice',
+                organisationId: '#V#org_alpha',
+                selectedRecipientId: '#V#user_carol',
+                recipientIds: ['#V#user_bob', '#V#user_carol'],
+                threadId: '#V#thread_carol',
+            },
+            {
+                label: 'thread',
+                actorId: '#V#user_alice',
+                organisationId: '#V#org_alpha',
+                selectedRecipientId: '#V#user_bob',
+                recipientIds: ['#V#user_bob'],
+                threadId: '#V#thread_two',
+            },
+        ];
+
+        for (const mismatchCase of mismatchCases) {
+            jest.resetModules();
+            jest.clearAllMocks();
+            localStorage.clear();
+            sessionStorage.clear();
+            renderFixture();
+            setMessageSessionScope(mismatchCase);
+            sessionStorage.setItem(replyAttemptStorageKey, originalAttemptRaw);
+
+            const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+            api.postJson.mockResolvedValue({});
+            api.postJsonDetailed.mockRejectedValueOnce(
+                new Error(`${mismatchCase.label} scope retry failed`),
+            );
+            const threadIdByRecipient = Object.fromEntries(
+                mismatchCase.recipientIds.map((recipientId) => [
+                    recipientId,
+                    recipientId === mismatchCase.selectedRecipientId
+                        ? mismatchCase.threadId
+                        : '#V#thread_one',
+                ]),
+            );
+            mockReplyReads(api.getJson, {
+                actorId: mismatchCase.actorId,
+                recipientIds: mismatchCase.recipientIds,
+                threadIdByRecipient,
+            });
+
+            const panel = require(modulePath);
+            panel.initializeMessagePanel();
+            await panel.showMessagesTab();
+            if (mismatchCase.label === 'recipient') {
+                expect(document.getElementById('messageInput').value).toBe(exactDraft);
+                document.querySelector(
+                    `.message-thread-item[data-user-id="${mismatchCase.selectedRecipientId}"]`,
+                ).click();
+                await flushUi();
+                await flushUi();
+            }
+
+            const input = document.getElementById('messageInput');
+            expect(input.value).toBe('');
+            input.value = exactDraft;
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            document.getElementById('sendMessageBtn').click();
+            await flushUi();
+            await flushUi();
+
+            const replacementKey = api.postJsonDetailed.mock.calls[0][1]
+                .delivery_idempotency_key;
+            expect(replacementKey).not.toBe(originalAttempt.key);
+            const replacementAttempt = JSON.parse(
+                sessionStorage.getItem(replyAttemptStorageKey),
+            );
+            expect(replacementAttempt.key).toBe(replacementKey);
+            expect(replacementAttempt.scope).toMatchObject({
+                actor_user_id: mismatchCase.actorId,
+                organisation_concept_id: mismatchCase.organisationId,
+                recipient_ids: [mismatchCase.selectedRecipientId],
+                thread_id: mismatchCase.threadId,
+            });
+        }
+    });
+
+    test('successful reply clears the persisted attempt and its visible draft', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const send = createDeferred();
+        postJson.mockResolvedValue({});
+        postJsonDetailed.mockImplementationOnce(() => send.promise);
+        mockReplyReads(getJson, {
+            threadIdByRecipient: { '#V#user_bob': '#V#thread_one' },
+        });
+
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        initializeMessagePanel();
+        await showMessagesTab();
+
+        const input = document.getElementById('messageInput');
+        input.value = 'Clear this after confirmed success.';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        document.getElementById('sendMessageBtn').click();
+
+        expect(JSON.parse(sessionStorage.getItem(replyAttemptStorageKey))).toMatchObject({
+            draft: 'Clear this after confirmed success.',
+            key: postJsonDetailed.mock.calls[0][1].delivery_idempotency_key,
+        });
+
+        send.resolve({
+            data: { success: true, message_id: '#V#message_sent' },
+            status: 201,
+            headers: { get: () => null },
+        });
+        await flushUi();
+        await flushUi();
+
+        expect(input.value).toBe('');
+        expect(sessionStorage.getItem(replyAttemptStorageKey)).toBeNull();
+    });
+
+    test('new-message explicit recovery organisation survives an ambiguous failure and module reload', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const firstApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        firstApi.postJson.mockResolvedValue({});
+        firstApi.postJsonDetailed
+            .mockRejectedValueOnce(buildSendError({
+                payload: {
+                    error: 'Use a shared organisation',
+                    common_organisation_options: [{
+                        concept_id: '#V#org_shared',
+                        name: 'Shared Lab',
+                        role: 'member',
+                    }],
+                },
+            }))
+            .mockRejectedValueOnce(new Error('Delivery receipt unavailable'));
+        mockNewMessageReads(firstApi.getJson);
+        const firstPanel = require(modulePath);
+        firstPanel.initializeMessagePanel();
+        await firstPanel.showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+        document.getElementById('newMessageRecipient').value = 'user_bob';
+        document.getElementById('newMessageContent').value = 'Retry through Shared Lab.';
+
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+        expect(document.getElementById('newMessageRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        const sharedOrganisationKey = JSON.parse(
+            sessionStorage.getItem(newMessageAttemptStorageKey),
+        ).key;
+
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+        expect(firstApi.postJsonDetailed.mock.calls[1][1]).toMatchObject({
+            organisation_concept_id: '#V#org_shared',
+            delivery_idempotency_key: sharedOrganisationKey,
+        });
+        expect(document.getElementById('newMessageFailure').textContent).toContain(
+            'Delivery receipt unavailable',
+        );
+        expect(document.getElementById('newMessageRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        expect(JSON.parse(sessionStorage.getItem(newMessageAttemptStorageKey))).toMatchObject({
+            key: sharedOrganisationKey,
+            scope: {
+                actor_user_id: '#V#user_alice',
+                organisation_concept_id: '#V#org_alpha',
+            },
+            delivery_scope: {
+                organisation_concept_id: '#V#org_shared',
+                recipient_ids: ['#V#user_bob'],
+            },
+            recovery_state: {
+                selectedOrganisationConceptId: '#V#org_shared',
+                organisationOptions: [{
+                    conceptId: '#V#org_shared',
+                    name: 'Shared Lab',
+                    role: 'member',
+                }],
+            },
+        });
+
+        await firstPanel.showMessagesTab();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('newMessageRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+
+        jest.resetModules();
+        jest.clearAllMocks();
+        renderFixture();
+        const reloadedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        reloadedApi.postJson.mockResolvedValue({});
+        reloadedApi.postJsonDetailed.mockRejectedValueOnce(
+            new Error('Still awaiting a canonical receipt'),
+        );
+        mockNewMessageReads(reloadedApi.getJson);
+        const reloadedPanel = require(modulePath);
+        reloadedPanel.initializeMessagePanel();
+        await reloadedPanel.showMessagesTab();
+
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('newMessageRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        document.getElementById('sendNewMessage').click();
+        await flushUi();
+        await flushUi();
+        expect(reloadedApi.postJsonDetailed.mock.calls[0][1]).toMatchObject({
+            organisation_concept_id: '#V#org_shared',
+            delivery_idempotency_key: sharedOrganisationKey,
+        });
+    });
+
+    test('reply explicit recovery organisation survives an ambiguous failure and module reload', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const firstApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        firstApi.postJson.mockResolvedValue({});
+        firstApi.postJsonDetailed
+            .mockRejectedValueOnce(buildSendError({
+                payload: {
+                    error: 'Use a shared organisation',
+                    common_organisation_options: [{
+                        concept_id: '#V#org_shared',
+                        name: 'Shared Lab',
+                        role: 'member',
+                    }],
+                },
+            }))
+            .mockRejectedValueOnce(new Error('Delivery receipt unavailable'));
+        mockReplyReads(firstApi.getJson, {
+            threadIdByRecipient: { '#V#user_bob': '#V#thread_bob' },
+        });
+        const firstPanel = require(modulePath);
+        firstPanel.initializeMessagePanel();
+        await firstPanel.showMessagesTab();
+        const exactDraft = '  Retry this reply through Shared Lab.  ';
+        document.getElementById('messageInput').value = exactDraft;
+
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+        expect(document.getElementById('messageComposeRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        const sharedOrganisationKey = JSON.parse(
+            sessionStorage.getItem(replyAttemptStorageKey),
+        ).key;
+
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+        expect(firstApi.postJsonDetailed.mock.calls[1][1]).toMatchObject({
+            organisation_concept_id: '#V#org_shared',
+            delivery_idempotency_key: sharedOrganisationKey,
+        });
+        expect(document.getElementById('messageComposeFailure').textContent).toContain(
+            'Delivery receipt unavailable',
+        );
+        expect(document.getElementById('messageComposeRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        expect(JSON.parse(sessionStorage.getItem(replyAttemptStorageKey))).toMatchObject({
+            key: sharedOrganisationKey,
+            draft: exactDraft,
+            scope: {
+                organisation_concept_id: '#V#org_shared',
+                recipient_ids: ['#V#user_bob'],
+                thread_id: '#V#thread_bob',
+            },
+            session_scope: {
+                actor_user_id: '#V#user_alice',
+                organisation_concept_id: '#V#org_alpha',
+            },
+            recovery_state: {
+                selectedOrganisationConceptId: '#V#org_shared',
+            },
+        });
+
+        await firstPanel.showMessagesTab();
+        expect(document.getElementById('messageInput').value).toBe(exactDraft);
+        expect(document.getElementById('messageComposeRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+
+        jest.resetModules();
+        jest.clearAllMocks();
+        renderFixture();
+        const reloadedApi = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        reloadedApi.postJson.mockResolvedValue({});
+        reloadedApi.postJsonDetailed.mockRejectedValueOnce(
+            new Error('Still awaiting a canonical receipt'),
+        );
+        mockReplyReads(reloadedApi.getJson, {
+            threadIdByRecipient: { '#V#user_bob': '#V#thread_bob' },
+        });
+        const reloadedPanel = require(modulePath);
+        reloadedPanel.initializeMessagePanel();
+        await reloadedPanel.showMessagesTab();
+
+        expect(document.getElementById('messageInput').value).toBe(exactDraft);
+        expect(document.getElementById('messageComposeRecoverySelect').value).toBe(
+            '#V#org_shared',
+        );
+        document.getElementById('sendMessageBtn').click();
+        await flushUi();
+        await flushUi();
+        expect(reloadedApi.postJsonDetailed.mock.calls[0][1]).toMatchObject({
+            organisation_concept_id: '#V#org_shared',
+            delivery_idempotency_key: sharedOrganisationKey,
+        });
+    });
+
+    test('new-message close and cancel fail closed while pending, then success force-closes', async () => {
+        setMessageSessionScope({
+            actorId: '#V#user_alice',
+            organisationId: '#V#org_alpha',
+        });
+        const { getJson, postJson, postJsonDetailed } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const send = createDeferred();
+        postJson.mockResolvedValue({});
+        postJsonDetailed.mockImplementationOnce(() => send.promise);
+        mockNewMessageReads(getJson);
+        const { initializeMessagePanel, showMessagesTab } = require(modulePath);
+        initializeMessagePanel();
+        await showMessagesTab();
+        document.getElementById('newMessageBtn').click();
+        document.getElementById('newMessageRecipient').value = 'user_bob';
+        document.getElementById('newMessageContent').value = 'Keep pending attempt visible';
+        document.getElementById('sendNewMessage').click();
+
+        const closeButton = document.getElementById('closeNewMessageModal');
+        const cancelButton = document.getElementById('cancelNewMessage');
+        const persistedWhilePending = sessionStorage.getItem(newMessageAttemptStorageKey);
+        expect(closeButton.disabled).toBe(true);
+        expect(cancelButton.disabled).toBe(true);
+        closeButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        cancelButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('newMessageRecipient').value).toBe('user_bob');
+        expect(document.getElementById('newMessageContent').value).toBe(
+            'Keep pending attempt visible',
+        );
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBe(
+            persistedWhilePending,
+        );
+
+        send.resolve({
+            data: { success: true, message_id: '#V#message_sent' },
+            status: 201,
+            headers: { get: () => null },
+        });
+        await flushUi();
+        await flushUi();
+
+        expect(sessionStorage.getItem(newMessageAttemptStorageKey)).toBeNull();
+        expect(document.getElementById('newMessageModal').classList.contains('hidden')).toBe(true);
     });
 });


### PR DESCRIPTION
Merge decision: ready — direct-message sends now give immediate pending feedback, converge to one durable effect across retries, and remain bound to the actor-owned tab organisation.

## User outcome

A user can send or retry a reply or new direct message without an inert-looking UI, accidental duplicate delivery, or cross-tab organisation leakage. This repairs the real Messages incident documented in JVNAUTOSCI-2690.

## Material changes

- Removes cold shared-workflow-registry construction from ordinary message text writes, using cached or exact represented workflow identity reads instead.
- Adds sender-scoped REST idempotency with deterministic server-owned Mongo identity, exact replay receipts, changed-payload conflicts, and an optional defensive index.
- Resolves supplied window selectors strictly for organisation-scoped sends while preserving explicit membership-authorised organisation recovery and legacy no-window clients.
- Makes both compose surfaces single-flight and visibly pending; persists exact per-tab draft, actor/window scope, delivery scope, recovery organisation, and retry key across ambiguity/reload; guards pending cancellation.
- Adds focused backend, concurrency, multi-org, frontend lifecycle, and index tests.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2690

## Evidence

- 145 affected backend tests passed, including a forced concurrent no-custom-index race.
- 23 Messages frontend tests passed.
- Fatal Ruff checks, frontend static lint, Node syntax, and diff checks passed.
- Isolated authenticated AgentTest browser replay showed Sending… and disabled/busy controls at 180 ms, overlapping-send suppression, pending New message Close/Cancel lock, and successful clearing.
- Canonical actor-authorised read-back found one durable message for each unique marker, exact retry returned the same message ID, changed payload returned 409, and a never-bound window selector returned 409 with zero writes.
- Live sends completed in 4.6–6.3 s versus 61.5–72.0 s in the incident; zero /von/generate requests and no real-user messages occurred.
- Independent final review found no material blocker.

## Ship boundary

- **Minimum ship criteria:** immediate pending UI; one durable actor-scoped effect for concurrent/exact retries; changed-intent conflict; strict selected-tab organisation binding; visible reload-safe retry state for reply and New message.
- **Stop-ship conditions:** duplicate durable effects, fallback from a supplied stale/foreign tab selector to browser-wide organisation, cold registry construction on the message write path, or loss of the exact draft/delivery scope/key after an ambiguous result.
- **Non-blocking observations:** the accepted Atlas-backed send remains above the generic one-second slow-request threshold, but is observable, completes in seconds, and no longer performs the minute-long cold registry build.
- **Non-goals:** deployment/activation, general chat prompt-queue architecture, event-workflow fan-out, or broad Messages read-path optimisation.