### PR TITLE
JVNAUTOSCI-2234: Render promoted summary fields and full literals

### DIFF
--- a/src/backend/services/concept_summary_field_resolver.py
+++ b/src/backend/services/concept_summary_field_resolver.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from .concept_service import get_concept_by_concept_id
@@ -40,6 +43,23 @@ _TYPE_FIELD_RELATIONSHIP_ALIASES: tuple[str, ...] = (
     SUMMARY_TYPE_FIELD_RELATIONSHIP,
     "#V#hasSummaryFields",
 )
+_DISPLAY_ORDER_PREDICATE_ALIASES: tuple[str, ...] = (
+    SUMMARY_FIELD_DISPLAY_ORDER_PREDICATE,
+    "#V#summaryFieldDisplayOrder",
+)
+
+
+@dataclass(frozen=True)
+class SummaryFieldDefinition:
+    """Resolved presentation metadata for one represented summary field."""
+
+    field_key: str
+    field_concept_id: str
+    label: str
+    display_order: float | None
+    text_predicates: tuple[str, ...]
+    relationship_predicates: tuple[str, ...]
+    origin_type_ids: tuple[str, ...]
 
 
 def _dedupe_preserve_order(values: list[str]) -> tuple[str, ...]:
@@ -98,6 +118,38 @@ def _normalise_predicate_list(raw_text: Any) -> tuple[str, ...]:
     return _dedupe_preserve_order([line.strip() for line in text.splitlines()])
 
 
+def _normalise_display_order(raw_text: Any) -> float | None:
+    if isinstance(raw_text, bool):
+        return None
+    try:
+        value = float(str(raw_text).strip())
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _fallback_field_label(field_key: str) -> str:
+    return " ".join(str(field_key or "").replace("_", " ").split()).title()
+
+
+def _field_label(concept: Mapping[str, Any] | None, field_key: str) -> str:
+    if isinstance(concept, Mapping):
+        name = concept.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        names = concept.get("names")
+        if isinstance(names, Sequence) and not isinstance(names, (str, bytes)):
+            for item in names:
+                if not isinstance(item, Mapping):
+                    continue
+                value = item.get("name")
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    return _fallback_field_label(field_key)
+
+
 class ConceptSummaryFieldResolver:
     """Resolve summary field predicates from Vontology-backed metadata."""
 
@@ -106,12 +158,16 @@ class ConceptSummaryFieldResolver:
         self._cache_loaded_at = 0.0
         self._text_predicates_by_field: dict[str, tuple[str, ...]] = {}
         self._relationship_predicates_by_field: dict[str, tuple[str, ...]] = {}
+        self._display_order_by_field: dict[str, float | None] = {}
+        self._field_labels_by_field: dict[str, str] = {}
         self._summary_fields_by_type: dict[str, tuple[str, ...]] = {}
 
     def invalidate_cache(self) -> None:
         self._cache_loaded_at = 0.0
         self._text_predicates_by_field = {}
         self._relationship_predicates_by_field = {}
+        self._display_order_by_field = {}
+        self._field_labels_by_field = {}
         self._summary_fields_by_type = {}
 
     def get_text_predicates_for_field(self, field_key: str) -> tuple[str, ...]:
@@ -138,15 +194,65 @@ class ConceptSummaryFieldResolver:
         return self._summary_fields_by_type.get(normalised, ())
 
     def get_summary_fields_for_types(self, type_ids: Sequence[str]) -> tuple[str, ...]:
+        return tuple(
+            definition.field_key
+            for definition in self.get_summary_field_definitions_for_types(type_ids)
+        )
+
+    def get_summary_field_definitions_for_types(
+        self,
+        type_ids: Sequence[str],
+    ) -> tuple[SummaryFieldDefinition, ...]:
+        """Resolve the ordered union of fields bound to every supplied type.
+
+        ``type_ids`` is expected to contain the direct types followed by their
+        ancestors.  A field inherited through more than one type is returned
+        once while retaining every origin type for inspectability.
+        """
+
         self._ensure_cache()
         ordered_type_ids = _normalise_strings(type_ids)
         self._load_type_bindings(ordered_type_ids)
+        ordered_field_keys: list[str] = []
+        origin_type_ids_by_field: dict[str, list[str]] = {}
         for type_id in ordered_type_ids:
             fields = self._summary_fields_by_type.get(type_id, ())
-            if fields:
-                self._load_field_metadata_for_fields(fields)
-                return fields
-        return ()
+            for field_key in fields:
+                if field_key not in origin_type_ids_by_field:
+                    ordered_field_keys.append(field_key)
+                    origin_type_ids_by_field[field_key] = []
+                origin_type_ids_by_field[field_key].append(type_id)
+        if not ordered_field_keys:
+            return ()
+
+        self._load_field_metadata_for_fields(ordered_field_keys)
+        discovery_index = {
+            field_key: index for index, field_key in enumerate(ordered_field_keys)
+        }
+        ordered_field_keys.sort(
+            key=lambda field_key: (
+                self._display_order_by_field.get(field_key) is None,
+                self._display_order_by_field.get(field_key)
+                if self._display_order_by_field.get(field_key) is not None
+                else 0.0,
+                discovery_index[field_key],
+            )
+        )
+        return tuple(
+            SummaryFieldDefinition(
+                field_key=field_key,
+                field_concept_id=_field_concept_id(field_key),
+                label=self._field_labels_by_field.get(field_key)
+                or _fallback_field_label(field_key),
+                display_order=self._display_order_by_field.get(field_key),
+                text_predicates=self._text_predicates_by_field.get(field_key, ()),
+                relationship_predicates=(
+                    self._relationship_predicates_by_field.get(field_key, ())
+                ),
+                origin_type_ids=tuple(origin_type_ids_by_field[field_key]),
+            )
+            for field_key in ordered_field_keys
+        )
 
     def _ensure_cache(self) -> None:
         if self._cache_loaded_at and (time.time() - self._cache_loaded_at) <= self._cache_ttl_seconds:
@@ -156,6 +262,8 @@ class ConceptSummaryFieldResolver:
     def _load_cache(self) -> None:
         self._text_predicates_by_field = {}
         self._relationship_predicates_by_field = {}
+        self._display_order_by_field = {}
+        self._field_labels_by_field = {}
         self._summary_fields_by_type = {}
         self._cache_loaded_at = time.time()
 
@@ -171,8 +279,18 @@ class ConceptSummaryFieldResolver:
             concept_id=concept_id,
             predicates=_RELATIONSHIP_PREDICATE_CONFIG_ALIASES,
         )
+        display_order = self._load_first_display_order(concept_id=concept_id)
+        try:
+            field_concept = get_concept_by_concept_id(concept_id)
+        except Exception:
+            field_concept = None
         self._text_predicates_by_field[field_key] = text_predicates
         self._relationship_predicates_by_field[field_key] = relationship_predicates
+        self._display_order_by_field[field_key] = display_order
+        self._field_labels_by_field[field_key] = _field_label(
+            field_concept if isinstance(field_concept, Mapping) else None,
+            field_key,
+        )
 
     def _load_type_binding(self, type_id: str) -> None:
         try:
@@ -261,12 +379,18 @@ class ConceptSummaryFieldResolver:
             for field_key in ordered_field_keys
             if field_key not in self._text_predicates_by_field
             or field_key not in self._relationship_predicates_by_field
+            or field_key not in self._display_order_by_field
+            or field_key not in self._field_labels_by_field
         ]
         if not missing_field_keys:
             return
         concept_ids = [_field_concept_id(key) for key in missing_field_keys]
         predicates = _dedupe_preserve_order(
-            [*_TEXT_PREDICATE_CONFIG_ALIASES, *_RELATIONSHIP_PREDICATE_CONFIG_ALIASES]
+            [
+                *_TEXT_PREDICATE_CONFIG_ALIASES,
+                *_RELATIONSHIP_PREDICATE_CONFIG_ALIASES,
+                *_DISPLAY_ORDER_PREDICATE_ALIASES,
+            ]
         )
         try:
             rows_by_concept = get_texts_for_concepts(
@@ -281,10 +405,31 @@ class ConceptSummaryFieldResolver:
             )
             rows_by_concept = {}
 
+        try:
+            field_docs = list(
+                ConceptsRepository.find(
+                    {"concept_id": {"$in": concept_ids}},
+                    {"concept_id": 1, "name": 1, "names": 1},
+                    limit=len(concept_ids),
+                )
+            )
+        except Exception as exc:
+            _logger.debug(
+                "[summary_field_resolver] Failed to batch-load field labels: %s",
+                exc,
+            )
+            field_docs = []
+        field_docs_by_id = {
+            str(doc.get("concept_id") or "").strip(): doc
+            for doc in field_docs
+            if isinstance(doc, Mapping)
+        }
+
         for field_key, concept_id in zip(missing_field_keys, concept_ids):
             rows = rows_by_concept.get(concept_id, [])
             text_predicates: tuple[str, ...] = ()
             relationship_predicates: tuple[str, ...] = ()
+            display_order: float | None = None
             for predicate in _TEXT_PREDICATE_CONFIG_ALIASES:
                 text_predicates = self._first_config_value(
                     [row for row in rows if row.get("predicate") == predicate]
@@ -297,9 +442,20 @@ class ConceptSummaryFieldResolver:
                 )
                 if relationship_predicates:
                     break
+            for predicate in _DISPLAY_ORDER_PREDICATE_ALIASES:
+                display_order = self._first_display_order(
+                    [row for row in rows if row.get("predicate") == predicate]
+                )
+                if display_order is not None:
+                    break
             self._text_predicates_by_field[field_key] = text_predicates
             self._relationship_predicates_by_field[field_key] = (
                 relationship_predicates
+            )
+            self._display_order_by_field[field_key] = display_order
+            self._field_labels_by_field[field_key] = _field_label(
+                field_docs_by_id.get(concept_id),
+                field_key,
             )
 
     @staticmethod
@@ -336,6 +492,36 @@ class ConceptSummaryFieldResolver:
                 return values
         return ()
 
+    @staticmethod
+    def _load_first_display_order(*, concept_id: str) -> float | None:
+        for predicate in _DISPLAY_ORDER_PREDICATE_ALIASES:
+            try:
+                rows = get_texts_for_concept(
+                    concept_id,
+                    predicate=predicate,
+                    limit=5,
+                )
+            except Exception as exc:
+                _logger.debug(
+                    "[summary_field_resolver] Failed to load display order for %s/%s: %s",
+                    concept_id,
+                    predicate,
+                    exc,
+                )
+                continue
+            value = ConceptSummaryFieldResolver._first_display_order(rows)
+            if value is not None:
+                return value
+        return None
+
+    @staticmethod
+    def _first_display_order(rows: list[dict[str, Any]]) -> float | None:
+        for row in rows:
+            value = _normalise_display_order(row.get("text"))
+            if value is not None:
+                return value
+        return None
+
 
 _resolver: ConceptSummaryFieldResolver | None = None
 
@@ -348,10 +534,11 @@ def get_concept_summary_field_resolver() -> ConceptSummaryFieldResolver:
 
 
 __all__ = [
-    "ConceptSummaryFieldResolver",
     "SUMMARY_FIELD_DISPLAY_ORDER_PREDICATE",
     "SUMMARY_RELATIONSHIP_PREDICATE_CONFIG",
     "SUMMARY_TEXT_PREDICATE_CONFIG",
     "SUMMARY_TYPE_FIELD_RELATIONSHIP",
+    "ConceptSummaryFieldResolver",
+    "SummaryFieldDefinition",
     "get_concept_summary_field_resolver",
 ]

--- a/src/backend/services/concept_summary_renderer_service.py
+++ b/src/backend/services/concept_summary_renderer_service.py
@@ -7,6 +7,7 @@ for the concept tab's top summary panel.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Mapping
 from typing import Any, cast
@@ -21,7 +22,10 @@ from .concept_service import (
     get_concept_by_concept_id,
     resolve_concept_display_names,
 )
-from .concept_summary_field_resolver import get_concept_summary_field_resolver
+from .concept_summary_field_resolver import (
+    SummaryFieldDefinition,
+    get_concept_summary_field_resolver,
+)
 from .concept_type_closure_service import load_type_closure
 from .conversation_projection_service import (
     ConversationProjectionAccessChangedError,
@@ -33,7 +37,8 @@ from .renderer_applicability_service import resolve_renderer_applicability_from_
 from .renderer_applicability_vontology_service import (
     load_renderer_definitions_from_concept_ids,
 )
-from .text_value_service import get_texts_for_concept
+from .scoped_assertion_service import list_visible_scoped_assertions_page
+from .text_value_service import get_texts_for_concept, get_texts_for_concepts
 
 CONCEPT_PAGE_RENDERER_CONCEPT_IDS: tuple[str, ...] = (
     "#V#concept_page_conversation_renderer",
@@ -77,6 +82,43 @@ _PERSON_ROLE_EXCLUSIONS: frozenset[str] = frozenset(
         "#V#von_user",
     }
 )
+
+_CONSUMED_SUMMARY_FIELDS_BY_RENDERER: dict[str | None, frozenset[str]] = {
+    "#V#concept_page_identity_renderer": frozenset(
+        {"description", "content", "email", "affiliation", "authored_work"}
+    ),
+    "#V#concept_page_document_renderer": frozenset(
+        {"description", "content", "author", "publication_date"}
+    ),
+    "#V#concept_page_task_renderer": frozenset(
+        {
+            "description",
+            "content",
+            "task_status",
+            "priority",
+            "due_date",
+            "task_source",
+        }
+    ),
+    "#V#concept_page_event_renderer": frozenset(
+        {
+            "description",
+            "content",
+            "event_date",
+            "meeting_participant",
+            "meeting_location",
+            "meeting_host",
+        }
+    ),
+    "#V#concept_page_location_renderer": frozenset(
+        {"description", "content", "capacity", "url"}
+    ),
+    None: frozenset({"description", "content"}),
+}
+
+_PROMOTED_FIELD_VALUE_LIMIT = 250
+
+_logger = logging.getLogger(__name__)
 
 
 def _normalise_strings(raw: Any) -> list[str]:
@@ -305,6 +347,296 @@ def _relationship_values(
             else:
                 values.append(raw)
     return _dedupe_preserve_order(values)
+
+
+def _source_context_for_scope(
+    scope: Any,
+    *,
+    preview_cache: Mapping[str, str],
+) -> dict[str, Any]:
+    scope_payload = scope if isinstance(scope, Mapping) else {}
+    mode = str(scope_payload.get("mode") or "").strip()
+    organisation_id = str(
+        scope_payload.get("organisation_concept_id") or ""
+    ).strip()
+    if mode == "organisation":
+        organisation_name = preview_cache.get(organisation_id)
+        return {
+            "kind": "organisation",
+            "label": (
+                f"Organisation — {organisation_name}"
+                if organisation_name
+                else "Organisation"
+            ),
+            "organisation_concept_id": organisation_id or None,
+        }
+    return {
+        "kind": "personal",
+        "label": "Personal — visible only to you",
+        "organisation_concept_id": None,
+    }
+
+
+def _prime_additional_preview_names(
+    concept_ids: list[str],
+    preview_cache: dict[str, str],
+) -> None:
+    missing_ids = _dedupe_preserve_order(
+        [
+            concept_id
+            for concept_id in concept_ids
+            if concept_id.startswith("#V#") and concept_id not in preview_cache
+        ]
+    )
+    if not missing_ids:
+        return
+    try:
+        docs = list(
+            ConceptsRepository.find(
+                {"concept_id": {"$in": missing_ids}},
+                {"concept_id": 1, "name": 1, "names": 1},
+                limit=len(missing_ids),
+            )
+        )
+    except Exception as exc:
+        _logger.debug(
+            "[concept_summary_renderer] Failed to load promoted value labels: %s",
+            exc,
+        )
+        docs = []
+    display_names = resolve_concept_display_names(docs)
+    for concept_id in missing_ids:
+        preview_cache[concept_id] = display_names.get(concept_id) or concept_id
+
+
+def _project_promoted_text_value(
+    row: Mapping[str, Any],
+    *,
+    preview_cache: Mapping[str, str],
+) -> dict[str, Any] | None:
+    text = row.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    is_scoped = row.get("row_kind") == "scoped_assertion"
+    scope = row.get("assertion_scope")
+    if not isinstance(scope, Mapping):
+        context = row.get("context")
+        scope = (
+            context.get("assertion_scope")
+            if isinstance(context, Mapping)
+            else None
+        )
+    return {
+        "kind": "text",
+        "text": text,
+        "language": str(row.get("lang") or "").strip() or None,
+        "predicate_id": str(row.get("predicate") or "").strip(),
+        "relation_id": row.get("relation_id"),
+        "assertion_id": row.get("assertion_id"),
+        "canonical_publication": not is_scoped,
+        "source_context": (
+            _source_context_for_scope(scope, preview_cache=preview_cache)
+            if is_scoped
+            else {"kind": "canonical", "label": "Canonical"}
+        ),
+        "provenance": row.get("provenance") or {},
+    }
+
+
+def _project_promoted_fields(
+    *,
+    concept_id: str,
+    relationships: Mapping[str, Any],
+    definitions: tuple[SummaryFieldDefinition, ...],
+    consumed_field_keys: frozenset[str],
+    preview_cache: dict[str, str],
+    actor_user_id: str | None,
+    organisation_concept_id: str | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Project every value of represented fields not owned by a legacy card."""
+
+    promoted_definitions = tuple(
+        definition
+        for definition in definitions
+        if definition.field_key not in consumed_field_keys
+    )
+    if not promoted_definitions:
+        return [], {
+            "context_view": "base_publication",
+            "text_query_truncated": False,
+            "relationship_query_truncated": False,
+        }
+
+    text_predicates = _dedupe_preserve_order(
+        [
+            predicate
+            for definition in promoted_definitions
+            for predicate in definition.text_predicates
+        ]
+    )
+    relationship_predicates = _dedupe_preserve_order(
+        [
+            predicate
+            for definition in promoted_definitions
+            for predicate in definition.relationship_predicates
+        ]
+    )
+    context_view = "actor_effective" if actor_user_id else "base_publication"
+    text_query_metadata: dict[str, Any] = {}
+    promoted_text_rows: list[dict[str, Any]] = []
+    if text_predicates:
+        rows_by_concept = get_texts_for_concepts(
+            [concept_id],
+            predicates=text_predicates,
+            limit_per_concept=_PROMOTED_FIELD_VALUE_LIMIT,
+            query_metadata=text_query_metadata,
+            context_view=context_view,
+        )
+        promoted_text_rows = list(rows_by_concept.get(concept_id) or [])
+
+    scoped_relationship_page: dict[str, Any] = {
+        "items": [],
+        "truncated": False,
+        "counts_are_lower_bounds": False,
+    }
+    if actor_user_id and relationship_predicates:
+        scoped_relationship_page = list_visible_scoped_assertions_page(
+            subject_concept_ids=[concept_id],
+            predicates=relationship_predicates,
+            object_kind="concept",
+            limit=_PROMOTED_FIELD_VALUE_LIMIT,
+            limit_per_subject=_PROMOTED_FIELD_VALUE_LIMIT,
+            user_concept_id=actor_user_id,
+            organisation_concept_id=organisation_concept_id,
+        )
+
+    referenced_ids: list[str] = []
+    for definition in promoted_definitions:
+        for predicate in definition.relationship_predicates:
+            referenced_ids.extend(_normalise_strings(relationships.get(predicate)))
+    for assertion in scoped_relationship_page.get("items") or []:
+        if not isinstance(assertion, Mapping):
+            continue
+        referenced_ids.extend(
+            [
+                str(assertion.get("object_concept_id") or "").strip(),
+                str(
+                    ((assertion.get("scope") or {}).get("organisation_concept_id"))
+                    if isinstance(assertion.get("scope"), Mapping)
+                    else ""
+                ).strip(),
+            ]
+        )
+    for row in promoted_text_rows:
+        scope = row.get("assertion_scope")
+        if not isinstance(scope, Mapping):
+            context = row.get("context")
+            scope = (
+                context.get("assertion_scope")
+                if isinstance(context, Mapping)
+                else None
+            )
+        if isinstance(scope, Mapping):
+            referenced_ids.append(
+                str(scope.get("organisation_concept_id") or "").strip()
+            )
+    _prime_additional_preview_names(referenced_ids, preview_cache)
+
+    fields: list[dict[str, Any]] = []
+    for definition in promoted_definitions:
+        values: list[dict[str, Any]] = []
+        text_predicate_set = set(definition.text_predicates)
+        for row in promoted_text_rows:
+            if str(row.get("predicate") or "").strip() not in text_predicate_set:
+                continue
+            projected = _project_promoted_text_value(
+                row,
+                preview_cache=preview_cache,
+            )
+            if projected is not None:
+                values.append(projected)
+
+        for predicate in definition.relationship_predicates:
+            for object_concept_id in _normalise_strings(
+                relationships.get(predicate)
+            ):
+                if not object_concept_id.startswith("#V#"):
+                    continue
+                values.append(
+                    {
+                        "kind": "concept",
+                        "concept_id": object_concept_id,
+                        "display_name": preview_cache.get(object_concept_id)
+                        or object_concept_id,
+                        "predicate_id": predicate,
+                        "relation_id": None,
+                        "assertion_id": None,
+                        "canonical_publication": True,
+                        "source_context": {
+                            "kind": "canonical",
+                            "label": "Canonical",
+                        },
+                        "provenance": {},
+                    }
+                )
+        relationship_predicate_set = set(definition.relationship_predicates)
+        for assertion in scoped_relationship_page.get("items") or []:
+            if not isinstance(assertion, Mapping):
+                continue
+            predicate = str(assertion.get("predicate") or "").strip()
+            if predicate not in relationship_predicate_set:
+                continue
+            object_concept_id = str(
+                assertion.get("object_concept_id") or ""
+            ).strip()
+            if not object_concept_id:
+                continue
+            values.append(
+                {
+                    "kind": "concept",
+                    "concept_id": object_concept_id,
+                    "display_name": preview_cache.get(object_concept_id)
+                    or object_concept_id,
+                    "predicate_id": predicate,
+                    "relation_id": None,
+                    "assertion_id": assertion.get("assertion_id"),
+                    "canonical_publication": False,
+                    "source_context": _source_context_for_scope(
+                        assertion.get("scope"),
+                        preview_cache=preview_cache,
+                    ),
+                    "provenance": assertion.get("provenance") or {},
+                }
+            )
+        if not values:
+            continue
+        fields.append(
+            {
+                "field_key": definition.field_key,
+                "field_concept_id": definition.field_concept_id,
+                "label": definition.label,
+                "display_order": definition.display_order,
+                "origin_type_ids": list(definition.origin_type_ids),
+                "values": values,
+            }
+        )
+
+    return fields, {
+        "context_view": context_view,
+        "text_query_truncated": bool(
+            text_query_metadata.get("relation_query_truncated")
+            or text_query_metadata.get("scoped_query_truncated")
+        ),
+        "text_counts_are_lower_bounds": bool(
+            text_query_metadata.get("scoped_counts_are_lower_bounds")
+        ),
+        "relationship_query_truncated": bool(
+            scoped_relationship_page.get("truncated")
+        ),
+        "relationship_counts_are_lower_bounds": bool(
+            scoped_relationship_page.get("counts_are_lower_bounds")
+        ),
+    }
 
 
 def _type_labels(
@@ -888,9 +1220,13 @@ def load_concept_summary_renderer(
     )
     present_predicates = _collect_present_predicates(relationships, text_rows)
     field_resolver = get_concept_summary_field_resolver()
-    summary_field_keys = frozenset(
-        field_resolver.get_summary_fields_for_types(resolved_type_ids)
+    summary_field_definitions = (
+        field_resolver.get_summary_field_definitions_for_types(resolved_type_ids)
     )
+    summary_field_key_list = [
+        definition.field_key for definition in summary_field_definitions
+    ]
+    summary_field_keys = frozenset(summary_field_key_list)
 
     definitions, loading_diagnostics = load_renderer_definitions_from_concept_ids(
         CONCEPT_PAGE_RENDERER_CONCEPT_IDS
@@ -949,6 +1285,13 @@ def load_concept_summary_renderer(
         if conversation_card is None:
             raise ConceptNotFoundError(f"Concept not found: {concept_id}")
         panel = _build_conversation_panel(conversation_card)
+        promoted_fields: list[dict[str, Any]] = []
+        promoted_field_diagnostics = {
+            "context_view": "actor_effective",
+            "skipped_for_conversation_projection": True,
+            "text_query_truncated": False,
+            "relationship_query_truncated": False,
+        }
     else:
         panel = _build_panel_for_renderer(
             renderer_id=selected_renderer_id,
@@ -960,6 +1303,63 @@ def load_concept_summary_renderer(
             preview_cache=preview_cache,
             summary_field_keys=summary_field_keys,
         )
+        consumed_field_keys = _CONSUMED_SUMMARY_FIELDS_BY_RENDERER.get(
+            selected_renderer_id,
+            _CONSUMED_SUMMARY_FIELDS_BY_RENDERER[None],
+        )
+        try:
+            promoted_fields, promoted_field_diagnostics = (
+                _project_promoted_fields(
+                    concept_id=concept_id,
+                    relationships=relationships,
+                    definitions=summary_field_definitions,
+                    consumed_field_keys=consumed_field_keys,
+                    preview_cache=preview_cache,
+                    actor_user_id=actor_user_id,
+                    organisation_concept_id=organisation_concept_id,
+                )
+            )
+            promoted_fields_truncated = bool(
+                promoted_field_diagnostics.get("text_query_truncated")
+                or promoted_field_diagnostics.get(
+                    "relationship_query_truncated"
+                )
+            )
+            panel["promoted_fields_status"] = {
+                "available": True,
+                "truncated": promoted_fields_truncated,
+                **(
+                    {
+                        "message": (
+                            "Some promoted values are not shown; use the full "
+                            "relationship view for the complete bounded page."
+                        )
+                    }
+                    if promoted_fields_truncated
+                    else {}
+                ),
+            }
+        except Exception as exc:
+            _logger.warning(
+                "[concept_summary_renderer] Promoted field projection failed for %s: %s",
+                concept_id,
+                exc,
+            )
+            promoted_fields = []
+            promoted_field_diagnostics = {
+                "context_view": (
+                    "actor_effective" if actor_user_id else "base_publication"
+                ),
+                "available": False,
+                "error_type": type(exc).__name__,
+                "text_query_truncated": False,
+                "relationship_query_truncated": False,
+            }
+            panel["promoted_fields_status"] = {
+                "available": False,
+                "message": "Promoted fields are temporarily unavailable.",
+            }
+        panel["promoted_fields"] = promoted_fields
 
     payload = {
         "success": True,
@@ -967,12 +1367,13 @@ def load_concept_summary_renderer(
         "display_name": _display_name(concept),
         "direct_type_ids": direct_type_ids,
         "resolved_type_ids": resolved_type_ids,
-        "summary_field_keys": sorted(summary_field_keys),
+        "summary_field_keys": summary_field_key_list,
         "selected_renderer": selected.to_dict() if selected else None,
         "panel": panel,
         "diagnostics": {
             "renderer_definition_loading": loading_diagnostics,
             "renderer_resolution": resolution.to_dict(),
+            "promoted_fields": promoted_field_diagnostics,
         },
     }
     if actor_user_id and not is_conversation:

--- a/src/backend/vontology/seed_bundles/concept_summary_fields_seed_bundle.json
+++ b/src/backend/vontology/seed_bundles/concept_summary_fields_seed_bundle.json
@@ -1,10 +1,11 @@
 {
   "schema_version": "concept_summary_field_seed_bundle.v1",
-  "seed_version": "1",
-  "source_tag": "JVNAUTOSCI-1958",
+  "seed_version": "2",
+  "source_tag": "JVNAUTOSCI-2234",
   "managed_by": "concept_summary_field_vontology_service",
   "concepts": [
     {"concept_id": "#V#thing", "name": "Thing", "parent_concept_ids": [], "create_as_instance": false, "description": "The most general Vontology type."},
+    {"concept_id": "#V#abstract_object", "name": "Abstract Object", "parent_concept_ids": ["#V#thing"], "create_as_instance": false, "description": "A non-physical object."},
     {"concept_id": "#V#predicate", "name": "Predicate", "parent_concept_ids": ["#V#thing"], "create_as_instance": false, "description": "A relationship or text-relation predicate concept."},
     {"concept_id": "#V#summary_field", "name": "Summary Field", "parent_concept_ids": ["#V#thing"], "create_as_instance": false, "description": "A type of represented concept-summary field configuration."},
     {"concept_id": "#V#has_summary_fields", "name": "has summary fields", "parent_concept_ids": ["#V#predicate"], "create_as_instance": true, "description": "Relates a Vontology type concept to the summary field concepts used for instances of that type."},
@@ -14,11 +15,13 @@
     {"concept_id": "#V#person", "name": "Person", "parent_concept_ids": ["#V#thing"]},
     {"concept_id": "#V#document", "name": "Document", "parent_concept_ids": ["#V#thing"]},
     {"concept_id": "#V#research_paper", "name": "Research Paper", "parent_concept_ids": ["#V#document"]},
+    {"concept_id": "#V#research_description", "name": "Research Description", "parent_concept_ids": ["#V#abstract_object"]},
     {"concept_id": "#V#task", "name": "Task", "parent_concept_ids": ["#V#thing"]},
     {"concept_id": "#V#meeting", "name": "Meeting", "parent_concept_ids": ["#V#thing"]},
     {"concept_id": "#V#room", "name": "Room", "parent_concept_ids": ["#V#thing"]},
     {"concept_id": "#V#summary_field_description", "name": "Description", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Concept-summary field configuration for description.", "system_tags": ["concept-summary-field", "renderer-support"]},
     {"concept_id": "#V#summary_field_content", "name": "Content", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Concept-summary field configuration for content.", "system_tags": ["concept-summary-field", "renderer-support"]},
+    {"concept_id": "#V#summary_field_research_description_as_of", "name": "Research Description As Of", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Promotes dated research-description text in the concept summary without changing KCAP salience.", "system_tags": ["concept-summary-field", "renderer-support"]},
     {"concept_id": "#V#summary_field_email", "name": "Email", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Concept-summary field configuration for email.", "system_tags": ["concept-summary-field", "renderer-support"]},
     {"concept_id": "#V#summary_field_publication_date", "name": "Publication Date", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Concept-summary field configuration for publication_date.", "system_tags": ["concept-summary-field", "renderer-support"]},
     {"concept_id": "#V#summary_field_task_status", "name": "Task Status", "parent_concept_ids": ["#V#summary_field"], "create_as_instance": true, "description": "Concept-summary field configuration for task_status.", "system_tags": ["concept-summary-field", "renderer-support"]},
@@ -40,6 +43,8 @@
     {"subject_concept_id": "#V#summary_field_description", "predicate": "#V#summary_field_display_order", "text": "10", "lang": "en-NZ"},
     {"subject_concept_id": "#V#summary_field_content", "predicate": "#V#has_summary_text_predicates_json", "text_json": ["hasContent", "#V#hasContent"], "lang": "en-NZ"},
     {"subject_concept_id": "#V#summary_field_content", "predicate": "#V#summary_field_display_order", "text": "20", "lang": "en-NZ"},
+    {"subject_concept_id": "#V#summary_field_research_description_as_of", "predicate": "#V#has_summary_text_predicates_json", "text_json": ["#V#has_research_description_as_of"], "lang": "en-NZ"},
+    {"subject_concept_id": "#V#summary_field_research_description_as_of", "predicate": "#V#summary_field_display_order", "text": "15", "lang": "en-NZ"},
     {"subject_concept_id": "#V#summary_field_email", "predicate": "#V#has_summary_text_predicates_json", "text_json": ["#V#has_email", "has_email"], "lang": "en-NZ"},
     {"subject_concept_id": "#V#summary_field_email", "predicate": "#V#summary_field_display_order", "text": "30", "lang": "en-NZ"},
     {"subject_concept_id": "#V#summary_field_publication_date", "predicate": "#V#has_summary_text_predicates_json", "text_json": ["#V#has_publication_date", "has_publication_date"], "lang": "en-NZ"},
@@ -78,6 +83,7 @@
     {"subject_concept_id": "#V#task", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_description", "#V#summary_field_task_status", "#V#summary_field_priority", "#V#summary_field_due_date", "#V#summary_field_task_source"]},
     {"subject_concept_id": "#V#meeting", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_description", "#V#summary_field_event_date", "#V#summary_field_meeting_participant", "#V#summary_field_meeting_location", "#V#summary_field_meeting_host"]},
     {"subject_concept_id": "#V#room", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_description", "#V#summary_field_capacity", "#V#summary_field_url"]},
-    {"subject_concept_id": "#V#thing", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_description", "#V#summary_field_content"]}
+    {"subject_concept_id": "#V#thing", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_description", "#V#summary_field_content"]},
+    {"subject_concept_id": "#V#research_description", "predicate": "#V#has_summary_fields", "object_concept_ids": ["#V#summary_field_research_description_as_of"]}
   ]
 }

--- a/src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js
@@ -1,5 +1,6 @@
 import { getJsonDetailed } from '../apiService.js';
 import { activateTab } from '../tabNavigation.js';
+import { copyTextWithClipboardFallback } from '../utils/copyJsonButtonState.js';
 
 const PANEL_VARIANTS = new Set([
   'identity',
@@ -10,6 +11,8 @@ const PANEL_VARIANTS = new Set([
   'conversation',
   'generic',
 ]);
+const LONG_PROMOTED_TEXT_MIN_CHARS = 60;
+let promotedTextDisclosureSequence = 0;
 
 function getMountElement(stepContainer, suffix) {
   return (
@@ -70,6 +73,142 @@ function createFacts(facts = []) {
     list.appendChild(fact);
   });
   return list;
+}
+
+function createPromotedValueMeta(value) {
+  const predicateId = cleanText(value?.predicate_id);
+  const sourceLabel = cleanText(value?.source_context?.label);
+  const rawScopeKind = cleanText(value?.source_context?.kind);
+  const scopeKind = ['canonical', 'personal', 'organisation'].includes(rawScopeKind)
+    ? rawScopeKind
+    : 'canonical';
+  if (!predicateId && !sourceLabel) return null;
+  const meta = document.createElement('div');
+  meta.className = 'concept-summary-promoted-value-meta';
+  if (sourceLabel) {
+    appendTextElement(
+      meta,
+      'span',
+      `concept-summary-promoted-scope scope-${scopeKind}`,
+      sourceLabel,
+    );
+  }
+  if (predicateId) {
+    const predicate = appendTextElement(
+      meta,
+      'span',
+      'concept-summary-promoted-predicate',
+      predicateId,
+    );
+    if (predicate) predicate.title = predicateId;
+  }
+  return meta;
+}
+
+function createPromotedTextValue(value) {
+  const exactText = typeof value?.text === 'string' ? value.text : '';
+  if (!exactText.trim()) return null;
+  const item = document.createElement('article');
+  item.className = 'concept-summary-promoted-value concept-summary-promoted-text-value';
+  const text = document.createElement('p');
+  text.className = 'concept-summary-promoted-text';
+  text.textContent = exactText;
+  const isLong = exactText.length > LONG_PROMOTED_TEXT_MIN_CHARS || exactText.includes('\n');
+  if (isLong) text.classList.add('is-collapsed');
+  const disclosureId = `conceptSummaryPromotedText_${++promotedTextDisclosureSequence}`;
+  text.id = disclosureId;
+  item.appendChild(text);
+
+  const controls = document.createElement('div');
+  controls.className = 'concept-summary-promoted-controls';
+  if (isLong) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'concept-summary-promoted-control concept-summary-promoted-toggle';
+    toggle.textContent = 'Show full text';
+    toggle.setAttribute('aria-controls', disclosureId);
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.addEventListener('click', () => {
+      const shouldExpand = text.classList.contains('is-collapsed');
+      text.classList.toggle('is-collapsed', !shouldExpand);
+      toggle.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
+      toggle.textContent = shouldExpand ? 'Show less' : 'Show full text';
+    });
+    controls.appendChild(toggle);
+  }
+
+  const copy = document.createElement('button');
+  copy.type = 'button';
+  copy.className = 'concept-summary-promoted-control concept-summary-promoted-copy';
+  copy.textContent = 'Copy';
+  copy.setAttribute('aria-label', 'Copy full text');
+  copy.setAttribute('aria-live', 'polite');
+  copy.addEventListener('click', async () => {
+    const copied = await copyTextWithClipboardFallback(exactText);
+    copy.textContent = copied ? 'Copied' : 'Copy failed';
+  });
+  controls.appendChild(copy);
+  item.appendChild(controls);
+  const meta = createPromotedValueMeta(value);
+  if (meta) item.appendChild(meta);
+  return item;
+}
+
+function createPromotedConceptValue(value) {
+  const conceptId = cleanText(value?.concept_id);
+  if (!conceptId.startsWith('#V#')) return null;
+  const item = document.createElement('article');
+  item.className = 'concept-summary-promoted-value concept-summary-promoted-concept-value';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'concept-summary-promoted-concept';
+  button.textContent = cleanText(value?.display_name) || conceptId;
+  button.title = conceptId;
+  button.addEventListener('click', () => {
+    document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+      detail: {
+        conceptId,
+        createConceptTab: true,
+        promoteExistingTab: true,
+        modifierKeys: { shiftKey: true },
+      },
+    }));
+  });
+  item.appendChild(button);
+  const meta = createPromotedValueMeta(value);
+  if (meta) item.appendChild(meta);
+  return item;
+}
+
+function createPromotedFields(rawFields = []) {
+  const fields = Array.isArray(rawFields) ? rawFields.slice(0, 100) : [];
+  const container = document.createElement('section');
+  container.className = 'concept-summary-promoted-fields';
+  let renderedFieldCount = 0;
+  fields.forEach((field) => {
+    const label = cleanText(field?.label);
+    const rawValues = Array.isArray(field?.values) ? field.values.slice(0, 250) : [];
+    if (!label || rawValues.length === 0) return;
+    const values = rawValues.flatMap((value) => {
+      const element = value?.kind === 'concept'
+        ? createPromotedConceptValue(value)
+        : value?.kind === 'text'
+          ? createPromotedTextValue(value)
+          : null;
+      return element ? [element] : [];
+    });
+    if (values.length === 0) return;
+    const section = document.createElement('section');
+    section.className = 'concept-summary-promoted-field';
+    appendTextElement(section, 'h4', 'concept-summary-promoted-label', label);
+    const valueList = document.createElement('div');
+    valueList.className = 'concept-summary-promoted-values';
+    valueList.append(...values);
+    section.appendChild(valueList);
+    container.appendChild(section);
+    renderedFieldCount += 1;
+  });
+  return renderedFieldCount > 0 ? container : null;
 }
 
 function createExpandedSections(expandedSections = []) {
@@ -271,6 +410,16 @@ function applyPanelPayload(panel, payload) {
   const facts = createFacts(panelData.facts);
   if (facts) panel.appendChild(facts);
   appendTextElement(panel, 'p', 'concept-summary-text', panelData.summary);
+  const promotedFields = createPromotedFields(panelData.promoted_fields);
+  if (promotedFields) panel.appendChild(promotedFields);
+  if (cleanText(panelData?.promoted_fields_status?.message)) {
+    appendTextElement(
+      panel,
+      'p',
+      'concept-summary-promoted-unavailable',
+      panelData.promoted_fields_status.message,
+    );
+  }
   const focus = createFocalConcepts(panelData.focal_concepts);
   if (focus) panel.appendChild(focus);
   const primaryAction = createOpenConversationButton(panelData.open_action);

--- a/src/frontend/web/von_interface/static/js/dynamicTabs.js
+++ b/src/frontend/web/von_interface/static/js/dynamicTabs.js
@@ -14,7 +14,7 @@ import { destroyPredicateView, initializePredicateView } from './predicateView.j
 import { getConceptTypeDisplayNames, setCurrentConceptType, setCurrentlySelectedConceptId, setSelectedConceptOriginalName } from './state.js';
 import { activateTab } from './tabNavigation.js';
 import { createVontologyCartouche, normalisePotentialConceptId } from './utils/textDecorator.js';
-import { copyJsonTextWithButtonFeedback, resetCopyJsonButtonPreCopyState } from './utils/copyJsonButtonState.js';
+import { copyJsonTextWithButtonFeedback, copyTextWithClipboardFallback, resetCopyJsonButtonPreCopyState } from './utils/copyJsonButtonState.js';
 import { mountJsonInspector } from './utils/jsonInspector.js';
 import {
     describePublicationContext,
@@ -7297,6 +7297,104 @@ async function initializeRelationshipsUI(conceptId, suffix, kind) {
 }
 
 const relationshipExtentPageState = new Map();
+let relationshipTextDisclosureSequence = 0;
+
+export function createRelationshipTextDisclosureCell(
+    value,
+    language = '',
+    { roleLabel = 'Argument', predicateLabel = 'relationship' } = {}
+) {
+    const exactText = typeof value === 'string' ? value : String(value ?? '');
+    const cell = document.createElement('td');
+    cell.className = 'relationship-text-cell';
+    const preview = document.createElement('span');
+    preview.className = 'relationship-text-preview';
+    preview.textContent = exactText;
+    cell.appendChild(preview);
+    if (language) {
+        const badge = document.createElement('span');
+        badge.className = 'relationship-text-language';
+        badge.textContent = language;
+        cell.appendChild(badge);
+    }
+
+    const isLong = exactText.length > 60 || exactText.includes('\n');
+    if (!isLong) {
+        return { cell, detailRow: null };
+    }
+    preview.classList.add('is-collapsed');
+    const disclosureId = `relationshipTextDetail_${++relationshipTextDisclosureSequence}`;
+    const controls = document.createElement('div');
+    controls.className = 'relationship-text-controls';
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'relationship-text-control relationship-text-toggle';
+    toggle.textContent = 'Show full';
+    toggle.setAttribute('aria-controls', disclosureId);
+    toggle.setAttribute('aria-expanded', 'false');
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.className = 'relationship-text-control relationship-text-copy';
+    copy.textContent = 'Copy';
+    copy.setAttribute('aria-label', `Copy full ${roleLabel} text`);
+    copy.setAttribute('aria-live', 'polite');
+    copy.addEventListener('click', async () => {
+        const copied = await copyTextWithClipboardFallback(exactText);
+        copy.textContent = copied ? 'Copied' : 'Copy failed';
+    });
+    controls.append(toggle, copy);
+    cell.appendChild(controls);
+
+    const detailRow = document.createElement('tr');
+    detailRow.className = 'relationship-text-detail-row';
+    detailRow.hidden = true;
+    const detailCell = document.createElement('td');
+    detailCell.colSpan = 10;
+    const detail = document.createElement('section');
+    detail.id = disclosureId;
+    detail.className = 'relationship-text-detail';
+    const detailHeader = document.createElement('div');
+    detailHeader.className = 'relationship-text-detail-header';
+    const detailTitle = document.createElement('strong');
+    detailTitle.textContent = `${roleLabel} · ${predicateLabel}`;
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'relationship-text-control relationship-text-close';
+    close.textContent = 'Close';
+    const fullText = document.createElement('pre');
+    fullText.className = 'relationship-text-full';
+    fullText.textContent = exactText;
+    const detailActions = document.createElement('div');
+    detailActions.className = 'relationship-text-detail-actions';
+    const detailCopy = document.createElement('button');
+    detailCopy.type = 'button';
+    detailCopy.className = 'relationship-text-control relationship-text-copy';
+    detailCopy.textContent = 'Copy full text';
+    detailCopy.setAttribute('aria-live', 'polite');
+    detailCopy.addEventListener('click', async () => {
+        const copied = await copyTextWithClipboardFallback(exactText);
+        detailCopy.textContent = copied ? 'Copied' : 'Copy failed';
+    });
+    detailActions.appendChild(detailCopy);
+    detailHeader.append(detailTitle, close);
+    detail.append(detailHeader, fullText, detailActions);
+    detailCell.appendChild(detail);
+    detailRow.appendChild(detailCell);
+
+    const setExpanded = (expanded) => {
+        detailRow.hidden = !expanded;
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        toggle.textContent = expanded ? 'Hide full' : 'Show full';
+    };
+    toggle.addEventListener('click', () => {
+        setExpanded(detailRow.hidden);
+    });
+    close.addEventListener('click', () => {
+        setExpanded(false);
+        toggle.focus();
+    });
+    return { cell, detailRow };
+}
 
 function relationshipExtentStateKey(conceptId, suffix) {
     return `${conceptId}::${suffix}`;
@@ -7434,23 +7532,6 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             return cell;
         };
 
-        const createTextCell = (value, language = '') => {
-            const cell = document.createElement('td');
-            const span = document.createElement('span');
-            span.textContent = value || '';
-            span.style.fontFamily = 'monospace';
-            cell.appendChild(span);
-            if (language) {
-                const badge = document.createElement('span');
-                badge.textContent = ` ${language}`;
-                badge.style.fontSize = '0.75rem';
-                badge.style.color = '#6b7280';
-                badge.style.marginLeft = '6px';
-                cell.appendChild(badge);
-            }
-            return cell;
-        };
-
         const createRelationStateCell = (row) => {
             const cell = document.createElement('td');
             const state = String(row?.relation_state || (row?.is_asserted ? 'asserted' : 'uncertain')).trim().toLowerCase() || 'asserted';
@@ -7505,6 +7586,7 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
         const tbody = document.createElement('tbody');
         for (const row of rows) {
             const tr = document.createElement('tr');
+            const textDetailRows = [];
 
             const roleCell = document.createElement('td');
             roleCell.textContent = row.role === 'arg2' ? 'arg2' : 'arg1';
@@ -7517,14 +7599,26 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             if (row.arg1_is_concept || arg1ConceptId) {
                 tr.appendChild(createConceptCell(arg1ConceptId || row.arg1_value, row.arg1_value));
             } else {
-                tr.appendChild(createTextCell(row.arg1_value || ''));
+                const disclosure = createRelationshipTextDisclosureCell(
+                    row.arg1_value || '',
+                    '',
+                    { roleLabel: 'Arg1', predicateLabel: row.predicate_id || 'relationship' }
+                );
+                tr.appendChild(disclosure.cell);
+                if (disclosure.detailRow) textDetailRows.push(disclosure.detailRow);
             }
 
             const arg2ConceptId = normalisePotentialConceptId(row.arg2_value);
             if (row.arg2_is_concept || arg2ConceptId) {
                 tr.appendChild(createConceptCell(arg2ConceptId || row.arg2_value, row.arg2_value));
             } else {
-                tr.appendChild(createTextCell(row.arg2_value || '', row.arg2_lang || ''));
+                const disclosure = createRelationshipTextDisclosureCell(
+                    row.arg2_value || '',
+                    row.arg2_lang || '',
+                    { roleLabel: 'Arg2', predicateLabel: row.predicate_id || 'relationship' }
+                );
+                tr.appendChild(disclosure.cell);
+                if (disclosure.detailRow) textDetailRows.push(disclosure.detailRow);
             }
 
             tr.appendChild(createRelationStateCell(row));
@@ -7681,6 +7775,7 @@ async function renderRelationships(conceptId, suffix, kind, { offset = 0, append
             tr.appendChild(actionCell);
 
             tbody.appendChild(tr);
+            textDetailRows.forEach((detailRow) => tbody.appendChild(detailRow));
         }
 
         table.appendChild(tbody);

--- a/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
+++ b/src/frontend/web/von_interface/static/js/test/dynamicTabsRelationshipsUncertainty.test.js
@@ -1,5 +1,6 @@
 import {
     buildDescriptionMetadataRows,
+    createRelationshipTextDisclosureCell,
     deriveRelationshipExtentQuery,
     getRelationshipConfidenceScore,
     resolveRelationshipExtentConceptKind,
@@ -89,5 +90,53 @@ describe('dynamicTabs uncertain relationship helpers', () => {
         expect(labels).toEqual(expect.arrayContaining(['Source', 'Attribution', 'Parent', 'Confidence', 'Updated']));
         const confidenceRow = rows.find((row) => row.label === 'Confidence');
         expect(confidenceRow?.value).toBe('83%');
+    });
+
+    test('long relationship literals disclose and copy their exact value', async () => {
+        const longText = 'As of 2026-08-05: current PhD research spans robust knowledge representation, provenance-aware assistants, and a deliberately long final clause.';
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        });
+
+        const { cell, detailRow } = createRelationshipTextDisclosureCell(
+            longText,
+            'en-NZ',
+            {
+                roleLabel: 'Arg2',
+                predicateLabel: '#V#has_research_description_as_of'
+            }
+        );
+        document.body.append(cell, detailRow);
+
+        expect(cell.querySelector('.relationship-text-preview').textContent).toBe(longText);
+        expect(cell.querySelector('.relationship-text-preview').classList.contains('is-collapsed')).toBe(true);
+        expect(detailRow.hidden).toBe(true);
+        const toggle = cell.querySelector('.relationship-text-toggle');
+        toggle.click();
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        expect(detailRow.hidden).toBe(false);
+        expect(detailRow.querySelector('.relationship-text-full').textContent).toBe(longText);
+        expect(detailRow.querySelector('strong').textContent).toContain(
+            '#V#has_research_description_as_of'
+        );
+
+        cell.querySelector('.relationship-text-copy').click();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(writeText).toHaveBeenCalledWith(longText);
+        expect(cell.querySelector('.relationship-text-copy').textContent).toBe('Copied');
+
+        detailRow.querySelector('.relationship-text-close').click();
+        expect(detailRow.hidden).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('short relationship literals stay compact without disclosure controls', () => {
+        const { cell, detailRow } = createRelationshipTextDisclosureCell('Short value');
+
+        expect(cell.textContent).toBe('Short value');
+        expect(cell.querySelector('.relationship-text-toggle')).toBeNull();
+        expect(detailRow).toBeNull();
     });
 });

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -11895,6 +11895,130 @@ button.prompt-vontology-cartouche {
     line-height: 1.55;
 }
 
+.concept-summary-promoted-fields {
+    display: grid;
+    gap: 10px;
+}
+
+.concept-summary-promoted-field {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
+    padding: 10px;
+    border: 1px solid #d9e1ec;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.82);
+}
+
+.concept-summary-promoted-label {
+    margin: 0;
+    color: #475569;
+    font-size: 0.76rem;
+    font-weight: 750;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.concept-summary-promoted-values {
+    display: grid;
+    gap: 9px;
+    min-width: 0;
+}
+
+.concept-summary-promoted-value {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
+}
+
+.concept-summary-promoted-value + .concept-summary-promoted-value {
+    padding-top: 9px;
+    border-top: 1px solid #e2e8f0;
+}
+
+.concept-summary-promoted-text {
+    margin: 0;
+    color: #0f172a;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.88rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.concept-summary-promoted-text.is-collapsed {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.concept-summary-promoted-controls,
+.concept-summary-promoted-value-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 7px;
+}
+
+.concept-summary-promoted-control,
+.concept-summary-promoted-concept {
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: #ffffff;
+    color: #0f172a;
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-weight: 650;
+    padding: 4px 9px;
+}
+
+.concept-summary-promoted-control:hover,
+.concept-summary-promoted-concept:hover {
+    background: #f1f5f9;
+}
+
+.concept-summary-promoted-concept {
+    justify-self: start;
+    border-color: #99d5cc;
+    background: #f0fdfa;
+    color: #115e59;
+}
+
+.concept-summary-promoted-scope,
+.concept-summary-promoted-predicate {
+    color: #64748b;
+    font-size: 0.72rem;
+}
+
+.concept-summary-promoted-scope {
+    border-radius: 999px;
+    padding: 2px 7px;
+    background: #f1f5f9;
+}
+
+.concept-summary-promoted-scope.scope-personal {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.concept-summary-promoted-scope.scope-organisation {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.concept-summary-promoted-predicate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.concept-summary-promoted-unavailable {
+    margin: 0;
+    color: #92400e;
+    font-size: 0.82rem;
+}
+
 .concept-summary-toggle {
     border: 1px solid #cbd5e1;
     background: #fff;
@@ -15805,6 +15929,113 @@ body.settings-body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.predicate-extent-table td.relationship-text-cell {
+    min-width: 180px;
+    max-width: 420px;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+}
+
+.relationship-text-preview {
+    display: block;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.relationship-text-preview.is-collapsed {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.relationship-text-language {
+    display: inline-flex;
+    margin-top: 4px;
+    border-radius: 999px;
+    padding: 1px 6px;
+    background: #f1f5f9;
+    color: #64748b;
+    font-size: 0.72rem;
+}
+
+.relationship-text-controls,
+.relationship-text-detail-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.relationship-text-control {
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    padding: 3px 8px;
+    background: #ffffff;
+    color: #334155;
+    cursor: pointer;
+    font-size: 0.72rem;
+    font-weight: 650;
+}
+
+.relationship-text-control:hover {
+    background: #f1f5f9;
+}
+
+.predicate-extent-table tbody tr.relationship-text-detail-row:hover {
+    background: transparent;
+}
+
+.predicate-extent-table tr.relationship-text-detail-row td {
+    max-width: none;
+    overflow: visible;
+    padding: 0 12px 12px;
+    text-overflow: clip;
+    white-space: normal;
+}
+
+.relationship-text-detail {
+    display: grid;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid #bfdbfe;
+    border-radius: 10px;
+    background: #f8fbff;
+}
+
+.relationship-text-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    color: #1e3a5f;
+    overflow-wrap: anywhere;
+}
+
+.relationship-text-detail-header strong {
+    min-width: 0;
+}
+
+.relationship-text-detail-header .relationship-text-close {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+.relationship-text-full {
+    max-height: 420px;
+    margin: 0;
+    overflow: auto;
+    color: #0f172a;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.86rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
 }
 
 .predicate-extent-table td.source-text_relations {

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -140,12 +140,103 @@ def test_summary_field_resolver_resolves_type_field_bindings(monkeypatch) -> Non
     )
 
 
+def test_summary_field_resolver_unions_inherited_fields_and_uses_represented_order(
+    monkeypatch,
+) -> None:
+    concept_docs: dict[str, dict[str, Any]] = {
+        "#V#researcher": {
+            "concept_id": "#V#researcher",
+            "relationships": {
+                "#V#has_summary_fields": [
+                    "#V#summary_field_research_description"
+                ]
+            },
+        },
+        "#V#person": {
+            "concept_id": "#V#person",
+            "relationships": {
+                "#V#has_summary_fields": ["#V#summary_field_email"]
+            },
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "relationships": {
+                "#V#has_summary_fields": ["#V#summary_field_description"]
+            },
+        },
+        "#V#summary_field_research_description": {
+            "concept_id": "#V#summary_field_research_description",
+            "name": "Research description",
+        },
+        "#V#summary_field_email": {
+            "concept_id": "#V#summary_field_email",
+            "name": "Email",
+        },
+        "#V#summary_field_description": {
+            "concept_id": "#V#summary_field_description",
+            "name": "Description",
+        },
+    }
+
+    def _find(filter_value, *_args, **_kwargs):
+        ids = (filter_value.get("concept_id") or {}).get("$in") or []
+        return [concept_docs[concept_id] for concept_id in ids]
+
+    rows_by_concept = {
+        "#V#summary_field_research_description": [
+            {
+                "predicate": "#V#has_summary_text_predicates_json",
+                "text": '["#V#has_research_description_as_of"]',
+            },
+            {"predicate": "#V#summary_field_display_order", "text": "5"},
+        ],
+        "#V#summary_field_description": [
+            {
+                "predicate": "#V#has_summary_text_predicates_json",
+                "text": '["hasDescription"]',
+            },
+            {"predicate": "#V#summary_field_display_order", "text": "10"},
+        ],
+        "#V#summary_field_email": [
+            {
+                "predicate": "#V#has_summary_text_predicates_json",
+                "text": '["#V#has_email"]',
+            },
+            {"predicate": "#V#summary_field_display_order", "text": "later"},
+        ],
+    }
+    monkeypatch.setattr(resolver_module.ConceptsRepository, "find", _find)
+    monkeypatch.setattr(
+        resolver_module,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: rows_by_concept,
+    )
+
+    resolver = resolver_module.ConceptSummaryFieldResolver(cache_ttl_seconds=60.0)
+    definitions = resolver.get_summary_field_definitions_for_types(
+        ["#V#researcher", "#V#person", "#V#thing"]
+    )
+
+    assert [definition.field_key for definition in definitions] == [
+        "research_description",
+        "description",
+        "email",
+    ]
+    assert definitions[0].label == "Research description"
+    assert definitions[0].display_order == 5.0
+    assert definitions[0].text_predicates == (
+        "#V#has_research_description_as_of",
+    )
+    assert definitions[0].origin_type_ids == ("#V#researcher",)
+    assert definitions[2].display_order is None
+
+
 def test_summary_field_bootstrap_materialises_vontology_metadata(
     _reset_mock_db: Any,
 ) -> None:
     report = bootstrap_canonical_concept_summary_fields()
     assert report["success"] is True
-    assert report["counts"]["fields_seen"] == 17
+    assert report["counts"]["fields_seen"] == 18
     assert report["counts"]["errors"] == 0
 
     person_doc = concept_service.get_concept_by_concept_id("#V#person")
@@ -166,6 +257,12 @@ def test_summary_field_bootstrap_materialises_vontology_metadata(
         "affiliation",
         "authored_work",
     )
+    assert resolver.get_summary_fields_for_type("#V#research_description") == (
+        "research_description_as_of",
+    )
+    assert resolver.get_text_predicates_for_field(
+        "research_description_as_of"
+    ) == ("#V#has_research_description_as_of",)
 
 
 def test_summary_field_bootstrap_uses_batched_noop_fast_path(
@@ -241,7 +338,7 @@ def test_summary_field_startup_receipt_hit_performs_no_canonical_scan(
             "fresh": True,
             "reason": "dependency_receipt_current",
             "events_examined": 0,
-            "metadata": {"counts": {"fields_seen": 17}},
+            "metadata": {"counts": {"fields_seen": 18}},
         },
     )
     monkeypatch.setattr(

--- a/tests/backend/test_concept_summary_renderer_service.py
+++ b/tests/backend/test_concept_summary_renderer_service.py
@@ -39,11 +39,34 @@ class _FakeSummaryFieldResolver:
         return self._relationship_predicates.get(field_key, ())
 
     def get_summary_fields_for_types(self, type_ids) -> tuple[str, ...]:
+        return tuple(
+            definition.field_key
+            for definition in self.get_summary_field_definitions_for_types(type_ids)
+        )
+
+    def get_summary_field_definitions_for_types(self, type_ids):
+        field_keys = []
+        origins = {}
         for type_id in type_ids:
-            fields = self._fields_by_type.get(type_id)
-            if fields:
-                return fields
-        return ()
+            for field_key in self._fields_by_type.get(type_id, ()):
+                if field_key not in origins:
+                    field_keys.append(field_key)
+                    origins[field_key] = []
+                origins[field_key].append(type_id)
+        return tuple(
+            service.SummaryFieldDefinition(
+                field_key=field_key,
+                field_concept_id=f"#V#summary_field_{field_key}",
+                label=field_key.replace("_", " ").title(),
+                display_order=float(index * 10),
+                text_predicates=self.get_text_predicates_for_field(field_key),
+                relationship_predicates=(
+                    self.get_relationship_predicates_for_field(field_key)
+                ),
+                origin_type_ids=tuple(origins[field_key]),
+            )
+            for index, field_key in enumerate(field_keys, start=1)
+        )
 
 
 def _install_summary_field_resolver(monkeypatch) -> None:
@@ -320,6 +343,182 @@ def test_load_concept_summary_renderer_falls_back_to_generic_text_summary(
     assert payload["selected_renderer"]["renderer_id"] == "#V#concept_page_text_summary_renderer"
     assert payload["panel"]["variant"] == "generic"
     assert payload["panel"]["summary"] == "Fallback summary content."
+
+
+def test_load_concept_summary_renderer_projects_all_values_of_custom_type_field(
+    monkeypatch,
+) -> None:
+    class _PromotedFieldResolver(_FakeSummaryFieldResolver):
+        _text_predicates = {
+            **_FakeSummaryFieldResolver._text_predicates,
+            "research_description": ("#V#has_research_description_as_of",),
+        }
+        _fields_by_type = {
+            **_FakeSummaryFieldResolver._fields_by_type,
+            "#V#researcher": (
+                "research_description",
+                "description",
+                "content",
+            ),
+        }
+
+        def get_summary_field_definitions_for_types(self, type_ids):
+            definitions = super().get_summary_field_definitions_for_types(type_ids)
+            return tuple(
+                service.SummaryFieldDefinition(
+                    field_key=definition.field_key,
+                    field_concept_id=definition.field_concept_id,
+                    label=(
+                        "Research description"
+                        if definition.field_key == "research_description"
+                        else definition.label
+                    ),
+                    display_order=(
+                        5.0
+                        if definition.field_key == "research_description"
+                        else definition.display_order
+                    ),
+                    text_predicates=definition.text_predicates,
+                    relationship_predicates=definition.relationship_predicates,
+                    origin_type_ids=definition.origin_type_ids,
+                )
+                for definition in definitions
+            )
+
+    _install_summary_field_resolver(monkeypatch)
+    monkeypatch.setattr(
+        service,
+        "get_concept_summary_field_resolver",
+        lambda: _PromotedFieldResolver(),
+    )
+    concept_docs = {
+        "#V#profile": {
+            "concept_id": "#V#profile",
+            "name": "Research profile",
+            "relationships": {"is_an_instance_of": ["#V#researcher"]},
+        },
+        "#V#researcher": {
+            "concept_id": "#V#researcher",
+            "name": "Researcher",
+            "relationships": {"is_a_type_of": ["#V#thing"]},
+        },
+        "#V#thing": {
+            "concept_id": "#V#thing",
+            "name": "Thing",
+            "relationships": {"is_a_type_of": []},
+        },
+    }
+    monkeypatch.setattr(
+        service,
+        "get_concept_by_concept_id",
+        lambda concept_id: concept_docs[concept_id],
+    )
+    monkeypatch.setattr(
+        service,
+        "enrich_concept_with_text_relations",
+        lambda concept: concept,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concept",
+        lambda subject_concept_id, limit=250: [],
+    )
+    captured_query = {}
+
+    def _promoted_texts(*_args, **kwargs):
+        captured_query.update(kwargs)
+        return {
+            "#V#profile": [
+                {
+                    "predicate": "#V#has_research_description_as_of",
+                    "text": "As of 2026-08-05: first exact long description.",
+                    "lang": "en-NZ",
+                    "relation_id": "rel-1",
+                    "row_kind": "base_text_relation",
+                    "provenance": {"source": "canonical"},
+                },
+                {
+                    "predicate": "#V#has_research_description_as_of",
+                    "text": "A personal revision that must remain separately labelled.",
+                    "lang": "en-NZ",
+                    "assertion_id": "assertion-1",
+                    "row_kind": "scoped_assertion",
+                    "assertion_scope": {"mode": "user"},
+                    "provenance": {"source": "conversation"},
+                },
+            ]
+        }
+
+    monkeypatch.setattr(service, "get_texts_for_concepts", _promoted_texts)
+    monkeypatch.setattr(
+        service,
+        "load_renderer_definitions_from_concept_ids",
+        lambda concept_ids: (
+            [
+                {
+                    "renderer_id": "#V#concept_page_text_summary_renderer",
+                    "renderer_type": "text_summary",
+                    "modalities": ["textual"],
+                    "applies_to_object_kinds": ["concept"],
+                    "required_context_tags": ["concept_page_summary"],
+                    "priority": 10,
+                }
+            ],
+            {
+                "loaded_definition_count": 1,
+                "requested_concept_ids": list(concept_ids),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "list_focal_conversation_backlinks",
+        lambda **_kwargs: {},
+    )
+
+    payload = service.load_concept_summary_renderer(
+        "#V#profile",
+        actor_user_id="#V#actor",
+        actor_namespace="#V#actor",
+    )
+
+    assert captured_query["predicates"] == [
+        "#V#has_research_description_as_of"
+    ]
+    assert captured_query["context_view"] == "actor_effective"
+    promoted = payload["panel"]["promoted_fields"]
+    assert len(promoted) == 1
+    assert promoted[0]["field_key"] == "research_description"
+    assert promoted[0]["label"] == "Research description"
+    assert [value["text"] for value in promoted[0]["values"]] == [
+        "As of 2026-08-05: first exact long description.",
+        "A personal revision that must remain separately labelled.",
+    ]
+    assert promoted[0]["values"][0]["canonical_publication"] is True
+    assert promoted[0]["values"][1]["source_context"]["kind"] == "personal"
+    assert payload["diagnostics"]["promoted_fields"]["context_view"] == (
+        "actor_effective"
+    )
+
+    monkeypatch.setattr(
+        service,
+        "get_texts_for_concepts",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("temporary promoted-field read failure")
+        ),
+    )
+    degraded_payload = service.load_concept_summary_renderer(
+        "#V#profile",
+        actor_user_id="#V#actor",
+        actor_namespace="#V#actor",
+    )
+    assert degraded_payload["panel"]["title"] == "Research profile"
+    assert degraded_payload["panel"]["promoted_fields"] == []
+    assert degraded_payload["panel"]["promoted_fields_status"] == {
+        "available": False,
+        "message": "Promoted fields are temporarily unavailable.",
+    }
+    assert degraded_payload["diagnostics"]["promoted_fields"]["available"] is False
 
 
 def _install_conversation_concept(monkeypatch, *, concept_id="#V#conversation_abc"):

--- a/tests/frontend/conceptSummaryRendererPanel.test.js
+++ b/tests/frontend/conceptSummaryRendererPanel.test.js
@@ -110,6 +110,15 @@ describe('concept summary renderer panel', () => {
                     facts: [{ label: '<b>Email</b>', value: '<svg onload="window.__summaryXss = true">' }],
                     summary: '<a href="javascript:window.__summaryXss = true">unsafe link</a>',
                     expanded_sections: [{ title: '<i>Details</i>', items: ['<iframe srcdoc="x"></iframe>'] }],
+                    promoted_fields: [{
+                        label: '<b>Promoted</b>',
+                        values: [{
+                            kind: 'text',
+                            text: '<img src=x onerror="window.__summaryXss = true"> exact promoted text that is deliberately long enough to disclose',
+                            predicate_id: '#V#unsafe_predicate',
+                            source_context: { kind: 'canonical', label: 'Canonical' },
+                        }],
+                    }],
                 },
             },
         });
@@ -129,7 +138,86 @@ describe('concept summary renderer panel', () => {
             '<script>window.__summaryXss = true</script>',
         );
         expect(panel.textContent).toContain('<a href="javascript:window.__summaryXss = true">unsafe link</a>');
+        expect(panel.textContent).toContain('<img src=x onerror="window.__summaryXss = true"> exact promoted text');
         expect(window.__summaryXss).toBeUndefined();
+    });
+
+    test('renders promoted type fields with exact disclosure, copy, scope, and concept navigation', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const longText = 'As of 2026-08-05: current PhD research spans robust knowledge representation, provenance-aware assistants, and a deliberately long final clause.';
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText },
+        });
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                panel: {
+                    variant: 'generic',
+                    title: 'Research profile',
+                    promoted_fields: [
+                        {
+                            field_key: 'research_description',
+                            label: 'Research description',
+                            values: [
+                                {
+                                    kind: 'text',
+                                    text: longText,
+                                    predicate_id: '#V#has_research_description_as_of',
+                                    source_context: {
+                                        kind: 'personal',
+                                        label: 'Personal — visible only to you',
+                                    },
+                                },
+                                {
+                                    kind: 'concept',
+                                    concept_id: '#V#knowledge_representation',
+                                    display_name: 'Knowledge representation',
+                                    predicate_id: '#V#research_topic',
+                                    source_context: { kind: 'canonical', label: 'Canonical' },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        });
+        const seen = [];
+        const handler = (event) => seen.push(event.detail);
+        document.addEventListener('von:selectConceptById', handler);
+
+        const {
+            ensureConceptSummaryRendererPanelForConceptTab,
+        } = require('../../src/frontend/web/von_interface/static/js/components/conceptSummaryRendererPanel.js');
+        await ensureConceptSummaryRendererPanelForConceptTab({
+            conceptId: '#V#research_profile',
+            suffix: 'test',
+        });
+
+        const text = document.querySelector('.concept-summary-promoted-text');
+        const toggle = document.querySelector('.concept-summary-promoted-toggle');
+        expect(text.textContent).toBe(longText);
+        expect(text.classList.contains('is-collapsed')).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        toggle.click();
+        expect(text.classList.contains('is-collapsed')).toBe(false);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        document.querySelector('.concept-summary-promoted-copy').click();
+        await flushMicrotasks();
+        expect(writeText).toHaveBeenCalledWith(longText);
+        expect(document.querySelector('.concept-summary-promoted-copy').textContent).toBe('Copied');
+        expect(document.querySelector('.concept-summary-promoted-scope').textContent).toBe(
+            'Personal — visible only to you',
+        );
+
+        document.querySelector('.concept-summary-promoted-concept').click();
+        expect(seen).toEqual([{
+            conceptId: '#V#knowledge_representation',
+            createConceptTab: true,
+            promoteExistingTab: true,
+            modifierKeys: { shiftKey: true },
+        }]);
+        document.removeEventListener('von:selectConceptById', handler);
     });
 
     test('opens an allow-listed conversation and focal concept through reauthorising controllers', async () => {


### PR DESCRIPTION
Merge decision: ready — merging makes long relationship literals fully inspectable and copyable, and lets Vontology type policy promote arbitrary fields into the concept summary without changing KCAP salience.

## User outcome

A concept-tab user can read and copy the complete text behind a truncated relationship value. Types can also use rendering-specific `#V#has_summary_fields` policy to place important exact values beside the description at the top of the concept page.

## Material changes

- Union direct and inherited summary-field bindings, resolve represented labels/order/configuration, and preserve origin types.
- Project unconsumed text or concept fields generically, including every value in the bounded read, canonical/personal/organisation scope, identifiers, provenance, and honest truncation/degraded-state diagnostics.
- Add release seed v2 for `#V#research_description` → `#V#summary_field_research_description_as_of` → `#V#has_research_description_as_of`; this is explicitly rendering policy and does not alter KCAP salience.
- Render promoted fields with wrapped exact text, accessible expand/collapse and copy controls, scope labels, and concept navigation.
- Replace relationship-table ellipsis-only literals with two-line previews, explicit full-width detail rows, and exact copy controls.
- Jira: [JVNAUTOSCI-2234](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2234)

## Evidence

- `.venv/bin/pytest -q tests/backend/test_concept_summary_field_resolver.py tests/backend/test_concept_summary_renderer_service.py tests/backend/test_concept_summary_renderer_routes.py` — 25 passed.
- Affected frontend Jest suites — 62 passed across summary rendering, relationship disclosure, tab sizing, and concept-tab ID behaviour.
- Pyright on both changed backend services — 0 errors.
- Static frontend lint on both changed JS modules — 0 errors; 15 existing warnings in `dynamicTabs.js`.
- Isolated AgentTest server plus Chrome/Playwright live app-shell replay at desktop and 390px: exact text retained on both surfaces, both disclosure controls expanded, clipboard matched byte-for-byte, no desktop body overflow, narrow summary stayed inside x=24..366, and the narrow Close control remained a non-wrapping 49x20px.
- Full Jest run: 894 passed and 9 failed in four unrelated suites. A detached clean `origin/main` worktree reproduced the same 9/9 failures, establishing them as baseline rather than candidate-caused.

## Ship boundary

- **Minimum ship criteria:** exact long literals are readable/copyable; type/ancestor policy promotes arbitrary configured fields without a new domain branch; exact multiple values and scope remain distinct; affected tests and the live responsive replay pass.
- **Stop-ship conditions:** widened authority, KCAP salience changes, silently selected/dropped values inside the declared bound, blocked core concept hydration, executable markup, inaccessible controls, or a candidate-caused regression on the affected path.
- **Non-blocking observations:** seed reconciliation/activation is a separate release operation and was not run against live Vontology; the complete repository Jest run retains nine independently reproduced baseline failures.
- **Non-goals:** remove all specialised summary-card builders, redesign the whole relationship table, deploy/activate a running environment, or repair unrelated Jest timing/mock failures.


[JVNAUTOSCI-2234]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ