### PR TITLE
Recover adaptive turns after structured transport failure

### DIFF
--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1247,6 +1247,46 @@ def _is_transient_model_request_liveness_failure(exc: BaseException) -> bool:
     return False
 
 
+def _structured_transport_failure_telemetry(
+    exc: StructuredToolTransportError,
+) -> dict[str, Any]:
+    """Retain the bounded provider decision that made a response unusable."""
+
+    raw_decision = getattr(exc, "decision", None)
+    decision = dict(raw_decision) if isinstance(raw_decision, Mapping) else {}
+    failure_kind = str(
+        decision.get("failure_kind")
+        or getattr(exc, "failure_kind", "structured_tool_transport_error")
+    ).strip()
+    retained_decision = {
+        key: decision[key]
+        for key in (
+            "provider",
+            "effective_api_surface",
+            "model",
+            "provider_status",
+            "provider_status_code",
+            "provider_error_code",
+            "provider_errors",
+            "failure_kind",
+        )
+        if key in decision
+    }
+    telemetry: dict[str, Any] = {
+        "failure_kind": failure_kind or "structured_tool_transport_error",
+    }
+    for key in (
+        "provider_status",
+        "provider_status_code",
+        "provider_error_code",
+    ):
+        if key in retained_decision:
+            telemetry[key] = retained_decision[key]
+    if retained_decision:
+        telemetry["transport_decision"] = retained_decision
+    return telemetry
+
+
 def _evidence_context_message(
     evidence_index: Sequence[Mapping[str, Any]],
     *,
@@ -6527,6 +6567,13 @@ def execute_adaptive_turn(
                 "usage": call.get("usage"),
                 "success": call.get("success"),
                 "duration_ms": call.get("duration_ms"),
+                "error": call.get("error"),
+                "error_class": call.get("error_class"),
+                "failure_kind": call.get("failure_kind"),
+                "provider_status": call.get("provider_status"),
+                "provider_status_code": call.get("provider_status_code"),
+                "provider_error_code": call.get("provider_error_code"),
+                "transport_decision": call.get("transport_decision"),
                 "llm_usage_cost_summary": current_llm_usage_cost_summary(),
                 "result_summary": (
                     "The model call completed; usage and cost evidence were updated."
@@ -8597,6 +8644,11 @@ def execute_adaptive_turn(
             provider_request_sent = (
                 False if isinstance(exc, ModelExecutionEligibilityError) else None
             )
+            transport_failure_telemetry = (
+                _structured_transport_failure_telemetry(exc)
+                if isinstance(exc, StructuredToolTransportError)
+                else {}
+            )
             llm_calls.append(
                 {
                     "call_id": model_call_id,
@@ -8620,6 +8672,7 @@ def execute_adaptive_turn(
                     "success": False,
                     "error": str(exc),
                     "error_class": type(exc).__name__,
+                    **transport_failure_telemetry,
                 }
             )
             emit_model_call_end(llm_calls[-1])
@@ -8628,6 +8681,41 @@ def execute_adaptive_turn(
                 return finish(str(exc), status=terminal_status)
             if final_synthesis and not answer_only:
                 enter_answer_only("evidence_call_failed")
+                continue
+            available_evidence_count = len(evidence_store.index())
+            # A provider may exhaust its own interaction budget only after a
+            # long, otherwise successful tool continuation. Preserve that work
+            # with one fresh no-tool synthesis instead of returning the adapter
+            # exception and discarding every completed observation.
+            if (
+                isinstance(exc, StructuredToolTransportError)
+                and not final_synthesis
+                and (available_evidence_count > 0 or bool(evidence_views))
+            ):
+                provider_status = transport_failure_telemetry.get(
+                    "provider_status"
+                )
+                recovery_reason = (
+                    "provider_budget_exhausted_after_evidence"
+                    if provider_status == "budget_exceeded"
+                    else "structured_transport_failed_after_evidence"
+                )
+                aux_calls.append(
+                    {
+                        "type": "adaptive_turn_model_transport_recovery",
+                        "schema_version": "adaptive_turn_model_transport_recovery.v1",
+                        "call_id": model_call_id,
+                        "reason": recovery_reason,
+                        "action": "fresh_answer_without_tools",
+                        "prior_model_call_count": model_call_sequence,
+                        "tool_invocation_count": len(tool_invocations),
+                        "evidence_count": available_evidence_count,
+                        "error": str(exc),
+                        "error_class": type(exc).__name__,
+                        **transport_failure_telemetry,
+                    }
+                )
+                enter_answer_only(recovery_reason)
                 continue
             if not final_synthesis and _is_transient_model_request_liveness_failure(
                 exc

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -25,6 +25,7 @@ from src.backend.languagemodels.structured_tool_calling.types import (
     LLMResponse,
     StructuredToolContextLimitError,
     StructuredToolProtocolError,
+    StructuredToolTransportError,
     ToolCall,
     ToolCallError,
     ToolResult,
@@ -9065,6 +9066,133 @@ def test_model_timeout_recovery_retains_existing_tool_evidence() -> None:
     assert evidence_payload["schema_version"] == "adaptive_turn_context_recovery.v1"
     assert evidence_payload["evidence"][0]["call_id"] == "read-before-timeout"
     assert "z" * 5_000 not in evidence_messages[0]["content"]
+
+
+def test_structured_transport_failure_after_evidence_gets_one_tool_free_answer() -> (
+    None
+):
+    provider_failure = StructuredToolTransportError(
+        "Gemini Interactions returned an unsuccessful provider status.",
+        decision={
+            "provider": "gemini",
+            "effective_api_surface": "interactions",
+            "model": "gemini-3.7-flash",
+            "provider_status": "budget_exceeded",
+            "provider_errors": [],
+            "failure_kind": "provider_response_failed",
+        },
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-provider-budget",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+            continuation=LLMContinuation(
+                provider="gemini",
+                api_surface="interactions",
+                model="gemini-3.7-flash",
+                state_mode="stateless",
+                input_items=[{"type": "user_input", "content": []}],
+                output_items=[
+                    {
+                        "type": "function_call",
+                        "id": "read-before-provider-budget",
+                        "name": "turn_invoke_capability",
+                        "arguments": {},
+                    }
+                ],
+            ),
+        ),
+        provider_failure,
+        LLMResponse(text_response="Recovered answer from retained evidence."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "success": True,
+                "students": [{"name": "Student A", "expected_end": "2027"}],
+            }
+        ),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-provider-budget-recovery",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "completed"
+    assert result.response_text == "Recovered answer from retained evidence."
+    assert len(client.calls) == 3
+    assert client.calls[1]["continuation"].state_mode == "stateless"
+    assert "continuation" not in client.calls[2]
+    assert "tool_results" not in client.calls[2]
+    assert client.calls[2]["available_tools"] == []
+    final_context = client.calls[2]["context"]
+    evidence_message = next(
+        item
+        for item in final_context
+        if item.get("role") == "user"
+        and "adaptive_turn_final_synthesis_evidence.v1" in str(item.get("content"))
+    )
+    assert "read-before-provider-budget" in evidence_message["content"]
+    failed_call = result.llm_calls[1]
+    assert failed_call["failure_kind"] == "provider_response_failed"
+    assert failed_call["provider_status"] == "budget_exceeded"
+    assert failed_call["transport_decision"]["provider"] == "gemini"
+    recovery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_model_transport_recovery"
+    )
+    assert recovery["reason"] == "provider_budget_exhausted_after_evidence"
+    assert recovery["action"] == "fresh_answer_without_tools"
+    assert recovery["evidence_count"] == 1
+    assert recovery["tool_invocation_count"] == 1
+
+
+def test_structured_transport_failure_without_evidence_remains_terminal() -> None:
+    client = _SequenceClient(
+        StructuredToolTransportError(
+            "Gemini Interactions returned an unsuccessful provider status.",
+            decision={
+                "provider": "gemini",
+                "provider_status": "failed",
+                "failure_kind": "provider_response_failed",
+            },
+        ),
+        LLMResponse(text_response="This response must not be requested."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=None,
+        prompt="Answer without any prior evidence.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-provider-failure-without-evidence",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert len(client.calls) == 1
+    assert result.terminal_status == "model_error"
+    assert result.llm_calls[0]["failure_kind"] == "provider_response_failed"
+    assert result.llm_calls[0]["provider_status"] == "failed"
+    assert not any(
+        item.get("type") == "adaptive_turn_model_transport_recovery"
+        for item in result.aux_llm_calls
+    )
 
 
 def test_model_timeout_does_not_retry_without_changed_context() -> None:

--- a/tests/backend/test_gemini_structured_tool_transport.py
+++ b/tests/backend/test_gemini_structured_tool_transport.py
@@ -401,7 +401,17 @@ def test_gemini_37_fails_clearly_without_interactions_sdk_surface() -> None:
         )
 
 
-@pytest.mark.parametrize("status", ["failed", "cancelled", "in_progress", "completed"])
+@pytest.mark.parametrize(
+    "status",
+    [
+        "failed",
+        "cancelled",
+        "in_progress",
+        "incomplete",
+        "budget_exceeded",
+        "completed",
+    ],
+)
 def test_interactions_unsuccessful_status_or_errors_are_typed_and_sanitised(
     status: str,
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve bounded provider transport diagnostics in adaptive-turn telemetry
- recover structured tool transport failures with one compact tool-free synthesis when useful evidence already exists
- retain honest terminal failure when no evidence was gathered
- cover Gemini incomplete and budget-exceeded transport outcomes

## Validation
- adaptive/Gemini transport suite: 245 passed
- final focused recovery suite: 8 passed
- diagnostics/capsule selected suite: 96 passed, with one unrelated pre-existing timing-telemetry expectation failure
- Python compilation and diff checks passed

No deployment or runtime activation is included.