### PR TITLE
Scope All Tasks to the active organisation and unscoped tasks

### DIFF
--- a/src/backend/db/repositories/concepts_repository.py
+++ b/src/backend/db/repositories/concepts_repository.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
+
+import logging
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional, Iterable, Literal, Mapping, Set
+from typing import Any, Deque, Dict, Iterable, List, Literal, Mapping, Optional, Set
+
 from pymongo.collection import Collection
 from pymongo.database import Database
-import logging
 
-from ..mongo_client import get_db, get_concepts_collection
 from ...security.access_control import (
     apply_concept_query_filter,
     apply_pipeline_filter,
     prewarm_concept_relationship_access,
     sanitize_concept_document,
 )
+from ..mongo_client import get_concepts_collection, get_db
 
 
 # --- Legacy Field Guard -------------------------------------------------
@@ -167,9 +169,15 @@ class _AccessControlledCursor:
                 except StopIteration:
                     self._exhausted = True
                     break
-            prewarm_concept_relationship_access(batch)
+            access_evaluator = prewarm_concept_relationship_access(batch)
             for doc in batch:
-                sanitised = sanitize_concept_document(doc)
+                if access_evaluator is None:
+                    sanitised = sanitize_concept_document(doc)
+                else:
+                    sanitised = sanitize_concept_document(
+                        doc,
+                        access_evaluator=access_evaluator,
+                    )
                 if sanitised is not None:
                     self._buffer.append(sanitised)
         return self._buffer.popleft()
@@ -448,7 +456,9 @@ class ConceptsRepository:
             if not source:
                 return collected
             try:
-                from ...services.concept_predicate_metadata_service import get_relationship_kinds
+                from ...services.concept_predicate_metadata_service import (
+                    get_relationship_kinds,
+                )
                 kinds: tuple[str, ...] = get_relationship_kinds()
             except Exception:
                 kinds = RELATIONSHIP_KINDS

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from contextvars import ContextVar
-import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from bson import BSON
@@ -471,9 +471,12 @@ def get_effective_organisation_concept_id() -> Optional[str]:
                 user_for_context,
                 require_known_window=True,
             )
-            org_id = _normalise_stored_org_concept_id(effective.get("organisation_id"))
-            if org_id:
-                return org_id
+            # A known window session is authoritative even when its explicit
+            # selection is Personal. Falling through here would resurrect the
+            # browser-wide Flask organisation selected by another tab.
+            return _normalise_stored_org_concept_id(
+                effective.get("organisation_id")
+            )
     except WindowSessionContextUnavailable:
         # An explicit unknown/expired/other-actor selector must never inherit
         # the browser-wide organisation selected by another tab.
@@ -799,11 +802,12 @@ def _relationship_concept_ids(value: Any) -> set[str]:
 
 def prewarm_concept_relationship_access(
     documents: Iterable[Dict[str, Any]],
-) -> None:
+) -> AccessEvaluator | None:
     """Batch-cache visibility for relationship targets in concept documents."""
 
     if not should_enforce_access_control():
-        return
+        return None
+    evaluator = _current_evaluator()
     concept_ids: set[str] = set()
     for document in documents:
         if not isinstance(document, dict):
@@ -812,17 +816,21 @@ def prewarm_concept_relationship_access(
         if isinstance(relationships, dict):
             concept_ids.update(_relationship_concept_ids(relationships))
     if concept_ids:
-        _current_evaluator().accessible_concept_ids(concept_ids)
+        evaluator.accessible_concept_ids(concept_ids)
+    return evaluator
 
 
 def sanitize_concept_document(
     doc: Optional[Dict[str, Any]],
+    *,
+    access_evaluator: AccessEvaluator | None = None,
 ) -> Optional[Dict[str, Any]]:
     if doc is None:
         return None
     if not should_enforce_access_control():
         return doc
-    user_id = get_effective_user_concept_id()
+    evaluator = access_evaluator or _current_evaluator()
+    user_id = evaluator.user_id
 
     # Get user email for detailed logging
     user_email = "unknown"
@@ -837,7 +845,7 @@ def sanitize_concept_document(
     relationships = relationships if isinstance(relationships, dict) else {}
     user_specific = _get_specific_to_user_values(relationships)
 
-    org_id = get_effective_organisation_concept_id()
+    org_id = evaluator.org_id
     org_specific = get_specific_to_org_values(relationships)
 
     if not _document_visible_to_actor(doc, user_id, org_id):
@@ -857,8 +865,7 @@ def sanitize_concept_document(
         )
     if not isinstance(relationships, dict):
         return doc
-    evaluator = _current_evaluator()
-    prewarm_concept_relationship_access((doc,))
+    evaluator.accessible_concept_ids(_relationship_concept_ids(relationships))
     new_relationships: Dict[str, Any] = {}
     changed = False
     for predicate, value in relationships.items():

--- a/src/backend/server/routes/task_routes.py
+++ b/src/backend/server/routes/task_routes.py
@@ -20,9 +20,12 @@ from ...services.task_external_resource_action_service import (
     resolve_task_external_resource_action,
 )
 from ...services.task_management_service import (
+    TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED,
+    TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY,
     InvalidTaskDataError,
     TaskManagementError,
     TaskNotFoundError,
+    TaskOrganisationScopeAccessError,
     add_task_attachment,
     add_task_comment,
     apply_bulk_task_visibility,
@@ -170,8 +173,17 @@ def _get_current_user_concept_id() -> str | None:
 
 
 def _get_current_org_concept_id() -> str | None:
-    """Get the current organisation's concept_id from session."""
-    org_concept_id = session.get("org_id") or session.get("organisation_concept_id")
+    """Get the exact active-window organisation from trusted server context."""
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        org_concept_id = get_effective_organisation_concept_id()
+    except Exception:
+        if request.headers.get("X-Von-Window-Session"):
+            return None
+        org_concept_id = session.get("org_id") or session.get(
+            "organisation_concept_id"
+        )
     if isinstance(org_concept_id, str) and org_concept_id.strip():
         return org_concept_id.strip()
     return None
@@ -366,6 +378,10 @@ def update_task_route(task_concept_id: str) -> ResponseReturnValue:
         return jsonify({"error": str(e)}), 404
     except InvalidTaskDataError as e:
         return jsonify({"error": str(e)}), 400
+    except TaskOrganisationScopeAccessError as e:
+        return jsonify(
+            {"error": e.safe_message, "reason_code": e.reason_code}
+        ), 403
     except TaskManagementError as e:
         logger.error(f"Failed to update task: {e}")
         return jsonify({"error": str(e)}), 500
@@ -455,6 +471,8 @@ def list_tasks_route() -> ResponseReturnValue:
 
         # If filtering by session, use get_tasks_for_conversation
         service_telemetry = None
+        organisation_concept_id = None
+        organisation_scope_mode = None
         if session_id:
             tasks = get_tasks_for_conversation(session_id=session_id)
             mark_load("conversation_task_query", raw_count=len(tasks))
@@ -493,7 +511,15 @@ def list_tasks_route() -> ResponseReturnValue:
                 total=len(visible_tasks),
             )
         else:
+            organisation_concept_id = _get_current_org_concept_id()
+            organisation_scope_mode = (
+                TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED
+                if organisation_concept_id
+                else TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY
+            )
             payload = list_tasks_with_visibility(
+                organisation_concept_id=organisation_concept_id,
+                organisation_scope_mode=organisation_scope_mode,
                 user_concept_id=user_concept_id,
                 include_created=include_created,
                 assignee_concept_id=assignee_concept_id,
@@ -536,6 +562,8 @@ def list_tasks_route() -> ResponseReturnValue:
                 "has_task_source_filter": bool(task_source_ids),
                 "include_total": include_total is not False,
                 "include_bulk_summary": include_bulk_summary is not False,
+                "organisation_concept_id": organisation_concept_id,
+                "organisation_scope_mode": organisation_scope_mode,
             },
             service=service_telemetry,
         )
@@ -684,7 +712,15 @@ def my_tasks_route() -> ResponseReturnValue:
         )
         bulk_collection_ids = _parse_bulk_collection_ids()
 
+        organisation_concept_id = _get_current_org_concept_id()
+        organisation_scope_mode = (
+            TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED
+            if organisation_concept_id
+            else TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY
+        )
         payload = list_tasks_with_visibility(
+            organisation_concept_id=organisation_concept_id,
+            organisation_scope_mode=organisation_scope_mode,
             user_concept_id=user_concept_id,
             status_filter=status_filter,
             include_created=include_created,

--- a/src/backend/services/task_management_service.py
+++ b/src/backend/services/task_management_service.py
@@ -8,16 +8,25 @@ All tasks are stored as first-class Vontology concepts (type: #V#task_specificat
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import contextvars
 import hashlib
 import logging
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.access_control import can_access_concept
+from ..security.visibility_predicates import (
+    CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
+    SPECIFIC_TO_ORG_PREDICATES_READ,
+    SPECIFIC_TO_USER_PREDICATES_WRITE,
+    get_specific_to_org_values,
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
 from ..services.text_value_service import (
     get_texts_for_concept,
     get_texts_for_concepts,
@@ -26,19 +35,13 @@ from ..services.text_value_service import (
 from ..utils.concept_id_utils import (
     ensure_v_concept_prefix,
 )
-from ..security.visibility_predicates import (
-    SPECIFIC_TO_ORG_PREDICATES_WRITE,
-    SPECIFIC_TO_USER_PREDICATES_WRITE,
-    set_specific_to_org_values,
-    set_specific_to_user_values,
-)
-from ..security.access_control import can_access_concept
 from .effort_unit_ontology_service import (
     ensure_effort_unit_ontology,
     extract_effort_unit_type_ids,
     persist_successor_effort_unit_type_links,
     resolve_successor_effort_unit_type_ids,
 )
+from .organisation_membership_service import is_user_member_of_organisation
 from .task_ontology_service import (
     DEFAULT_TASK_SOURCE_ID,
     EVIDENCE_TEXT_PREDICATES,
@@ -55,16 +58,18 @@ from .task_ontology_service import (
     REPORTS_TO_RELATIONSHIP_PREDICATES,
     TASK_REFERENCE_CODE_TEXT_PREDICATES,
     TASK_ROLE_TEXT_PREDICATES,
-    TASK_SOURCE_RELATIONSHIP_PREDICATES,
     TASK_SOURCE_DEFINITIONS,
+    TASK_SOURCE_RELATIONSHIP_PREDICATES,
     TASK_TYPE_DEFINITIONS,
-    ensure_task_ontology,
+    ensure_task_ontology,  # noqa: F401  # retained as the task-ontology test seam
     get_task_source_definition,
-    get_task_taxonomy as get_task_taxonomy_definition,
     get_task_type_definition,
     is_known_task_type_id,
     normalise_task_source_id,
     normalise_task_type_ids,
+)
+from .task_ontology_service import (
+    get_task_taxonomy as get_task_taxonomy_definition,
 )
 from .workflow_event_integration_service import (
     maybe_launch_effort_unit_completed_workflow,
@@ -77,6 +82,8 @@ logger = logging.getLogger(__name__)
 TASK_LIST_LOAD_TELEMETRY_SCHEMA_VERSION = "task_list_load_telemetry.v1"
 TASK_SEARCH_ACCESSIBLE_CANDIDATE_LIMIT = 400
 TASK_LIST_MAX_PAGE_SIZE = 200
+TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED = "current_plus_unscoped"
+TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY = "unscoped_only"
 
 
 def _round_duration_ms(duration_seconds: float) -> float:
@@ -329,6 +336,15 @@ class InvalidTaskDataError(TaskManagementError):
     """Invalid task data provided."""
 
     pass
+
+
+class TaskOrganisationScopeAccessError(TaskManagementError):
+    """The actor may not move a task into or out of an organisation scope."""
+
+    def __init__(self, reason_code: str, safe_message: str):
+        super().__init__(safe_message)
+        self.reason_code = reason_code
+        self.safe_message = safe_message
 
 
 def _task_concept_id_for_agent_creation_fingerprint(
@@ -1839,6 +1855,29 @@ def _get_task_conversation_details(
     return details
 
 
+def _task_doc_organisation_concept_id(doc: Mapping[str, Any]) -> str | None:
+    relationships_raw = doc.get("relationships")
+    metadata_raw = doc.get("metadata")
+    relationships = (
+        relationships_raw if isinstance(relationships_raw, dict) else {}
+    )
+    metadata = metadata_raw if isinstance(metadata_raw, Mapping) else {}
+    canonical_organisation_id = _normalise_optional_concept_id(
+        _first_relationship_value(
+            relationships.get(CANONICAL_SPECIFIC_TO_ORG_PREDICATE)
+        )
+    )
+    represented_organisation_ids = get_specific_to_org_values(relationships)
+    metadata_organisation_id = _normalise_optional_concept_id(
+        metadata.get(TASK_METADATA_KEY_ORGANISATION)
+    )
+    return (
+        canonical_organisation_id
+        or (represented_organisation_ids[0] if represented_organisation_ids else None)
+        or metadata_organisation_id
+    )
+
+
 def _build_task_response(
     doc: Dict[str, Any],
     *,
@@ -1911,6 +1950,7 @@ def _build_task_response(
     task_type_ids = _task_type_ids_from_doc(doc)
 
     metadata = doc.get("metadata", {})
+    organisation_concept_id = _task_doc_organisation_concept_id(doc)
     labels = _metadata_string_list(metadata.get(TASK_METADATA_KEY_LABELS))
     components = _metadata_string_list(metadata.get(TASK_METADATA_KEY_COMPONENTS))
     fix_versions = _metadata_string_list(metadata.get(TASK_METADATA_KEY_FIX_VERSIONS))
@@ -2028,7 +2068,7 @@ def _build_task_response(
         "conversation_name": conversation_name,
         "start_date": start_date,
         "due_date": due_date,
-        "organisation_concept_id": metadata.get(TASK_METADATA_KEY_ORGANISATION),
+        "organisation_concept_id": organisation_concept_id,
         "labels": labels,
         "components": components,
         "fix_versions": fix_versions,
@@ -2585,6 +2625,7 @@ def _has_nonempty_filter_values(value: list[str] | str | None) -> bool:
 def _build_task_listing_query(
     *,
     organisation_concept_id: str | None = None,
+    organisation_scope_mode: str | None = None,
     user_concept_id: str | None = None,
     include_created: bool = False,
     assignee_concept_id: str | None = None,
@@ -2594,13 +2635,36 @@ def _build_task_listing_query(
         "relationships.is_an_instance_of": TASK_SPECIFICATION_TYPE_ID,
     }
 
+    organisation_id = None
     if organisation_concept_id:
         organisation_id = _normalise_optional_concept_id(organisation_concept_id)
         if not organisation_id:
             raise InvalidTaskDataError(
                 f"Invalid organisation_concept_id: {organisation_concept_id}"
             )
-        base_query[f"metadata.{TASK_METADATA_KEY_ORGANISATION}"] = organisation_id
+    organisation_field = f"metadata.{TASK_METADATA_KEY_ORGANISATION}"
+    if organisation_scope_mode == TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED:
+        if not organisation_id:
+            raise InvalidTaskDataError(
+                "current_plus_unscoped requires organisation_concept_id"
+            )
+        base_query["$or"] = [
+            {organisation_field: organisation_id},
+            {organisation_field: None},
+            {organisation_field: {"$exists": False}},
+        ]
+    elif organisation_scope_mode == TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY:
+        base_query["$or"] = [
+            {organisation_field: None},
+            {organisation_field: {"$exists": False}},
+        ]
+    elif organisation_scope_mode is not None:
+        raise InvalidTaskDataError(
+            f"Invalid organisation_scope_mode: {organisation_scope_mode}"
+        )
+    elif organisation_id:
+        # Preserve the existing exact-organisation contract for direct callers.
+        base_query[organisation_field] = organisation_id
 
     clauses: list[Mapping[str, Any]] = [base_query]
 
@@ -2639,10 +2703,28 @@ def _build_task_listing_query(
     return _and_query_clauses(*clauses)
 
 
+def _task_doc_matches_organisation_scope(
+    doc: Mapping[str, Any],
+    *,
+    organisation_concept_id: str | None,
+    organisation_scope_mode: str | None,
+) -> bool:
+    if organisation_scope_mode is None:
+        return True
+    effective_organisation_id = _task_doc_organisation_concept_id(doc)
+    if organisation_scope_mode == TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY:
+        return effective_organisation_id is None
+    if organisation_scope_mode == TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED:
+        return effective_organisation_id in {None, organisation_concept_id}
+    return False
+
+
 def _build_bulk_visibility_summary_for_query(
     base_query: Mapping[str, Any],
     *,
     collection_ids: set[str],
+    organisation_concept_id: str | None = None,
+    organisation_scope_mode: str | None = None,
 ) -> Dict[str, Any]:
     hidden_query = _and_query_clauses(
         base_query,
@@ -2650,11 +2732,19 @@ def _build_bulk_visibility_summary_for_query(
     )
     projection = {
         "concept_id": 1,
+        "relationships": 1,
+        f"metadata.{TASK_METADATA_KEY_ORGANISATION}": 1,
         f"metadata.{TASK_METADATA_KEY_BULK_TASK_COLLECTIONS}": 1,
     }
     hidden_task_stubs: list[Dict[str, Any]] = []
     for doc in ConceptsRepository.find(hidden_query, projection=projection):
         if not isinstance(doc, Mapping):
+            continue
+        if not _task_doc_matches_organisation_scope(
+            doc,
+            organisation_concept_id=organisation_concept_id,
+            organisation_scope_mode=organisation_scope_mode,
+        ):
             continue
         metadata_raw = doc.get("metadata")
         metadata: Mapping[str, Any] = (
@@ -2733,6 +2823,7 @@ def _filter_task_response_list(
 def list_tasks_with_visibility(
     *,
     organisation_concept_id: str | None = None,
+    organisation_scope_mode: str | None = None,
     user_concept_id: str | None = None,
     include_created: bool = False,
     assignee_concept_id: str | None = None,
@@ -2783,6 +2874,7 @@ def list_tasks_with_visibility(
 
     base_query = _build_task_listing_query(
         organisation_concept_id=organisation_concept_id,
+        organisation_scope_mode=organisation_scope_mode,
         user_concept_id=user_concept_id,
         include_created=include_created,
         assignee_concept_id=assignee_concept_id,
@@ -2795,6 +2887,8 @@ def list_tasks_with_visibility(
     )
     mark_load(
         "build_queries",
+        organisation_scope_mode=organisation_scope_mode,
+        has_organisation_scope=bool(organisation_concept_id),
         has_user_scope=bool(user_concept_id),
         include_created=bool(include_created),
         has_assignee_scope=bool(assignee_concept_id),
@@ -2809,6 +2903,8 @@ def list_tasks_with_visibility(
         visibility_summary = _build_bulk_visibility_summary_for_query(
             base_query,
             collection_ids=collection_ids,
+            organisation_concept_id=organisation_concept_id,
+            organisation_scope_mode=organisation_scope_mode,
         )
         mark_load(
             "bulk_visibility_summary",
@@ -2846,6 +2942,17 @@ def list_tasks_with_visibility(
             )
         )
         mark_load("repository_find_all", raw_count=len(docs))
+
+        docs = [
+            doc
+            for doc in docs
+            if _task_doc_matches_organisation_scope(
+                doc,
+                organisation_concept_id=organisation_concept_id,
+                organisation_scope_mode=organisation_scope_mode,
+            )
+        ]
+        mark_load("organisation_scope_filter", filtered_count=len(docs))
 
         tasks = _build_task_responses(docs)
         mark_load("build_task_responses", response_count=len(tasks))
@@ -2894,6 +3001,22 @@ def list_tasks_with_visibility(
             total_is_exhaustive = False
             docs = docs[:limit]
 
+        docs = [
+            doc
+            for doc in docs
+            if _task_doc_matches_organisation_scope(
+                doc,
+                organisation_concept_id=organisation_concept_id,
+                organisation_scope_mode=organisation_scope_mode,
+            )
+        ]
+        mark_load("organisation_scope_filter", filtered_count=len(docs))
+        if organisation_scope_mode is not None:
+            # The indexed metadata mirror bounds the page, while represented
+            # relationships make the final authority decision. Legacy drift can
+            # therefore make a metadata count an upper bound rather than exact.
+            total_is_exhaustive = False
+
         paged_tasks = _build_task_responses(docs)
         mark_load("build_task_responses", response_count=len(paged_tasks))
 
@@ -2917,6 +3040,8 @@ def list_tasks_with_visibility(
         "hidden_bulk_task_collections": visibility_summary[
             "hidden_bulk_task_collections"
         ],
+        "organisation_concept_id": organisation_concept_id,
+        "organisation_scope_mode": organisation_scope_mode,
     }
     mark_load("response_payload", returned_count=len(paged_tasks), total=total)
     payload["load_telemetry"] = finish_load(
@@ -2925,6 +3050,8 @@ def list_tasks_with_visibility(
             "offset": offset,
             "bulk_visibility": visibility,
             "bulk_collection_count": len(collection_ids),
+            "organisation_concept_id": organisation_concept_id,
+            "organisation_scope_mode": organisation_scope_mode,
             "has_user_scope": bool(user_concept_id),
             "include_created": bool(include_created),
             "has_assignee_scope": bool(assignee_concept_id),
@@ -4411,6 +4538,49 @@ def update_task_fields(
     warnings: list[str] = []
     existing_task_type_ids = set(existing_task.get("task_type_ids") or [])
 
+    organisation_field_present = "organisation_concept_id" in fields
+    existing_organisation_concept_id = _normalise_optional_concept_id(
+        existing_task.get("organisation_concept_id")
+    )
+    organisation_concept_id = existing_organisation_concept_id
+    if organisation_field_present:
+        raw_org = fields.get("organisation_concept_id")
+        if raw_org is None or (isinstance(raw_org, str) and not raw_org.strip()):
+            organisation_concept_id = None
+        else:
+            organisation_concept_id = _normalise_optional_concept_id(raw_org)
+            if not organisation_concept_id:
+                raise InvalidTaskDataError(
+                    f"Invalid organisation_concept_id: {raw_org}"
+                )
+            if not ConceptsRepository.find_one(
+                {"concept_id": organisation_concept_id},
+                projection={"_id": 1},
+            ):
+                raise InvalidTaskDataError(
+                    f"organisation_concept_id not found: {organisation_concept_id}"
+                )
+        if organisation_concept_id != existing_organisation_concept_id:
+            actor_id = _normalise_optional_concept_id(actor_concept_id)
+            if not actor_id:
+                raise TaskOrganisationScopeAccessError(
+                    "authenticated_actor_required",
+                    "An authenticated actor is required to change task organisation scope",
+                )
+            for required_membership_org_id in dict.fromkeys(
+                [existing_organisation_concept_id, organisation_concept_id]
+            ):
+                if not required_membership_org_id:
+                    continue
+                if not is_user_member_of_organisation(
+                    actor_id,
+                    required_membership_org_id,
+                ):
+                    raise TaskOrganisationScopeAccessError(
+                        "organisation_membership_required",
+                        "You must be a represented member of both the source and destination organisations",
+                    )
+
     current_start = _parse_datetime(existing_task.get("start_date"))
     current_due = _parse_datetime(existing_task.get("due_date"))
     next_start = current_start
@@ -4754,37 +4924,50 @@ def update_task_fields(
         )
         changed_fields.append("backlog_rank")
 
-    if "organisation_concept_id" in fields:
-        raw_org = fields.get("organisation_concept_id")
-        if raw_org is None or (isinstance(raw_org, str) and not raw_org.strip()):
-            organisation_concept_id = None
-        else:
-            organisation_concept_id = _normalise_optional_concept_id(raw_org)
-            if not organisation_concept_id:
-                raise InvalidTaskDataError(
-                    f"Invalid organisation_concept_id: {raw_org}"
-                )
-            if not ConceptsRepository.find_one(
-                {"concept_id": organisation_concept_id},
-                projection={"_id": 1},
-            ):
-                raise InvalidTaskDataError(
-                    f"organisation_concept_id not found: {organisation_concept_id}"
-                )
-        _set_task_metadata_value(
-            task_concept_id=task_concept_id,
-            metadata_key=TASK_METADATA_KEY_ORGANISATION,
-            value=organisation_concept_id,
-        )
-        relationship_updates: Dict[str, Any] = {}
-        org_targets = [organisation_concept_id] if organisation_concept_id else []
-        for predicate in SPECIFIC_TO_ORG_PREDICATES_WRITE:
-            relationship_updates[f"relationships.{predicate}"] = list(org_targets)
-        ConceptsRepository.update_one(
-            {"concept_id": task_concept_id},
-            {"$set": relationship_updates},
-        )
-        changed_fields.append("organisation_concept_id")
+    if organisation_field_present:
+        if organisation_concept_id != existing_organisation_concept_id:
+            actor_id = _normalise_optional_concept_id(actor_concept_id)
+            assert actor_id is not None
+
+            current_relationships = task_doc.get("relationships")
+            if not isinstance(current_relationships, dict):
+                current_relationships = {}
+            updated_relationships = set_specific_to_org_values(
+                current_relationships,
+                [organisation_concept_id] if organisation_concept_id else [],
+            )
+            set_values: Dict[str, Any] = {
+                f"metadata.{TASK_METADATA_KEY_ORGANISATION}": organisation_concept_id,
+                "updated_at": _now(),
+            }
+            unset_values: Dict[str, str] = {}
+            for predicate in SPECIFIC_TO_ORG_PREDICATES_READ:
+                field_path = f"relationships.{predicate}"
+                if predicate in updated_relationships:
+                    set_values[field_path] = updated_relationships[predicate]
+                elif predicate in current_relationships:
+                    unset_values[field_path] = ""
+            scope_history_event = {
+                "event_id": f"event_{uuid.uuid4().hex[:12]}",
+                "event_type": "task_organisation_scope_changed",
+                "timestamp": _now().isoformat(),
+                "actor_concept_id": actor_id,
+                "details": {
+                    "from_organisation_concept_id": existing_organisation_concept_id,
+                    "to_organisation_concept_id": organisation_concept_id,
+                },
+            }
+            update_document: Dict[str, Any] = {
+                "$set": set_values,
+                "$push": {f"metadata.{TASK_METADATA_KEY_HISTORY}": scope_history_event},
+            }
+            if unset_values:
+                update_document["$unset"] = unset_values
+            ConceptsRepository.update_one(
+                {"concept_id": task_concept_id},
+                update_document,
+            )
+            changed_fields.append("organisation_concept_id")
 
     if "reporter_concept_id" in fields:
         raw_reporter = fields.get("reporter_concept_id")

--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -37,6 +37,10 @@ let _globalTasksOpenPromise = null;
 let _globalTaskNextOffset = 0;
 let _globalTaskHasMore = false;
 let _globalTaskTotal = null;
+let _globalTaskLoadGeneration = 0;
+let _activeOrganisationConceptId;
+let _taskOrganisationOptions = [];
+let _taskOrganisationOptionsLoaded = false;
 let _taskTaxonomy = {
     task_types: [],
     task_sources: [],
@@ -52,6 +56,7 @@ const TASK_GROUP_STORAGE_KEY_PREFIX = 'von_task_group_filter_v1';
 const TASK_LIST_LIMIT = '500';
 const GLOBAL_TASK_PAGE_SIZE = 50;
 const TASK_PANEL_LOAD_TELEMETRY_SCHEMA_VERSION = 'task_panel_load_telemetry.v1';
+const TASK_PANEL_ORG_SWITCH_HANDLER_KEY = '__vonTaskPanelOrgSwitchHandler';
 const TASK_EXTERNAL_RESOURCE_ACTION_HREF_PATTERN = /^\/api\/tasks\/[A-Za-z0-9%_-]+\/external-resource-actions\/[A-Za-z0-9._%-]+$/;
 
 // Constants
@@ -105,6 +110,84 @@ function getCurrentUserConceptId() {
     } catch (_) {
         return '';
     }
+}
+
+function getCurrentOrganisationConceptId() {
+    if (_activeOrganisationConceptId !== undefined) {
+        return normaliseTaskConceptId(_activeOrganisationConceptId || '');
+    }
+    try {
+        const ctx = getUserContext ? getUserContext() : {};
+        return normaliseTaskConceptId(ctx?.org_id || ctx?.organisation_id || '');
+    } catch (_) {
+        return '';
+    }
+}
+
+function normaliseTaskOrganisationOption(option) {
+    const conceptId = normaliseTaskConceptId(option?.concept_id || '');
+    if (!conceptId) return null;
+    return {
+        concept_id: conceptId,
+        name: typeof option?.name === 'string' && option.name.trim()
+            ? option.name.trim()
+            : deriveConceptNameFromId(conceptId),
+        role: typeof option?.role === 'string' ? option.role.trim() : '',
+    };
+}
+
+async function ensureTaskOrganisationOptionsLoaded() {
+    if (_taskOrganisationOptionsLoaded) return;
+    try {
+        const response = await getJson('/von/api/organisations/my_organisations');
+        const seen = new Set();
+        _taskOrganisationOptions = (Array.isArray(response?.organisations)
+            ? response.organisations
+            : [])
+            .map(normaliseTaskOrganisationOption)
+            .filter((option) => {
+                if (!option || seen.has(option.concept_id)) return false;
+                seen.add(option.concept_id);
+                return true;
+            });
+        _taskOrganisationOptionsLoaded = true;
+    } catch (err) {
+        console.debug('[taskPanel] Failed to load organisation memberships:', err);
+    }
+}
+
+function handleTaskPanelOrganisationSwitch(event) {
+    _activeOrganisationConceptId = normaliseTaskConceptId(
+        event?.detail?.organisation_id || '',
+    );
+    _globalTaskLoadGeneration += 1;
+    _isLoading = false;
+    _tasks = [];
+    _taskDetailState = {};
+    _selectedTaskId = '';
+    _globalTaskNextOffset = 0;
+    _globalTaskHasMore = false;
+    _globalTaskTotal = null;
+    _hiddenBulkTaskTotal = 0;
+    _hiddenBulkTaskCollections = [];
+    loadTaskGroupSelectionFromStorage();
+
+    if (_isGlobalTabMode) {
+        renderTaskList();
+        void loadGlobalTasks();
+    } else if (_isVisible) {
+        renderTaskList();
+        void refreshTasks();
+    }
+}
+
+function ensureTaskPanelOrganisationSwitchListener() {
+    const previousHandler = document[TASK_PANEL_ORG_SWITCH_HANDLER_KEY];
+    if (typeof previousHandler === 'function') {
+        document.removeEventListener('orgSwitched', previousHandler);
+    }
+    document[TASK_PANEL_ORG_SWITCH_HANDLER_KEY] = handleTaskPanelOrganisationSwitch;
+    document.addEventListener('orgSwitched', handleTaskPanelOrganisationSwitch);
 }
 
 function getTaskTypeOptions() {
@@ -493,6 +576,7 @@ export function initializeTaskPanel() {
         return;
     }
     loadTaskGroupSelectionFromStorage();
+    ensureTaskPanelOrganisationSwitchListener();
     renderTaskGroupFilterControls();
 
     // Set up close button
@@ -608,6 +692,11 @@ async function openGlobalTasks() {
     _globalTaskNextOffset = 0;
     _globalTaskHasMore = false;
     _globalTaskTotal = null;
+    _globalTaskLoadGeneration += 1;
+    _tasks = [];
+    _taskDetailState = {};
+    _selectedTaskId = '';
+    ensureTaskPanelOrganisationSwitchListener();
 
     // Initialize the global tasks container if needed
     if (!_globalTasksContainer) {
@@ -622,7 +711,10 @@ async function openGlobalTasks() {
     renderTaskLoadProgress('Preparing All Tasks workspace', telemetry);
     markTaskLoadStage(telemetry, 'taxonomy_request', 'Loading task filters');
     renderTaskLoadProgress('Loading task filters', telemetry);
-    await ensureTaskTaxonomyLoaded();
+    await Promise.all([
+        ensureTaskTaxonomyLoaded(),
+        ensureTaskOrganisationOptionsLoaded(),
+    ]);
     markTaskLoadStage(telemetry, 'taxonomy_response', 'Task filters loaded');
     renderTaskLoadProgress('Task filters loaded', telemetry);
     renderGlobalTasksTabContent();
@@ -974,6 +1066,8 @@ async function loadGlobalTasks(options = {}) {
     if (_isLoading) return;
 
     const append = options?.append === true;
+    const requestGeneration = _globalTaskLoadGeneration;
+    const requestOrganisationConceptId = getCurrentOrganisationConceptId();
     const requestOffset = append ? _globalTaskNextOffset : 0;
     const telemetry = options?.telemetry || createTaskLoadTelemetry(
         append ? 'global_tasks_next_page' : 'global_tasks_refresh',
@@ -1004,6 +1098,12 @@ async function loadGlobalTasks(options = {}) {
         renderTaskLoadProgress('Requesting tasks from Von', telemetry);
 
         const response = await getJson(url);
+        if (
+            requestGeneration !== _globalTaskLoadGeneration
+            || requestOrganisationConceptId !== getCurrentOrganisationConceptId()
+        ) {
+            return;
+        }
         telemetry.backend = response?.load_telemetry || null;
         markTaskLoadStage(telemetry, 'response_received', 'Task payload received', {
             returned_count: Array.isArray(response?.tasks) ? response.tasks.length : 0,
@@ -1062,6 +1162,7 @@ async function loadGlobalTasks(options = {}) {
         });
         renderTaskLoadProgress(`Loaded ${_tasks.length} tasks`, telemetry);
     } catch (err) {
+        if (requestGeneration !== _globalTaskLoadGeneration) return;
         console.error('[taskPanel] Failed to load global tasks:', err);
         finishTaskLoadTelemetry(telemetry, 'error', 'Failed to load tasks', {
             error_type: err?.name || 'Error',
@@ -1070,9 +1171,11 @@ async function loadGlobalTasks(options = {}) {
         showToast('Failed to load tasks', 'error');
     } finally {
         stopProgressTicker();
-        _isLoading = false;
-        updateLoadingState(false);
-        renderGlobalTaskPagination();
+        if (requestGeneration === _globalTaskLoadGeneration) {
+            _isLoading = false;
+            updateLoadingState(false);
+            renderGlobalTaskPagination();
+        }
     }
 }
 
@@ -1445,7 +1548,7 @@ function getTaskGroupStorageKey() {
     try {
         const ctx = getUserContext ? getUserContext() : {};
         const normalisedUser = normaliseTaskConceptId(ctx?.user_id);
-        const normalisedOrg = normaliseTaskConceptId(ctx?.org_id);
+        const normalisedOrg = getCurrentOrganisationConceptId();
         if (normalisedUser) userId = normalisedUser;
         if (normalisedOrg) orgId = normalisedOrg;
     } catch (_) {
@@ -1779,6 +1882,48 @@ function renderTaskHistoryRows(history) {
     `).join('');
 }
 
+function getTaskOrganisationDisplayName(organisationConceptId) {
+    const conceptId = normaliseTaskConceptId(organisationConceptId || '');
+    if (!conceptId) return 'Unscoped';
+    return _taskOrganisationOptions.find((option) => option.concept_id === conceptId)?.name
+        || deriveConceptNameFromId(conceptId);
+}
+
+function renderTaskOrganisationField(task) {
+    const currentOrganisationId = normaliseTaskConceptId(
+        task?.organisation_concept_id || '',
+    );
+    const options = [..._taskOrganisationOptions];
+    if (
+        currentOrganisationId
+        && !options.some((option) => option.concept_id === currentOrganisationId)
+    ) {
+        options.unshift({
+            concept_id: currentOrganisationId,
+            name: deriveConceptNameFromId(currentOrganisationId),
+            role: '',
+        });
+    }
+    const hasAssignableOrganisation = options.length > 0;
+    const disabled = !currentOrganisationId && !hasAssignableOrganisation;
+    return `
+        <label class="task-detail-label">
+            Organisation
+            <select class="task-detail-input task-detail-organisation-input" ${disabled ? 'disabled' : ''}>
+                ${!currentOrganisationId ? '<option value="" selected>Unscoped</option>' : ''}
+                ${options.map((option) => `
+                    <option value="${escapeHtml(option.concept_id)}" ${currentOrganisationId === option.concept_id ? 'selected' : ''}>
+                        ${escapeHtml(option.name)}${option.role ? ` (${escapeHtml(option.role)})` : ''}
+                    </option>
+                `).join('')}
+            </select>
+            <span class="task-detail-help">
+                ${disabled ? 'Organisation memberships are unavailable.' : 'Only represented organisation memberships can be selected.'}
+            </span>
+        </label>
+    `;
+}
+
 function renderTaskDetailsPanel(task, detailState) {
     const taskId = getTaskId(task);
     const detailTask = detailState.task || task;
@@ -1837,6 +1982,7 @@ function renderTaskDetailsPanel(task, detailState) {
                             `).join('')}
                         </select>
                     </label>
+                    ${renderTaskOrganisationField(detailTask)}
                     <label class="task-detail-label">
                         Report to concept ID
                         <input class="task-detail-input task-detail-report-to-input" type="text" value="${escapeHtml(reportToValue)}" />
@@ -2098,6 +2244,7 @@ function renderTaskInspector(task, detailState) {
                 <div class="task-inspector-row"><div class="task-inspector-label">Title</div><div class="task-inspector-value">${escapeHtml(detailTask.title || 'Untitled task')}</div></div>
                 <div class="task-inspector-row"><div class="task-inspector-label">Type</div><div class="task-inspector-value">${taskTypes.length > 0 ? taskTypes.map((item) => `<span class="task-type-chip">${escapeHtml(item.label || item.concept_id || 'Typed')}</span>`).join('') : '<span class="task-empty-inline">Unspecified</span>'}</div></div>
                 <div class="task-inspector-row"><div class="task-inspector-label">Source</div><div class="task-inspector-value">${sourceSummary ? `<span class="task-source-chip">${escapeHtml(sourceSummary.label)}</span>` : '<span class="task-empty-inline">Unspecified</span>'}</div></div>
+                <div class="task-inspector-row"><div class="task-inspector-label">Organisation</div><div class="task-inspector-value">${escapeHtml(getTaskOrganisationDisplayName(detailTask.organisation_concept_id))}</div></div>
                 ${renderTaskExternalResourceActions(detailTask)}
                 <div class="task-inspector-row"><div class="task-inspector-label">Priority</div><div class="task-inspector-value">${escapeHtml(getPriorityInfo(detailTask.priority).label)}</div></div>
                 <div class="task-inspector-row"><div class="task-inspector-label">Owner</div><div class="task-inspector-value">${renderTaskConceptValue(detailTask.assignee_concept_id)}</div></div>
@@ -2137,6 +2284,7 @@ function renderTaskInspector(task, detailState) {
                             `).join('')}
                         </select>
                     </label>
+                    ${renderTaskOrganisationField(detailTask)}
                     <label class="task-detail-label">
                         Report to concept ID
                         <input class="task-detail-input task-detail-report-to-input" type="text" value="${escapeHtml(reportToValue)}" />
@@ -2382,6 +2530,14 @@ function renderTaskItem(task) {
             </span>
         `).join('')}</div>`
         : '';
+    const organisationChipHtml = `
+        <div class="task-meta-chip-row">
+            <span class="task-source-chip task-organisation-chip ${task.organisation_concept_id ? '' : 'task-organisation-unscoped'}"
+                title="Task organisation scope">
+                ${escapeHtml(getTaskOrganisationDisplayName(task.organisation_concept_id))}
+            </span>
+        </div>
+    `;
     const parentChipHtml = task.parent_task_concept_id
         ? renderTaskConceptLink({
             conceptId: task.parent_task_concept_id,
@@ -2413,6 +2569,7 @@ function renderTaskItem(task) {
             <div class="task-item-body">
                 <p class="task-description">${truncatedDescription}</p>
                 ${typeChipsHtml}
+                ${organisationChipHtml}
                 ${bulkCollectionChipsHtml}
                 ${labelsHtml}
                 ${componentsHtml}
@@ -2540,8 +2697,28 @@ async function saveTaskParityFields(taskId, panelEl) {
     setIfPresent('.task-detail-start-input', 'start_date', localInputValueToIso);
     setIfPresent('.task-detail-due-input', 'due_date', localInputValueToIso);
 
+    const previousOrganisationId = normaliseTaskConceptId(
+        (_tasks.find((task) => getTaskId(task) === taskId)?.organisation_concept_id) || '',
+    );
+    const organisationInput = panelEl.querySelector('.task-detail-organisation-input');
+    const requestedOrganisationId = normaliseTaskConceptId(
+        organisationInput?.value || '',
+    );
+    if (organisationInput && requestedOrganisationId !== previousOrganisationId) {
+        payload.organisation_concept_id = requestedOrganisationId || null;
+    }
     await patchJson(`/api/tasks/${encodeURIComponent(taskId)}`, payload);
     showToast('Task fields updated', 'success');
+    if (Object.prototype.hasOwnProperty.call(payload, 'organisation_concept_id')) {
+        if (_isGlobalTabMode) {
+            _selectedTaskId = '';
+            delete _taskDetailState[taskId];
+            await loadGlobalTasks();
+        } else {
+            await refreshTasks();
+        }
+        return;
+    }
     await loadTaskDetails(taskId, { refreshList: true });
 }
 

--- a/tests/backend/test_access_control_identity_resolution.py
+++ b/tests/backend/test_access_control_identity_resolution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from flask import Flask
 import pytest
+from flask import Flask
 
 
 class _FakeConceptCollection:
@@ -127,8 +127,9 @@ def test_header_identity_cache_is_request_local(monkeypatch) -> None:
 def test_explicit_anonymous_actor_suppresses_ambient_identity_without_a_source(
     monkeypatch,
 ) -> None:
-    import src.backend.security.access_control as access_control
     from flask import session
+
+    import src.backend.security.access_control as access_control
 
     app = Flask(__name__)
     app.secret_key = "test-secret"
@@ -155,8 +156,9 @@ def test_explicit_anonymous_actor_suppresses_ambient_identity_without_a_source(
 def test_visibility_evaluator_is_rebuilt_for_each_request_after_revocation(
     monkeypatch,
 ) -> None:
-    import src.backend.security.access_control as access_control
     from flask import session
+
+    import src.backend.security.access_control as access_control
 
     app = Flask(__name__)
     app.secret_key = "test-secret"
@@ -186,8 +188,9 @@ def test_visibility_evaluator_is_rebuilt_for_each_request_after_revocation(
 def test_visibility_evaluator_can_be_invalidated_within_one_request(
     monkeypatch,
 ) -> None:
-    import src.backend.security.access_control as access_control
     from flask import session
+
+    import src.backend.security.access_control as access_control
 
     app = Flask(__name__)
     app.secret_key = "test-secret"
@@ -422,14 +425,56 @@ def test_access_controlled_cursor_prewarms_relationships_in_bounded_batches(
     assert [len(batch) for batch in prewarmed_batches] == [64, 64, 2]
 
 
+def test_access_controlled_cursor_resolves_actor_scope_once_per_batch(
+    monkeypatch,
+) -> None:
+    import src.backend.db.repositories.concepts_repository as concepts_repository
+    import src.backend.security.access_control as access_control
+
+    documents = [
+        {
+            "concept_id": f"#V#batch_scope_source_{index}",
+            "relationships": {},
+        }
+        for index in range(130)
+    ]
+    calls = {"user": 0, "organisation": 0}
+
+    def _current_user() -> str:
+        calls["user"] += 1
+        return "#V#member"
+
+    def _current_organisation() -> str:
+        calls["organisation"] += 1
+        return "#V#sail"
+
+    monkeypatch.setattr(access_control, "should_enforce_access_control", lambda: True)
+    monkeypatch.setattr(access_control, "get_effective_user_concept_id", _current_user)
+    monkeypatch.setattr(
+        access_control,
+        "get_effective_organisation_concept_id",
+        _current_organisation,
+    )
+
+    access_control.invalidate_current_access_evaluator()
+    try:
+        returned = list(concepts_repository._AccessControlledCursor(iter(documents)))
+    finally:
+        access_control.invalidate_current_access_evaluator()
+
+    assert returned == documents
+    assert calls == {"user": 3, "organisation": 3}
+
+
 def test_window_session_organisation_context_controls_visibility(monkeypatch) -> None:
     mongomock = pytest.importorskip("mongomock")
+    from flask import session
+
     import src.backend.security.access_control as access_control
     import src.backend.services.window_session_context_service as window_context
     from src.backend.services.window_session_context_service import (
         set_window_organisation,
     )
-    from flask import session
 
     window_context._window_session_store = None
     set_window_organisation(
@@ -472,3 +517,36 @@ def test_window_session_organisation_context_controls_visibility(monkeypatch) ->
             )["accessible"]
             is True
         )
+
+
+def test_window_session_personal_context_does_not_inherit_flask_organisation() -> None:
+    from flask import session
+
+    import src.backend.security.access_control as access_control
+    import src.backend.services.window_session_context_service as window_context
+    from src.backend.services.window_session_context_service import (
+        WindowSessionContext,
+        WindowSessionStore,
+    )
+
+    window_context._window_session_store = WindowSessionStore()
+    window_context._window_session_store.set(
+        WindowSessionContext(
+            window_session_id="ws_personal",
+            user_id="#V#michael_witbrock",
+            organisation_concept_id=None,
+            role_in_org=None,
+            namespace="#V#michael_witbrock",
+        )
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    with app.test_request_context(
+        "/api/tasks/",
+        headers={"X-Von-Window-Session": "ws_personal"},
+    ):
+        session["user_concept_id"] = "#V#michael_witbrock"
+        session["organisation_concept_id"] = "#V#other_tab_org"
+
+        assert access_control.get_effective_organisation_concept_id() is None

--- a/tests/backend/test_task_management_service.py
+++ b/tests/backend/test_task_management_service.py
@@ -16,49 +16,54 @@ from src.backend.security.visibility_predicates import (
     CANONICAL_SPECIFIC_TO_ORG_PREDICATE,
 )
 from src.backend.services.task_management_service import (
-    TASK_SPECIFICATION_TYPE_ID,
-    TASK_STATUS_PENDING,
-    TASK_STATUS_IN_PROGRESS,
-    TASK_STATUS_COMPLETED,
-    TASK_STATUS_CANCELLED,
-    VALID_TASK_STATUSES,
-    VALID_PRIORITIES,
-    PRIORITY_MEDIUM,
     JIRA_MIGRATION_BULK_COLLECTION_ID,
-    TaskNotFoundError,
+    PRIORITY_MEDIUM,
+    TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED,
+    TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY,
+    TASK_SPECIFICATION_TYPE_ID,
+    TASK_STATUS_CANCELLED,
+    TASK_STATUS_COMPLETED,
+    TASK_STATUS_IN_PROGRESS,
+    TASK_STATUS_PENDING,
+    VALID_PRIORITIES,
+    VALID_TASK_STATUSES,
     InvalidTaskDataError,
-    apply_bulk_task_visibility,
-    backfill_jira_migration_bulk_task_collections,
-    build_jira_migration_bulk_task_collection,
-    create_task,
-    find_task_by_agent_creation_fingerprint,
-    get_task,
-    get_task_taxonomy,
-    find_task_by_external_reference,
+    TaskNotFoundError,
+    TaskOrganisationScopeAccessError,
+    _build_task_listing_query,
+    _task_doc_matches_organisation_scope,
     add_task_attachment,
     add_task_comment,
     add_task_worklog,
-    record_task_history_event,
-    upsert_task_external_reference,
-    update_task_status,
-    update_task_fields,
+    apply_bulk_task_visibility,
     assign_task,
+    backfill_jira_migration_bulk_task_collections,
+    build_jira_migration_bulk_task_collection,
+    create_task,
+    delete_task,
+    find_task_by_agent_creation_fingerprint,
+    find_task_by_external_reference,
+    get_task,
+    get_task_taxonomy,
     get_tasks_for_user,
     list_tasks,
     list_tasks_with_visibility,
+    record_task_history_event,
     search_tasks,
-    delete_task,
+    update_task_fields,
+    update_task_status,
+    upsert_task_external_reference,
 )
 from src.backend.services.task_ontology_service import (
     DEFAULT_TASK_SOURCE_ID,
     DEFAULT_TASK_TYPE_ID,
     JIRA_IMPORTED_TASK_SOURCE_ID,
+    PREDICATE_HAS_EVIDENCE,
+    PREDICATE_HAS_NEXT_CHECKPOINT,
+    PREDICATE_HAS_PROGRESS_SIGNAL,
     PREDICATE_HAS_TASK_REFERENCE_CODE,
     PREDICATE_HAS_TASK_ROLE,
     PREDICATE_HAS_TASK_SOURCE,
-    PREDICATE_HAS_NEXT_CHECKPOINT,
-    PREDICATE_HAS_PROGRESS_SIGNAL,
-    PREDICATE_HAS_EVIDENCE,
     PREDICATE_REPORTS_TO,
 )
 
@@ -1149,6 +1154,47 @@ class TestBulkTaskCollections:
             JIRA_MIGRATION_BULK_COLLECTION_ID
         )
 
+    def test_task_listing_query_includes_current_organisation_and_unscoped(self) -> None:
+        query = _build_task_listing_query(
+            organisation_concept_id="#V#household_org",
+            organisation_scope_mode=TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED,
+        )
+
+        assert query["$or"] == [
+            {"metadata.organisation_concept_id": "#V#household_org"},
+            {"metadata.organisation_concept_id": None},
+            {"metadata.organisation_concept_id": {"$exists": False}},
+        ]
+
+    def test_task_listing_query_personal_scope_is_unscoped_only(self) -> None:
+        query = _build_task_listing_query(
+            organisation_scope_mode=TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY,
+        )
+
+        assert query["$or"] == [
+            {"metadata.organisation_concept_id": None},
+            {"metadata.organisation_concept_id": {"$exists": False}},
+        ]
+
+    def test_task_scope_filter_treats_represented_org_as_authoritative(self) -> None:
+        legacy_drifted_task = {
+            "relationships": {
+                CANONICAL_SPECIFIC_TO_ORG_PREDICATE: ["#V#other_org"]
+            },
+            "metadata": {"organisation_concept_id": None},
+        }
+
+        assert not _task_doc_matches_organisation_scope(
+            legacy_drifted_task,
+            organisation_concept_id="#V#household_org",
+            organisation_scope_mode=TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED,
+        )
+        assert not _task_doc_matches_organisation_scope(
+            legacy_drifted_task,
+            organisation_concept_id=None,
+            organisation_scope_mode=TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY,
+        )
+
     @patch("src.backend.services.task_management_service.ConceptsRepository")
     @patch("src.backend.services.task_management_service.get_texts_for_concept")
     def test_search_tasks_excludes_bulk_collection_before_pagination(
@@ -1651,8 +1697,13 @@ class TestTaskParityDatesAndEpic:
     @patch("src.backend.services.task_management_service.get_task")
     @patch("src.backend.services.task_management_service.ConceptsRepository")
     @patch("src.backend.services.task_management_service.get_texts_for_concept")
+    @patch(
+        "src.backend.services.task_management_service.is_user_member_of_organisation",
+        return_value=True,
+    )
     def test_update_task_fields_supports_creator_reporter_and_watchers(
         self,
+        mock_is_member: MagicMock,
         mock_get_texts: MagicMock,
         mock_repo: MagicMock,
         mock_get_task: MagicMock,
@@ -1742,6 +1793,73 @@ class TestTaskParityDatesAndEpic:
             == ["#V#sail_org"]
             for payload in set_payloads
         )
+        scope_events = [
+            payload["$push"]["metadata.task_history"]
+            for payload in update_payloads
+            if payload.get("$push", {}).get("metadata.task_history", {}).get(
+                "event_type"
+            )
+            == "task_organisation_scope_changed"
+        ]
+        assert len(scope_events) == 1
+        assert scope_events[0]["actor_concept_id"] == "#V#user_alice"
+        assert scope_events[0]["details"] == {
+            "from_organisation_concept_id": None,
+            "to_organisation_concept_id": "#V#sail_org",
+        }
+        mock_is_member.assert_called_once_with("#V#user_alice", "#V#sail_org")
+
+    @patch("src.backend.services.task_management_service.get_task")
+    @patch("src.backend.services.task_management_service.ConceptsRepository")
+    @patch("src.backend.services.task_management_service.get_texts_for_concept")
+    @patch("src.backend.services.task_management_service.upsert_text_for_concept")
+    @patch(
+        "src.backend.services.task_management_service.is_user_member_of_organisation",
+        return_value=False,
+    )
+    def test_update_task_fields_rejects_destination_without_membership(
+        self,
+        mock_is_member: MagicMock,
+        mock_upsert_text: MagicMock,
+        mock_get_texts: MagicMock,
+        mock_repo: MagicMock,
+        mock_get_task: MagicMock,
+    ) -> None:
+        task_doc = {
+            "concept_id": "#V#task_1",
+            "relationships": {"is_an_instance_of": [TASK_SPECIFICATION_TYPE_ID]},
+            "metadata": {},
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+
+        def _fake_find_one(query, projection=None):
+            if query.get("concept_id") == "#V#task_1":
+                return task_doc
+            if query.get("concept_id") == "#V#other_org":
+                return {"concept_id": "#V#other_org"}
+            return None
+
+        mock_repo.find_one.side_effect = _fake_find_one
+        mock_get_texts.return_value = []
+
+        with pytest.raises(
+            TaskOrganisationScopeAccessError,
+            match="represented member",
+        ) as exc_info:
+            update_task_fields(
+                "#V#task_1",
+                fields={
+                    "priority": "high",
+                    "organisation_concept_id": "#V#other_org",
+                },
+                actor_concept_id="#V#user_alice",
+            )
+
+        assert exc_info.value.reason_code == "organisation_membership_required"
+        mock_is_member.assert_called_once_with("#V#user_alice", "#V#other_org")
+        mock_upsert_text.assert_not_called()
+        mock_get_task.assert_not_called()
 
     @patch("src.backend.services.task_management_service.ConceptsRepository")
     @patch("src.backend.services.task_management_service.get_texts_for_concept")

--- a/tests/backend/test_task_routes_parity_fields.py
+++ b/tests/backend/test_task_routes_parity_fields.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from flask import Flask
 
 from src.backend.server.routes.task_routes import task_bp
+from src.backend.services.task_management_service import (
+    TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED,
+    TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY,
+    TaskOrganisationScopeAccessError,
+)
 
 
 def _build_client():
@@ -162,6 +167,29 @@ def test_update_task_route_uses_update_task_fields(monkeypatch):
     assert captured["actor_concept_id"] == "#V#user_alice"
 
 
+def test_update_task_route_returns_typed_scope_denial(monkeypatch):
+    client = _build_client()
+
+    def _deny_scope_change(*args, **kwargs):
+        raise TaskOrganisationScopeAccessError(
+            "organisation_membership_required",
+            "You must be a represented member of both the source and destination organisations",
+        )
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.update_task_fields",
+        _deny_scope_change,
+    )
+
+    response = client.patch(
+        "/api/tasks/%23V%23task_1",
+        json={"organisation_concept_id": "#V#other_org"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["reason_code"] == "organisation_membership_required"
+
+
 def test_search_tasks_route_supports_start_and_epic_filters(monkeypatch):
     client = _build_client()
     captured: dict = {}
@@ -230,6 +258,10 @@ def test_list_tasks_route_forwards_bulk_visibility_and_user_scope(monkeypatch):
         "src.backend.server.routes.task_routes.list_tasks_with_visibility",
         _fake_list_tasks_with_visibility,
     )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes._get_current_org_concept_id",
+        lambda: "#V#household_org",
+    )
 
     response = client.get(
         "/api/tasks/?bulk_visibility=exclude&limit=10&offset=5"
@@ -253,6 +285,11 @@ def test_list_tasks_route_forwards_bulk_visibility_and_user_scope(monkeypatch):
     assert captured["offset"] == 5
     assert captured["include_total"] is False
     assert captured["include_bulk_summary"] is False
+    assert captured["organisation_concept_id"] == "#V#household_org"
+    assert (
+        captured["organisation_scope_mode"]
+        == TASK_ORGANISATION_SCOPE_CURRENT_PLUS_UNSCOPED
+    )
     telemetry = payload["load_telemetry"]
     assert telemetry["schema_version"] == "task_list_load_telemetry.v1"
     assert telemetry["source"] == "task_routes.list_tasks_route"
@@ -291,6 +328,10 @@ def test_list_tasks_route_telemetry_handles_missing_bulk_collection_ids(monkeypa
     assert response.status_code == 200
     telemetry = response.get_json()["load_telemetry"]
     assert telemetry["request"]["bulk_collection_count"] == 0
+    assert (
+        telemetry["request"]["organisation_scope_mode"]
+        == TASK_ORGANISATION_SCOPE_UNSCOPED_ONLY
+    )
 
 
 def test_my_tasks_route_uses_visibility_listing(monkeypatch):

--- a/tests/frontend/taskPanelGroupFilters.test.js
+++ b/tests/frontend/taskPanelGroupFilters.test.js
@@ -568,6 +568,148 @@ describe('task panel ontology-backed groups', () => {
         );
     });
 
+    test('shows unscoped tasks and assigns one to a represented organisation', async () => {
+        const { getJson, patchJson } = require(apiServiceModulePath);
+        const unscopedTask = {
+            task_concept_id: '#V#task_unscoped',
+            title: 'Unscoped task',
+            description: 'Needs an organisation',
+            status: 'pending',
+            priority: 'medium',
+            organisation_concept_id: null,
+            task_type_ids: ['#V#one_off_task_specification'],
+            task_source_id: '#V#von_native_task_source',
+        };
+
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve(buildTaxonomyResponse());
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({
+                    organisations: [
+                        { concept_id: '#V#group_org', name: 'Household', role: 'member' },
+                        { concept_id: '#V#other_org', name: 'Other lab', role: 'admin' },
+                    ],
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                return Promise.resolve({
+                    tasks: [unscopedTask],
+                    count: 1,
+                    offset: 0,
+                    has_more: false,
+                });
+            }
+            if (url === '/api/tasks/%23V%23task_unscoped') {
+                return Promise.resolve(unscopedTask);
+            }
+            if (typeof url === 'string' && url.includes('/comments?')) {
+                return Promise.resolve({ comments: [] });
+            }
+            if (typeof url === 'string' && url.includes('/attachments?')) {
+                return Promise.resolve({ attachments: [] });
+            }
+            if (typeof url === 'string' && url.includes('/history?')) {
+                return Promise.resolve({ history: [] });
+            }
+            return Promise.resolve({});
+        });
+        patchJson.mockResolvedValue({
+            task: { ...unscopedTask, organisation_concept_id: '#V#other_org' },
+            changed_fields: ['organisation_concept_id'],
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        expect(document.querySelector('.task-organisation-unscoped')?.textContent || '')
+            .toContain('Unscoped');
+
+        document.querySelector('.task-detail-toggle-btn').click();
+        await flushRenderQueue();
+
+        const organisationSelect = document.querySelector(
+            '#globalTaskInspector .task-detail-organisation-input',
+        );
+        expect(organisationSelect).toBeTruthy();
+        expect(Array.from(organisationSelect.options).map((option) => option.value))
+            .toEqual(['', '#V#group_org', '#V#other_org']);
+
+        organisationSelect.value = '#V#other_org';
+        document.querySelector('#globalTaskInspector .task-save-fields-btn').click();
+        await flushRenderQueue();
+
+        expect(patchJson).toHaveBeenCalledWith(
+            '/api/tasks/%23V%23task_unscoped',
+            expect.objectContaining({ organisation_concept_id: '#V#other_org' }),
+        );
+    });
+
+    test('clears old cards and ignores an in-flight response after organisation switch', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        let resolveOldTasks;
+        let taskRequestCount = 0;
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve(buildTaxonomyResponse());
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({ organisations: [] });
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                taskRequestCount += 1;
+                if (taskRequestCount === 1) {
+                    return new Promise((resolve) => {
+                        resolveOldTasks = resolve;
+                    });
+                }
+                return Promise.resolve({
+                    tasks: [{
+                        task_concept_id: '#V#task_new_org',
+                        title: 'New organisation task',
+                        status: 'pending',
+                        priority: 'medium',
+                        organisation_concept_id: '#V#new_org',
+                    }],
+                    count: 1,
+                    offset: 0,
+                    has_more: false,
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks, getTasks } = require(taskPanelModulePath);
+        const opening = showGlobalTasks();
+        await flushRenderQueue();
+
+        document.dispatchEvent(new CustomEvent('orgSwitched', {
+            detail: { organisation_id: '#V#new_org' },
+        }));
+        await flushRenderQueue();
+
+        resolveOldTasks({
+            tasks: [{
+                task_concept_id: '#V#task_old_org',
+                title: 'Old organisation task',
+                status: 'pending',
+                priority: 'medium',
+                organisation_concept_id: '#V#group_org',
+            }],
+            count: 1,
+            offset: 0,
+            has_more: false,
+        });
+        await opening;
+        await flushRenderQueue();
+
+        expect(taskRequestCount).toBe(2);
+        expect(getTasks().map((task) => task.title)).toEqual(['New organisation task']);
+        expect(document.body.textContent).not.toContain('Old organisation task');
+    });
+
     test('loads side-panel user tasks with hidden bulk collections excluded by default', async () => {
         document.body.innerHTML = `
             <div id="taskPanel" class="hidden">


### PR DESCRIPTION
Jira: JVNAUTOSCI-2691

Summary:
- scope task listings to the trusted active-window organisation plus unscoped tasks; Personal is unscoped-only
- show task organisation scope and let represented members assign unscoped tasks from the detail UI
- enforce source/destination membership, canonical scope relations, provenance, stale-response fencing, and Personal window isolation
- reuse the trusted access evaluator per sanitisation batch to keep the scoped page responsive

Validation:
- 102 targeted backend tests passed
- 12 targeted frontend tests passed
- targeted frontend static lint, JavaScript syntax, Ruff import/undefined-name checks, and diff check passed
- isolated browser replay: Personal 50/50 unscoped and 0 scoped; represented org 34 scoped plus 16 unscoped; assignment selector showed only Unscoped plus represented membership
- same 50-task API page improved from 29.9 s to 4.37 s

No deployment is included.