### PR TITLE
Fix task board overflow and preserve scrolling

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -824,7 +824,11 @@ function renderGlobalTasksTabContent() {
             <div id="globalTaskGroupFilterRow" class="task-group-filter-row hidden" aria-label="Task groups"></div>
             <div class="global-task-layout">
                 <div class="global-task-main">
-                    <div id="globalTaskList" class="task-list"></div>
+                    <p id="globalTaskBoardScrollHint" class="task-board-scroll-hint hidden">
+                        <span aria-hidden="true">↔</span>
+                        Scroll horizontally to view all status lanes
+                    </p>
+                    <div id="globalTaskList" class="task-list" role="region" tabindex="0"></div>
                     <div id="globalTaskPagination" class="task-pagination-control" aria-live="polite"></div>
                 </div>
                 <aside id="globalTaskInspector" class="task-inspector" aria-live="polite"></aside>
@@ -1393,6 +1397,19 @@ function renderBulkTaskVisibilityControls() {
 function renderTaskList() {
     if (!_taskListEl) return;
 
+    const previousScrollLeft = _taskListEl.scrollLeft;
+    const previousScrollTop = _taskListEl.scrollTop;
+    const isBoardView = _viewMode === 'board';
+    const scrollHintEl = _globalTasksContainer?.querySelector('#globalTaskBoardScrollHint');
+    _taskListEl.dataset.viewMode = _viewMode;
+    _taskListEl.setAttribute('aria-label', isBoardView ? 'Task board' : 'Task list');
+    if (isBoardView) {
+        _taskListEl.setAttribute('aria-describedby', 'globalTaskBoardScrollHint');
+    } else {
+        _taskListEl.removeAttribute('aria-describedby');
+    }
+    scrollHintEl?.classList.toggle('hidden', !isBoardView);
+
     const filteredTasks = getFilteredTasks();
     ensureSelectedTaskStillValid(filteredTasks);
     renderGlobalTaskSummary(filteredTasks);
@@ -1441,7 +1458,10 @@ function renderTaskList() {
     }
 
     _taskListEl.innerHTML = html;
-    _taskListEl.dataset.viewMode = _viewMode;
+    if (isBoardView) {
+        _taskListEl.scrollLeft = previousScrollLeft;
+        _taskListEl.scrollTop = previousScrollTop;
+    }
 
     renderGlobalTaskInspector();
     attachTaskEventListeners();
@@ -2226,7 +2246,7 @@ function renderTaskInspector(task, detailState) {
     return `
         <div class="task-inspector-card" data-task-id="${escapeHtml(taskId)}">
             <div class="task-inspector-header">
-                <div>
+                <div class="task-inspector-heading">
                     <div class="task-inspector-eyebrow">${escapeHtml(detailTask.reference_code || taskId)}</div>
                     <h3>${escapeHtml(detailTask.title || 'Untitled task')}</h3>
                     <p>${escapeHtml(detailTask.description || 'No description yet.')}</p>

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1740,6 +1740,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    min-width: 0;
     padding: 10px 12px;
     background: #fff;
     border: 1px solid #e2e8f0;
@@ -1762,6 +1763,7 @@ body {
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+    min-width: 0;
 }
 
 .task-priority {
@@ -1769,6 +1771,8 @@ body {
 }
 
 .task-title {
+    flex: 1 1 120px;
+    min-width: 0;
     font-weight: 600;
     font-size: 0.9rem;
     color: #1e293b;
@@ -1811,6 +1815,7 @@ body {
 }
 
 .task-item-body {
+    min-width: 0;
     padding-left: 24px;
 }
 
@@ -1819,6 +1824,7 @@ body {
     font-size: 0.8rem;
     color: #64748b;
     line-height: 1.4;
+    overflow-wrap: anywhere;
 }
 
 .task-meta-chip-row {
@@ -1869,6 +1875,8 @@ body {
     background: #f8fafc;
     border: 1px solid #cbd5e1;
     color: #334155;
+    max-width: 100%;
+    overflow-wrap: anywhere;
 }
 
 .task-hierarchy-chip.task-concept-link {
@@ -1889,11 +1897,13 @@ body {
 
 .task-conversation-link {
     display: inline-block;
+    max-width: 100%;
     margin-top: 4px;
     font-size: 0.75rem;
     color: #2563eb;
     text-decoration: none;
     cursor: pointer;
+    overflow-wrap: anywhere;
 }
 
 .task-conversation-link:hover {
@@ -1995,6 +2005,7 @@ body {
 }
 
 .task-status-select {
+    max-width: 100%;
     padding: 4px 8px;
     font-size: 0.75rem;
     border: 1px solid #d1d5db;
@@ -3439,7 +3450,43 @@ button.unified-search-conversation-main {
 
 .global-task-main {
     min-width: 0;
-    overflow-x: auto;
+}
+
+.task-board-scroll-hint {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: fit-content;
+    margin: 0 0 8px;
+    padding: 5px 9px;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #475569;
+    font-size: 0.75rem;
+    line-height: 1.25;
+}
+
+.task-list[data-view-mode="board"] {
+    max-width: 100%;
+    max-height: clamp(420px, 68dvh, 760px);
+    overflow: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    touch-action: pan-x pan-y;
+    padding: 3px 4px 10px 3px;
+}
+
+.task-list[data-view-mode="board"]:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 3px;
+    border-radius: 10px;
+}
+
+.task-list[data-view-mode="list"] {
+    max-height: none;
+    overflow: visible;
+    padding: 0;
 }
 
 .task-pagination-control {
@@ -3589,6 +3636,7 @@ button.unified-search-conversation-main {
     display: flex;
     flex-direction: column;
     gap: 16px;
+    min-width: 0;
     padding: 20px;
 }
 
@@ -3597,26 +3645,36 @@ button.unified-search-conversation-main {
     justify-content: space-between;
     gap: 14px;
     align-items: flex-start;
+    min-width: 0;
+}
+
+.task-inspector-heading {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .task-inspector-header h3 {
     margin: 6px 0 6px;
     color: #0f172a;
     font-size: 1.25rem;
+    overflow-wrap: anywhere;
 }
 
 .task-inspector-header p {
     margin: 0;
     color: #475569;
     line-height: 1.5;
+    overflow-wrap: anywhere;
 }
 
 .task-inspector-eyebrow {
+    max-width: 100%;
     font-size: 0.76rem;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: #0f766e;
+    overflow-wrap: anywhere;
 }
 
 .task-inspector-badges {
@@ -3624,6 +3682,7 @@ button.unified-search-conversation-main {
     flex-wrap: wrap;
     gap: 8px;
     justify-content: flex-end;
+    max-width: 100%;
 }
 
 .task-inspector-timeline {
@@ -3690,6 +3749,7 @@ button.unified-search-conversation-main {
 .task-inspector-table {
     display: flex;
     flex-direction: column;
+    min-width: 0;
     border: 1px solid #e2e8f0;
     border-radius: 16px;
     overflow: hidden;
@@ -3722,6 +3782,7 @@ button.unified-search-conversation-main {
     align-items: center;
     color: #0f172a;
     line-height: 1.5;
+    overflow-wrap: anywhere;
 }
 
 .task-external-resource-action {

--- a/tests/frontend/taskPanelLayout.test.js
+++ b/tests/frontend/taskPanelLayout.test.js
@@ -1,0 +1,167 @@
+/** @jest-environment jsdom */
+
+const fs = require('fs');
+const path = require('path');
+
+const taskPanelModulePath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+const styles = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/styles.css'),
+    'utf8',
+);
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    getUserContext: jest.fn(() => ({ user_id: '#V#layout_user', org_id: '#V#layout_org' })),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn(),
+}));
+
+function cssRule(selector) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return styles.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`, 'm'))?.[1] || '';
+}
+
+function buildTaxonomyResponse() {
+    return {
+        task_types: [{ concept_id: '#V#one_off_task_specification', label: 'One-off' }],
+        task_sources: [{ concept_id: '#V#von_native_task_source', label: 'Von native' }],
+        defaults: {
+            task_type_id: '#V#one_off_task_specification',
+            task_source_id: '#V#von_native_task_source',
+        },
+    };
+}
+
+function buildTasks() {
+    return [
+        {
+            task_concept_id: '#V#task_layout_pending',
+            title: 'Pending layout check',
+            description: 'A task with ordinary content.',
+            status: 'pending',
+            priority: 'medium',
+            task_type_ids: ['#V#one_off_task_specification'],
+            task_source_id: '#V#von_native_task_source',
+        },
+        {
+            task_concept_id: '#V#task_layout_cancelled_with_a_deliberately_long_identifier',
+            title: 'Cancelled layout check with a deliberately long title',
+            description: 'A deliberately long_unbroken_value_that_must_not_expand_the_task_board_or_inspector.',
+            status: 'cancelled',
+            priority: 'medium',
+            task_type_ids: ['#V#one_off_task_specification'],
+            task_source_id: '#V#von_native_task_source',
+        },
+    ];
+}
+
+async function flushRenderQueue() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('global task board layout', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.spyOn(console, 'debug').mockImplementation(() => {});
+        localStorage.clear();
+        document.body.innerHTML = `
+            <div id="globalTasksContainer"></div>
+            <span id="taskCountBadge" class="hidden"></span>
+            <span id="globalTaskCountBadge" class="hidden"></span>
+        `;
+
+        const tasks = buildTasks();
+        const { getJson } = require(apiServiceModulePath);
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve(buildTaxonomyResponse());
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?') && url.includes('limit=50')) {
+                return Promise.resolve({ tasks });
+            }
+            const detailTask = tasks.find((task) => (
+                url === `/api/tasks/${encodeURIComponent(task.task_concept_id)}`
+            ));
+            if (detailTask) return Promise.resolve(detailTask);
+            if (typeof url === 'string' && url.includes('/comments?')) {
+                return Promise.resolve({ comments: [] });
+            }
+            if (typeof url === 'string' && url.includes('/attachments?')) {
+                return Promise.resolve({ attachments: [] });
+            }
+            if (typeof url === 'string' && url.includes('/history?')) {
+                return Promise.resolve({ history: [] });
+            }
+            return Promise.resolve({});
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('mounts a labelled board viewport and preserves its scroll position during selection', async () => {
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        const taskList = document.querySelector('#globalTaskList');
+        const scrollHint = document.querySelector('#globalTaskBoardScrollHint');
+        expect(taskList.dataset.viewMode).toBe('board');
+        expect(taskList.getAttribute('role')).toBe('region');
+        expect(taskList.getAttribute('tabindex')).toBe('0');
+        expect(taskList.getAttribute('aria-label')).toBe('Task board');
+        expect(taskList.getAttribute('aria-describedby')).toBe('globalTaskBoardScrollHint');
+        expect(scrollHint.classList.contains('hidden')).toBe(false);
+        expect(document.querySelectorAll('.task-board-view .task-group')).toHaveLength(5);
+
+        taskList.scrollLeft = 320;
+        taskList.scrollTop = 180;
+        document.querySelector('[data-task-id="#V#task_layout_pending"]').click();
+        expect(taskList.scrollLeft).toBe(320);
+        expect(taskList.scrollTop).toBe(180);
+    });
+
+    test('removes the nested scrolling affordance in list mode', async () => {
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        const viewMode = document.querySelector('#globalTaskViewMode');
+        viewMode.value = 'list';
+        viewMode.dispatchEvent(new Event('change', { bubbles: true }));
+
+        const taskList = document.querySelector('#globalTaskList');
+        expect(taskList.dataset.viewMode).toBe('list');
+        expect(taskList.getAttribute('aria-label')).toBe('Task list');
+        expect(taskList.hasAttribute('aria-describedby')).toBe(false);
+        expect(document.querySelector('#globalTaskBoardScrollHint').classList.contains('hidden')).toBe(true);
+        expect(document.querySelector('.task-list-mode')).toBeTruthy();
+    });
+
+    test('keeps overflow on the stable board viewport and contains long task content', () => {
+        const boardViewportRule = cssRule('.task-list[data-view-mode="board"]');
+        const listViewportRule = cssRule('.task-list[data-view-mode="list"]');
+        const mainRule = cssRule('.global-task-main');
+
+        expect(boardViewportRule).toContain('overflow: auto');
+        expect(boardViewportRule).toContain('max-height: clamp(');
+        expect(boardViewportRule).toContain('overscroll-behavior: contain');
+        expect(listViewportRule).toContain('overflow: visible');
+        expect(mainRule).not.toContain('overflow-x: auto');
+        expect(cssRule('.task-description')).toContain('overflow-wrap: anywhere');
+        expect(cssRule('.task-inspector-value')).toContain('overflow-wrap: anywhere');
+        expect(cssRule('.task-inspector-heading')).toContain('min-width: 0');
+    });
+});


### PR DESCRIPTION
## Outcome
- gives the five-lane task board a bounded two-axis scroll viewport
- keeps pagination and the task inspector outside the scroll region
- preserves board scroll position across task selection rerenders
- contains long task and inspector content without page-level horizontal overflow
- adds an accessible scroll hint and focused regression coverage

## Validation
- npm test -- --runInBand tests/frontend/taskPanelLayout.test.js tests/frontend/taskPanelGroupFilters.test.js tests/frontend/taskPanelConceptLinks.test.js tests/frontend/tabContentSizing.test.js
- npm run lint:frontend:static -- --files src/frontend/web/von_interface/static/js/components/taskPanel.js tests/frontend/taskPanelLayout.test.js
- node --check on both changed JavaScript files
- authenticated AgentTest browser validation at 1600x900 and 800x900: final lane reachable, inspector separated or stacked correctly, scroll position retained, and no document-level horizontal overflow

## Scope
Frontend repository publication only. No runtime deployment or activation.