### PR TITLE
Bound chat transcript hydration fanout

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -21997,6 +21997,9 @@ const chatConceptMetaCache = new Map();
 const chatConceptMetaPending = new Map();
 let chatConceptMetaHydrationGeneration = 0;
 const chatConceptMetaFetchAbortControllers = new Set();
+const CHAT_CONCEPT_META_MAX_CONCURRENT_REQUESTS = 2;
+let chatConceptMetaActiveRequestCount = 0;
+const chatConceptMetaRequestQueue = [];
 
 const CHAT_CONCEPT_META_MAX_RETRIES = 3;
 const chatConceptMetaRetryCounts = new Map();
@@ -22015,24 +22018,70 @@ function isChatConceptMetaHydrationCurrent(generation) {
     return generation === chatConceptMetaHydrationGeneration;
 }
 
-function fetchOptionalChatConceptResource(url, options = {}, generation = chatConceptMetaHydrationGeneration) {
+function createChatConceptHydrationAbortError() {
+    const error = new Error('Chat concept hydration superseded.');
+    error.name = 'AbortError';
+    return error;
+}
+
+function drainChatConceptMetaRequestQueue() {
+    while (
+        chatConceptMetaActiveRequestCount < CHAT_CONCEPT_META_MAX_CONCURRENT_REQUESTS
+        && chatConceptMetaRequestQueue.length > 0
+    ) {
+        const queued = chatConceptMetaRequestQueue.shift();
+        if (!queued) {
+            continue;
+        }
+        if (!isChatConceptMetaHydrationCurrent(queued.generation)) {
+            queued.reject(createChatConceptHydrationAbortError());
+            continue;
+        }
+        chatConceptMetaActiveRequestCount += 1;
+        queued.resolve();
+    }
+}
+
+function acquireChatConceptMetaRequestSlot(generation) {
     if (!isChatConceptMetaHydrationCurrent(generation)) {
-        const error = new Error('Chat concept hydration superseded.');
-        error.name = 'AbortError';
-        return Promise.reject(error);
+        return Promise.reject(createChatConceptHydrationAbortError());
+    }
+    if (chatConceptMetaActiveRequestCount < CHAT_CONCEPT_META_MAX_CONCURRENT_REQUESTS) {
+        chatConceptMetaActiveRequestCount += 1;
+        return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+        chatConceptMetaRequestQueue.push({ generation, resolve, reject });
+    });
+}
+
+function releaseChatConceptMetaRequestSlot() {
+    chatConceptMetaActiveRequestCount = Math.max(0, chatConceptMetaActiveRequestCount - 1);
+    drainChatConceptMetaRequestQueue();
+}
+
+async function fetchOptionalChatConceptResource(
+    url,
+    options = {},
+    generation = chatConceptMetaHydrationGeneration
+) {
+    await acquireChatConceptMetaRequestSlot(generation);
+    if (!isChatConceptMetaHydrationCurrent(generation)) {
+        releaseChatConceptMetaRequestSlot();
+        throw createChatConceptHydrationAbortError();
     }
 
     const abortController = new AbortController();
     chatConceptMetaFetchAbortControllers.add(abortController);
-    const request = fetch(url, {
-        ...options,
-        signal: abortController.signal
-    });
-    const releaseController = () => {
+    try {
+        return await fetch(url, {
+            ...options,
+            signal: abortController.signal
+        });
+    } finally {
         chatConceptMetaFetchAbortControllers.delete(abortController);
-    };
-    request.then(releaseController, releaseController);
-    return request;
+        releaseChatConceptMetaRequestSlot();
+    }
 }
 
 function cancelChatConceptMetaHydration() {
@@ -22045,6 +22094,10 @@ function cancelChatConceptMetaHydration() {
         }
     });
     chatConceptMetaFetchAbortControllers.clear();
+    const queuedRequests = chatConceptMetaRequestQueue.splice(0);
+    queuedRequests.forEach((queued) => {
+        queued.reject(createChatConceptHydrationAbortError());
+    });
     chatConceptMetaPending.clear();
     for (const timerId of chatConceptMetaRetryTimers.values()) {
         try {
@@ -27867,6 +27920,44 @@ async function switchToChatSession(sessionId, options = {}) {
         return { ok: false, error: 'Conversation panel unavailable.' };
     }
 
+    const restorePreviousSession = (failureMessage) => {
+        setActiveChatSession(previousSessionId, previousSessionName);
+        if (sessionTabsCache.length > 0) {
+            renderChatSessionTabs(sessionTabsCache, previousSessionId || sid);
+        }
+
+        chatSessionMetadataOpenKey = null;
+        if (previousSessionId) {
+            void loadChatSessionLinks(previousSessionId, { force: false });
+        } else {
+            _clearChatSessionMetadata();
+        }
+
+        setChatSessionTabLoading(sid, false);
+        const cached = previousSessionId
+            ? getSessionHistoryCache(previousSessionId)
+            : null;
+        const restoredFromCache = cached
+            ? rehydrateFromCache(scrollableField, cached)
+            : false;
+        if (restoredFromCache) {
+            displayedHistorySessionId = previousSessionId;
+            clearHistoryLoadState({ sessionId: previousSessionId });
+            return true;
+        }
+
+        scrollableField.innerHTML = (
+            `<div class="chat-session-loading">${escapeHtml(failureMessage)}</div>`
+        );
+        void loadChatHistory({
+            segments: 1,
+            scrollToBottom: true,
+            showResetNotice: false,
+            forceScrollToBottom: true
+        });
+        return false;
+    };
+
     scrollableField.innerHTML = '<div class="chat-session-loading">Switching chat…</div>';
     transcriptTurns.length = 0;
     clearLlmDebugDataEntries();
@@ -27936,26 +28027,7 @@ async function switchToChatSession(sessionId, options = {}) {
 
         if (!response.ok) {
             const msg = data?.error ? String(data.error) : 'Unable to switch session.';
-            setActiveChatSession(previousSessionId, previousSessionName);
-            if (sessionTabsCache.length > 0) {
-                renderChatSessionTabs(sessionTabsCache, previousSessionId || sid);
-            }
-
-            chatSessionMetadataOpenKey = null;
-            if (previousSessionId) {
-                void loadChatSessionLinks(previousSessionId, { force: false });
-            } else {
-                _clearChatSessionMetadata();
-            }
-
-            setChatSessionTabLoading(sid, false);
-            scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(msg)}</div>`;
-            void loadChatHistory({
-                segments: 1,
-                scrollToBottom: true,
-                showResetNotice: false,
-                forceScrollToBottom: true
-            });
+            restorePreviousSession(msg);
             return { ok: false, error: msg };
         }
 
@@ -28066,29 +28138,10 @@ async function switchToChatSession(sessionId, options = {}) {
         } else {
             console.error('Error switching chat session:', err);
         }
-        setActiveChatSession(previousSessionId, previousSessionName);
-        if (sessionTabsCache.length > 0) {
-            renderChatSessionTabs(sessionTabsCache, previousSessionId || sid);
-        }
-
-        chatSessionMetadataOpenKey = null;
-        if (previousSessionId) {
-            void loadChatSessionLinks(previousSessionId, { force: false });
-        } else {
-            _clearChatSessionMetadata();
-        }
-
-        setChatSessionTabLoading(sid, false);
         const failureMessage = timedOut
             ? 'Conversation switch timed out. Restoring the previous conversation…'
             : 'Unable to switch session.';
-        scrollableField.innerHTML = `<div class="chat-session-loading">${escapeHtml(failureMessage)}</div>`;
-        void loadChatHistory({
-            segments: 1,
-            scrollToBottom: true,
-            showResetNotice: false,
-            forceScrollToBottom: true
-        });
+        restorePreviousSession(failureMessage);
         console.log('[chatTab] switchToChatSession failed', {
             session_id: sid,
             reason: timedOut ? 'timeout' : 'error',

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -9656,18 +9656,20 @@ describe('chat session composer state', () => {
 
         const conceptRoot = document.createElement('div');
         conceptRoot.innerHTML = `
-            <span class="vontology-cartouche" data-full-concept-id="#V#slow_concept">
-                <span class="vontology-cartouche-name"></span>
-                <span class="vontology-cartouche-kind"></span>
-            </span>
+            ${Array.from({ length: 5 }, (_, index) => `
+                <span class="vontology-cartouche" data-full-concept-id="#V#slow_concept_${index}">
+                    <span class="vontology-cartouche-name"></span>
+                    <span class="vontology-cartouche-kind"></span>
+                </span>
+            `).join('')}
         `;
         document.body.appendChild(conceptRoot);
 
-        let conceptLookupSignal = null;
+        const conceptLookupSignals = [];
         global.fetch = jest.fn((url, options = {}) => {
             const requestUrl = String(url);
             if (requestUrl.startsWith('/vontology/api/vontology/node_content')) {
-                conceptLookupSignal = options.signal;
+                conceptLookupSignals.push(options.signal);
                 return new Promise((_, reject) => {
                     options.signal.addEventListener('abort', () => {
                         const error = new Error('aborted');
@@ -9706,14 +9708,18 @@ describe('chat session composer state', () => {
         });
 
         __testOnly_hydrateChatConceptCartouches(conceptRoot);
-        expect(conceptLookupSignal).toBeInstanceOf(AbortSignal);
-        expect(conceptLookupSignal.aborted).toBe(false);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(conceptLookupSignals).toHaveLength(2);
+        expect(conceptLookupSignals.every(signal => signal instanceof AbortSignal)).toBe(true);
+        expect(conceptLookupSignals.every(signal => !signal.aborted)).toBe(true);
 
         await expect(switchToChatSession('session-2')).resolves.toEqual(
             expect.objectContaining({ ok: true })
         );
 
-        expect(conceptLookupSignal.aborted).toBe(true);
+        expect(conceptLookupSignals).toHaveLength(2);
+        expect(conceptLookupSignals.every(signal => signal.aborted)).toBe(true);
         expect(document.getElementById('scrollableField').textContent).not.toContain('Switching chat');
         __testOnly_resetChatConceptMetaCaches();
     });
@@ -9752,15 +9758,23 @@ describe('chat session composer state', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            history: [],
-                            segments_returned: 0,
-                            total_segments: 0,
-                            total_messages: 0
+                            history: [{
+                                role: 'user',
+                                content: 'Cached prior transcript',
+                                timestamp: '2026-08-30T20:00:00Z'
+                            }],
+                            segments_returned: 1,
+                            total_segments: 1,
+                            total_messages: 1
                         })
                     });
                 }
                 return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
             });
+
+            await expect(__testOnly_loadChatHistory({ segments: 1 })).resolves.toBe(true);
+            expect(document.getElementById('scrollableField').textContent)
+                .toContain('Cached prior transcript');
 
             const switching = switchToChatSession('session-2', { requestTimeoutMs: 25 });
             await Promise.resolve();
@@ -9776,6 +9790,8 @@ describe('chat session composer state', () => {
             expect(setSessionSignal.aborted).toBe(true);
             expect(__testOnly_buildConversationSituationExportPayload().session_id).toBe('session-1');
             expect(document.getElementById('scrollableField').textContent).not.toContain('Switching chat');
+            expect(document.getElementById('scrollableField').textContent)
+                .toContain('Cached prior transcript');
         } finally {
             jest.clearAllTimers();
             jest.useRealTimers();


### PR DESCRIPTION
## Outcome

Follow-up to #483 based on live browser replay. Conversation switching now retains capacity while a large transcript decorates Vontology references, and timeout recovery immediately restores the cached prior transcript.

## Live evidence addressed

- the 15-second selection boundary correctly ended the indefinite “Switching chat…” state
- already-queued optional hydration continued issuing expensive Atlas reads server-side
- timeout selected the prior tab but left a restoration placeholder while a fresh history read was starved

## Changes

- cap optional transcript concept requests at two concurrent requests
- cancel queued hydration work on conversation or organisation change
- reuse cached prior history immediately when selection fails or times out

## Validation

- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/chatTab.js`
- `npx jest src/frontend/web/von_interface/static/js/test/chatTab.test.js tests/frontend/orgSwitchRefreshChatTabs.test.js --runInBand --silent` (281/281)
