### PR TITLE
JVNAUTOSCI-2692: Add inspectable conversation references

### DIFF
--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -43,6 +43,7 @@ from ...services.concept_summary_renderer_service import (
 )
 from ...services.concept_effective_assertion_service import (
     DEFAULT_PAGE_LIMIT as DEFAULT_EFFECTIVE_ASSERTION_PAGE_LIMIT,
+    load_effective_assertion_by_id,
     load_concept_effective_assertions,
 )
 from ...vontology.utils_vontology import (
@@ -409,6 +410,46 @@ def get_concept_effective_assertions(concept_id: str) -> ResponseReturnValue:
             exc_info=True,
         )
         return jsonify({"error": "Failed to load actor-effective assertions"}), 500
+
+
+@concept_bp.route("/assertions/<string:assertion_id>", methods=["GET"])
+def get_effective_assertion_by_id(assertion_id: str) -> ResponseReturnValue:
+    """Return one exact assertion without disclosing inaccessible IDs."""
+
+    if not _get_current_user_concept_id():
+        return jsonify({"error": "assertion_not_found"}), 404
+    try:
+        payload = load_effective_assertion_by_id(assertion_id)
+        if payload is None:
+            return jsonify({"error": "assertion_not_found"}), 404
+        return jsonify(payload), 200
+    except (PermissionError, ValueError):
+        return jsonify({"error": "assertion_not_found"}), 404
+    except RuntimeError as exc:
+        current_app.logger.warning(
+            "Exact actor-effective assertion unavailable for %s: %s",
+            assertion_id,
+            exc,
+            exc_info=True,
+        )
+        return (
+            jsonify(
+                {
+                    "error": "Assertion is temporarily unavailable",
+                    "error_code": "actor_effective_assertion_unavailable",
+                    "retryable": True,
+                }
+            ),
+            503,
+        )
+    except Exception as exc:
+        current_app.logger.error(
+            "Failed to load exact actor-effective assertion %s: %s",
+            assertion_id,
+            exc,
+            exc_info=True,
+        )
+        return jsonify({"error": "Failed to load assertion"}), 500
 
 
 @concept_bp.route("/", methods=["GET"])

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -138,6 +138,10 @@ from ...services.turn_output_health_service import (
     build_turn_output_health,
     turn_output_health_issue_messages,
 )
+from ...services.turn_reference_manifest_service import (
+    build_turn_reference_manifest,
+    build_turn_reference_manifest_from_debug,
+)
 from ...services.turn_failure_capsule_service import (
     TURN_FAILURE_CAPSULE_MAX_BYTES,
     TURN_FAILURE_CAPSULE_SCHEMA_VERSION,
@@ -8090,6 +8094,16 @@ def _finalise_llm_debug_info(
         ),
     )
     llm_debug_info["turn_failure_capsule"] = turn_failure_capsule
+    reference_manifest = build_turn_reference_manifest(
+        response_text=final_response_text,
+        request_id=llm_debug_info.get("request_id"),
+        evidence_index=evidence_index,
+        outcome_report=outcome_report,
+        tool_invocations=turn_record_tool_invocations_payload,
+        user_concept_id=(user_id or resolved_actor_concept_id),
+        organisation_concept_id=org_id,
+    )
+    llm_debug_info["reference_manifest"] = reference_manifest
     turn_execution_record: dict[str, Any] = {
         "schema_version": "turn_execution_record.observational.v1",
         "record_kind": "observational",
@@ -8129,6 +8143,7 @@ def _finalise_llm_debug_info(
         ),
         "search_evidence": list(search_evidence_payload or []),
         "evidence_index": evidence_index,
+        "reference_manifest": reference_manifest,
         "turn_execution_diagnostics": (
             dict(diagnostics_payload)
             if isinstance(diagnostics_payload, Mapping)
@@ -14754,6 +14769,38 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         )
 
 
+def _with_viewer_scoped_history_reference_manifests(
+    messages: list[dict[str, Any]],
+    *,
+    user_concept_id: str,
+    organisation_concept_id: str | None,
+) -> list[dict[str, Any]]:
+    """Project inspectable references onto history without rewriting it."""
+
+    projected: list[dict[str, Any]] = []
+    for raw_message in messages:
+        if not isinstance(raw_message, dict):
+            continue
+        message = dict(raw_message)
+        response_text = message.get("content")
+        if message.get("role") != "assistant" or not isinstance(response_text, str):
+            projected.append(message)
+            continue
+        raw_debug = message.get("llm_debug_data")
+        debug = dict(raw_debug) if isinstance(raw_debug, Mapping) else {}
+        manifest = build_turn_reference_manifest_from_debug(
+            response_text=response_text,
+            debug_info=debug,
+            user_concept_id=user_concept_id,
+            organisation_concept_id=organisation_concept_id,
+        )
+        if debug or int(manifest.get("reference_count") or 0) > 0:
+            debug["reference_manifest"] = manifest
+            message["llm_debug_data"] = debug
+        projected.append(message)
+    return projected
+
+
 @von_bp.route("/history", methods=["GET"])
 def history():
     """Retrieve chat history segments for the current user."""
@@ -14817,9 +14864,10 @@ def history():
         effective = get_effective_context(
             window_session_id, dict(session), user_concept_id
         )
-        namespace = effective.get(
-            "namespace"
-        ) or chat_history_service.resolve_chat_history_namespace(user_concept_id)
+        namespace, organisation_concept_id = _resolve_history_request_scope_hints(
+            user_concept_id=user_concept_id,
+            effective_context=effective,
+        )
         owner_user_id = user_concept_id
         shared_invite = None
 
@@ -14934,6 +14982,12 @@ def history():
         segment_count = min(segment_count, total_segments)
         selected_segments = segments[-segment_count:]
         flattened_history = [msg for segment in selected_segments for msg in segment]
+        if include_debug:
+            flattened_history = _with_viewer_scoped_history_reference_manifests(
+                flattened_history,
+                user_concept_id=user_concept_id,
+                organisation_concept_id=organisation_concept_id,
+            )
         segments_returned = len(selected_segments)
         history_truncated = bool(meta.get("history_truncated"))
         has_more = history_truncated or segments_returned < total_segments
@@ -15206,6 +15260,17 @@ def history_debug():
                         "history_index": history_index,
                     },
                 }
+            )
+        stored_response = (
+            debug_data.get("response") if isinstance(debug_data, Mapping) else None
+        )
+        if isinstance(stored_response, str):
+            debug_data = dict(debug_data)
+            debug_data["reference_manifest"] = build_turn_reference_manifest_from_debug(
+                response_text=stored_response,
+                debug_info=debug_data,
+                user_concept_id=user_concept_id,
+                organisation_concept_id=organisation_concept_id,
             )
         if view in {"transformations", "response_transformations"}:
             transformation_payload = None

--- a/src/backend/services/concept_effective_assertion_service.py
+++ b/src/backend/services/concept_effective_assertion_service.py
@@ -8,12 +8,19 @@ predicate, object, and organisation labels in one concept batch.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+import json
+from collections.abc import Mapping
+from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from .concept_service import resolve_concept_display_names
+from .paper_recommendation_constants import (
+    GENERIC_PAPER_MATCH_PROFILE_JSON_PREDICATE_ID,
+)
 from .scoped_assertion_service import (
     MAX_PAGE_LIMIT,
+    STANDALONE_TEXT_ASSERTION_FORM,
+    get_visible_scoped_assertion_by_id,
     list_visible_scoped_assertions_page,
 )
 
@@ -32,7 +39,7 @@ def _normalise_page_value(
     if value is None:
         return default
     if isinstance(value, bool):
-        raise ValueError(f"{field_name} must be an integer")
+        raise ValueError(f"{field_name} must be an integer")  # noqa: TRY004
     try:
         resolved = int(value)
     except (TypeError, ValueError) as exc:
@@ -46,8 +53,7 @@ def _humanise_identifier(value: Any, *, fallback: str) -> str:
     token = str(value or "").strip()
     if not token:
         return fallback
-    if token.startswith("#V#"):
-        token = token[3:]
+    token = token.removeprefix("#V#")
     return " ".join(token.replace("_", " ").split()) or fallback
 
 
@@ -57,6 +63,7 @@ def _referenced_concept_ids(items: list[Mapping[str, Any]]) -> list[str]:
     for item in items:
         scope = item.get("scope")
         candidates = [
+            item.get("subject_concept_id"),
             item.get("predicate"),
             item.get("object_concept_id"),
             (
@@ -87,11 +94,26 @@ def _display_names_for_ids(concept_ids: list[str]) -> dict[str, str]:
     return resolve_concept_display_names(concept_docs)
 
 
+def _profile_text_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [cleaned for item in value if (cleaned := str(item or "").strip())]
+
+
 def _project_item(
     item: Mapping[str, Any],
     *,
     display_names: Mapping[str, str],
 ) -> dict[str, Any]:
+    assertion_form = str(item.get("assertion_form") or "relation").strip()
+    subject_id = str(item.get("subject_concept_id") or "").strip()
+    subject_label = display_names.get(subject_id) or _humanise_identifier(
+        subject_id,
+        fallback="Source assertion",
+    )
     predicate_id = str(item.get("predicate") or "").strip()
     predicate_label = display_names.get(predicate_id) or _humanise_identifier(
         predicate_id,
@@ -115,6 +137,44 @@ def _project_item(
             "text": str(text_payload.get("text") or ""),
             "language": str(text_payload.get("language") or "") or None,
         }
+
+    if assertion_form == STANDALONE_TEXT_ASSERTION_FORM:
+        human_statement = str(object_payload.get("text") or "")
+    else:
+        object_label = str(
+            object_payload.get("display_name") or object_payload.get("text") or ""
+        ).strip()
+        human_statement = " ".join(
+            part for part in (subject_label, predicate_label, object_label) if part
+        )
+
+    presentation: dict[str, Any] | None = None
+    if (
+        predicate_id == GENERIC_PAPER_MATCH_PROFILE_JSON_PREDICATE_ID
+        and object_payload.get("kind") == "text"
+    ):
+        try:
+            profile = json.loads(str(object_payload.get("text") or ""))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            profile = None
+        if isinstance(profile, Mapping):
+            presentation = {
+                "kind": "paper_matching_profile",
+                "project_description": str(profile.get("project_description") or ""),
+                "stated_interest_terms": _profile_text_list(
+                    profile.get("stated_interest_terms")
+                ),
+                "negative_interest_terms": _profile_text_list(
+                    profile.get("negative_interest_terms")
+                ),
+                "preferred_authors": _profile_text_list(
+                    profile.get("preferred_authors")
+                ),
+                "preferred_venues": _profile_text_list(profile.get("preferred_venues")),
+                "notes": str(profile.get("notes") or ""),
+                "updated_at": profile.get("updated_at"),
+            }
+            human_statement = f"{subject_label} has a paper-matching profile."
 
     scope = item.get("scope")
     scope_payload = scope if isinstance(scope, Mapping) else {}
@@ -143,13 +203,19 @@ def _project_item(
     return {
         "assertion_id": item.get("assertion_id"),
         "assertion_revision": item.get("assertion_revision"),
-        "subject_concept_id": item.get("subject_concept_id"),
+        "assertion_form": assertion_form,
+        "subject": {
+            "concept_id": subject_id or None,
+            "display_name": subject_label,
+        },
         "predicate": {
             "concept_id": predicate_id if predicate_id.startswith("#V#") else None,
             "storage_id": predicate_id,
             "display_name": predicate_label,
         },
         "object": object_payload,
+        "human_statement": human_statement,
+        "presentation": presentation,
         "source_context": source_context,
         "status": item.get("status"),
         "canonical_publication": False,
@@ -157,6 +223,20 @@ def _project_item(
         "provenance": item.get("provenance"),
         "created_at": item.get("created_at"),
         "updated_at": item.get("updated_at"),
+    }
+
+
+def load_effective_assertion_by_id(assertion_id: Any) -> dict[str, Any] | None:
+    """Return one current, presentation-ready assertion after exact actor checks."""
+
+    item = get_visible_scoped_assertion_by_id(assertion_id)
+    if not isinstance(item, Mapping):
+        return None
+    display_names = _display_names_for_ids(_referenced_concept_ids([item]))
+    return {
+        "success": True,
+        "context_view": "actor_effective",
+        "assertion": _project_item(item, display_names=display_names),
     }
 
 
@@ -219,4 +299,5 @@ __all__ = [
     "DEFAULT_PAGE_LIMIT",
     "MAX_CONCEPT_PAGE_LIMIT",
     "load_concept_effective_assertions",
+    "load_effective_assertion_by_id",
 ]

--- a/src/backend/services/scoped_assertion_service.py
+++ b/src/backend/services/scoped_assertion_service.py
@@ -1856,6 +1856,64 @@ def list_visible_scoped_assertions_page(
         }
 
 
+def get_visible_scoped_assertion_by_id(
+    assertion_id: Any,
+    *,
+    user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return one exact actor-visible assertion in any lifecycle state.
+
+    Exact inspection is deliberately separate from the active assertion-list
+    query. A retracted occurrence remains inspectable by an authorised actor,
+    while audience and referenced-concept visibility still fail closed. Missing,
+    inaccessible, and malformed identifiers all return the same absence result.
+    """
+
+    assertion_token = str(assertion_id or "").strip()
+    if (
+        not assertion_token.startswith("ska_")
+        or len(assertion_token) > 256
+        or not re.fullmatch(r"ska_[A-Za-z0-9_-]+", assertion_token)
+    ):
+        return None
+
+    actor_user_id, actor_org_id = _resolve_read_actor(
+        user_concept_id=user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+    audience_keys = _audience_keys_for_actor(
+        user_concept_id=actor_user_id,
+        organisation_concept_id=actor_org_id,
+    )
+    if not audience_keys:
+        return None
+
+    collection = get_scoped_knowledge_assertions_collection()
+    if collection is None:
+        raise RuntimeError("scoped assertion store unavailable")
+
+    audience_query = {
+        "$or": [
+            {"scope.audience_key": {"$in": audience_keys}},
+            {"scope.audience_keys": {"$in": audience_keys}},
+        ]
+    }
+    with override_current_actor(actor_user_id, actor_org_id):
+        document = collection.find_one(
+            {
+                "assertion_id": assertion_token,
+                **audience_query,
+            }
+        )
+        if not isinstance(document, Mapping):
+            return None
+        visible_documents = _visible_assertion_documents([document])
+        if len(visible_documents) != 1:
+            return None
+        return _serialise(visible_documents[0])
+
+
 def list_visible_scoped_assertions(
     *,
     subject_concept_ids: Sequence[str] | None = None,
@@ -1924,6 +1982,7 @@ def scoped_text_assertion_to_relation_row(
 __all__ = [
     "STANDALONE_TEXT_ASSERTION_FORM",
     "add_text_assertion_concept_links",
+    "get_visible_scoped_assertion_by_id",
     "list_visible_scoped_assertions",
     "list_visible_scoped_assertions_page",
     "retract_scoped_assertion",

--- a/src/backend/services/turn_reference_manifest_service.py
+++ b/src/backend/services/turn_reference_manifest_service.py
@@ -1,0 +1,335 @@
+"""Typed, bounded references for one user-visible conversation turn.
+
+The manifest is a presentation contract, not another source of truth. Evidence
+entries are projected from the persisted turn envelope, workflow instances from
+structured effect facts, and assertion IDs are admitted only after an exact
+actor-visible lookup. Regexes discover candidates in screen text; they never
+decide what an identifier means.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from .scoped_assertion_service import get_visible_scoped_assertion_by_id
+
+SCHEMA_VERSION = "turn_reference_manifest.v1"
+MAX_REFERENCES = 64
+
+_ASSERTION_CANDIDATE_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(ska_[A-Za-z0-9_-]{4,256})(?![A-Za-z0-9_-])"
+)
+
+
+def _clean(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    token = value.strip()
+    return token or None
+
+
+def _outcome_facts(outcome_report: Mapping[str, Any] | None) -> list[Mapping[str, Any]]:
+    if not isinstance(outcome_report, Mapping):
+        return []
+    facts = outcome_report.get("facts")
+    if not isinstance(facts, list):
+        return []
+    return [item for item in facts if isinstance(item, Mapping)]
+
+
+def _reference_entry(
+    *,
+    reference_id: str,
+    reference_type: str,
+    screen_text: str,
+    source: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "reference_id": reference_id,
+        "reference_type": reference_type,
+        "label": {
+            "scoped_assertion": "Assertion",
+            "turn_evidence": "Turn evidence",
+            "workflow_instance": "Workflow instance",
+            "ontology_mutation_receipt": "Ontology mutation receipt",
+        }.get(reference_type, "Reference"),
+        "source": source,
+        "occurrence_count": screen_text.count(reference_id),
+        **extra,
+    }
+
+
+def _bounded_evidence_envelope(value: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = (
+        "schema_version",
+        "evidence_id",
+        "tool_name",
+        "call_id",
+        "turn_id",
+        "status",
+        "trust_boundary",
+        "sha256",
+        "size_bytes",
+        "char_count",
+        "content_type",
+        "value_kind",
+        "shape",
+        "preview",
+        "preview_format",
+        "preview_truncated",
+        "provenance",
+        "source_diagnostics",
+        "available_selectors",
+    )
+    return {key: value.get(key) for key in allowed if key in value}
+
+
+def build_turn_reference_manifest(
+    *,
+    response_text: Any,
+    request_id: Any,
+    evidence_index: Sequence[Mapping[str, Any]] = (),
+    outcome_report: Mapping[str, Any] | None = None,
+    tool_invocations: Sequence[Mapping[str, Any]] = (),
+    user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+    assertion_resolver: Callable[..., Mapping[str, Any] | None] = (
+        get_visible_scoped_assertion_by_id
+    ),
+) -> dict[str, Any]:
+    """Build one server-typed manifest for identifiers present on screen."""
+
+    screen_text = str(response_text or "")
+    references: dict[str, dict[str, Any]] = {}
+
+    envelope_by_id: dict[str, Mapping[str, Any]] = {}
+    for envelope in evidence_index:
+        if not isinstance(envelope, Mapping):
+            continue
+        evidence_id = _clean(envelope.get("evidence_id"))
+        if evidence_id:
+            envelope_by_id[evidence_id] = envelope
+
+    structured_evidence_ids: set[str] = set(envelope_by_id)
+    workflow_instances: dict[str, dict[str, Any]] = {}
+    mutation_receipt_ids: set[str] = set()
+    for fact in _outcome_facts(outcome_report):
+        evidence_id = _clean(fact.get("evidence_id"))
+        if evidence_id:
+            structured_evidence_ids.add(evidence_id)
+        instance_id = _clean(fact.get("instance_id"))
+        if instance_id:
+            workflow_instances[instance_id] = {
+                "workflow_id": _clean(fact.get("workflow_id")),
+                "effect_status": _clean(fact.get("effect_status")),
+                "canonical_readback_verified": (
+                    fact.get("canonical_readback_verified") is True
+                ),
+            }
+
+    for invocation in tool_invocations:
+        if not isinstance(invocation, Mapping):
+            continue
+        evidence = invocation.get("evidence")
+        if isinstance(evidence, Mapping):
+            evidence_id = _clean(evidence.get("evidence_id"))
+            if evidence_id:
+                structured_evidence_ids.add(evidence_id)
+        workflow_id = _clean(invocation.get("workflow_id"))
+        execution_id = _clean(invocation.get("execution_id"))
+        if workflow_id and execution_id:
+            workflow_instances.setdefault(
+                execution_id,
+                {"workflow_id": workflow_id},
+            )
+        for key in ("receipt_id", "mutation_receipt_id"):
+            receipt_id = _clean(invocation.get(key))
+            if receipt_id:
+                mutation_receipt_ids.add(receipt_id)
+
+    for evidence_id in structured_evidence_ids:
+        if evidence_id not in screen_text:
+            continue
+        envelope = envelope_by_id.get(evidence_id)
+        references[evidence_id] = _reference_entry(
+            reference_id=evidence_id,
+            reference_type="turn_evidence",
+            screen_text=screen_text,
+            source=(
+                "persisted_evidence_index" if envelope else "structured_effect_fact"
+            ),
+            evidence=(
+                _bounded_evidence_envelope(envelope) if envelope is not None else None
+            ),
+            lifecycle={
+                "handle_scope": "exact_actor_and_turn",
+                "complete_result_lifetime": "ordinary_turn_only",
+                "persisted_projection": "bounded_envelope",
+                "durable_evidence_receipt": False,
+            },
+        )
+
+    for instance_id, instance in workflow_instances.items():
+        if instance_id not in screen_text:
+            continue
+        references[instance_id] = _reference_entry(
+            reference_id=instance_id,
+            reference_type="workflow_instance",
+            screen_text=screen_text,
+            source="structured_workflow_effect",
+            workflow=instance,
+        )
+
+    for receipt_id in mutation_receipt_ids:
+        if receipt_id not in screen_text:
+            continue
+        references[receipt_id] = _reference_entry(
+            reference_id=receipt_id,
+            reference_type="ontology_mutation_receipt",
+            screen_text=screen_text,
+            source="structured_mutation_receipt",
+        )
+
+    assertion_candidates: list[str] = []
+    seen_candidates: set[str] = set()
+    for match in _ASSERTION_CANDIDATE_RE.finditer(screen_text):
+        assertion_id = match.group(1)
+        if assertion_id in seen_candidates:
+            continue
+        seen_candidates.add(assertion_id)
+        assertion_candidates.append(assertion_id)
+        if len(assertion_candidates) >= MAX_REFERENCES:
+            break
+    for assertion_id in assertion_candidates:
+        try:
+            assertion = assertion_resolver(
+                assertion_id,
+                user_concept_id=user_concept_id,
+                organisation_concept_id=organisation_concept_id,
+            )
+        except Exception:  # noqa: BLE001 - inspection must not break the turn
+            # Reference enrichment is fail-soft; assertion content remains
+            # available through its canonical store once that read recovers.
+            assertion = None
+        if not isinstance(assertion, Mapping):
+            continue
+        references[assertion_id] = _reference_entry(
+            reference_id=assertion_id,
+            reference_type="scoped_assertion",
+            screen_text=screen_text,
+            source="exact_actor_visible_assertion_read",
+            assertion={
+                key: assertion.get(key)
+                for key in (
+                    "assertion_form",
+                    "assertion_revision",
+                    "status",
+                    "subject_concept_id",
+                    "predicate",
+                    "object_kind",
+                    "updated_at",
+                )
+                if key in assertion
+            },
+        )
+
+    ordered = sorted(
+        references.values(),
+        key=lambda item: screen_text.find(str(item.get("reference_id") or "")),
+    )[:MAX_REFERENCES]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "request_id": _clean(request_id),
+        "references": ordered,
+        "reference_count": len(ordered),
+        "typing_rule": "structured_or_exact_actor_visible_read",
+    }
+
+
+def build_turn_reference_manifest_from_debug(
+    *,
+    response_text: Any,
+    debug_info: Mapping[str, Any] | None,
+    user_concept_id: str | None = None,
+    organisation_concept_id: str | None = None,
+    assertion_resolver: Callable[..., Mapping[str, Any] | None] = (
+        get_visible_scoped_assertion_by_id
+    ),
+) -> dict[str, Any]:
+    """Reconstruct a viewer-scoped manifest from persisted turn diagnostics.
+
+    History entries created before the manifest contract still retain bounded
+    evidence and effect projections. Rebuilding at read time makes those
+    references inspectable without rewriting history, and re-runs assertion
+    visibility for the current viewer rather than trusting the original actor's
+    manifest.
+    """
+
+    debug = debug_info if isinstance(debug_info, Mapping) else {}
+    tool_invocations = (
+        debug.get("turn_execution_record_tool_invocations")
+        if isinstance(debug.get("turn_execution_record_tool_invocations"), list)
+        else (
+            debug.get("tool_invocations")
+            if isinstance(debug.get("tool_invocations"), list)
+            else []
+        )
+    )
+    auxiliary_calls = (
+        debug.get("aux_llm_calls")
+        if isinstance(debug.get("aux_llm_calls"), list)
+        else []
+    )
+
+    evidence_index: list[dict[str, Any]] = []
+    for entry in reversed(auxiliary_calls):
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get("type") != "adaptive_turn_evidence_index":
+            continue
+        raw_evidence = entry.get("evidence")
+        if isinstance(raw_evidence, list):
+            evidence_index = [
+                dict(item) for item in raw_evidence if isinstance(item, Mapping)
+            ]
+        break
+
+    outcome_sources: list[Any] = [*auxiliary_calls]
+    diagnostics = debug.get("turn_execution_diagnostics")
+    if isinstance(diagnostics, Mapping):
+        diagnostic_auxiliary_calls = diagnostics.get("aux_llm_calls")
+        if isinstance(diagnostic_auxiliary_calls, list):
+            outcome_sources.extend(diagnostic_auxiliary_calls)
+
+    outcome_report: Mapping[str, Any] | None = None
+    for entry in reversed(outcome_sources):
+        if not isinstance(entry, Mapping):
+            continue
+        if (
+            entry.get("type") == "adaptive_turn_effect_outcome_report"
+            and entry.get("schema_version") == "adaptive_turn_effect_outcome_report.v1"
+        ):
+            outcome_report = entry
+            break
+
+    return build_turn_reference_manifest(
+        response_text=response_text,
+        request_id=debug.get("request_id"),
+        evidence_index=evidence_index,
+        outcome_report=outcome_report,
+        tool_invocations=tool_invocations,
+        user_concept_id=user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        assertion_resolver=assertion_resolver,
+    )
+
+
+__all__ = [
+    "MAX_REFERENCES",
+    "SCHEMA_VERSION",
+    "build_turn_reference_manifest",
+    "build_turn_reference_manifest_from_debug",
+]

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -10,6 +10,10 @@ import { initializeMessagePanel, loadUnreadCount } from './components/messagePan
 import { loadMyOrganisations } from './components/orgSelector.js';
 import { initializePromptCartoucheOverlay, normaliseVontologyIdsForBackend } from './components/promptCartoucheOverlay.js';
 import { initializeTaskPanel, isTaskPanelVisible, setCurrentSession as setTaskPanelSession, toggleTaskPanel } from './components/taskPanel.js';
+import {
+    decorateInspectableReferences,
+    initializeReferenceInspector
+} from './components/referenceInspector.js';
 import { elements, getCurrentUserConceptId, renderSpanSuggestions } from './domUtils.js';
 import { activateTab } from './tabNavigation.js';
 import { isAnnotationEnabled } from './featureFlags.js';
@@ -22320,6 +22324,7 @@ function renderAssistantMessageContent(container, message, debugData) {
         hydrateChatConceptCartouches(container);
         void resolveInlineVontologyAliasesInElement(container, { expectedRenderMode: 'text' });
         renderTableDisplayElementsIntoContainer(container, debugData);
+        decorateInspectableReferences(container, debugData?.reference_manifest);
         return;
     }
 
@@ -22340,12 +22345,32 @@ function renderAssistantMessageContent(container, message, debugData) {
     void renderChatMarkdownIntoContainer(container, text)
         .then(() => {
             renderTableDisplayElementsIntoContainer(container, debugData);
+            decorateInspectableReferences(container, debugData?.reference_manifest);
         })
         .catch((err) => {
             console.error('[chatTab] Server markdown render failed; falling back to plain text:', err);
             container.textContent = text;
             renderTableDisplayElementsIntoContainer(container, debugData);
+            decorateInspectableReferences(container, debugData?.reference_manifest);
         });
+}
+
+function refreshInspectableReferencesForTurn(turnId, debugData = null) {
+    if (!turnId) return 0;
+    const escapedTurnId = (
+        typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+            ? CSS.escape(String(turnId))
+            : String(turnId).replace(/["\\]/g, '\\$&')
+    );
+    const messageContainer = document.querySelector(
+        `.message-container[data-turn-id="${escapedTurnId}"]`
+    );
+    const messageText = messageContainer?.querySelector('.chat-message-text');
+    if (!messageText) return 0;
+    return decorateInspectableReferences(
+        messageText,
+        debugData?.reference_manifest || llmDebugData.get(turnId)?.reference_manifest
+    );
 }
 
 function formatKindLabel(kind) {
@@ -32167,6 +32192,7 @@ export function initializeChatTab() {
 
     // Initialize LLM debug popup handlers
     initializeLlmDebugPopup();
+    initializeReferenceInspector();
     bindDiagnosticsExportShortcut();
     initializeHistoryControls();
     initializeConversationSituationPanel();
@@ -36089,6 +36115,7 @@ async function loadLlmDebugDataForTurn(turnId, options = {}) {
                     : (existing?.timestamp || null)
             };
             setLlmDebugDataEntry(turnId, merged);
+            refreshInspectableReferencesForTurn(turnId, merged);
             if (!renderRetainedThinkingCardForDebugData(turnId, merged)) {
                 renderRetainedThinkingUnavailableState(turnId);
             }

--- a/src/frontend/web/von_interface/static/js/components/referenceInspector.js
+++ b/src/frontend/web/von_interface/static/js/components/referenceInspector.js
@@ -1,0 +1,496 @@
+import { getJsonDetailed } from '../apiService.js';
+import { copyTextWithClipboardFallback } from '../utils/copyJsonButtonState.js';
+import { showToast } from '../utils/toast.js';
+
+export const REFERENCE_MANIFEST_SCHEMA_VERSION = 'turn_reference_manifest.v1';
+
+let currentReference = null;
+let initialised = false;
+
+function byId(id) {
+  return document.getElementById(id);
+}
+
+function clean(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normaliseList(value) {
+  return Array.isArray(value)
+    ? value.map((item) => clean(item)).filter(Boolean)
+    : [];
+}
+
+export function normaliseReferenceManifest(value) {
+  if (!value || typeof value !== 'object') return null;
+  if (value.schema_version !== REFERENCE_MANIFEST_SCHEMA_VERSION) return null;
+  const references = Array.isArray(value.references)
+    ? value.references.filter((item) => (
+      item
+      && typeof item === 'object'
+      && clean(item.reference_id)
+      && clean(item.reference_type)
+    ))
+    : [];
+  return {
+    ...value,
+    references,
+    reference_count: references.length,
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function shouldSkipTextNode(node) {
+  const parent = node?.parentElement;
+  if (!parent || !clean(node.nodeValue)) return true;
+  return !!parent.closest(
+    'button, a, input, textarea, select, option, script, style, '
+    + '.vontology-cartouche, .chat-reference-token'
+  );
+}
+
+export function decorateInspectableReferences(
+  container,
+  manifestValue,
+  { onOpen = openReferenceInspector } = {},
+) {
+  if (!(container instanceof Element)) return 0;
+  const manifest = normaliseReferenceManifest(manifestValue);
+  if (!manifest?.references?.length) return 0;
+
+  const referenceById = new Map(
+    manifest.references.map((item) => [clean(item.reference_id), item]),
+  );
+  const ids = [...referenceById.keys()].filter(Boolean).sort((a, b) => b.length - a.length);
+  if (!ids.length) return 0;
+  const pattern = new RegExp(`(${ids.map(escapeRegExp).join('|')})`, 'g');
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) {
+    if (!shouldSkipTextNode(walker.currentNode)) nodes.push(walker.currentNode);
+  }
+
+  let decorated = 0;
+  for (const node of nodes) {
+    const text = node.nodeValue || '';
+    pattern.lastIndex = 0;
+    if (!pattern.test(text)) continue;
+    pattern.lastIndex = 0;
+    const fragment = document.createDocumentFragment();
+    let cursor = 0;
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      if (match.index > cursor) fragment.appendChild(document.createTextNode(text.slice(cursor, match.index)));
+      const reference = referenceById.get(match[0]);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'chat-reference-token';
+      button.dataset.referenceId = match[0];
+      button.dataset.referenceType = reference.reference_type;
+      button.textContent = match[0];
+      button.title = `Inspect ${reference.label || 'reference'}`;
+      button.setAttribute('aria-label', `Inspect ${reference.label || 'reference'} ${match[0]}`);
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void onOpen(reference, { trigger: button });
+      });
+      fragment.appendChild(button);
+      cursor = match.index + match[0].length;
+      decorated += 1;
+    }
+    if (cursor < text.length) fragment.appendChild(document.createTextNode(text.slice(cursor)));
+    node.replaceWith(fragment);
+  }
+  return decorated;
+}
+
+function clearBody() {
+  const body = byId('conversationReferenceInspectorBody');
+  if (body) body.replaceChildren();
+  return body;
+}
+
+function setStatus(message) {
+  const status = byId('conversationReferenceInspectorStatus');
+  if (status) status.textContent = message || '';
+}
+
+function setBusy(busy) {
+  const body = byId('conversationReferenceInspectorBody');
+  if (body) body.setAttribute('aria-busy', busy ? 'true' : 'false');
+}
+
+function appendText(parent, tagName, className, text) {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
+}
+
+function appendSection(parent, title) {
+  const section = document.createElement('section');
+  section.className = 'chat-reference-section';
+  appendText(section, 'h4', 'chat-reference-section-title', title);
+  parent.appendChild(section);
+  return section;
+}
+
+function displayValue(value) {
+  if (value === true) return 'Yes';
+  if (value === false) return 'No';
+  if (value === null || value === undefined || value === '') return 'Not recorded';
+  if (Array.isArray(value)) return value.join(', ') || 'None';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function appendFields(parent, fields) {
+  const list = document.createElement('dl');
+  list.className = 'chat-reference-fields';
+  for (const [label, value] of fields) {
+    const term = document.createElement('dt');
+    term.textContent = label;
+    const description = document.createElement('dd');
+    description.textContent = displayValue(value);
+    list.append(term, description);
+  }
+  parent.appendChild(list);
+  return list;
+}
+
+function appendConceptButton(parent, conceptId, label) {
+  const id = clean(conceptId);
+  if (!id) return null;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'chat-reference-native-link';
+  button.textContent = label || id;
+  button.title = `Open concept ${id}`;
+  button.addEventListener('click', (event) => {
+    document.dispatchEvent(new CustomEvent('von:selectConceptById', {
+      detail: {
+        conceptId: id,
+        createConceptTab: true,
+        promoteExistingTab: true,
+        modifierKeys: { shiftKey: !!event.shiftKey },
+      },
+    }));
+  });
+  parent.appendChild(button);
+  return button;
+}
+
+function appendTechnicalDetails(parent, payload) {
+  const details = document.createElement('details');
+  details.className = 'chat-reference-technical';
+  appendText(details, 'summary', '', 'Technical details');
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(payload, null, 2);
+  details.appendChild(pre);
+  parent.appendChild(details);
+}
+
+function appendProfileList(parent, label, values) {
+  const cleanValues = normaliseList(values);
+  if (!cleanValues.length) return;
+  const row = document.createElement('div');
+  row.className = 'chat-reference-profile-row';
+  appendText(row, 'div', 'chat-reference-profile-label', label);
+  const valuesElement = document.createElement('div');
+  valuesElement.className = 'chat-reference-profile-values';
+  for (const value of cleanValues) appendText(valuesElement, 'span', 'chat-reference-chip', value);
+  row.appendChild(valuesElement);
+  parent.appendChild(row);
+}
+
+function renderAssertion(payload) {
+  const body = clearBody();
+  if (!body) return;
+  const assertion = payload?.assertion || {};
+  const summary = appendSection(body, 'Summary');
+  appendText(
+    summary,
+    'p',
+    'chat-reference-statement',
+    clean(assertion.human_statement) || 'This assertion has no displayable statement.',
+  );
+  const subject = assertion.subject || {};
+  if (clean(subject.concept_id)) {
+    const links = document.createElement('div');
+    links.className = 'chat-reference-native-links';
+    appendConceptButton(links, subject.concept_id, subject.display_name || subject.concept_id);
+    if (clean(assertion.predicate?.concept_id)) {
+      appendConceptButton(
+        links,
+        assertion.predicate.concept_id,
+        assertion.predicate.display_name || assertion.predicate.concept_id,
+      );
+    }
+    if (assertion.object?.kind === 'concept' && clean(assertion.object.concept_id)) {
+      appendConceptButton(
+        links,
+        assertion.object.concept_id,
+        assertion.object.display_name || assertion.object.concept_id,
+      );
+    }
+    summary.appendChild(links);
+  }
+
+  const profile = assertion.presentation?.kind === 'paper_matching_profile'
+    ? assertion.presentation
+    : null;
+  if (profile) {
+    const content = appendSection(body, 'Paper-matching profile');
+    if (clean(profile.project_description)) {
+      appendText(content, 'p', 'chat-reference-profile-description', profile.project_description);
+    }
+    appendProfileList(content, 'Interest terms', profile.stated_interest_terms);
+    appendProfileList(content, 'Avoid', profile.negative_interest_terms);
+    appendProfileList(content, 'Preferred authors', profile.preferred_authors);
+    appendProfileList(content, 'Preferred venues', profile.preferred_venues);
+    if (clean(profile.notes)) appendFields(content, [['Notes', profile.notes]]);
+  } else {
+    const content = appendSection(body, 'Content');
+    appendFields(content, [
+      ['Form', assertion.assertion_form],
+      ['Object', assertion.object?.display_name || assertion.object?.text],
+      ['Language', assertion.object?.language],
+    ]);
+  }
+
+  const provenance = appendSection(body, 'Provenance and scope');
+  appendFields(provenance, [
+    ['Visibility', assertion.source_context?.label],
+    ['Recorded by', assertion.provenance?.asserted_by_user_concept_id],
+    ['Source capability', assertion.provenance?.capability_name],
+    ['Source turn', assertion.provenance?.turn_id],
+    ['Evidence', assertion.provenance?.evidence],
+  ]);
+  const lifecycle = appendSection(body, 'Lifecycle');
+  appendFields(lifecycle, [
+    ['Status', assertion.status],
+    ['Revision', assertion.assertion_revision],
+    ['Created', assertion.created_at],
+    ['Updated', assertion.updated_at],
+    ['Context', assertion.assertion_context],
+  ]);
+  appendTechnicalDetails(body, payload);
+}
+
+function renderEvidence(reference) {
+  const body = clearBody();
+  if (!body) return;
+  const envelope = reference.evidence || {};
+  const summary = appendSection(body, 'Summary');
+  appendText(
+    summary,
+    'p',
+    'chat-reference-notice',
+    'This ev_ ID was an exact actor-and-turn handle to a tool result. The complete result was retained only for that ordinary turn; this is the bounded projection saved with the conversation.',
+  );
+  appendFields(summary, [
+    ['Source', envelope.tool_name || 'Structured effect fact'],
+    ['Status', envelope.status],
+    ['Content type', envelope.content_type],
+    ['Shape', envelope.shape],
+  ]);
+  const content = appendSection(body, 'Saved preview');
+  const preview = document.createElement('pre');
+  preview.className = 'chat-reference-preview';
+  preview.textContent = clean(envelope.preview) || 'No preview was retained for this handle.';
+  content.appendChild(preview);
+  if (envelope.preview_truncated === true) {
+    appendText(content, 'p', 'chat-reference-muted', 'The saved preview is truncated.');
+  }
+  const provenance = appendSection(body, 'Provenance');
+  appendFields(provenance, [
+    ['Tool', envelope.tool_name],
+    ['Call', envelope.call_id],
+    ['Turn', envelope.turn_id],
+    ['Trust boundary', envelope.trust_boundary],
+    ['Source diagnostics', envelope.source_diagnostics],
+    ['Provenance', envelope.provenance],
+  ]);
+  const lifecycle = appendSection(body, 'Lifecycle');
+  appendFields(lifecycle, [
+    ['Handle scope', reference.lifecycle?.handle_scope],
+    ['Complete result lifetime', reference.lifecycle?.complete_result_lifetime],
+    ['Saved form', reference.lifecycle?.persisted_projection],
+    ['Durable evidence receipt', reference.lifecycle?.durable_evidence_receipt],
+  ]);
+  appendTechnicalDetails(body, {
+    reference_id: reference.reference_id,
+    sha256: envelope.sha256,
+    size_bytes: envelope.size_bytes,
+    char_count: envelope.char_count,
+    available_selectors: envelope.available_selectors,
+  });
+}
+
+function renderWorkflow(payload) {
+  const body = clearBody();
+  if (!body) return;
+  const summary = appendSection(body, 'Summary');
+  appendFields(summary, [
+    ['Workflow', payload.workflow_name || payload.workflow_id],
+    ['Status', payload.status || payload.current_state],
+    ['Started', payload.started_at || payload.created_at],
+    ['Updated', payload.updated_at],
+    ['Completed', payload.completed_at],
+    ['Error step', payload.error_step],
+    ['Error', payload.error],
+  ]);
+  const workflowId = clean(payload.workflow_id);
+  if (workflowId?.startsWith('#V#')) {
+    const links = document.createElement('div');
+    links.className = 'chat-reference-native-links';
+    appendConceptButton(links, workflowId, 'Open workflow definition');
+    summary.appendChild(links);
+  }
+  if (payload.outputs && typeof payload.outputs === 'object') {
+    const output = appendSection(body, 'Outputs');
+    appendTechnicalDetails(output, payload.outputs);
+  }
+  appendTechnicalDetails(body, payload);
+}
+
+function renderMutationReceipt(payload) {
+  const body = clearBody();
+  if (!body) return;
+  const receipt = payload?.receipt || payload || {};
+  const summary = appendSection(body, 'Summary');
+  appendFields(summary, [
+    ['Operation', receipt.operation || receipt.method_name],
+    ['Status', receipt.status || receipt.effect_status],
+    ['Changed', receipt.changed],
+    ['Created', receipt.created_at],
+    ['Updated', receipt.updated_at],
+    ['Error code', receipt.error_code],
+  ]);
+  appendTechnicalDetails(body, receipt);
+}
+
+function renderError(message) {
+  const body = clearBody();
+  if (!body) return;
+  appendText(body, 'p', 'chat-reference-error', message);
+}
+
+function setHeader(reference) {
+  const eyebrow = byId('conversationReferenceInspectorEyebrow');
+  const title = byId('conversationReferenceInspectorTitle');
+  const explanation = byId('conversationReferenceInspectorExplanation');
+  if (eyebrow) eyebrow.textContent = reference.label || 'Conversation reference';
+  if (title) title.textContent = reference.label || 'Reference Inspector';
+  if (explanation) explanation.textContent = reference.reference_id;
+}
+
+async function loadCurrentReference() {
+  const reference = currentReference;
+  if (!reference) return;
+  setBusy(true);
+  setStatus(`Loading ${reference.label || 'reference'}`);
+  const body = clearBody();
+  if (body) appendText(body, 'p', 'chat-reference-muted', 'Loading…');
+  try {
+    if (reference.reference_type === 'turn_evidence') {
+      renderEvidence(reference);
+    } else if (reference.reference_type === 'scoped_assertion') {
+      const { data } = await getJsonDetailed(
+        `/api/concepts/assertions/${encodeURIComponent(reference.reference_id)}`,
+        { cache: 'no-store' },
+      );
+      if (reference !== currentReference) return;
+      renderAssertion(data);
+    } else if (reference.reference_type === 'workflow_instance') {
+      const { data } = await getJsonDetailed(
+        `/api/workflows/instances/${encodeURIComponent(reference.reference_id)}`,
+        { cache: 'no-store' },
+      );
+      if (reference !== currentReference) return;
+      renderWorkflow(data);
+    } else if (reference.reference_type === 'ontology_mutation_receipt') {
+      const { data } = await getJsonDetailed(
+        `/api/ontology-authority/receipts/${encodeURIComponent(reference.reference_id)}`,
+        { cache: 'no-store' },
+      );
+      if (reference !== currentReference) return;
+      renderMutationReceipt(data);
+    } else {
+      throw new Error('This reference type does not have an inspector.');
+    }
+    setStatus(`${reference.label || 'Reference'} loaded`);
+  } catch (error) {
+    if (reference !== currentReference) return;
+    const message = error?.status === 404
+      ? 'This reference is not available in your current scope.'
+      : (error?.message || 'The reference could not be loaded.');
+    renderError(message);
+    setStatus(message);
+  } finally {
+    if (reference === currentReference) setBusy(false);
+  }
+}
+
+export async function openReferenceInspector(reference, { trigger = null } = {}) {
+  if (!reference || typeof reference !== 'object') return false;
+  const id = clean(reference.reference_id);
+  const type = clean(reference.reference_type);
+  if (!id || !type) return false;
+  currentReference = { ...reference, reference_id: id, reference_type: type };
+  const panel = byId('conversationReferenceInspector');
+  if (!panel) return false;
+
+  const situation = byId('conversationSituationPanel');
+  const situationToggle = byId('conversationSituationToggleBtn');
+  situation?.classList.add('hidden');
+  situationToggle?.setAttribute('aria-expanded', 'false');
+  panel.classList.remove('hidden');
+  panel.dataset.referenceId = id;
+  panel.dataset.referenceType = type;
+  setHeader(currentReference);
+  await loadCurrentReference();
+  panel.focus({ preventScroll: true });
+  if (trigger instanceof HTMLElement) panel.dataset.triggerReferenceId = trigger.dataset.referenceId || '';
+  return true;
+}
+
+export function closeReferenceInspector() {
+  const panel = byId('conversationReferenceInspector');
+  panel?.classList.add('hidden');
+  panel?.removeAttribute('data-reference-id');
+  currentReference = null;
+}
+
+export function initializeReferenceInspector() {
+  if (initialised) return;
+  const panel = byId('conversationReferenceInspector');
+  if (!panel) return;
+  initialised = true;
+  byId('conversationReferenceInspectorCloseBtn')?.addEventListener('click', closeReferenceInspector);
+  byId('conversationReferenceInspectorRefreshBtn')?.addEventListener('click', () => {
+    void loadCurrentReference();
+  });
+  byId('conversationReferenceInspectorCopyBtn')?.addEventListener('click', async () => {
+    const id = currentReference?.reference_id;
+    if (!id) return;
+    const copied = await copyTextWithClipboardFallback(id);
+    showToast(copied ? 'Reference ID copied.' : 'Could not copy reference ID.', copied ? 'success' : 'error');
+  });
+  panel.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeReferenceInspector();
+    }
+  });
+}
+
+export function __testOnly_resetReferenceInspector() {
+  currentReference = null;
+  initialised = false;
+}

--- a/src/frontend/web/von_interface/static/js/test/referenceInspector.test.js
+++ b/src/frontend/web/von_interface/static/js/test/referenceInspector.test.js
@@ -1,0 +1,205 @@
+import {
+  __testOnly_resetReferenceInspector,
+  decorateInspectableReferences,
+  initializeReferenceInspector,
+  normaliseReferenceManifest,
+  openReferenceInspector,
+} from '../components/referenceInspector.js';
+import { getJsonDetailed } from '../apiService.js';
+
+jest.mock('../apiService.js', () => ({
+  getJsonDetailed: jest.fn(),
+}));
+
+jest.mock('../utils/copyJsonButtonState.js', () => ({
+  copyTextWithClipboardFallback: jest.fn(async () => true),
+}));
+
+jest.mock('../utils/toast.js', () => ({
+  showToast: jest.fn(),
+}));
+
+function installInspectorDom() {
+  document.body.innerHTML = `
+    <button id="conversationSituationToggleBtn" aria-expanded="true"></button>
+    <section id="conversationSituationPanel"></section>
+    <aside id="conversationReferenceInspector" class="hidden" tabindex="-1">
+      <div id="conversationReferenceInspectorEyebrow"></div>
+      <h3 id="conversationReferenceInspectorTitle"></h3>
+      <p id="conversationReferenceInspectorExplanation"></p>
+      <p id="conversationReferenceInspectorStatus"></p>
+      <div id="conversationReferenceInspectorBody"></div>
+      <button id="conversationReferenceInspectorRefreshBtn"></button>
+      <button id="conversationReferenceInspectorCopyBtn"></button>
+      <button id="conversationReferenceInspectorCloseBtn"></button>
+    </aside>
+  `;
+}
+
+describe('conversation reference inspector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __testOnly_resetReferenceInspector();
+    installInspectorDom();
+    initializeReferenceInspector();
+  });
+
+  test('accepts only the typed server manifest contract', () => {
+    expect(normaliseReferenceManifest({ schema_version: 'wrong', references: [] })).toBeNull();
+    expect(normaliseReferenceManifest({
+      schema_version: 'turn_reference_manifest.v1',
+      references: [
+        { reference_id: 'ev_1', reference_type: 'turn_evidence' },
+        { reference_id: '', reference_type: 'turn_evidence' },
+      ],
+    })?.references).toHaveLength(1);
+  });
+
+  test('decorates only identifiers typed by the server, including duplicate occurrences', () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <code>ska_visible_1234</code>
+      <span>ev_visible_1234 then ev_visible_1234</span>
+      <code>#V#actor@organisation</code>
+      <code>bd571204-d0ac-43e6-8764-11d757c37d35</code>
+    `;
+    const onOpen = jest.fn();
+    const count = decorateInspectableReferences(container, {
+      schema_version: 'turn_reference_manifest.v1',
+      references: [
+        {
+          reference_id: 'ska_visible_1234',
+          reference_type: 'scoped_assertion',
+          label: 'Assertion',
+        },
+        {
+          reference_id: 'ev_visible_1234',
+          reference_type: 'turn_evidence',
+          label: 'Turn evidence',
+        },
+      ],
+    }, { onOpen });
+
+    expect(count).toBe(3);
+    const buttons = container.querySelectorAll('.chat-reference-token');
+    expect(buttons).toHaveLength(3);
+    expect(container.querySelector('[data-reference-id="#V#actor@organisation"]')).toBeNull();
+    expect(container.querySelector('[data-reference-type="workflow_instance"]')).toBeNull();
+
+    buttons[0].click();
+    expect(onOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ reference_id: 'ska_visible_1234' }),
+      expect.objectContaining({ trigger: buttons[0] }),
+    );
+  });
+
+  test('loads and renders a human-facing paper profile assertion', async () => {
+    getJsonDetailed.mockResolvedValue({
+      data: {
+        success: true,
+        assertion: {
+          assertion_id: 'ska_profile_1234',
+          assertion_revision: 2,
+          status: 'asserted',
+          human_statement: 'Student A has paper matching profile',
+          subject: { concept_id: '#V#student_a', display_name: 'Student A' },
+          predicate: {
+            concept_id: '#V#has_paper_matching_profile_json',
+            display_name: 'Has paper matching profile',
+          },
+          object: { kind: 'text', text: '{}' },
+          source_context: { label: 'Organisation — Strong AI Lab' },
+          provenance: {
+            asserted_by_user_concept_id: '#V#actor',
+            capability_name: 'upsert_scoped_assertion',
+          },
+          presentation: {
+            kind: 'paper_matching_profile',
+            project_description: 'Robust multimodal learning',
+            stated_interest_terms: ['multimodal learning'],
+            negative_interest_terms: [],
+            preferred_authors: [],
+            preferred_venues: ['NeurIPS'],
+            notes: 'Derived from represented papers',
+          },
+        },
+      },
+    });
+
+    await openReferenceInspector({
+      reference_id: 'ska_profile_1234',
+      reference_type: 'scoped_assertion',
+      label: 'Assertion',
+    });
+
+    expect(getJsonDetailed).toHaveBeenCalledWith(
+      '/api/concepts/assertions/ska_profile_1234',
+      { cache: 'no-store' },
+    );
+    const panel = document.getElementById('conversationReferenceInspector');
+    expect(panel.classList.contains('hidden')).toBe(false);
+    expect(panel.textContent).toContain('Paper-matching profile');
+    expect(panel.textContent).toContain('Robust multimodal learning');
+    expect(panel.textContent).toContain('NeurIPS');
+    expect(panel.textContent).toContain('Organisation — Strong AI Lab');
+    expect(document.getElementById('conversationSituationPanel').classList.contains('hidden')).toBe(true);
+  });
+
+  test('renders persisted turn evidence without fetching or calling it a durable receipt', async () => {
+    await openReferenceInspector({
+      reference_id: 'ev_exact_turn_1234',
+      reference_type: 'turn_evidence',
+      label: 'Turn evidence',
+      evidence: {
+        tool_name: 'list_scoped_assertions',
+        call_id: 'call-1',
+        turn_id: 'turn-1',
+        status: 'ok',
+        trust_boundary: 'untrusted_tool_output',
+        preview: '{"assertions":[{"assertion_id":"ska_1"}]}',
+        preview_truncated: true,
+        sha256: 'abc',
+        size_bytes: 100,
+      },
+      lifecycle: {
+        handle_scope: 'exact_actor_and_turn',
+        complete_result_lifetime: 'ordinary_turn_only',
+        persisted_projection: 'bounded_envelope',
+        durable_evidence_receipt: false,
+      },
+    });
+
+    expect(getJsonDetailed).not.toHaveBeenCalled();
+    const text = document.getElementById('conversationReferenceInspector').textContent;
+    expect(text).toContain('complete result was retained only for that ordinary turn');
+    expect(text).toContain('list_scoped_assertions');
+    expect(text).toContain('The saved preview is truncated.');
+    expect(text).toContain('Durable evidence receipt');
+    expect(text).toContain('No');
+  });
+
+  test('loads a workflow instance through its actor-filtered canonical endpoint', async () => {
+    getJsonDetailed.mockResolvedValue({
+      data: {
+        instance_id: 'bd571204-d0ac-43e6-8764-11d757c37d35',
+        workflow_id: '#V#identity_resolution_workflow',
+        status: 'completed',
+        outputs: { resolved: true },
+      },
+    });
+
+    await openReferenceInspector({
+      reference_id: 'bd571204-d0ac-43e6-8764-11d757c37d35',
+      reference_type: 'workflow_instance',
+      label: 'Workflow instance',
+    });
+
+    expect(getJsonDetailed).toHaveBeenCalledWith(
+      '/api/workflows/instances/bd571204-d0ac-43e6-8764-11d757c37d35',
+      { cache: 'no-store' },
+    );
+    const text = document.getElementById('conversationReferenceInspector').textContent;
+    expect(text).toContain('completed');
+    expect(text).toContain('Open workflow definition');
+  });
+});

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -8438,6 +8438,234 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     overscroll-behavior: contain;
 }
 
+.chat-reference-inspector {
+    position: fixed;
+    top: clamp(72px, 10vh, 110px);
+    right: 18px;
+    bottom: 64px;
+    z-index: 1310;
+    width: min(620px, calc(100vw - 36px));
+    min-width: min(360px, calc(100vw - 36px));
+    max-width: min(900px, calc(100vw - 36px));
+    padding: 16px 18px;
+    box-sizing: border-box;
+    border: 1px solid #cbd5e1;
+    border-radius: 14px;
+    background: #ffffff;
+    box-shadow: 0 18px 52px rgba(15, 23, 42, 0.24);
+    color: #0f172a;
+    overflow: auto;
+    overscroll-behavior: contain;
+    resize: horizontal;
+}
+
+.chat-reference-inspector-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.chat-reference-inspector-eyebrow {
+    margin-bottom: 3px;
+    color: #7c3aed;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.chat-reference-inspector-title {
+    margin: 0;
+    font-size: 20px;
+    line-height: 1.25;
+}
+
+.chat-reference-inspector-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 7px;
+    flex-wrap: wrap;
+}
+
+.chat-reference-inspector-explanation {
+    margin: 9px 0 14px;
+    color: #475569;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+}
+
+.chat-reference-inspector-body,
+.chat-reference-section {
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+}
+
+.chat-reference-inspector-body {
+    gap: 14px;
+}
+
+.chat-reference-section {
+    padding: 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #f8fafc;
+}
+
+.chat-reference-section-title {
+    margin: 0;
+    color: #334155;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.chat-reference-statement,
+.chat-reference-notice,
+.chat-reference-profile-description,
+.chat-reference-muted,
+.chat-reference-error {
+    margin: 0;
+    line-height: 1.5;
+}
+
+.chat-reference-statement {
+    color: #111827;
+    font-size: 16px;
+}
+
+.chat-reference-notice {
+    padding: 9px 10px;
+    border-left: 3px solid #7c3aed;
+    border-radius: 6px;
+    background: #f5f3ff;
+    color: #4c1d95;
+    font-size: 13px;
+}
+
+.chat-reference-muted {
+    color: #64748b;
+    font-size: 13px;
+}
+
+.chat-reference-error {
+    padding: 10px;
+    border-radius: 8px;
+    background: #fef2f2;
+    color: #991b1b;
+}
+
+.chat-reference-fields {
+    display: grid;
+    grid-template-columns: minmax(110px, 0.35fr) minmax(0, 1fr);
+    gap: 6px 12px;
+    margin: 0;
+    font-size: 13px;
+}
+
+.chat-reference-fields dt {
+    color: #64748b;
+    font-weight: 600;
+}
+
+.chat-reference-fields dd {
+    min-width: 0;
+    margin: 0;
+    color: #1e293b;
+    overflow-wrap: anywhere;
+}
+
+.chat-reference-native-links,
+.chat-reference-profile-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+}
+
+.chat-reference-native-link,
+.chat-reference-chip {
+    padding: 3px 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: #fff;
+    color: #1e40af;
+    font-size: 12px;
+}
+
+.chat-reference-native-link {
+    cursor: pointer;
+}
+
+.chat-reference-native-link:hover,
+.chat-reference-native-link:focus-visible {
+    border-color: #60a5fa;
+    background: #eff6ff;
+}
+
+.chat-reference-profile-row {
+    display: grid;
+    grid-template-columns: minmax(110px, 0.35fr) minmax(0, 1fr);
+    gap: 8px 12px;
+    align-items: start;
+}
+
+.chat-reference-profile-label {
+    color: #64748b;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.chat-reference-preview,
+.chat-reference-technical pre {
+    max-height: 300px;
+    margin: 0;
+    padding: 10px;
+    border-radius: 8px;
+    background: #0f172a;
+    color: #e2e8f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.chat-reference-technical > summary {
+    cursor: pointer;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.chat-reference-technical[open] > summary {
+    margin-bottom: 8px;
+}
+
+.chat-reference-token {
+    display: inline;
+    margin: 0;
+    padding: 0 2px;
+    border: 0;
+    border-bottom: 1px dotted currentColor;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    text-align: inherit;
+    cursor: pointer;
+}
+
+.chat-reference-token:hover,
+.chat-reference-token:focus-visible {
+    border-radius: 3px;
+    background: #ede9fe;
+    color: #5b21b6;
+    outline: 2px solid transparent;
+}
+
 .chat-situation-header {
     display: flex;
     align-items: flex-start;
@@ -8652,6 +8880,33 @@ body[data-active-tab="settingsTab"] .tab-content-area {
         left: 10px;
         width: auto;
         padding: 13px;
+    }
+
+    .chat-reference-inspector {
+        top: 56px;
+        right: 10px;
+        bottom: 52px;
+        left: 10px;
+        width: auto;
+        min-width: 0;
+        max-width: none;
+        padding: 13px;
+        resize: none;
+    }
+
+    .chat-reference-inspector-header {
+        flex-direction: column;
+    }
+
+    .chat-reference-inspector-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .chat-reference-fields,
+    .chat-reference-profile-row {
+        grid-template-columns: 1fr;
+        gap: 3px;
     }
 
     .chat-situation-header {

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -85,6 +85,27 @@
       <div id="conversationSituationBody" class="chat-situation-body" aria-busy="false"></div>
     </section>
 
+    <aside id="conversationReferenceInspector" class="chat-reference-inspector hidden" role="complementary"
+      aria-labelledby="conversationReferenceInspectorTitle" tabindex="-1">
+      <div class="chat-reference-inspector-header">
+        <div>
+          <div id="conversationReferenceInspectorEyebrow" class="chat-reference-inspector-eyebrow">Conversation reference</div>
+          <h3 id="conversationReferenceInspectorTitle" class="chat-reference-inspector-title">Reference Inspector</h3>
+        </div>
+        <div class="chat-reference-inspector-actions">
+          <button id="conversationReferenceInspectorRefreshBtn" class="btn-mini" type="button">Refresh</button>
+          <button id="conversationReferenceInspectorCopyBtn" class="btn-mini" type="button">Copy ID</button>
+          <button id="conversationReferenceInspectorCloseBtn" class="btn-mini" type="button"
+            aria-label="Close reference inspector">Close</button>
+        </div>
+      </div>
+      <p id="conversationReferenceInspectorExplanation" class="chat-reference-inspector-explanation">
+        Inspect the object named by this conversation reference.
+      </p>
+      <p id="conversationReferenceInspectorStatus" class="visually-hidden" role="status" aria-live="polite"></p>
+      <div id="conversationReferenceInspectorBody" class="chat-reference-inspector-body" aria-busy="false"></div>
+    </aside>
+
     <div id="workflowStatusPanel" class="workflow-status-panel" aria-live="polite" aria-label="Workflow status">
       <div class="workflow-status-header">
         <div class="workflow-status-titlebar">

--- a/tests/backend/test_concept_effective_assertion_routes.py
+++ b/tests/backend/test_concept_effective_assertion_routes.py
@@ -109,3 +109,64 @@ def test_effective_assertion_route_returns_retryable_degraded_state(
         "error_code": "actor_effective_assertions_unavailable",
         "retryable": True,
     }
+
+
+def test_exact_assertion_route_is_non_disclosing_for_anonymous_and_missing(
+    monkeypatch,
+) -> None:
+    app = _make_app()
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_effective_assertion_by_id",
+        lambda _assertion_id: (_ for _ in ()).throw(
+            AssertionError("anonymous requests must not inspect assertions")
+        ),
+    )
+
+    with app.test_client() as client:
+        anonymous = client.get("/api/concepts/assertions/ska_private")
+
+    assert anonymous.status_code == 404
+    assert anonymous.get_json() == {"error": "assertion_not_found"}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: "#V#actor",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_effective_assertion_by_id",
+        lambda _assertion_id: None,
+    )
+    with app.test_client() as client:
+        missing = client.get("/api/concepts/assertions/ska_private")
+
+    assert missing.status_code == 404
+    assert missing.get_json() == {"error": "assertion_not_found"}
+
+
+def test_exact_assertion_route_returns_actor_visible_projection(monkeypatch) -> None:
+    app = _make_app()
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes._get_current_user_concept_id",
+        lambda: "#V#actor",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.concept_routes.load_effective_assertion_by_id",
+        lambda assertion_id: {
+            "success": True,
+            "context_view": "actor_effective",
+            "assertion": {"assertion_id": assertion_id, "status": "retracted"},
+        },
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/concepts/assertions/ska_visible")
+
+    assert response.status_code == 200
+    assert response.get_json()["assertion"] == {
+        "assertion_id": "ska_visible",
+        "status": "retracted",
+    }

--- a/tests/backend/test_concept_effective_assertion_service.py
+++ b/tests/backend/test_concept_effective_assertion_service.py
@@ -58,6 +58,7 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
             "limit": limit,
         }
         return [
+            {"concept_id": "#V#event", "name": "Research event"},
             {"concept_id": "#V#date_of_event", "name": "Date of event"},
             {"concept_id": "#V#event_location", "name": "Event location"},
             {"concept_id": "#V#room", "name": "Room 1"},
@@ -87,6 +88,7 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
     assert captured["find"]["filter"] == {
         "concept_id": {
             "$in": [
+                "#V#event",
                 "#V#date_of_event",
                 "#V#event_location",
                 "#V#room",
@@ -94,7 +96,7 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
             ]
         }
     }
-    assert captured["find"]["limit"] == 4
+    assert captured["find"]["limit"] == 5
     assert result["has_more"] is True
     assert result["next_offset"] == 2
     assert result["counts_are_lower_bounds"] is True
@@ -114,6 +116,74 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
     assert result["items"][1]["source_context"]["label"] == (
         "Organisation — Example Lab"
     )
+    assert result["items"][0]["subject"] == {
+        "concept_id": "#V#event",
+        "display_name": "Research event",
+    }
+    assert result["items"][0]["human_statement"] == (
+        "Research event Date of event June 2026"
+    )
+
+
+def test_exact_profile_assertion_projects_user_facing_profile(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_visible_scoped_assertion_by_id",
+        lambda _assertion_id: {
+            "assertion_id": "ska_profile",
+            "assertion_revision": 2,
+            "subject_concept_id": "#V#student",
+            "predicate": "#V#has_paper_matching_profile_json",
+            "object_kind": "text",
+            "object_text": {
+                "text": (
+                    '{"schema_version":"paper_matching_profile.v1",'
+                    '"project_description":"Robust multimodal learning",'
+                    '"stated_interest_terms":["multimodal learning"],'
+                    '"negative_interest_terms":[],"preferred_authors":[],'
+                    '"preferred_venues":["NeurIPS"],"notes":"Derived from papers"}'
+                ),
+                "language": "en-NZ",
+            },
+            "scope": {"mode": "organisation", "organisation_concept_id": "#V#lab"},
+            "status": "asserted",
+            "provenance": {"capability_name": "upsert_scoped_assertion"},
+        },
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"concept_id": "#V#student", "name": "Student A"},
+            {
+                "concept_id": "#V#has_paper_matching_profile_json",
+                "name": "Has paper matching profile",
+            },
+            {"concept_id": "#V#lab", "name": "Strong AI Lab"},
+        ],
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_concept_display_names",
+        lambda docs: {row["concept_id"]: row["name"] for row in docs},
+    )
+
+    result = service.load_effective_assertion_by_id("ska_profile")
+
+    assert result is not None
+    assertion = result["assertion"]
+    assert assertion["subject"]["display_name"] == "Student A"
+    assert assertion["human_statement"] == "Student A has a paper-matching profile."
+    assert assertion["presentation"] == {
+        "kind": "paper_matching_profile",
+        "project_description": "Robust multimodal learning",
+        "stated_interest_terms": ["multimodal learning"],
+        "negative_interest_terms": [],
+        "preferred_authors": [],
+        "preferred_venues": ["NeurIPS"],
+        "notes": "Derived from papers",
+        "updated_at": None,
+    }
 
 
 def test_load_effective_assertions_does_not_query_metadata_for_empty_page(

--- a/tests/backend/test_scoped_assertion_service.py
+++ b/tests/backend/test_scoped_assertion_service.py
@@ -248,6 +248,66 @@ def test_standalone_text_is_visible_without_links_and_links_are_optional(
     assert degraded[0]["concept_links"] == []
 
 
+def test_exact_assertion_read_keeps_retracted_lifecycle_and_hides_other_audience(
+    monkeypatch,
+) -> None:
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    row = _stored_text_assertion(
+        assertion_id="ska_exact_retracted",
+        subject_concept_id="#V#event",
+    )
+    row["status"] = "retracted"
+    row["assertion_revision"] = 3
+    collection.insert_one(row)
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+
+    visible = service.get_visible_scoped_assertion_by_id(
+        "ska_exact_retracted",
+        user_concept_id="#V#member",
+        organisation_concept_id="#V#trusted_org",
+    )
+    hidden = service.get_visible_scoped_assertion_by_id(
+        "ska_exact_retracted",
+        user_concept_id="#V#outsider",
+        organisation_concept_id="#V#other_org",
+    )
+
+    assert visible is not None
+    assert visible["status"] == "retracted"
+    assert visible["assertion_revision"] == 3
+    assert hidden is None
+
+
+def test_exact_assertion_read_rejects_lookalike_without_store_access(
+    monkeypatch,
+) -> None:
+    from src.backend.services import scoped_assertion_service as service
+
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("malformed IDs must not reach storage")
+        ),
+    )
+
+    assert service.get_visible_scoped_assertion_by_id(
+        "not_ska_123",
+        user_concept_id="#V#member",
+    ) is None
+
+
 def test_standalone_retraction_is_canonical_and_marks_rag_delete(monkeypatch):
     from src.backend.services import scoped_assertion_service as service
 

--- a/tests/backend/test_turn_reference_manifest_service.py
+++ b/tests/backend/test_turn_reference_manifest_service.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from src.backend.services.turn_reference_manifest_service import (
+    build_turn_reference_manifest,
+    build_turn_reference_manifest_from_debug,
+)
+
+
+def test_manifest_types_only_structured_or_actor_visible_references() -> None:
+    visible_assertion = "ska_visible_1234"
+    hidden_assertion = "ska_hidden_1234"
+    evidence_id = "ev_exact_turn_evidence"
+    instance_id = "bd571204-d0ac-43e6-8764-11d757c37d35"
+    namespace = "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+    text = (
+        f"Assertion `{visible_assertion}` and `{hidden_assertion}`; evidence "
+        f"`{evidence_id}`; instance `{instance_id}`; namespace `{namespace}`."
+    )
+
+    def resolve(assertion_id, **_kwargs):
+        if assertion_id == visible_assertion:
+            return {
+                "assertion_id": assertion_id,
+                "assertion_revision": 2,
+                "status": "asserted",
+            }
+        return None
+
+    manifest = build_turn_reference_manifest(
+        response_text=text,
+        request_id="request-1",
+        evidence_index=[
+            {
+                "schema_version": "turn_evidence_envelope.v1",
+                "evidence_id": evidence_id,
+                "tool_name": "upsert_scoped_assertion",
+                "status": "ok",
+                "preview": '{"assertion_id":"ska_visible_1234"}',
+                "sha256": "abc",
+                "size_bytes": 42,
+            }
+        ],
+        outcome_report={
+            "facts": [
+                {
+                    "instance_id": instance_id,
+                    "workflow_id": "#V#identity_resolution_workflow",
+                    "effect_status": "succeeded",
+                    "evidence_id": evidence_id,
+                    "target_ids": [instance_id],
+                }
+            ]
+        },
+        assertion_resolver=resolve,
+    )
+
+    references = {item["reference_id"]: item for item in manifest["references"]}
+    assert references[visible_assertion]["reference_type"] == "scoped_assertion"
+    assert hidden_assertion not in references
+    assert references[evidence_id]["reference_type"] == "turn_evidence"
+    assert references[evidence_id]["evidence"]["preview"].startswith("{")
+    assert references[evidence_id]["lifecycle"] == {
+        "handle_scope": "exact_actor_and_turn",
+        "complete_result_lifetime": "ordinary_turn_only",
+        "persisted_projection": "bounded_envelope",
+        "durable_evidence_receipt": False,
+    }
+    assert references[instance_id]["reference_type"] == "workflow_instance"
+    assert namespace not in references
+
+
+def test_duplicate_workflow_target_is_one_typed_instance_reference() -> None:
+    instance_id = "bd571204-d0ac-43e6-8764-11d757c37d35"
+    manifest = build_turn_reference_manifest(
+        response_text=f"instance `{instance_id}`; target `{instance_id}`",
+        request_id="request-2",
+        outcome_report={
+            "facts": [
+                {
+                    "instance_id": instance_id,
+                    "target_ids": [instance_id],
+                    "effect_status": "succeeded",
+                }
+            ]
+        },
+    )
+
+    assert manifest["reference_count"] == 1
+    assert manifest["references"][0]["reference_type"] == "workflow_instance"
+    assert manifest["references"][0]["occurrence_count"] == 2
+
+
+def test_manifest_can_be_reconstructed_from_legacy_debug_projections() -> None:
+    evidence_id = "ev_legacy_turn_evidence"
+    instance_id = "bd571204-d0ac-43e6-8764-11d757c37d35"
+    manifest = build_turn_reference_manifest_from_debug(
+        response_text=f"instance `{instance_id}`; evidence `{evidence_id}`",
+        debug_info={
+            "request_id": "request-legacy",
+            "aux_llm_calls": [
+                {
+                    "type": "adaptive_turn_evidence_index",
+                    "evidence": [
+                        {
+                            "evidence_id": evidence_id,
+                            "tool_name": "workflow_get_instance",
+                            "preview": '{"status":"failed"}',
+                        }
+                    ],
+                },
+                {
+                    "type": "adaptive_turn_effect_outcome_report",
+                    "schema_version": "adaptive_turn_effect_outcome_report.v1",
+                    "facts": [
+                        {
+                            "instance_id": instance_id,
+                            "workflow_id": "#V#legacy_workflow",
+                            "effect_status": "failed",
+                            "evidence_id": evidence_id,
+                        }
+                    ],
+                },
+            ],
+        },
+    )
+
+    references = {item["reference_id"]: item for item in manifest["references"]}
+    assert references[evidence_id]["source"] == "persisted_evidence_index"
+    assert references[evidence_id]["evidence"]["preview"] == '{"status":"failed"}'
+    assert references[instance_id]["workflow"] == {
+        "workflow_id": "#V#legacy_workflow",
+        "effect_status": "failed",
+        "canonical_readback_verified": False,
+    }

--- a/tests/backend/test_von_history_debug_endpoint.py
+++ b/tests/backend/test_von_history_debug_endpoint.py
@@ -175,6 +175,82 @@ def test_history_endpoint_returns_compact_debug_refs_without_hydration(monkeypat
     }
 
 
+def test_history_endpoint_projects_reference_manifest_for_legacy_turn(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+
+    evidence_id = "ev_legacy_history_evidence"
+    instance_id = "bd571204-d0ac-43e6-8764-11d757c37d35"
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {
+            "namespace": "#V#test_user@org",
+            "organisation_id": "#V#org",
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.get_chat_history_session_state",
+        lambda **_kwargs: {
+            "history": [
+                {
+                    "role": "assistant",
+                    "content": f"instance `{instance_id}`; evidence `{evidence_id}`",
+                    "llm_debug_data": {
+                        "request_id": "request-legacy-history",
+                        "aux_llm_calls": [
+                            {
+                                "type": "adaptive_turn_evidence_index",
+                                "evidence": [
+                                    {
+                                        "evidence_id": evidence_id,
+                                        "preview": "bounded legacy preview",
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "adaptive_turn_effect_outcome_report",
+                                "schema_version": "adaptive_turn_effect_outcome_report.v1",
+                                "facts": [
+                                    {
+                                        "instance_id": instance_id,
+                                        "workflow_id": "#V#legacy_workflow",
+                                        "effect_status": "failed",
+                                        "evidence_id": evidence_id,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                }
+            ]
+        },
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_bp, url_prefix="/von")
+
+    response = app.test_client().get(
+        "/von/history",
+        query_string={"session_id": "session-legacy", "segments": 1},
+    )
+
+    assert response.status_code == 200
+    debug = response.get_json()["history"][0]["llm_debug_data"]
+    manifest = debug["reference_manifest"]
+    references = {item["reference_id"]: item for item in manifest["references"]}
+    assert references[evidence_id]["reference_type"] == "turn_evidence"
+    assert references[evidence_id]["evidence"]["preview"] == "bounded legacy preview"
+    assert references[instance_id]["reference_type"] == "workflow_instance"
+
+
 def test_history_debug_returns_stored_turn_execution_diagnostics(monkeypatch):
     from src.backend.server.routes.von_routes import von_bp
 


### PR DESCRIPTION
## Summary

- add a non-modal, horizontally resizable Reference Inspector for typed assertion, turn-evidence, workflow-instance, and ontology-receipt IDs
- expose exact actor-safe assertion reads with human-facing paper-profile projections and native concept links
- persist a bounded server-typed reference manifest and reconstruct it for legacy conversation history without rewriting stored turns
- explain turn-local evidence-handle lifetime while showing only the bounded saved preview

## Validation

- 90 targeted backend tests
- 273 targeted frontend tests
- changed static JavaScript lint
- authenticated local browser replay of a legacy evidence handle and workflow instance, including canonical workflow read-back
- live actor-scoped read-back of an existing paper-profile assertion

Jira: JVNAUTOSCI-2692