### PR TITLE
Recover Atlas DNS without widening resolver scope

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,6 +44,16 @@ MONGO_ALLOW_LOCAL_FALLBACK=0
 # MONGO_SSH_TUNNEL_EXPECTED_REPLICA_SET=atlas-example-shard-0
 # A direct-host Atlas URI, useful when only SRV lookup is failing.
 # MONGO_DNS_FALLBACK_URI=mongodb://YOUR_DIRECT_ATLAS_URI
+# Optional: after system DNS fails for a host explicitly listed in the direct
+# fallback URI, resolve only that host through these literal-IP resolvers.
+# TLS still verifies the original Mongo hostname. No public resolver is used
+# unless this setting is explicitly enabled.
+# MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS=8.8.8.8,8.8.4.4
+# MONGO_DNS_RESOLVER_FALLBACK_TIMEOUT_SECONDS=2
+# MONGO_DNS_RESOLVER_FALLBACK_CACHE_SECONDS=60
+# Optional: start on the configured direct-host route when the primary SRV
+# resolver is known to be unavailable, avoiding the SRV lookup delay.
+# MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT=0
 #
 # How long to keep a working fallback before probing the primary route again.
 # VON_MONGO_FALLBACK_STICKY_SECONDS=300

--- a/docs/engineering/environment_minimums.md
+++ b/docs/engineering/environment_minimums.md
@@ -98,6 +98,19 @@ Why these matter:
   when the set name cannot be derived from an existing URI
 - `MONGO_DNS_FALLBACK_URI=<direct-host Atlas URI>` can still be used as a
   non-local recovery path when SRV/DNS resolution is flaky
+- `MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS=<literal IP list>` optionally gives
+  that direct-host path a second resolver only after the system resolver has
+  failed. It is restricted to seed hosts explicitly named in
+  `MONGO_DNS_FALLBACK_URI`; PyMongo still supplies the original hostname for
+  TLS certificate verification. No public resolver is selected by default.
+- `MONGO_DNS_RESOLVER_FALLBACK_TIMEOUT_SECONDS=2` bounds each explicit resolver
+  attempt without imposing a Mongo operation timeout
+- `MONGO_DNS_RESOLVER_FALLBACK_CACHE_SECONDS=60` coalesces driver lookups and
+  briefly reuses successful answers; the original hostname remains the TLS
+  identity even while an address is cached
+- `MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT=1` explicitly starts on the
+  configured direct-host route when the primary SRV resolver is known to be
+  unavailable, avoiding an otherwise unbounded SRV lookup delay
 - `VON_MONGO_FALLBACK_STICKY_SECONDS=300` controls how long a working fallback
   is reused before Von probes the direct primary route again
 - `VON_SKIP_BROWSER_LAUNCH=1` avoids remote hosts trying to open a local browser

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -2,6 +2,7 @@ import datetime  # Added for type hinting and __main__ example
 import ipaddress
 import logging
 import os
+import socket
 import sys
 import threading
 import time
@@ -456,6 +457,74 @@ MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS = _parse_ssh_tunnel_fallback_endpoints(
 MONGO_SSH_TUNNEL_EXPECTED_REPLICA_SET = _get_nonempty_env_value(
     "MONGO_SSH_TUNNEL_EXPECTED_REPLICA_SET"
 )
+MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS = _get_nonempty_env_value(
+    "MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS"
+)
+
+
+def _parse_mongo_dns_resolver_fallback_nameservers(
+    raw: str | None,
+) -> tuple[str, ...]:
+    """Return an ordered, literal-IP resolver list without accepting URLs."""
+
+    if not raw:
+        return ()
+    nameservers: list[str] = []
+    for index, value in enumerate(raw.split(","), start=1):
+        candidate = value.strip()
+        if not candidate:
+            continue
+        try:
+            normalised = str(ipaddress.ip_address(candidate))
+        except ValueError:
+            logger.warning(
+                "[mongo_dns_resolver_fallback] Ignoring invalid nameserver #%s; "
+                "only literal IP addresses are accepted.",
+                index,
+            )
+            continue
+        if normalised not in nameservers:
+            nameservers.append(normalised)
+    return tuple(nameservers)
+
+
+def _mongo_seed_hosts(uri: str | None) -> frozenset[str]:
+    """Extract lower-cased seed hosts without retaining URI credentials."""
+
+    if not uri:
+        return frozenset()
+    try:
+        authority = urlsplit(uri).netloc.rsplit("@", 1)[-1]
+    except (TypeError, ValueError):
+        return frozenset()
+    hosts: set[str] = set()
+    for raw_seed in authority.split(","):
+        seed = raw_seed.strip()
+        if not seed:
+            continue
+        try:
+            host = urlsplit(f"//{seed}").hostname
+        except ValueError:
+            continue
+        if host:
+            hosts.add(host.rstrip(".").lower())
+    return frozenset(hosts)
+
+
+_ORIGINAL_SOCKET_GETADDRINFO = socket.getaddrinfo
+_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS = (
+    _parse_mongo_dns_resolver_fallback_nameservers(
+        MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+    )
+)
+_MONGO_DNS_RESOLVER_FALLBACK_HOSTS = _mongo_seed_hosts(MONGO_DNS_FALLBACK_URI)
+_MONGO_DNS_RESOLVER_FALLBACK_LOGGED_HOSTS: set[str] = set()
+_MONGO_DNS_RESOLVER_FALLBACK_LOG_LOCK = threading.Lock()
+_MONGO_DNS_RESOLVER_FALLBACK_CACHE: dict[
+    tuple[str, int], tuple[float, tuple[str, ...]]
+] = {}
+_MONGO_DNS_RESOLVER_FALLBACK_CACHE_LOCK = threading.Lock()
+_MONGO_DNS_RESOLVER_FALLBACK_INSTALLED = False
 
 
 @dataclass(frozen=True)
@@ -522,6 +591,142 @@ def _mongo_server_selection_timeout_ms() -> int:
 
 def _mongo_connect_timeout_ms() -> int:
     return _get_positive_int_env("MONGO_CONNECT_TIMEOUT_MS", 5000)
+
+
+def _mongo_dns_resolver_fallback_cache_seconds() -> float:
+    return _get_positive_float_env("MONGO_DNS_RESOLVER_FALLBACK_CACHE_SECONDS", 60.0)
+
+
+def _mongo_dns_resolver_fallback_prefer_direct() -> bool:
+    return get_env_bool("MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT", False)
+
+
+def _resolve_mongo_host_with_fallback_nameservers(host: str, family: int) -> list[str]:
+    """Resolve one configured Mongo host through explicitly selected resolvers."""
+
+    cache_key = (host, family)
+    with _MONGO_DNS_RESOLVER_FALLBACK_CACHE_LOCK:
+        now = time.monotonic()
+        cached = _MONGO_DNS_RESOLVER_FALLBACK_CACHE.get(cache_key)
+        if cached is not None and cached[0] > now:
+            return list(cached[1])
+
+        try:
+            import dns.exception
+            import dns.resolver
+        except ImportError:
+            return []
+
+        resolver = dns.resolver.Resolver(configure=False)
+        resolver.nameservers = list(_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS)
+        resolver.timeout = _get_positive_float_env(
+            "MONGO_DNS_RESOLVER_FALLBACK_TIMEOUT_SECONDS", 2.0
+        )
+        resolver.lifetime = resolver.timeout
+        record_types: tuple[str, ...]
+        if family == socket.AF_INET:
+            record_types = ("A",)
+        elif family == socket.AF_INET6:
+            record_types = ("AAAA",)
+        else:
+            record_types = ("A", "AAAA")
+
+        addresses: list[str] = []
+        for record_type in record_types:
+            try:
+                answer = resolver.resolve(host, record_type, search=False)
+            except dns.exception.DNSException:
+                continue
+            for item in answer:
+                address = getattr(item, "address", None)
+                if isinstance(address, str) and address not in addresses:
+                    addresses.append(address)
+        if addresses:
+            _MONGO_DNS_RESOLVER_FALLBACK_CACHE[cache_key] = (
+                now + _mongo_dns_resolver_fallback_cache_seconds(),
+                tuple(addresses),
+            )
+        return addresses
+
+
+def _mongo_getaddrinfo_with_configured_fallback(
+    host,
+    port,
+    family=0,
+    type=0,
+    proto=0,
+    flags=0,
+):
+    """Use explicit DNS only for configured Mongo seeds after libc DNS fails.
+
+    PyMongo retains ``host`` as the TLS ``server_hostname`` after consuming
+    these address records, so certificate hostname verification is unchanged.
+    The fallback never applies to an unlisted host or before the system
+    resolver has failed.
+    """
+
+    try:
+        return _ORIGINAL_SOCKET_GETADDRINFO(host, port, family, type, proto, flags)
+    except socket.gaierror:
+        normalised_host = host.rstrip(".").lower() if isinstance(host, str) else None
+        if (
+            not normalised_host
+            or normalised_host not in _MONGO_DNS_RESOLVER_FALLBACK_HOSTS
+            or not _MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+        ):
+            raise
+        addresses = _resolve_mongo_host_with_fallback_nameservers(
+            normalised_host, family
+        )
+
+        resolved: list[tuple] = []
+        for address in addresses:
+            try:
+                candidates = _ORIGINAL_SOCKET_GETADDRINFO(
+                    address, port, family, type, proto, flags
+                )
+            except socket.gaierror:
+                continue
+            for candidate in candidates:
+                if candidate not in resolved:
+                    resolved.append(candidate)
+        if not resolved:
+            raise
+
+        with _MONGO_DNS_RESOLVER_FALLBACK_LOG_LOCK:
+            if normalised_host not in _MONGO_DNS_RESOLVER_FALLBACK_LOGGED_HOSTS:
+                _MONGO_DNS_RESOLVER_FALLBACK_LOGGED_HOSTS.add(normalised_host)
+                logger.warning(
+                    "[mongo_dns_resolver_fallback] Resolved configured Mongo "
+                    "seed host after system resolver failure: %s",
+                    normalised_host,
+                )
+        return resolved
+
+
+def _install_mongo_dns_resolver_fallback() -> bool:
+    """Install the opt-in, host-scoped resolver fallback once per process."""
+
+    global _MONGO_DNS_RESOLVER_FALLBACK_INSTALLED
+    if _MONGO_DNS_RESOLVER_FALLBACK_INSTALLED:
+        return True
+    if (
+        not _MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+        or not _MONGO_DNS_RESOLVER_FALLBACK_HOSTS
+    ):
+        return False
+    socket.getaddrinfo = _mongo_getaddrinfo_with_configured_fallback
+    _MONGO_DNS_RESOLVER_FALLBACK_INSTALLED = True
+    logger.info(
+        "[mongo_dns_resolver_fallback] Enabled for %s configured Mongo seed "
+        "host(s) using %s explicit resolver(s).",
+        len(_MONGO_DNS_RESOLVER_FALLBACK_HOSTS),
+        len(_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS),
+    )
+    return True
+
+
+_install_mongo_dns_resolver_fallback()
 
 
 def _build_ssh_tunnel_mongo_uri(primary_uri: str, endpoint: str) -> str:
@@ -1072,12 +1277,52 @@ def _try_configured_fallback_candidate(
     return None
 
 
+def _try_initial_direct_dns_candidate() -> _MongoConnectionCandidate | None:
+    """Start on the direct route when its resolver recovery is explicit."""
+
+    if not (
+        _mongo_dns_resolver_fallback_prefer_direct()
+        and _MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+        and _MONGO_DNS_RESOLVER_FALLBACK_HOSTS
+    ):
+        return None
+    target = next(
+        (
+            item
+            for item in _connection_fallback_targets(prefer_dns=True)
+            if item.kind == "dns"
+        ),
+        None,
+    )
+    if target is None:
+        return None
+    logger.warning(
+        "[mongo_fallback] Preferring the configured direct-host Atlas route "
+        "to avoid an unavailable primary SRV resolver."
+    )
+    try:
+        return _fallback_candidate(
+            target,
+            preference_reason="explicit direct-host resolver recovery",
+        )
+    except Exception as exc:
+        logger.warning(
+            "[mongo_fallback] Initial direct-host Atlas connection failed: %s",
+            exc,
+        )
+        return None
+
+
 def _build_real_connection_candidate() -> tuple[_MongoConnectionCandidate | None, bool]:
     """Run one complete route-selection wave without publishing partial state."""
 
     preferred_candidate, preferred_failed = _try_preferred_fallback_candidate()
     if preferred_candidate is not None:
         return preferred_candidate, False
+
+    initial_direct_candidate = _try_initial_direct_dns_candidate()
+    if initial_direct_candidate is not None:
+        return initial_direct_candidate, False
 
     try:
         client = _try_connect_uri(MONGO_URI)
@@ -1489,6 +1734,21 @@ def get_mongo_fallback_policy_state() -> dict[str, object]:
                 _configured_replica_set_name()
             ),
             "dns_fallback_configured": bool(MONGO_DNS_FALLBACK_URI),
+            "dns_resolver_fallback_configured": bool(
+                _MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+                and _MONGO_DNS_RESOLVER_FALLBACK_HOSTS
+            ),
+            "dns_resolver_fallback_installed": (_MONGO_DNS_RESOLVER_FALLBACK_INSTALLED),
+            "dns_resolver_fallback_nameserver_count": len(
+                _MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS
+            ),
+            "dns_resolver_fallback_host_count": len(_MONGO_DNS_RESOLVER_FALLBACK_HOSTS),
+            "dns_resolver_fallback_cache_seconds": (
+                _mongo_dns_resolver_fallback_cache_seconds()
+            ),
+            "dns_resolver_fallback_prefer_direct": (
+                _mongo_dns_resolver_fallback_prefer_direct()
+            ),
             "dns_fallback_sticky": bool(
                 remaining_seconds > 0 and _preferred_fallback_kind in {None, "dns"}
             ),

--- a/tests/backend/test_mongo_dns_fallback_recovery.py
+++ b/tests/backend/test_mongo_dns_fallback_recovery.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import socket
 import time
 
+import dns.resolver
 import pytest
 
 from src.backend.db import mongo_client as mc
@@ -131,3 +133,201 @@ def test_get_db_prefers_recent_successful_dns_fallback(monkeypatch) -> None:
     assert (
         mc.get_effective_mongo_uri() == "mongodb://direct-host.example:27017/?tls=true"
     )
+
+
+def test_resolver_fallback_configuration_is_literal_ip_and_host_scoped() -> None:
+    nameservers = mc._parse_mongo_dns_resolver_fallback_nameservers(
+        "8.8.8.8, resolver.example, 2001:4860:4860::8888,8.8.8.8"
+    )
+    hosts = mc._mongo_seed_hosts(
+        "mongodb://user:do-not-log@Seed-A.Example:27017,seed-b.example:27017/?tls=true"
+    )
+
+    assert nameservers == ("8.8.8.8", "2001:4860:4860::8888")
+    assert hosts == frozenset({"seed-a.example", "seed-b.example"})
+
+
+def test_getaddrinfo_falls_back_only_after_system_failure_for_configured_host(
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+    system_error = socket.gaierror(socket.EAI_NONAME, "not known")
+
+    def _fake_original(host, port, family, type, proto, flags):
+        calls.append(str(host))
+        if host == "seed.example":
+            raise system_error
+        if host == "203.0.113.7":
+            return [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    ("203.0.113.7", port),
+                )
+            ]
+        raise AssertionError(f"Unexpected host: {host}")
+
+    monkeypatch.setattr(mc, "_ORIGINAL_SOCKET_GETADDRINFO", _fake_original)
+    monkeypatch.setattr(
+        mc, "_MONGO_DNS_RESOLVER_FALLBACK_HOSTS", frozenset({"seed.example"})
+    )
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS", ("8.8.8.8",))
+    monkeypatch.setattr(
+        mc,
+        "_resolve_mongo_host_with_fallback_nameservers",
+        lambda host, family: ["203.0.113.7"],
+    )
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_LOGGED_HOSTS", set())
+
+    result = mc._mongo_getaddrinfo_with_configured_fallback(
+        "seed.example",
+        27017,
+        socket.AF_UNSPEC,
+        socket.SOCK_STREAM,
+        0,
+        0,
+    )
+
+    assert result[0][4] == ("203.0.113.7", 27017)
+    assert calls == ["seed.example", "203.0.113.7"]
+
+
+def test_getaddrinfo_never_bypasses_system_dns_for_unconfigured_host(
+    monkeypatch,
+) -> None:
+    system_error = socket.gaierror(socket.EAI_NONAME, "not known")
+
+    def _fake_original(*_args):
+        raise system_error
+
+    monkeypatch.setattr(mc, "_ORIGINAL_SOCKET_GETADDRINFO", _fake_original)
+    monkeypatch.setattr(
+        mc, "_MONGO_DNS_RESOLVER_FALLBACK_HOSTS", frozenset({"seed.example"})
+    )
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS", ("8.8.8.8",))
+    monkeypatch.setattr(
+        mc,
+        "_resolve_mongo_host_with_fallback_nameservers",
+        lambda *_args: pytest.fail("Fallback resolver must not be called"),
+    )
+
+    with pytest.raises(socket.gaierror) as exc_info:
+        mc._mongo_getaddrinfo_with_configured_fallback(
+            "other.example", 27017, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, 0
+        )
+
+    assert exc_info.value is system_error
+
+
+def test_getaddrinfo_preserves_system_result_without_fallback(monkeypatch) -> None:
+    expected = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("192.0.2.9", 27017),
+        )
+    ]
+    fallback_calls: list[tuple[str, int]] = []
+
+    monkeypatch.setattr(
+        mc, "_ORIGINAL_SOCKET_GETADDRINFO", lambda *_args: list(expected)
+    )
+    monkeypatch.setattr(
+        mc, "_MONGO_DNS_RESOLVER_FALLBACK_HOSTS", frozenset({"seed.example"})
+    )
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS", ("8.8.8.8",))
+    monkeypatch.setattr(
+        mc,
+        "_resolve_mongo_host_with_fallback_nameservers",
+        lambda host, family: fallback_calls.append((host, family)) or [],
+    )
+
+    result = mc._mongo_getaddrinfo_with_configured_fallback(
+        "seed.example", 27017, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, 0
+    )
+
+    assert result == expected
+    assert fallback_calls == []
+
+
+def test_explicit_resolver_results_are_briefly_cached(monkeypatch) -> None:
+    class _Address:
+        address = "203.0.113.8"
+
+    calls: list[tuple[str, str]] = []
+
+    class _Resolver:
+        nameservers: list[str]
+        timeout: float
+        lifetime: float
+
+        def __init__(self, *, configure: bool) -> None:
+            assert configure is False
+
+        def resolve(self, host: str, record_type: str, *, search: bool):
+            assert search is False
+            calls.append((host, record_type))
+            return [_Address()]
+
+    monkeypatch.setattr(dns.resolver, "Resolver", _Resolver)
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS", ("8.8.8.8",))
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_CACHE", {})
+
+    first = mc._resolve_mongo_host_with_fallback_nameservers(
+        "seed.example", socket.AF_INET
+    )
+    second = mc._resolve_mongo_host_with_fallback_nameservers(
+        "seed.example", socket.AF_INET
+    )
+
+    assert first == ["203.0.113.8"]
+    assert second == first
+    assert calls == [("seed.example", "A")]
+
+
+def test_direct_route_preference_is_explicit(monkeypatch) -> None:
+    monkeypatch.setenv("MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT", "0")
+    assert mc._mongo_dns_resolver_fallback_prefer_direct() is False
+
+    monkeypatch.setenv("MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT", "1")
+    assert mc._mongo_dns_resolver_fallback_prefer_direct() is True
+
+
+def test_initial_direct_route_uses_only_dns_fallback_target(monkeypatch) -> None:
+    direct_target = mc._MongoFallbackTarget(
+        uri="mongodb://direct-host.example:27017/?tls=true",
+        kind="dns",
+        label="direct-host Atlas",
+    )
+    tunnel_target = mc._MongoFallbackTarget(
+        uri="mongodb://127.0.0.1:27018/?tls=true",
+        kind="ssh_tunnel",
+        label="SSH tunnel",
+    )
+    calls: list[mc._MongoFallbackTarget] = []
+    expected = object()
+
+    monkeypatch.setenv("MONGO_DNS_RESOLVER_FALLBACK_PREFER_DIRECT", "1")
+    monkeypatch.setattr(mc, "_MONGO_DNS_RESOLVER_FALLBACK_NAMESERVERS", ("8.8.8.8",))
+    monkeypatch.setattr(
+        mc, "_MONGO_DNS_RESOLVER_FALLBACK_HOSTS", frozenset({"direct-host.example"})
+    )
+    monkeypatch.setattr(
+        mc,
+        "_connection_fallback_targets",
+        lambda *, prefer_dns: [direct_target, tunnel_target],
+    )
+
+    def _fake_fallback_candidate(target, *, preference_reason):
+        assert preference_reason == "explicit direct-host resolver recovery"
+        calls.append(target)
+        return expected
+
+    monkeypatch.setattr(mc, "_fallback_candidate", _fake_fallback_candidate)
+
+    assert mc._try_initial_direct_dns_candidate() is expected
+    assert calls == [direct_target]


### PR DESCRIPTION
## Outcome
- keeps the existing system resolver as the first lookup for direct Atlas seeds
- optionally retries only configured Mongo seed hosts through literal-IP resolvers
- caches successful answers briefly and preserves the original TLS hostname
- optionally starts on the direct-host Atlas route when SRV resolution is known unavailable

## Validation
- 127 Mongo-adjacent tests passed
- Ruff fatal/static checks and compileall passed
- live authenticated forced-system-DNS-failure replay reached the writable Atlas primary and expected replica set

## Scope
No resolver is selected by default. Unlisted hosts never use the fallback, invalid resolver values are rejected, and no TLS certificate or hostname checks are disabled.