### PR TITLE
Fix concept Q&A session scope and model routing

### DIFF
--- a/src/backend/languagemodels/llm_interface.py
+++ b/src/backend/languagemodels/llm_interface.py
@@ -3100,6 +3100,14 @@ def get_llm_client(
     # Always ensure clients are up-to-date
     initialize_clients(force=force_init)
 
+    # Legacy HTTP callers often omit explicit actor arguments. Resolve the same
+    # trusted request scope used by model-name and eligibility lookup so the
+    # provider and model cannot silently come from different settings.
+    user_concept_id, org_concept_id = _resolve_effective_llm_actor_scope(
+        user_concept_id,
+        org_concept_id,
+    )
+
     provider = None
     model = None
     host = None

--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -54,6 +54,20 @@ from ...db.mongo_client import get_db
 concept_bp = Blueprint("concepts", __name__)  # Define blueprint
 
 
+def _get_trusted_interaction_user() -> str | None:
+    """Return authenticated interaction actor; legacy identity headers are not authority."""
+
+    from ...security.access_control import (
+        LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+        get_effective_user_concept_id_with_source,
+    )
+
+    user_id, actor_source = get_effective_user_concept_id_with_source()
+    if actor_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+        return None
+    return user_id
+
+
 def _governed_mutation_response(
     result: dict[str, Any], *, success_status: int = 200
 ) -> ResponseReturnValue:
@@ -1147,21 +1161,27 @@ def start_concept_interaction_route(concept_id: str):
     """
     try:
         # Use the centralized and secure method to get the effective user concept ID
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import get_effective_organisation_concept_id
 
-        user_id = get_effective_user_concept_id()
+        user_id = _get_trusted_interaction_user()
         if not user_id:
             return (
-                jsonify(
-                    error="Missing user context: provide X-User-Client-ID header or establish session"
-                ),
-                400,
+                jsonify(error="Concept Q&A requires authenticated user context"),
+                401,
             )
 
-        initial_notes = request.json.get("initial_notes", "") if request.json else ""
+        organisation_concept_id = get_effective_organisation_concept_id()
+        data = request.get_json(silent=True) or {}
+        initial_notes = data.get("initial_notes", "")
 
         result = concept_service.start_interaction_session(
-            concept_id, user_id=user_id, initial_notes=initial_notes
+            concept_id,
+            user_id=user_id,
+            initial_notes=initial_notes,
+            organisation_concept_id=organisation_concept_id,
+            model_provider=data.get("model_provider"),
+            model=data.get("model"),
+            model_parameters=data.get("model_parameters"),
         )
         return jsonify(result), 200
     except ConceptNotFoundError as e:
@@ -1194,10 +1214,31 @@ def generate_initial_question_route(concept_id: str):
     API endpoint to generate an initial question for an concept based on its current state.
     """
     try:
-        # Get optional initial_notes from request body
-        initial_notes = request.json.get("initial_notes", "") if request.json else ""
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        user_id = _get_trusted_interaction_user()
+        if not user_id:
+            return jsonify(error="Concept Q&A requires authenticated user context"), 401
+
+        data = request.get_json(silent=True) or {}
+        interaction_id = data.get("interaction_id")
+        if not isinstance(interaction_id, str) or not interaction_id.strip():
+            return jsonify(error="interaction_id is required"), 400
+
+        organisation_concept_id = get_effective_organisation_concept_id()
+        interaction_session = concept_service.get_interaction_session_by_id(
+            interaction_id,
+            user_id=user_id,
+            organisation_concept_id=organisation_concept_id,
+        )
+        if not interaction_session:
+            return jsonify(error="Interaction session not found"), 404
+
+        initial_notes = data.get("initial_notes", "")
         question = concept_service.generate_initial_question(
-            concept_id, initial_notes=initial_notes
+            str(interaction_session["concept_id"]),
+            initial_notes=initial_notes,
+            interaction_session=interaction_session,
         )
         return jsonify({"question": question}), 200
     except ConceptNotFoundError as e:
@@ -1448,74 +1489,21 @@ def submit_concept_answer_route(concept_id: str):
         return jsonify(error="answer is required (can be an empty string)"), 400
 
     try:
-        # The concept_id from the path might be redundant if interaction_id is globally unique
-        # and contains enough context. However, it's good for namespacing/validation.
-        # The service layer's submit_concept_answer currently takes interaction_id and user_answer.
-        # It might internally fetch the session using interaction_id.
-        # We need to ensure the service layer handles the session context correctly.
-        # For now, we assume the service layer's submit_concept_answer can retrieve the session
-        # or that the session details are passed if needed.
-        # The current concept_service.submit_concept_answer expects `session` as a parameter.
-        # This route does not have the session object. This indicates a mismatch.
-        # For now, I will assume the service layer needs to be adapted or this route needs to fetch the session.
-        # Let's proceed by calling the service as it is defined in the provided concept_service.py snippet,
-        # which means this route is likely missing the logic to retrieve the session.
-        # This is a potential issue to flag.
-        #
-        # REVISITING: The concept_service.submit_concept_answer signature is:
-        # submit_concept_answer(interaction_id: str, user_answer: str, session: dict) -> dict:
-        # This route does not have `session`. This is a problem.
-        # For now, I will call it without `session` and assume the service might be updated,
-        # or this will highlight the discrepancy.
-        # A more robust solution would be to fetch the interaction session here first.
-        # However, without a `get_interaction_session_by_id` in the service, that's not possible.
+        from ...security.access_control import get_effective_organisation_concept_id
 
-        # Placeholder for fetching session if it were available:
-        # interaction_session = concept_service.get_interaction_session(interaction_id) # Fictional function
-        # if not interaction_session:
-        #    return jsonify(error="Interaction session not found"), 404
-        # result = concept_service.submit_concept_answer(interaction_id, answer, session=interaction_session)
-
-        # Given the current service signature, this call will fail if the service strictly requires `session`.
-        # This is a simplification for now, focusing on route structure.
-        # A proper implementation would require fetching the session or modifying the service.
-        # For the purpose of this exercise, I will call a hypothetical version or assume the service handles it.
-        # Let's assume the service layer's `submit_concept_answer` is updated to fetch the session itself
-        # or that the `session` parameter is optional / handled internally if not provided.
-        # The provided concept_service.py has `submit_concept_answer(interaction_id: str, user_answer: str, session: dict)`.
-        # This route cannot fulfill that contract without fetching the session.
-        #
-        # Let's assume a simplified service call for now, or that the service is more flexible.
-        # This is a point that needs clarification or refactoring in the service layer.
-        # For now, I will construct a dummy session or indicate this problem.
-        #
-        # Given the constraints, I will proceed as if the service layer's `submit_concept_answer`
-        # can function with just `interaction_id` and `user_answer`, or that the `session`
-        # parameter in the service is meant to be populated by the service itself.
-        # This is a common pattern where the route passes minimal info and the service handles the details.
-
-        # If the service strictly requires the session object, this route is incomplete.
-        # Let's assume for now the service can look up the session by interaction_id.
-        # The call below would be more like:
-        # result = concept_service.process_answer_for_interaction(interaction_id, answer, concept_id)
-        # Since `submit_concept_answer` is what's in the service, we'll call that,
-        # acknowledging the `session` parameter issue.
-
-        # Use the centralized and secure method to get the effective user concept ID
-        from ...security.access_control import get_effective_user_concept_id
-
-        user_id = get_effective_user_concept_id()
+        user_id = _get_trusted_interaction_user()
         if not user_id:
             return (
-                jsonify(
-                    error="Missing user context: provide X-User-Client-ID header or establish session"
-                ),
-                400,
+                jsonify(error="Concept Q&A requires authenticated user context"),
+                401,
             )
 
         # Fetch the interaction session by ID (scoped to effective user/org)
+        organisation_concept_id = get_effective_organisation_concept_id()
         session = concept_service.get_interaction_session_by_id(
-            interaction_id, user_id=user_id
+            interaction_id,
+            user_id=user_id,
+            organisation_concept_id=organisation_concept_id,
         )
         if not session:
             current_app.logger.warning(
@@ -1560,7 +1548,10 @@ def get_active_interactions_route(concept_id: str):
     """
     try:
         # Use the centralized and secure method to get the effective user concept ID
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import (
+            get_effective_organisation_concept_id,
+            get_effective_user_concept_id,
+        )
 
         user_id = get_effective_user_concept_id()
         if not user_id:
@@ -1570,8 +1561,11 @@ def get_active_interactions_route(concept_id: str):
                 ),
                 400,
             )
+        organisation_concept_id = get_effective_organisation_concept_id()
         active_interactions = concept_service.get_active_interactions_for_concept(
-            concept_id, user_id
+            concept_id,
+            user_id,
+            organisation_concept_id=organisation_concept_id,
         )
 
         return (
@@ -1613,7 +1607,10 @@ def resume_interaction_route(concept_id: str):
         if not data or "interaction_id" not in data:
             return jsonify(error="interaction_id is required"), 400
 
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import (
+            get_effective_organisation_concept_id,
+            get_effective_user_concept_id,
+        )
 
         user_id = get_effective_user_concept_id()
         if not user_id:
@@ -1625,8 +1622,11 @@ def resume_interaction_route(concept_id: str):
             )
 
         interaction_id = data["interaction_id"]
+        organisation_concept_id = get_effective_organisation_concept_id()
         resumed_session = concept_service.resume_interaction_session(
-            interaction_id, user_id=user_id
+            interaction_id,
+            user_id=user_id,
+            organisation_concept_id=organisation_concept_id,
         )
 
         return jsonify(resumed_session), 200

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -30,7 +30,7 @@ import os
 import uuid  # Added for GUID generation
 from datetime import datetime, timedelta, timezone  # Ensure timezone is imported
 import requests  # Added for requests.exceptions.ConnectionError
-from typing import Dict, Any, Optional, List, Tuple, Iterable  # Added Tuple
+from typing import Dict, Any, Optional, List, Tuple, Iterable, Mapping  # Added Tuple
 from pymongo.errors import PyMongoError  # Added for DB operations
 
 try:
@@ -2632,6 +2632,120 @@ def get_user_concept_tracking_collection_service() -> Optional[Collection]:
 # --- Interaction Session Management ---
 
 
+_INTERACTION_LLM_PROVIDERS = {"openai", "openrouter", "ollama", "gemini"}
+
+
+def _canonical_organisation_concept_id(value: Any) -> Optional[str]:
+    """Return the canonical concept-ID form used by trusted org context."""
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned if cleaned.startswith("#V#") else f"#V#{cleaned}"
+
+
+def _organisation_scope_values(value: Any) -> list[str]:
+    """Return canonical and legacy encodings for a single organisation scope."""
+
+    canonical = _canonical_organisation_concept_id(value)
+    if not canonical:
+        return []
+    legacy = canonical.removeprefix("#V#")
+    return [canonical] if legacy == canonical else [canonical, legacy]
+
+
+def _normalise_interaction_llm_selection(
+    *,
+    provider: Any = None,
+    model: Any = None,
+    model_parameters: Any = None,
+) -> Optional[Dict[str, Any]]:
+    """Normalise an explicit browser-local model choice for session persistence."""
+
+    provider_name = provider.strip().lower() if isinstance(provider, str) else ""
+    model_name = model.strip() if isinstance(model, str) else ""
+    if not provider_name and not model_name:
+        return None
+    if provider_name not in _INTERACTION_LLM_PROVIDERS or not model_name:
+        raise InvalidConceptDataError(
+            "model_provider and model must identify a supported model together"
+        )
+
+    from .model_parameter_service import normalise_model_parameters_for_storage
+
+    normalised_parameters = normalise_model_parameters_for_storage(
+        model_parameters,
+        provider=provider_name,
+        model=model_name,
+        include_registry=True,
+    )
+    selection: Dict[str, Any] = {
+        "provider": provider_name,
+        "model": model_name,
+        "source": "browser_preference",
+    }
+    if normalised_parameters:
+        selection["model_parameters"] = normalised_parameters
+    return selection
+
+
+def _resolve_interaction_llm_runtime(
+    interaction_session: Optional[Mapping[str, Any]] = None,
+) -> tuple[Any, Optional[str], Dict[str, Any]]:
+    """Resolve one coherent actor-scoped client, model, and parameter bundle."""
+
+    from ..languagemodels.llm_interface import (
+        get_active_model_name,
+        get_active_model_parameters,
+        get_llm_client,
+    )
+    from .settings_service import resolve_llm_setting
+
+    session_doc = interaction_session or {}
+    user_concept_id = session_doc.get("user_id")
+    org_concept_id = _canonical_organisation_concept_id(
+        session_doc.get("organisation_concept_id")
+    )
+    selection = session_doc.get("llm_selection")
+    if isinstance(selection, Mapping):
+        provider = str(selection.get("provider") or "").strip().lower()
+        model = str(selection.get("model") or "").strip()
+        if provider in _INTERACTION_LLM_PROVIDERS and model:
+            params = selection.get("model_parameters")
+            client = get_llm_client(
+                client_type=provider,
+                user_concept_id=user_concept_id,
+                org_concept_id=org_concept_id,
+            )
+            return client, model, dict(params) if isinstance(params, Mapping) else {}
+
+    active_setting = resolve_llm_setting(
+        user_concept_id=user_concept_id,
+        org_concept_id=org_concept_id,
+    )
+    provider = None
+    if isinstance(active_setting, Mapping):
+        candidate_provider = str(active_setting.get("provider") or "").strip().lower()
+        if candidate_provider in _INTERACTION_LLM_PROVIDERS:
+            provider = candidate_provider
+    model = get_active_model_name(
+        user_concept_id=user_concept_id,
+        org_concept_id=org_concept_id,
+    )
+    params = get_active_model_parameters(
+        user_concept_id=user_concept_id,
+        org_concept_id=org_concept_id,
+    )
+    client = get_llm_client(
+        client_type=provider,
+        user_concept_id=user_concept_id,
+        org_concept_id=org_concept_id,
+    )
+    return client, model, dict(params or {})
+
+
 def get_interaction_sessions_collection_service() -> Optional[Collection]:
     """Helper to get the 'interaction_sessions' collection."""
     try:
@@ -2647,7 +2761,13 @@ def get_interaction_sessions_collection_service() -> Optional[Collection]:
 
 
 def start_interaction_session(
-    concept_id: str, user_id: Optional[str], initial_notes: Optional[str] = None
+    concept_id: str,
+    user_id: Optional[str],
+    initial_notes: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
+    model_provider: Optional[str] = None,
+    model: Optional[str] = None,
+    model_parameters: Any = None,
 ) -> Dict[str, Any]:
     """Starts a new interaction session with an concept.
 
@@ -2746,47 +2866,31 @@ def start_interaction_session(
 
     # Derive composite namespace for the session (user@org isolation for RAG/search)
     # Phase 1: Support basic user@org namespace with stubbed roles
-    from ..services.namespace_service import derive_namespace
+    from ..services.namespace_service import (
+        concept_id_to_namespace_slug,
+        derive_namespace_for_actor,
+    )
     from ..security.role_resolver import get_user_role
 
-    # Get org context from session (if available)
-    org_id = None
+    # Prefer the trusted request-scoped organisation supplied by the route.
+    org_id = _canonical_organisation_concept_id(organisation_concept_id)
     role_in_org = None
-    try:
-        from flask import session as flask_session
-
-        if flask_session:
-            org_id = flask_session.get("organisation_concept_id")
-            role_in_org = flask_session.get("role_in_org")
-    except Exception:
-        pass
-
-    # Derive namespace using user and org context
-    try:
-        # Clean user_id for namespace
-        user_slug = user_id.strip().lower().replace(" ", "_")
-
-        # If org_id available, derive composite namespace; otherwise user-only
-        if org_id:
-            session_namespace = derive_namespace(user_slug, org_id)
-            # Get role from resolver if not in session
-            if not role_in_org:
-                try:
-                    role_in_org = get_user_role(user_slug, org_id)
-                except Exception:
-                    role_in_org = "member"  # Default fallback
-        else:
-            session_namespace = derive_namespace(user_slug)
-            # No org context, no role
-    except Exception as e:
-        logger.warning(
-            f"Failed to derive composite namespace: {e}, falling back to default"
+    session_namespace = derive_namespace_for_actor(user_id, org_id)
+    if not session_namespace:
+        raise ConceptServiceError(
+            "Could not derive the interaction namespace from the authenticated actor scope"
         )
-        session_namespace = os.environ.get(
-            "VON_DEFAULT_NAMESPACE", "#V#default_namespace"
-        )
-        org_id = None
-        role_in_org = None
+    if org_id:
+        user_slug = concept_id_to_namespace_slug(user_id)
+        org_slug = concept_id_to_namespace_slug(org_id)
+        if user_slug and org_slug:
+            role_in_org = get_user_role(user_slug, org_slug)
+
+    llm_selection = _normalise_interaction_llm_selection(
+        provider=model_provider,
+        model=model,
+        model_parameters=model_parameters,
+    )
 
     session_doc = {
         "concept_id": ObjectId(actual_concept_id),
@@ -2800,6 +2904,8 @@ def start_interaction_session(
         "indexing_status": "pending",
         "namespace": session_namespace,  # Composite: #V#user@org or #V#user
     }
+    if llm_selection:
+        session_doc["llm_selection"] = llm_selection
 
     if initial_notes:
         session_doc["history"].append(
@@ -2834,7 +2940,9 @@ def start_interaction_session(
 
 
 def get_active_interactions_for_concept(
-    concept_id: str, user_id: Optional[str]
+    concept_id: str,
+    user_id: Optional[str],
+    organisation_concept_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Retrieves active interaction sessions for a specific concept and user.
 
@@ -2867,16 +2975,10 @@ def get_active_interactions_for_concept(
             "user_id": user_id,
         }
 
-        # If an organisation is selected in the current request context, scope
-        # active interactions to that organisation.
-        try:
-            from flask import session as flask_session
-
-            org_id = flask_session.get("organisation_concept_id")
-            if org_id:
-                query["organisation_concept_id"] = org_id
-        except Exception:
-            pass
+        org_scope_values = _organisation_scope_values(organisation_concept_id)
+        query["organisation_concept_id"] = (
+            {"$in": org_scope_values} if org_scope_values else {"$in": [None, ""]}
+        )
 
         active_sessions = list(
             sessions_coll.find(query).sort("last_updated_time", -1)
@@ -2906,6 +3008,7 @@ def get_active_interactions_for_concept(
 def resume_interaction_session(
     interaction_id: str,
     user_id: Optional[str] = None,
+    organisation_concept_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Resumes an existing interaction session by returning its current state.
 
@@ -2922,7 +3025,11 @@ def resume_interaction_session(
     logger.info(f"Resuming interaction session: {interaction_id}")
 
     try:
-        session = get_interaction_session_by_id(interaction_id, user_id=user_id)
+        session = get_interaction_session_by_id(
+            interaction_id,
+            user_id=user_id,
+            organisation_concept_id=organisation_concept_id,
+        )
         if not session:
             raise ConceptServiceError(f"Interaction session {interaction_id} not found")
 
@@ -3338,15 +3445,25 @@ def submit_concept_answer(interaction_id: str, user_answer: str, session: dict) 
 
     # IMPORTANT: Do synthesis FIRST before generating the next question
     # This ensures the next question is based on updated notes that include the current synthesis
+    try:
+        llm_client, selected_model, llm_params = _resolve_interaction_llm_runtime(
+            session
+        )
+        safe_model = selected_model or "default"
+    except Exception as e:
+        logger.error(
+            "Could not resolve the interaction model for session %s: %s",
+            interaction_id,
+            e,
+            exc_info=True,
+        )
+        return {
+            "error": "Could not resolve the selected interaction model",
+            "status": "error_llm_selection",
+        }
+
     synthesis_result = None
     try:
-        from ..languagemodels.llm_interface import get_llm_client, get_active_model_name
-
-        llm_client = get_llm_client()
-        selected_model = get_active_model_name()
-
-        # Ensure model is a string; provide a safe default if None
-        safe_model = selected_model or "default"
         synthesis_result = synthesize_and_update_concept_notes(
             concept_id=concept_id_str,
             concept=concept,
@@ -3355,6 +3472,7 @@ def submit_concept_answer(interaction_id: str, user_answer: str, session: dict) 
             concept_type_name=concept_type_name_for_prompt,
             ollama_client=llm_client,  # Pass the unified LLM client
             model=safe_model,
+            llm_params=llm_params,
             session=session,  # Pass session to access initial notes
         )
 
@@ -3434,16 +3552,10 @@ def submit_concept_answer(interaction_id: str, user_answer: str, session: dict) 
 
     llm_response_text = None
     try:
-        # Use unified LLM interface instead of hardcoded Ollama
-        from ..languagemodels.llm_interface import get_llm_client, get_active_model_name
-
-        # Get the configured LLM client and model
-        llm_client = get_llm_client()
-        selected_model = get_active_model_name()
-
-        # Use the correct generate method with prompt parameter
         raw_llm_response = llm_client.generate(
-            prompt=final_prompt_for_llm, model=selected_model
+            prompt=final_prompt_for_llm,
+            model=safe_model,
+            llm_params=llm_params or None,
         )
         # The generate method returns a string directly
         if isinstance(raw_llm_response, str):
@@ -3827,16 +3939,10 @@ def get_interaction_session_by_id(
     if user_id:
         query["user_id"] = user_id
 
-    if organisation_concept_id is None:
-        try:
-            from flask import session as flask_session
-
-            organisation_concept_id = flask_session.get("organisation_concept_id")
-        except Exception:
-            organisation_concept_id = None
-
-    if organisation_concept_id:
-        query["organisation_concept_id"] = organisation_concept_id
+    org_scope_values = _organisation_scope_values(organisation_concept_id)
+    query["organisation_concept_id"] = (
+        {"$in": org_scope_values} if org_scope_values else {"$in": [None, ""]}
+    )
 
     try:
         session = sessions_coll.find_one(query)
@@ -3863,6 +3969,7 @@ def synthesize_and_update_concept_notes(
     concept_type_name: str,
     ollama_client,  # Generic LLM client (keeping name for compatibility)
     model: str,
+    llm_params: Optional[Dict[str, Any]] = None,
     session: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
     """
@@ -3936,7 +4043,11 @@ def synthesize_and_update_concept_notes(
     )
 
     # Get synthesis from LLM
-    synthesis_response = ollama_client.generate(prompt=synthesis_prompt, model=model)
+    synthesis_response = ollama_client.generate(
+        prompt=synthesis_prompt,
+        model=model,
+        llm_params=llm_params or None,
+    )
 
     if isinstance(synthesis_response, str):
         synthesis_text = synthesis_response.strip()
@@ -4493,7 +4604,9 @@ def import_concepts(
 
 
 def generate_initial_question(
-    concept_id: str, initial_notes: Optional[str] = None
+    concept_id: str,
+    initial_notes: Optional[str] = None,
+    interaction_session: Optional[Mapping[str, Any]] = None,
 ) -> dict:
     """
     Ask the LLM for the *first* question to pose about an concept.
@@ -4565,16 +4678,20 @@ def generate_initial_question(
 
     # ------------------------------------------------------------------ 3. call LLM
     try:
-        from ..languagemodels.llm_interface import get_llm_client, get_active_model_name
-
-        llm_client = get_llm_client()
-        model_name = get_active_model_name()  # Get the active model from settings
-
-        raw = llm_client.generate(prompt=final_prompt, model=model_name)
+        llm_client, model_name, llm_params = _resolve_interaction_llm_runtime(
+            interaction_session
+        )
+        raw = llm_client.generate(
+            prompt=final_prompt,
+            model=model_name or "default",
+            llm_params=llm_params or None,
+        )
         initial_question = (raw if isinstance(raw, str) else str(raw)).strip()
     except Exception as e:
         logger.error("LLM call failed: %s", e, exc_info=True)
-        initial_question = ""
+        raise ConceptServiceError(
+            "The selected model could not generate the initial concept question"
+        ) from e
 
     # ------------------------------------------------------------------ 4. fallback & return
     from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1,4 +1,13 @@
-import { createConcept, deleteJson, getJson, patchJson, postJson, putJson } from './apiService.js';
+import {
+  createConcept,
+  deleteJson,
+  ensureUniqueWindowSessionId,
+  getJson,
+  patchJson,
+  postJson,
+  putJson,
+  WINDOW_SESSION_HEADER,
+} from './apiService.js';
 import { elements, getCurrentUserConceptId, getUserClientId } from './domUtils.js';
 import { populateLanguageSelect } from './languageConfig.js';
 import { renderMarkdownViaServer } from './markdownUtils.js';
@@ -13,6 +22,7 @@ import {
   setSelectedConceptOriginalName
 } from './state.js';
 import { getSessionScopedOrgId } from './utils/sessionScopedStorage.js';
+import { buildLocalModelRequestFields } from './utils/localModelPreferences.js';
 import { annotateElementText, linkifyVontologyTokensInElement } from './utils/textDecorator.js';
 import { chooseBestTypeForIndividual, insertNodeIntoVontologyTree, selectVontologyNodeByIdentifier } from './vontology.js';
 
@@ -43,6 +53,15 @@ export function initializeConceptTabState() {
 
 // Global interaction state
 let currentInteractionId = null;
+
+async function buildConceptInteractionHeaders() {
+  const windowSessionId = await ensureUniqueWindowSessionId();
+  return {
+    'Content-Type': 'application/json',
+    [WINDOW_SESSION_HEADER]: windowSessionId,
+    'X-User-Concept-ID': getCurrentUserConceptId()
+  };
+}
 
 /**
  * Open the ordinary Von-conversation launcher for the currently selected
@@ -1777,24 +1796,18 @@ export async function handleStartInteraction() {
   elements.conceptStep2Status.style.color = "blue";
 
   try {
-    const userClientId = getUserClientId();
     console.log("[handleStartInteraction] Sending initial_notes:", originalNotes);
     console.log("[handleStartInteraction] originalNotes length:", originalNotes.length);
 
-    // Only send initial_notes if they are different from what's already in the database
-    // to avoid duplication in the backend's note combination logic
-    const requestBody = {};
-    // Don't send initial_notes if they're the same as the current concept notes
-    // The backend will combine them with existing notes, causing duplication
+    // Bind the browser-local model choice to this interaction. Initial notes
+    // stay out of the start call to avoid duplicating the concept's saved notes.
+    const requestBody = buildLocalModelRequestFields();
     console.log("[handleStartInteraction] Not sending initial_notes to prevent duplication");
 
     const response = await fetch(`/api/concepts/${encodeURIComponent(currentlySelectedconceptId)}/start_interaction`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-User-Concept-ID': getCurrentUserConceptId()
-      },
-      body: JSON.stringify(requestBody) // Send empty body to use only existing notes
+      headers: await buildConceptInteractionHeaders(),
+      body: JSON.stringify(requestBody)
     });
 
     if (!response.ok) {
@@ -1810,11 +1823,11 @@ export async function handleStartInteraction() {
 
     const questionResponse = await fetch(`/api/concepts/${encodeURIComponent(currentlySelectedconceptId)}/generate_initial_question`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-User-Concept-ID': getCurrentUserConceptId()
-      },
-      body: JSON.stringify({ initial_notes: originalNotes }) // Pass the same notes to question generation
+      headers: await buildConceptInteractionHeaders(),
+      body: JSON.stringify({
+        interaction_id: currentInteractionId,
+        initial_notes: originalNotes
+      })
     });
 
     if (!questionResponse.ok) {
@@ -2016,13 +2029,9 @@ async function handleSubmitAnswer() {
   elements.conceptStep2Status.style.color = "blue";
 
   try {
-    const userClientId = getUserClientId();
     const response = await fetch(`/api/concepts/${encodeURIComponent(currentlySelectedconceptId)}/submit_answer`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-User-Concept-ID': getCurrentUserConceptId()
-      },
+      headers: await buildConceptInteractionHeaders(),
       body: JSON.stringify({
         interaction_id: currentInteractionId,
         answer: answer

--- a/tests/backend/test_concept_interaction_session_scope.py
+++ b/tests/backend/test_concept_interaction_session_scope.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+from src.backend.languagemodels import llm_interface
+from src.backend.security import role_resolver
+from src.backend.services import concept_service, settings_service
+
+
+def test_interaction_session_preserves_actor_org_namespace_and_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = mongomock.MongoClient()["concept_interaction_scope"]
+    concept_id = ObjectId()
+    database.concepts.insert_one(
+        {
+            "_id": concept_id,
+            "concept_id": "#V#primary_labs",
+            "name": "Primary Labs",
+        }
+    )
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository,
+        "collection",
+        lambda: database.concepts,
+    )
+    monkeypatch.setattr(concept_service, "get_db", lambda: database)
+    monkeypatch.setattr(role_resolver, "get_user_role", lambda *_args: "member")
+
+    started = concept_service.start_interaction_session(
+        "#V#primary_labs",
+        user_id="#V#michael_witbrock",
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+        model_provider="gemini",
+        model="gemini-3.7-flash",
+        model_parameters={"temperature": 0.2},
+    )
+
+    stored = database.interactions.find_one(
+        {"_id": ObjectId(started["interaction_id"])}
+    )
+    assert stored is not None
+    assert (
+        stored["organisation_concept_id"] == "#V#university_of_auckland_strong_ai_lab"
+    )
+    assert (
+        stored["namespace"]
+        == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+    )
+    assert stored["llm_selection"] == {
+        "provider": "gemini",
+        "model": "gemini-3.7-flash",
+        "source": "browser_preference",
+        "model_parameters": {"temperature": 0.2},
+    }
+
+    matching = concept_service.get_interaction_session_by_id(
+        started["interaction_id"],
+        user_id="#V#michael_witbrock",
+        organisation_concept_id="#V#university_of_auckland_strong_ai_lab",
+    )
+    assert matching is not None
+
+    wrong_org = concept_service.get_interaction_session_by_id(
+        started["interaction_id"],
+        user_id="#V#michael_witbrock",
+        organisation_concept_id="#V#another_organisation",
+    )
+    assert wrong_org is None
+
+
+def test_interaction_model_runtime_reuses_exact_persisted_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    def fake_get_llm_client(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(llm_interface, "get_llm_client", fake_get_llm_client)
+    monkeypatch.setattr(
+        llm_interface,
+        "get_active_model_name",
+        lambda **_kwargs: pytest.fail("persisted model must not be re-resolved"),
+    )
+    monkeypatch.setattr(
+        llm_interface,
+        "get_active_model_parameters",
+        lambda **_kwargs: pytest.fail("persisted parameters must not be re-resolved"),
+    )
+    monkeypatch.setattr(
+        settings_service,
+        "resolve_llm_setting",
+        lambda **_kwargs: pytest.fail("persisted provider must not be re-resolved"),
+    )
+
+    client, model, params = concept_service._resolve_interaction_llm_runtime(
+        {
+            "user_id": "#V#michael_witbrock",
+            "organisation_concept_id": "#V#university_of_auckland_strong_ai_lab",
+            "llm_selection": {
+                "provider": "gemini",
+                "model": "gemini-3.7-flash",
+                "model_parameters": {"temperature": 0.2},
+            },
+        }
+    )
+
+    assert client is sentinel
+    assert model == "gemini-3.7-flash"
+    assert params == {"temperature": 0.2}
+    assert captured == {
+        "client_type": "gemini",
+        "user_concept_id": "#V#michael_witbrock",
+        "org_concept_id": "#V#university_of_auckland_strong_ai_lab",
+    }

--- a/tests/backend/test_concept_service_question_prompting.py
+++ b/tests/backend/test_concept_service_question_prompting.py
@@ -94,11 +94,11 @@ def test_generate_concept_question_does_not_apply_person_pronoun_rule_to_types(
 def test_generate_initial_question_fallback_uses_minimal_imposition_prompt(
     monkeypatch,
 ) -> None:
-    from src.backend.services import concept_service
     from src.backend.languagemodels import llm_interface
+    from src.backend.services import concept_service
 
     class _LLMClient:
-        def generate(self, *, prompt: str, model: str) -> str:
+        def generate(self, *, prompt: str, model: str, llm_params=None) -> str:
             return ""
 
     concept = {
@@ -125,8 +125,13 @@ def test_generate_initial_question_fallback_uses_minimal_imposition_prompt(
         lambda _concept: "Alex Smith",
     )
     monkeypatch.setattr(concept_service, "get_concept_notes", lambda _concept: "")
-    monkeypatch.setattr(llm_interface, "get_llm_client", lambda: _LLMClient())
-    monkeypatch.setattr(llm_interface, "get_active_model_name", lambda: "test-model")
+    monkeypatch.setattr(llm_interface, "get_llm_client", lambda **_kwargs: _LLMClient())
+    monkeypatch.setattr(
+        llm_interface, "get_active_model_name", lambda **_kwargs: "test-model"
+    )
+    monkeypatch.setattr(
+        llm_interface, "get_active_model_parameters", lambda **_kwargs: {}
+    )
 
     result = concept_service.generate_initial_question("#V#alex_smith")
 

--- a/tests/backend/test_model_execution_eligibility.py
+++ b/tests/backend/test_model_execution_eligibility.py
@@ -220,6 +220,51 @@ def test_gemini_factory_binds_the_trusted_actor_scope(
     assert captured["model_execution_actor_scope_bound"] is True
 
 
+def test_zero_argument_factory_resolves_provider_from_authenticated_actor_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services import settings_service
+
+    app = Flask(__name__)
+    app.secret_key = "eligibility-test"
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    monkeypatch.setattr(llm_interface, "initialize_clients", lambda **_kwargs: None)
+
+    def fake_resolve_llm_setting(**kwargs: Any) -> dict[str, str]:
+        captured["setting_scope"] = kwargs
+        return {
+            "provider": "gemini",
+            "model": "gemini-3.7-flash",
+            "scope": "user",
+        }
+
+    def fake_gemini_client(**kwargs: Any) -> object:
+        captured["client_scope"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(settings_service, "resolve_llm_setting", fake_resolve_llm_setting)
+    monkeypatch.setattr(llm_interface, "GeminiClient", fake_gemini_client)
+
+    with app.test_request_context():
+        session["user_concept_id"] = "#V#current_user"
+        session["organisation_concept_id"] = "#V#current_org"
+        result = llm_interface.get_llm_client()
+
+    assert result is sentinel
+    assert captured["setting_scope"] == {
+        "user_concept_id": "#V#current_user",
+        "org_concept_id": "#V#current_org",
+    }
+    assert captured["client_scope"]["model_execution_user_concept_id"] == (
+        "#V#current_user"
+    )
+    assert captured["client_scope"]["model_execution_org_concept_id"] == (
+        "#V#current_org"
+    )
+
+
 def test_actorless_factory_bound_gemini_embedding_is_denied_before_provider_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/frontend/interactionSessionRecovery.test.js
+++ b/tests/frontend/interactionSessionRecovery.test.js
@@ -12,6 +12,11 @@ import {
     setupConceptTabEventListenersWithSuffix,
 } from "../../src/frontend/web/von_interface/static/js/conceptTab.js";
 import { setCurrentlySelectedConceptId } from "../../src/frontend/web/von_interface/static/js/state.js";
+import {
+    setLocalPremiumModelUseEnabled,
+    setStoredGeminiSelectedModel,
+    setStoredPremiumModelProvider,
+} from "../../src/frontend/web/von_interface/static/js/utils/localModelPreferences.js";
 
 function okJson(data) {
     return {
@@ -31,6 +36,12 @@ function errorJson(status, data) {
 
 describe("Concept interaction session recovery", () => {
     beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        setStoredPremiumModelProvider("gemini");
+        setStoredGeminiSelectedModel("gemini-3.7-flash");
+        setLocalPremiumModelUseEnabled(true, "gemini");
+
         document.body.innerHTML = `
       <div class="tab-content active" id="conceptTab_s1" data-concept-id="#V#test_concept" data-concept-name="Test concept"></div>
 
@@ -103,6 +114,31 @@ describe("Concept interaction session recovery", () => {
         const submitBtn = document.getElementById("submitAnswerButton_s1");
         expect(startBtn.disabled).toBe(false);
         expect(submitBtn.disabled).toBe(true);
+    });
+
+    it("binds the window scope and Gemini selection to the new session", async () => {
+        await handleStartInteraction();
+
+        const startCall = global.fetch.mock.calls.find(([url]) =>
+            String(url).includes("/start_interaction")
+        );
+        const questionCall = global.fetch.mock.calls.find(([url]) =>
+            String(url).includes("/generate_initial_question")
+        );
+
+        expect(startCall).toBeDefined();
+        expect(questionCall).toBeDefined();
+        expect(startCall[1].headers["X-Von-Window-Session"]).toMatch(/^ws_/);
+        expect(questionCall[1].headers["X-Von-Window-Session"]).toBe(
+            startCall[1].headers["X-Von-Window-Session"]
+        );
+        expect(JSON.parse(startCall[1].body)).toMatchObject({
+            model_provider: "gemini",
+            model: "gemini-3.7-flash",
+        });
+        expect(JSON.parse(questionCall[1].body)).toMatchObject({
+            interaction_id: "interaction-1",
+        });
     });
 
     it("keeps ordinary discussion distinct from the guided interaction", () => {


### PR DESCRIPTION
## Summary
- preserve the authenticated window-specific organisation on concept Q&A sessions
- bind the browser-selected model to the session and reuse it for initial, synthesis, and follow-up calls
- make zero-argument LLM client resolution use the same trusted actor scope as model-name resolution
- add backend and frontend regressions for cross-org lookup and Gemini Flash routing

## Validation
- 38 targeted and near-neighbour backend tests passed
- 20 frontend tests passed
- frontend static lint completed with no errors (11 pre-existing warnings)
- authenticated AgentTest browser replay on Primary Labs completed start, Gemini initial question, and submit/follow-up; no note update occurred for NO_UPDATE
- persisted session read-back: user Michael, Strong AI Lab org, canonical composite namespace, gemini:gemini-3.7-flash

## Static analysis
- fatal Ruff checks passed
- targeted Pyright surfaced two pre-existing errors in untouched lines (Gemini contents typing and an OpenAI test fixture assignment)