### PR TITLE
JVNAUTOSCI-2696: Recover consecutive incomplete model responses

### DIFF
--- a/src/backend/languagemodels/structured_tool_calling/providers/gemini_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/gemini_client.py
@@ -9,6 +9,7 @@ a compatibility surface, including exact model-content replay.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from time import monotonic
@@ -487,10 +488,65 @@ class GeminiClient(LLMClient):
             else None
         )
         provider_errors = _provider_error_evidence(_value(interaction, "errors"))
+        output_steps = [
+            _provider_mapping(step) for step in (_value(interaction, "steps") or [])
+        ]
+        output_steps = [step for step in output_steps if step]
+        step_text = self._text_from_interaction_steps(output_steps)
+        output_text = _value(interaction, "output_text")
+        text = (
+            output_text
+            if isinstance(output_text, str) and output_text.strip()
+            else step_text
+        )
+        usage = _value(interaction, "usage")
+        mapped_usage = self._usage_mapping(usage)
+        actual_model = _value(interaction, "model")
         actionable_statuses = {"completed", "requires_action"}
         if (
             status is not None and status not in actionable_statuses
         ) or provider_errors:
+            partial_response = None
+            partial_text = text.strip() if isinstance(text, str) else ""
+            if status == "incomplete" and not provider_errors and partial_text:
+                effective_model = (
+                    str(actual_model)
+                    if isinstance(actual_model, str) and actual_model.strip()
+                    else model
+                )
+                partial_response = LLMResponse(
+                    text_response=partial_text,
+                    tool_calls=[],
+                    raw_response={
+                        "id": _value(interaction, "id"),
+                        "model": actual_model,
+                        "status": status,
+                        "step_types": [
+                            str(step.get("type") or "unknown")
+                            for step in output_steps[:20]
+                        ],
+                        "step_count": len(output_steps),
+                        "usage": _provider_mapping(usage),
+                    },
+                    model=effective_model,
+                    usage=mapped_usage,
+                    transport_metadata={
+                        "provider": "gemini",
+                        "requested_model": model,
+                        "effective_model": effective_model,
+                        "effective_api_surface": GEMINI_INTERACTIONS_SURFACE,
+                        "connection_id": (
+                            self.config.connection_id or "gemini_developer_api"
+                        ),
+                        "deployment_id": self.config.deployment_id or model,
+                        "continuation_mode": "stateless",
+                        "store": False,
+                        "effective_model_parameters": dict(effective_parameters),
+                        "provider_status": status,
+                        "response_complete": False,
+                        "partial_response": True,
+                    },
+                )
             raise StructuredToolTransportError(
                 "Gemini Interactions returned an unsuccessful provider status.",
                 decision={
@@ -500,15 +556,24 @@ class GeminiClient(LLMClient):
                     "provider_status": status,
                     "provider_errors": provider_errors,
                     "failure_kind": "provider_response_failed",
+                    "partial_response_available": partial_response is not None,
+                    **(
+                        {
+                            "partial_response_char_count": len(partial_text),
+                            "partial_response_sha256": hashlib.sha256(
+                                partial_text.encode("utf-8")
+                            ).hexdigest(),
+                            "provider_output_step_types": [
+                                str(step.get("type") or "unknown")
+                                for step in output_steps[:20]
+                            ],
+                        }
+                        if partial_response is not None
+                        else {}
+                    ),
                 },
+                partial_response=partial_response,
             )
-        output_steps = [
-            _provider_mapping(step) for step in (_value(interaction, "steps") or [])
-        ]
-        output_steps = [step for step in output_steps if step]
-        text = _value(interaction, "output_text")
-        if not isinstance(text, str):
-            text = self._text_from_interaction_steps(output_steps)
         tool_calls, diagnostics, call_names = self._normalise_function_steps(
             output_steps,
             available_tools,
@@ -524,7 +589,6 @@ class GeminiClient(LLMClient):
                     "failure_kind": "missing_provider_call_correlation",
                 },
             )
-        actual_model = _value(interaction, "model")
         return self._response(
             text=text or "",
             tool_calls=tool_calls,
@@ -535,13 +599,13 @@ class GeminiClient(LLMClient):
             requested_model=model,
             actual_model=actual_model,
             surface=GEMINI_INTERACTIONS_SURFACE,
-            usage=_value(interaction, "usage"),
+            usage=usage,
             raw_response={
                 "id": _value(interaction, "id"),
                 "model": actual_model,
                 "status": _value(interaction, "status"),
                 "steps": output_steps,
-                "usage": _provider_mapping(_value(interaction, "usage")),
+                "usage": _provider_mapping(usage),
                 "errors": provider_errors,
             },
             effective_parameters=effective_parameters,

--- a/src/backend/languagemodels/structured_tool_calling/types.py
+++ b/src/backend/languagemodels/structured_tool_calling/types.py
@@ -26,9 +26,15 @@ class StructuredToolTransportError(ToolCallError):
         message: str,
         *,
         decision: Mapping[str, Any] | None = None,
+        partial_response: "LLMResponse | None" = None,
     ) -> None:
         super().__init__(message)
         self.decision = dict(decision or {})
+        # Some providers return an explicitly incomplete interaction together
+        # with usable visible output. Keep that output in memory so a bounded
+        # controller can recover or deliver it honestly; it is never a
+        # successful response by itself.
+        self.partial_response = partial_response
 
 
 class UnsupportedStructuredToolTransportError(StructuredToolTransportError):

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -12817,7 +12817,8 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             )
         )
         adaptive_partial_delivery = (
-            adaptive_terminal_status == "effect_partially_completed"
+            adaptive_terminal_status
+            in {"effect_partially_completed", "answer_partially_completed"}
             and isinstance(response_text, str)
             and bool(response_text.strip())
         )

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -88,6 +88,7 @@ _DEFAULT_OUTER_TOOL_WORKERS = 8
 _SUCCESSFUL_MODEL_DURATION_ADVISORY_MULTIPLIER = 1.25
 _MODEL_EVIDENCE_INDEX_MAX_BYTES = 24_000
 _MODEL_TOOL_RESULT_BATCH_MAX_BYTES = 24_000
+_MODEL_TRANSPORT_RECOVERY_CONTEXT_MAX_BYTES = 64_000
 _MODEL_EVIDENCE_PREVIEW_MAX_CHARS = 240
 _CAPABILITY_PURPOSE_MAX_CHARS = 160
 _CAPABILITY_CATALOGUE_SCHEMA_VERSION = "adaptive_turn_capabilities.v1"
@@ -1269,6 +1270,10 @@ def _structured_transport_failure_telemetry(
             "provider_error_code",
             "provider_errors",
             "failure_kind",
+            "partial_response_available",
+            "partial_response_char_count",
+            "partial_response_sha256",
+            "provider_output_step_types",
         )
         if key in decision
     }
@@ -1279,6 +1284,9 @@ def _structured_transport_failure_telemetry(
         "provider_status",
         "provider_status_code",
         "provider_error_code",
+        "partial_response_available",
+        "partial_response_char_count",
+        "partial_response_sha256",
     ):
         if key in retained_decision:
             telemetry[key] = retained_decision[key]
@@ -2095,8 +2103,9 @@ def _scope_message(
         message += (
             "\n- The answer-only checkpoint has been reached. Answer now from the "
             "bounded evidence already present in the request. Do not request "
-            "tools or new external capabilities. State material limitations "
-            "instead of filling evidence gaps."
+            "tools or new external capabilities. Produce a compact, complete "
+            "answer within the available response space. State material "
+            "limitations instead of filling evidence gaps."
         )
     elif final_synthesis:
         message += (
@@ -8649,6 +8658,24 @@ def execute_adaptive_turn(
                 if isinstance(exc, StructuredToolTransportError)
                 else {}
             )
+            partial_response = getattr(exc, "partial_response", None)
+            partial_response_text = (
+                partial_response.text_response.strip()
+                if isinstance(partial_response, LLMResponse)
+                and partial_response.text_response.strip()
+                else ""
+            )
+            if isinstance(partial_response, LLMResponse):
+                _usage_add(usage_totals, partial_response.usage)
+            partial_response_model = (
+                partial_response.model.strip()
+                if isinstance(partial_response, LLMResponse)
+                and isinstance(partial_response.model, str)
+                and partial_response.model.strip()
+                else None
+            )
+            if isinstance(partial_response, LLMResponse):
+                provider_request_sent = True
             llm_calls.append(
                 {
                     "call_id": model_call_id,
@@ -8659,8 +8686,12 @@ def execute_adaptive_turn(
                     "provider": configured_provider or None,
                     "requested_model": model,
                     "selected_model": model,
-                    "effective_model": None,
-                    "model_identity_source": None,
+                    "effective_model": partial_response_model,
+                    "model_identity_source": (
+                        "provider_partial_response"
+                        if partial_response_model
+                        else None
+                    ),
                     "provider_request_sent": provider_request_sent,
                     "request_timeout_seconds": None,
                     "request_advisory_seconds": effective_model_call_advisory,
@@ -8670,15 +8701,51 @@ def execute_adaptive_turn(
                     ),
                     "status": "failed",
                     "success": False,
+                    "usage": (
+                        dict(partial_response.usage)
+                        if isinstance(partial_response, LLMResponse)
+                        and partial_response.usage
+                        else None
+                    ),
+                    "partial_response_retained": bool(partial_response_text),
                     "error": str(exc),
                     "error_class": type(exc).__name__,
                     **transport_failure_telemetry,
                 }
             )
             emit_model_call_end(llm_calls[-1])
+            if partial_response_text:
+                last_partial_text = partial_response_text
+                last_partial_effect_generation = request_effect_generation
             if isinstance(exc, ModelExecutionEligibilityError):
                 terminal_status = exc.failure_kind
                 return finish(str(exc), status=terminal_status)
+            if (
+                isinstance(exc, StructuredToolTransportError)
+                and answer_only
+                and partial_response_text
+            ):
+                aux_calls.append(
+                    {
+                        "type": "adaptive_turn_partial_answer_delivery",
+                        "schema_version": "adaptive_turn_partial_answer_delivery.v1",
+                        "call_id": model_call_id,
+                        "reason": "answer_only_provider_response_incomplete",
+                        "action": "deliver_visible_partial_response_with_caveat",
+                        "partial_response_char_count": len(partial_response_text),
+                        "partial_response_sha256": hashlib.sha256(
+                            partial_response_text.encode("utf-8")
+                        ).hexdigest(),
+                        **transport_failure_telemetry,
+                    }
+                )
+                terminal_status = "answer_partially_completed"
+                return finish(
+                    "Partial answer — the model provider stopped before the "
+                    "response completed, so some requested rows or details may "
+                    "be missing.\n\n" + partial_response_text,
+                    status=terminal_status,
+                )
             if final_synthesis and not answer_only:
                 enter_answer_only("evidence_call_failed")
                 continue
@@ -8700,6 +8767,28 @@ def execute_adaptive_turn(
                     if provider_status == "budget_exceeded"
                     else "structured_transport_failed_after_evidence"
                 )
+                recovery_context_before_bytes = len(_json_bytes(current_context))
+                enter_answer_only(recovery_reason)
+                compact_answer_context = _compact_context_after_limit(
+                    prompt=prompt,
+                    context=final_context_base or (),
+                    evidence_index=evidence_store.index(),
+                    before_size=(
+                        2
+                        * (
+                            _MODEL_TRANSPORT_RECOVERY_CONTEXT_MAX_BYTES
+                            + len(prompt.encode("utf-8"))
+                        )
+                    ),
+                    evidence_views=evidence_views,
+                )
+                if compact_answer_context is not None:
+                    compact_answer_context_bytes = len(
+                        _json_bytes(compact_answer_context)
+                    )
+                    if compact_answer_context_bytes < len(_json_bytes(current_context)):
+                        current_context = compact_answer_context
+                recovery_context_after_bytes = len(_json_bytes(current_context))
                 aux_calls.append(
                     {
                         "type": "adaptive_turn_model_transport_recovery",
@@ -8710,12 +8799,20 @@ def execute_adaptive_turn(
                         "prior_model_call_count": model_call_sequence,
                         "tool_invocation_count": len(tool_invocations),
                         "evidence_count": available_evidence_count,
+                        "context_compacted": (
+                            recovery_context_after_bytes
+                            < recovery_context_before_bytes
+                        ),
+                        "context_before_bytes": recovery_context_before_bytes,
+                        "context_after_bytes": recovery_context_after_bytes,
+                        "context_max_bytes": (
+                            _MODEL_TRANSPORT_RECOVERY_CONTEXT_MAX_BYTES
+                        ),
                         "error": str(exc),
                         "error_class": type(exc).__name__,
                         **transport_failure_telemetry,
                     }
                 )
-                enter_answer_only(recovery_reason)
                 continue
             if not final_synthesis and _is_transient_model_request_liveness_failure(
                 exc

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -9123,7 +9123,12 @@ def test_structured_transport_failure_after_evidence_gets_one_tool_free_answer()
             }
         ),
         prompt="Make a table of my current students.",
-        context=[],
+        context=[
+            {
+                "role": "assistant",
+                "content": "old conversational context " * 20_000,
+            }
+        ],
         llm_client=client,
         model="gemini-3.7-flash",
         turn_id="turn-provider-budget-recovery",
@@ -9143,9 +9148,10 @@ def test_structured_transport_failure_after_evidence_gets_one_tool_free_answer()
         item
         for item in final_context
         if item.get("role") == "user"
-        and "adaptive_turn_final_synthesis_evidence.v1" in str(item.get("content"))
+        and "adaptive_turn_context_recovery.v1" in str(item.get("content"))
     )
     assert "read-before-provider-budget" in evidence_message["content"]
+    assert len(_json_bytes(final_context)) <= 64_512
     failed_call = result.llm_calls[1]
     assert failed_call["failure_kind"] == "provider_response_failed"
     assert failed_call["provider_status"] == "budget_exceeded"
@@ -9159,6 +9165,195 @@ def test_structured_transport_failure_after_evidence_gets_one_tool_free_answer()
     assert recovery["action"] == "fresh_answer_without_tools"
     assert recovery["evidence_count"] == 1
     assert recovery["tool_invocation_count"] == 1
+    assert recovery["context_compacted"] is True
+    assert recovery["context_after_bytes"] < recovery["context_before_bytes"]
+    assert recovery["context_max_bytes"] == 64_000
+
+
+def test_consecutive_incomplete_responses_deliver_visible_partial_answer() -> None:
+    first_incomplete = StructuredToolTransportError(
+        "Gemini Interactions returned an unsuccessful provider status.",
+        decision={
+            "provider": "gemini",
+            "effective_api_surface": "interactions",
+            "model": "gemini-3.7-flash",
+            "provider_status": "incomplete",
+            "provider_errors": [],
+            "failure_kind": "provider_response_failed",
+            "partial_response_available": False,
+        },
+    )
+    partial_table = (
+        "| Student | Expected end | Co-adviser | Topic |\n"
+        "|---|---|---|---|\n"
+        "| Student A | 2027 | Adviser B | Reliable agents |"
+    )
+    second_incomplete = StructuredToolTransportError(
+        "Gemini Interactions returned an unsuccessful provider status.",
+        decision={
+            "provider": "gemini",
+            "effective_api_surface": "interactions",
+            "model": "gemini-3.7-flash",
+            "provider_status": "incomplete",
+            "provider_errors": [],
+            "failure_kind": "provider_response_failed",
+            "partial_response_available": True,
+            "partial_response_char_count": len(partial_table),
+        },
+        partial_response=LLMResponse(
+            text_response=partial_table,
+            model="gemini-3.7-flash-20260815",
+            usage={"input_tokens": 410, "output_tokens": 61, "total_tokens": 471},
+            transport_metadata={
+                "provider": "gemini",
+                "provider_status": "incomplete",
+                "response_complete": False,
+            },
+        ),
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-consecutive-incomplete",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+            continuation=LLMContinuation(
+                provider="gemini",
+                api_surface="interactions",
+                model="gemini-3.7-flash",
+                state_mode="stateless",
+                input_items=[{"type": "user_input", "content": []}],
+                output_items=[
+                    {
+                        "type": "function_call",
+                        "id": "read-before-consecutive-incomplete",
+                        "name": "turn_invoke_capability",
+                        "arguments": {},
+                    }
+                ],
+            ),
+        ),
+        first_incomplete,
+        second_incomplete,
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "success": True,
+                "students": [{"name": "Student A", "expected_end": "2027"}],
+            }
+        ),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-consecutive-incomplete-partial-delivery",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "answer_partially_completed"
+    assert result.response_text.startswith(
+        "Partial answer — the model provider stopped before the response completed"
+    )
+    assert partial_table in result.response_text
+    assert len(client.calls) == 3
+    assert client.calls[2]["available_tools"] == []
+    assert "continuation" not in client.calls[2]
+    assert "tool_results" not in client.calls[2]
+    assert "Produce a compact, complete answer" in client.calls[2][
+        "system_message"
+    ]
+    assert len(_json_bytes(client.calls[2]["context"])) <= 64_512
+    assert result.llm_usage == {
+        "input_tokens": 410,
+        "output_tokens": 61,
+        "total_tokens": 471,
+    }
+    final_call = result.llm_calls[2]
+    assert final_call["status"] == "failed"
+    assert final_call["provider_request_sent"] is True
+    assert final_call["partial_response_retained"] is True
+    assert final_call["effective_model"] == "gemini-3.7-flash-20260815"
+    assert final_call["usage"] == {
+        "input_tokens": 410,
+        "output_tokens": 61,
+        "total_tokens": 471,
+    }
+    delivery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_partial_answer_delivery"
+    )
+    assert delivery["action"] == "deliver_visible_partial_response_with_caveat"
+    assert delivery["provider_status"] == "incomplete"
+    assert delivery["partial_response_char_count"] == len(partial_table)
+    recovery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_model_transport_recovery"
+    )
+    assert recovery["context_compacted"] is False
+    assert recovery["context_max_bytes"] == 64_000
+
+
+def test_consecutive_incomplete_without_partial_response_remains_terminal() -> None:
+    def incomplete() -> StructuredToolTransportError:
+        return StructuredToolTransportError(
+            "Gemini Interactions returned an unsuccessful provider status.",
+            decision={
+                "provider": "gemini",
+                "provider_status": "incomplete",
+                "failure_kind": "provider_response_failed",
+                "partial_response_available": False,
+            },
+        )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-empty-incomplete",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+        ),
+        incomplete(),
+        incomplete(),
+        LLMResponse(text_response="A fourth call must not happen."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True, "students": []}),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-consecutive-incomplete-without-partial",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "model_error"
+    assert len(client.calls) == 3
+    assert "StructuredToolTransportError" in result.response_text
+    assert not any(
+        item.get("type") == "adaptive_turn_partial_answer_delivery"
+        for item in result.aux_llm_calls
+    )
 
 
 def test_structured_transport_failure_without_evidence_remains_terminal() -> None:

--- a/tests/backend/test_gemini_structured_tool_transport.py
+++ b/tests/backend/test_gemini_structured_tool_transport.py
@@ -438,3 +438,72 @@ def test_interactions_unsuccessful_status_or_errors_are_typed_and_sanitised(
     assert exc_info.value.decision["failure_kind"] == "provider_response_failed"
     assert "secret-provider-value" not in str(exc_info.value.decision)
     assert "[redacted]" in str(exc_info.value.decision)
+
+
+def test_interactions_incomplete_retains_only_visible_partial_response() -> None:
+    interaction = _Resource(
+        id="interaction-incomplete",
+        model="gemini-3.7-flash-20260815",
+        status="incomplete",
+        output_text="",
+        steps=[
+            _Resource(
+                type="thought",
+                summary=[{"type": "text", "text": "private reasoning"}],
+                signature="private-signature",
+            ),
+            _Resource(
+                type="model_output",
+                content=[
+                    {
+                        "type": "text",
+                        "text": "| Student | End date |\n|---|---|\n| A | 2027 |",
+                    }
+                ],
+                signature="answer-signature",
+            ),
+        ],
+        usage=_Resource(
+            total_input_tokens=320,
+            total_output_tokens=41,
+            total_thought_tokens=9,
+            total_tokens=370,
+        ),
+        errors=None,
+    )
+    client = _client(_Interactions([interaction]))
+
+    with pytest.raises(StructuredToolTransportError) as exc_info:
+        asyncio.run(client.generate_with_tools("Make the table.", [_tool()]))
+
+    error = exc_info.value
+    assert error.decision["provider_status"] == "incomplete"
+    assert error.decision["partial_response_available"] is True
+    assert error.decision["partial_response_char_count"] == 45
+    assert error.decision["provider_output_step_types"] == [
+        "thought",
+        "model_output",
+    ]
+    assert "Student" not in str(error.decision)
+    assert "private reasoning" not in str(error.decision)
+
+    partial = error.partial_response
+    assert partial is not None
+    assert partial.text_response == (
+        "| Student | End date |\n|---|---|\n| A | 2027 |"
+    )
+    assert partial.tool_calls == []
+    assert partial.model == "gemini-3.7-flash-20260815"
+    assert partial.usage == {
+        "input_tokens": 320,
+        "output_tokens": 50,
+        "visible_output_tokens": 41,
+        "total_tokens": 370,
+        "thought_tokens": 9,
+    }
+    assert partial.transport_metadata["response_complete"] is False
+    assert partial.transport_metadata["provider_status"] == "incomplete"
+    assert partial.raw_response is not None
+    assert partial.raw_response["step_types"] == ["thought", "model_output"]
+    assert "private reasoning" not in str(partial.raw_response)
+    assert "private-signature" not in str(partial.raw_response)

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -216,6 +216,33 @@ def test_ordinary_generate_uses_adaptive_turn_without_master_workflow_or_gate(
     assert "workflow_instance_id" not in payload
 
 
+def test_partial_answer_terminal_status_is_delivered_as_honest_success(
+    app: Flask,
+) -> None:
+    partial = (
+        "Partial answer — the model provider stopped before the response completed, "
+        "so some requested rows or details may be missing.\n\n"
+        "| Student | Expected end |\n|---|---|\n| Student A | 2027 |"
+    )
+    adaptive_state = app.config["_ADAPTIVE_TURN_STATE"]
+    adaptive_state["response_text"] = partial
+    adaptive_state["terminal_status"] = "answer_partially_completed"
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={"prompt": "Make the table."},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["terminal_status"] == "answer_partially_completed"
+    assert payload["response"] == partial
+    assert payload["llm_debug"]["llm_interaction"][
+        "ordinary_turn_terminal_status"
+    ] == "answer_partially_completed"
+
+
 def test_ordinary_generate_does_not_run_disabled_buttonify_model(
     app: Flask,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Outcome

Preserves Gemini Interactions visible output when the provider returns `incomplete`, bounds the evidence-based answer-only retry, and delivers a second incomplete response honestly as a caveated partial answer instead of replacing it with `StructuredToolTransportError`.

## Changes

- retain provider-designated visible partial text, usage and model identity without retaining thought content or signatures
- cap transport-recovery context at 64 kB while retaining the original prompt and bounded evidence
- make at most one answer-only recovery call, with no tools or continuation
- return usable second-incomplete output with terminal status `answer_partially_completed`; retain `model_error` when no output is usable
- preserve that honest partial status through `/von/generate`

## Validation

- `tests/backend/test_gemini_structured_tool_transport.py`: 12 passed
- `tests/backend/test_adaptive_turn_service.py`: 234 passed
- `tests/backend/test_von_generate_workflow_instances.py`: 27 passed
- Ruff passes on the changed provider/test files; no Ruff or Pyright finding lands on changed lines in larger modules with existing backlog

Jira: [JVNAUTOSCI-2696](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2696)

No runtime deployment or activation is included.

[JVNAUTOSCI-2696]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ