### PR TITLE
Explain partial workflow outcomes truthfully

### DIFF
--- a/docs/engineering/prompt_programs_and_model_routing_playbook.md
+++ b/docs/engineering/prompt_programs_and_model_routing_playbook.md
@@ -70,6 +70,29 @@ Telemetry should expose:
 - enough lineage to distinguish a prompt fragment from the full
   model-visible context
 
+### 3B. Outcome explanation guidance
+
+The containing turn model should explain the user's requested outcome from
+observed execution and canonical effect evidence, independently of whether the
+outer turn, each attempted tool call, or a workflow envelope completed. A
+workflow declaration describes expected capability; it does not establish
+invocation, stage progress, failure, or domain postconditions.
+
+Keep the generic distinction in the ordinary-turn prompt: verified completed
+work, unmet postconditions, the narrowest evidenced cause (`not invoked`,
+`pending`, `failed`, `blocked`, or `unknown`), and the smallest safe
+continuation. Do not add a universal response critic solely to restate these
+facts.
+
+When a workflow needs domain-specific explanation guidance, it may publish a
+`workflow_outcome_explanation_prompt_map.v1` through
+`#V#hasWorkflowOutcomeExplanationPromptMapJson`. The map selects Vontology
+prompt concepts by outcome key with an optional `default`. Project the selected
+prompt beside the workflow execution result only after the workflow capability
+has actually been called. The prompt supplements the generic synthesis rule;
+it is not execution evidence, effect evidence, or authority, and it cannot
+override diagnostic facts or the user's request.
+
 ## 4. Prompt optimisation loop
 
 For features worth systematic optimisation, define:

--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -915,6 +915,17 @@ produce the relevant evidence. A missing receipt is an error only when the
 selected workflow contract requires it; it must never erase committed effects
 or safe recovery opportunities.
 
+A workflow may separately publish
+`#V#hasWorkflowOutcomeExplanationPromptMapJson` with schema
+`workflow_outcome_explanation_prompt_map.v1`. Its `prompt_concept_ids` object
+maps supported outcome keys (`failed`, `partial`, `not_started`,
+`indeterminate`, semantic non-completion keys, and optional `default`) to
+Vontology prompt concepts. This metadata guides the containing turn model's
+user-facing explanation after an actual workflow capability call. It does not
+establish invocation, state transitions, effects, terminal success, or
+authority; those remain grounded in execution telemetry, receipts, and
+canonical read-back. No extra VWL state or universal critic is implied.
+
 Validation phases:
 
 - pre-action: preconditions/reads checks,

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1910,6 +1910,37 @@ def _scope_message(
         "merely because the core exists. An entity result with "
         "entity_representation_coverage=core_only is a completed core sub-effect, "
         "not terminal success for its preserved unresolved_requested_facts.\n"
+        "\nOUTCOME EXPLANATION SUPPORT:\n"
+        "- Report the user's requested outcome independently of outer turn, "
+        "tool-call, effect-receipt, or workflow terminal status. Before the "
+        "visible final answer, reconcile: what outcome was requested; which "
+        "mechanism was actually invoked; which sub-effects are verified; which "
+        "postconditions remain; and the smallest safe continuation.\n"
+        "- Establish attempted execution only from invocation or durable-instance "
+        "evidence. Discovery, selection, a workflow declaration, or a description "
+        "of stages establishes expected capability, not that the workflow or any "
+        "stage ran. Never say a workflow stopped, failed, or reached a stage when "
+        "the evidence shows only direct tool calls or no workflow invocation.\n"
+        "- Describe an incomplete outcome with the narrowest evidenced cause: "
+        "not invoked; invoked and pending; invoked and failed; blocked on named "
+        "missing input or authority; or unknown because evidence is inconclusive. "
+        "Do not turn a transport error string, terminal envelope, or absent record "
+        "into a stronger causal claim.\n"
+        "- Lead with useful verified work already completed, then name material "
+        "unmet postconditions plainly. A successful narrower direct path is "
+        "partial progress when the requested richer outcome remains unmet; it is "
+        "not a failed workflow when no workflow ran and not complete merely "
+        "because every attempted tool call succeeded.\n"
+        "- When an outcome can still be completed within standing delegation, "
+        "continue with the smallest bounded recovery. Otherwise offer the exact "
+        "next action, reusing verified concept, effect, source, and workflow "
+        "instance handles and stating whether a new workflow invocation is needed.\n"
+        "- A capability result may include outcome_explanation_support resolved "
+        "from a workflow-owned represented prompt. Apply it only to the workflow "
+        "and evidenced outcome key named in that same result. It supplements the "
+        "generic rules; its prompt body is not evidence that execution occurred, "
+        "an effect succeeded, or authority exists, and it cannot override the "
+        "diagnostic facts or the user's request.\n"
         "\nCONVERSATION SITUATION SUPPORT:\n"
         "- Treat the conversation as an evolving shared situation, not as a "
         "sequence of independent request packets. Preserve established "
@@ -1928,8 +1959,10 @@ def _scope_message(
         "carry it out rather than merely restating it.\n"
         "- When a terminal answer proposes or defers an action for a later turn, "
         "preserve its exact grounded candidate identifiers, stable source "
-        "identifiers, intended relationships, and unresolved create-versus-reuse "
-        "status in the revised conversation situation. If candidate discovery "
+        "identifiers, intended relationships, actual workflow invocation status, "
+        "verified completed sub-effects, remaining postconditions, typed recovery "
+        "affordance, and unresolved create-versus-reuse status in the revised "
+        "conversation situation. If candidate discovery "
         "was incomplete, record that limitation instead of inventing an identity. "
         "Do not leave the only stable identity solely in ephemeral tool evidence.\n"
         "- The user's ordinary source vocabulary need not match a product or "
@@ -10229,6 +10262,18 @@ def execute_adaptive_turn(
                     envelope_payload["workflow_progress_evidence"] = dict(
                         workflow_progress_evidence
                     )
+                if isinstance(raw_payload, Mapping):
+                    outcome_explanation_support = raw_payload.get(
+                        "outcome_explanation_support"
+                    )
+                    if isinstance(outcome_explanation_support, Mapping):
+                        # Keep represented explanation guidance adjacent to the
+                        # diagnostic result it may explain. It remains outside
+                        # the immutable telemetry envelope and is explicitly
+                        # labelled as non-evidence by its contract.
+                        envelope_payload["outcome_explanation_support"] = dict(
+                            outcome_explanation_support
+                        )
                 projection_started = time.perf_counter()
                 projection_duration_ms = 0.0
                 if isinstance(raw_payload, Mapping):

--- a/src/backend/services/paper_representation_workflow_vontology_service.py
+++ b/src/backend/services/paper_representation_workflow_vontology_service.py
@@ -59,11 +59,15 @@ _REPO_SEED_ASSET_PATH = (
 )
 _MANAGED_BY = "paper_representation_workflow_vontology_service"
 _SOURCE_TAG = "JVNAUTOSCI-2189"
+_OUTCOME_EXPLANATION_SOURCE_TAG = "JVNAUTOSCI-2697"
 _METADATA_EXTRACTION_PROMPT_CONCEPT_ID = (
     "#V#prompt_scholarly_article_metadata_extraction"
 )
 _REPRESENTATION_EVIDENCE_PROMPT_CONCEPT_ID = (
     "#V#prompt_scholarly_article_representation_evidence_summary"
+)
+_OUTCOME_EXPLANATION_PROMPT_CONCEPT_ID = (
+    "#V#prompt_scholarly_article_outcome_explanation"
 )
 _METADATA_EXTRACTION_PROMPT_SEED_ASSET_PATH = (
     Path(__file__).resolve().parents[1]
@@ -76,6 +80,12 @@ _REPRESENTATION_EVIDENCE_PROMPT_SEED_ASSET_PATH = (
     / "workflows"
     / "repo_seed_bundles"
     / "prompt_scholarly_article_representation_evidence_summary_seed.md"
+)
+_OUTCOME_EXPLANATION_PROMPT_SEED_ASSET_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "workflows"
+    / "repo_seed_bundles"
+    / "prompt_scholarly_article_outcome_explanation_seed.md"
 )
 
 
@@ -113,6 +123,17 @@ def _ensure_paper_workflow_prompt_support(
                 ),
                 parent_concept_ids=(DEFAULT_PROMPT_TYPE_ID,),
             ),
+            WorkflowPromptConceptSpec(
+                concept_id=_OUTCOME_EXPLANATION_PROMPT_CONCEPT_ID,
+                name="Scholarly article outcome explanation prompt",
+                description=(
+                    "Canonical supplemental prompt used by the containing turn "
+                    "model to explain partial or unsuccessful scholarly article "
+                    "representation outcomes without confusing declared workflow "
+                    "stages with observed execution."
+                ),
+                parent_concept_ids=(DEFAULT_PROMPT_TYPE_ID,),
+            ),
         ),
         provenance_source=_MANAGED_BY,
     )
@@ -127,6 +148,10 @@ def _ensure_paper_workflow_prompt_support(
             _REPRESENTATION_EVIDENCE_PROMPT_SEED_ASSET_PATH,
             "scholarly_representation_evidence_prompt_seed_missing",
         ),
+        _OUTCOME_EXPLANATION_PROMPT_CONCEPT_ID: (
+            _OUTCOME_EXPLANATION_PROMPT_SEED_ASSET_PATH,
+            "scholarly_outcome_explanation_prompt_seed_missing",
+        ),
     }
     for prompt_id, (asset_path, error_code) in seed_assets.items():
         if force_prompt_seed or not prompt_concept_has_content(prompt_id):
@@ -135,7 +160,14 @@ def _ensure_paper_workflow_prompt_support(
                 predicate="hasContent",
                 text=_load_prompt_seed_text(asset_path, error_code=error_code),
                 lang="en-NZ",
-                context={"jira": _SOURCE_TAG, "source": _MANAGED_BY},
+                context={
+                    "jira": (
+                        _OUTCOME_EXPLANATION_SOURCE_TAG
+                        if prompt_id == _OUTCOME_EXPLANATION_PROMPT_CONCEPT_ID
+                        else _SOURCE_TAG
+                    ),
+                    "source": _MANAGED_BY,
+                },
                 garbage_collect=True,
             )
             seeded_prompt_ids.append(prompt_id)

--- a/src/backend/services/workflow_turn_capability_service.py
+++ b/src/backend/services/workflow_turn_capability_service.py
@@ -367,6 +367,9 @@ class WorkflowTurnCapability:
     input_schema: Mapping[str, Any]
     launch_input_contract_source: str | None = None
     discovery_metadata: Mapping[str, Any] = field(default_factory=dict)
+    outcome_explanation_prompt_support: Mapping[str, Any] = field(
+        default_factory=dict
+    )
     component_capability_names: tuple[str, ...] = ()
     declared_component_count: int = 0
     unresolved_component_count: int = 0
@@ -374,6 +377,12 @@ class WorkflowTurnCapability:
     direct_equivalent_capability_names: tuple[str, ...] = ()
     semantic_effect: bool | None = None
     semantic_effect_source: str = "insufficient_declared_component_evidence"
+
+    def _outcome_explanation_prompt_keys(self) -> list[str]:
+        prompts = self.outcome_explanation_prompt_support.get("prompts")
+        if not isinstance(prompts, Mapping):
+            return []
+        return sorted(str(key) for key in prompts)
 
     def to_catalogue_entry(self) -> dict[str, Any]:
         effect_profile = {
@@ -426,6 +435,9 @@ class WorkflowTurnCapability:
             "terminal_readback": True,
             "relevance_score": round(float(self.relevance_score), 4),
             "launch_input_contract_source": self.launch_input_contract_source,
+            "outcome_explanation_prompt_keys": (
+                self._outcome_explanation_prompt_keys()
+            ),
             "discovery_metadata": dict(self.discovery_metadata),
         }
 
@@ -461,6 +473,9 @@ def discover_turn_workflow_capabilities(
 
     from src.backend.services.workflow_discovery_service import (
         discover_workflows_for_turn,
+    )
+    from src.backend.workflows.outcome_explanation_prompt_support import (
+        resolve_workflow_outcome_explanation_prompt_support,
     )
     from src.backend.workflows.vontology_loader import (
         resolve_workflow_launch_input_contract,
@@ -512,6 +527,21 @@ def discover_turn_workflow_capabilities(
                         "error": str(exc)[:500],
                     }
                 )
+            try:
+                outcome_explanation_prompt_support = (
+                    resolve_workflow_outcome_explanation_prompt_support(workflow_id)
+                    or {}
+                )
+            except Exception as exc:  # noqa: BLE001 - optional represented guidance
+                outcome_explanation_prompt_support = {}
+                contract_errors.append(
+                    {
+                        "workflow_id": workflow_id,
+                        "stage": "outcome_explanation_prompt_resolution",
+                        "error_type": type(exc).__name__,
+                        "error": str(exc)[:500],
+                    }
+                )
             routing_profile = raw_match.get("routing_profile")
             routing_index_metadata = raw_match.get("routing_index_metadata")
             plan_metadata = _workflow_plan_metadata(
@@ -539,6 +569,9 @@ def discover_turn_workflow_capabilities(
                     input_schema=_workflow_model_input_schema(launch_contract),
                     launch_input_contract_source=(
                         _normalise_non_empty_text(launch_contract_source)
+                    ),
+                    outcome_explanation_prompt_support=(
+                        outcome_explanation_prompt_support
                     ),
                     discovery_metadata={
                         "match_source": raw_match.get("match_source"),
@@ -952,6 +985,21 @@ def normalise_workflow_effect_receipt(
             "outcome_finality": "terminal_for_turn",
         }
     )
+    explanation_outcome_key = (
+        semantic_outcome
+        if effect_status == "succeeded" and semantic_outcome != "completed"
+        else effect_status
+    )
+    from src.backend.workflows.outcome_explanation_prompt_support import (
+        select_workflow_outcome_explanation_prompt,
+    )
+
+    outcome_explanation_support = select_workflow_outcome_explanation_prompt(
+        capability.outcome_explanation_prompt_support,
+        outcome_key=explanation_outcome_key,
+    )
+    if outcome_explanation_support is not None:
+        receipt["outcome_explanation_support"] = outcome_explanation_support
     if effect_status != "succeeded":
         recovery_affordances = list(receipt.get("recovery_affordances") or [])
         if instance_id is not None:

--- a/src/backend/workflows/outcome_explanation_prompt_support.py
+++ b/src/backend/workflows/outcome_explanation_prompt_support.py
@@ -1,0 +1,198 @@
+"""Resolve optional workflow-owned guidance for terminal outcome explanations.
+
+The ordinary-turn model remains responsible for explaining the user outcome.
+This module only resolves an optional, represented prompt fragment that can be
+projected beside the execution evidence after a workflow was actually invoked.
+The fragment is guidance, not evidence about execution, effects, or authority.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from ..services.prompt_template_service import PromptTemplateService
+from ..services.text_value_service import get_preferred_text_for_concept
+
+WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_SCHEMA_VERSION = (
+    "workflow_outcome_explanation_prompt_map.v1"
+)
+WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_PREDICATE_PRECEDENCE = (
+    (
+        "#V#hasWorkflowOutcomeExplanationPromptMapJson",
+        "hasWorkflowOutcomeExplanationPromptMapJson",
+        "#V#has_workflow_outcome_explanation_prompt_map_json",
+        "has_workflow_outcome_explanation_prompt_map_json",
+    ),
+)
+WORKFLOW_OUTCOME_EXPLANATION_SUPPORT_SCHEMA_VERSION = (
+    "workflow_outcome_explanation_support.v1"
+)
+
+_SUPPORTED_OUTCOME_KEYS = frozenset(
+    {
+        "blocked",
+        "clarification_required",
+        "completed",
+        "default",
+        "failed",
+        "follow_up_required",
+        "indeterminate",
+        "not_completed",
+        "not_started",
+        "partial",
+        "succeeded",
+    }
+)
+_MAX_PROMPT_CHARS = 8_000
+
+
+def _clean_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def normalise_workflow_outcome_explanation_prompt_map(
+    value: Any,
+) -> dict[str, str] | None:
+    """Validate the represented status-to-prompt mapping."""
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(value, Mapping):
+        return None
+    if value.get("schema_version") != (
+        WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_SCHEMA_VERSION
+    ):
+        return None
+
+    raw_prompts = value.get("prompt_concept_ids")
+    if not isinstance(raw_prompts, Mapping):
+        return None
+
+    prompt_ids: dict[str, str] = {}
+    for raw_key, raw_prompt_id in raw_prompts.items():
+        clean_key = _clean_text(raw_key)
+        key = clean_key.lower() if clean_key else None
+        prompt_id = _clean_text(raw_prompt_id)
+        if (
+            key not in _SUPPORTED_OUTCOME_KEYS
+            or prompt_id is None
+            or not prompt_id.startswith("#V#")
+        ):
+            continue
+        prompt_ids[key] = prompt_id
+    return prompt_ids or None
+
+
+def resolve_workflow_outcome_explanation_prompt_support(
+    workflow_id: str,
+) -> dict[str, Any] | None:
+    """Resolve represented prompt IDs and bounded bodies for one workflow."""
+
+    clean_workflow_id = _clean_text(workflow_id)
+    if clean_workflow_id is None:
+        return None
+    preferred = get_preferred_text_for_concept(
+        clean_workflow_id,
+        predicate_precedence=(
+            WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_PREDICATE_PRECEDENCE
+        ),
+        preferred_languages=("en-NZ", "en"),
+        limit=200,
+    )
+    if not isinstance(preferred, Mapping):
+        return None
+    prompt_ids = normalise_workflow_outcome_explanation_prompt_map(
+        preferred.get("text")
+    )
+    if prompt_ids is None:
+        return None
+
+    prompt_service = PromptTemplateService(default_max_chars=_MAX_PROMPT_CHARS)
+    resolved_prompts: dict[str, dict[str, str]] = {}
+    for outcome_key, prompt_id in prompt_ids.items():
+        resolved_prompt_id, prompt_text = prompt_service.resolve_prompt_text(
+            [prompt_id],
+            fallback=None,
+            max_chars=_MAX_PROMPT_CHARS,
+        )
+        clean_prompt_text = _clean_text(prompt_text)
+        if clean_prompt_text is None:
+            continue
+        resolved_prompts[outcome_key] = {
+            "prompt_concept_id": resolved_prompt_id or prompt_id,
+            "prompt_text": clean_prompt_text,
+        }
+    if not resolved_prompts:
+        return None
+
+    predicate = _clean_text(preferred.get("predicate"))
+    return {
+        "schema_version": WORKFLOW_OUTCOME_EXPLANATION_SUPPORT_SCHEMA_VERSION,
+        "workflow_id": clean_workflow_id,
+        "source": f"text_relation:{predicate}" if predicate else "text_relation",
+        "prompts": resolved_prompts,
+    }
+
+
+def select_workflow_outcome_explanation_prompt(
+    support: Mapping[str, Any] | None,
+    *,
+    outcome_key: str,
+) -> dict[str, Any] | None:
+    """Select exact-status guidance, falling back to the represented default."""
+
+    if not isinstance(support, Mapping):
+        return None
+    prompts = support.get("prompts")
+    if not isinstance(prompts, Mapping):
+        return None
+    raw_outcome_key = _clean_text(outcome_key)
+    clean_outcome_key = raw_outcome_key.lower() if raw_outcome_key else None
+    if clean_outcome_key in prompts:
+        selected_key = clean_outcome_key
+    elif clean_outcome_key in {"completed", "succeeded"}:
+        # A generic failure/partial-outcome prompt should not decorate an
+        # ordinary success. Workflows may opt in with an explicit success key.
+        return None
+    else:
+        selected_key = "default"
+    selected = prompts.get(selected_key)
+    if not isinstance(selected, Mapping):
+        return None
+    prompt_id = _clean_text(selected.get("prompt_concept_id"))
+    prompt_text = _clean_text(selected.get("prompt_text"))
+    if prompt_id is None or prompt_text is None:
+        return None
+    return {
+        "schema_version": WORKFLOW_OUTCOME_EXPLANATION_SUPPORT_SCHEMA_VERSION,
+        "workflow_id": _clean_text(support.get("workflow_id")),
+        "outcome_key": clean_outcome_key,
+        "matched_prompt_key": selected_key,
+        "prompt_concept_id": prompt_id,
+        "prompt_text": prompt_text,
+        "source": _clean_text(support.get("source")),
+        "role": "supplemental_explanation_guidance",
+        "evidence_boundary": (
+            "This represented prompt is guidance for explaining independently "
+            "observed execution evidence. It is not evidence that the workflow "
+            "ran, succeeded, failed, changed canonical state, or has authority."
+        ),
+    }
+
+
+__all__ = [
+    "WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_PREDICATE_PRECEDENCE",
+    "WORKFLOW_OUTCOME_EXPLANATION_PROMPT_MAP_SCHEMA_VERSION",
+    "WORKFLOW_OUTCOME_EXPLANATION_SUPPORT_SCHEMA_VERSION",
+    "normalise_workflow_outcome_explanation_prompt_map",
+    "resolve_workflow_outcome_explanation_prompt_support",
+    "select_workflow_outcome_explanation_prompt",
+]

--- a/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/paper_representation_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "paper_representation_workflow_seed_bundle",
   "managed_by": "paper_representation_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "35",
+  "seed_version": "36",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#arxiv_paper_representation_workflow": {
       "18": [
@@ -95,6 +95,11 @@
         {
           "predicate": "#V#hasWorkflowLifecycleJson",
           "text": "{\"phase\": \"published\", \"published\": true, \"schema_version\": \"workflow_publication_lifecycle.v1\"}",
+          "lang": "en-NZ"
+        },
+        {
+          "predicate": "#V#hasWorkflowOutcomeExplanationPromptMapJson",
+          "text": "{\"prompt_concept_ids\": {\"blocked\": \"#V#prompt_scholarly_article_outcome_explanation\", \"clarification_required\": \"#V#prompt_scholarly_article_outcome_explanation\", \"default\": \"#V#prompt_scholarly_article_outcome_explanation\", \"failed\": \"#V#prompt_scholarly_article_outcome_explanation\", \"follow_up_required\": \"#V#prompt_scholarly_article_outcome_explanation\", \"indeterminate\": \"#V#prompt_scholarly_article_outcome_explanation\", \"not_completed\": \"#V#prompt_scholarly_article_outcome_explanation\", \"not_started\": \"#V#prompt_scholarly_article_outcome_explanation\", \"partial\": \"#V#prompt_scholarly_article_outcome_explanation\"}, \"schema_version\": \"workflow_outcome_explanation_prompt_map.v1\"}",
           "lang": "en-NZ"
         },
         {

--- a/src/backend/workflows/repo_seed_bundles/prompt_scholarly_article_outcome_explanation_seed.md
+++ b/src/backend/workflows/repo_seed_bundles/prompt_scholarly_article_outcome_explanation_seed.md
@@ -1,0 +1,7 @@
+Explain this scholarly-article workflow outcome from the supplied execution evidence.
+
+State which article representation facts were canonically verified, including the article concept, source identity, metadata, author links, topic links, and read-back only when the evidence establishes each one. Name any requested facts that remain unverified.
+
+If the workflow was not invoked, say so and do not describe an internal stage as having stopped. If it was invoked, distinguish a durable pending instance, a terminal workflow failure, and a completed workflow whose semantic postconditions remain incomplete. Preserve the exact article, source, effect, and workflow-instance identifiers supplied by the evidence.
+
+Offer the smallest continuation that completes only the remaining postconditions. Reuse an existing verified article or person concept and never propose recreating a confirmed effect. Treat this prompt as explanation guidance only: it does not establish that the workflow ran, that any effect succeeded, or that the actor has authority.

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -883,6 +883,14 @@ def test_scope_message_contains_boundaries_and_preserves_request_scope() -> None
     assert "get_concept_elicitation_opportunities" in message
     assert "giving the user's own questions priority" in message
     assert "preserve the exact text with provenance" in message
+    assert "OUTCOME EXPLANATION SUPPORT" in message
+    assert "which mechanism was actually invoked" in message
+    assert "Discovery, selection, a workflow declaration" in message
+    assert "Never say a workflow stopped, failed, or reached a stage" in message
+    assert "not invoked; invoked and pending; invoked and failed" in message
+    assert "every attempted tool call succeeded" in message
+    assert "outcome_explanation_support" in message
+    assert "its prompt body is not evidence" in message
 
 
 def test_progressive_evidence_guidance_survives_post_read_continuation() -> None:
@@ -961,6 +969,10 @@ def test_scope_message_carries_brief_approval_and_exact_recovery_state() -> None
     assert "entity_representation_coverage=core_only" in message
     assert "not terminal success" in message
     assert "preserve its exact grounded candidate identifiers" in message
+    assert "actual workflow invocation status" in message
+    assert "verified completed sub-effects" in message
+    assert "remaining postconditions" in message
+    assert "typed recovery affordance" in message
     assert "unresolved create-versus-reuse status" in message
     assert "Do not leave the only stable identity solely" in message
     assert "including when you made a proposal intended for later approval" in message
@@ -10479,6 +10491,17 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
         relevance_score=0.94,
         semantic_effect=True,
         semantic_effect_source="represented_workflow_declaration",
+        outcome_explanation_prompt_support={
+            "schema_version": "workflow_outcome_explanation_support.v1",
+            "workflow_id": "#V#represented_test_workflow",
+            "source": "text_relation:#V#hasWorkflowOutcomeExplanationPromptMapJson",
+            "prompts": {
+                "succeeded": {
+                    "prompt_concept_id": "#V#prompt_test_success_explanation",
+                    "prompt_text": "Explain only the canonically verified result.",
+                }
+            },
+        },
         input_schema={
             "type": "object",
             "properties": {
@@ -10627,6 +10650,9 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
 
     catalogue_result = client.calls[1]["tool_results"][0].output
     assert catalogue_result["represented_workflow_total"] == 1
+    assert "Explain only the canonically verified result." not in json.dumps(
+        catalogue_result
+    )
     workflow_purpose = next(
         item
         for item in catalogue_result["purpose_index"]["entries"]
@@ -10700,6 +10726,22 @@ def test_represented_workflow_is_discovered_and_invoked_as_bound_capability(
             "value": "2026-08-05",
         },
     ]
+    invocation_model_result = client.calls[2]["tool_results"][0].output
+    assert invocation_model_result["outcome_explanation_support"] == {
+        "schema_version": "workflow_outcome_explanation_support.v1",
+        "workflow_id": "#V#represented_test_workflow",
+        "outcome_key": "succeeded",
+        "matched_prompt_key": "succeeded",
+        "prompt_concept_id": "#V#prompt_test_success_explanation",
+        "prompt_text": "Explain only the canonically verified result.",
+        "source": "text_relation:#V#hasWorkflowOutcomeExplanationPromptMapJson",
+        "role": "supplemental_explanation_guidance",
+        "evidence_boundary": (
+            "This represented prompt is guidance for explaining independently "
+            "observed execution evidence. It is not evidence that the workflow "
+            "ran, succeeded, failed, changed canonical state, or has authority."
+        ),
+    }
     selection_trace = next(
         item
         for item in result.aux_llm_calls

--- a/tests/backend/test_paper_representation_workflow_vontology_service.py
+++ b/tests/backend/test_paper_representation_workflow_vontology_service.py
@@ -500,6 +500,30 @@ def test_bootstrap_materialises_paper_representation_workflow_family(
         limit=2,
     )
     assert evidence_prompt_rows
+    outcome_prompt_rows = get_texts_for_concept(
+        "#V#prompt_scholarly_article_outcome_explanation",
+        predicate="hasContent",
+        limit=2,
+    )
+    assert outcome_prompt_rows
+
+    from src.backend.workflows.outcome_explanation_prompt_support import (
+        resolve_workflow_outcome_explanation_prompt_support,
+    )
+
+    outcome_prompt_support = resolve_workflow_outcome_explanation_prompt_support(
+        SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
+    )
+    assert outcome_prompt_support is not None
+    assert set(outcome_prompt_support["prompts"]) >= {
+        "default",
+        "failed",
+        "not_started",
+        "partial",
+    }
+    assert outcome_prompt_support["prompts"]["failed"]["prompt_concept_id"] == (
+        "#V#prompt_scholarly_article_outcome_explanation"
+    )
 
     metadata_definition = load_workflow_definition_from_vontology(
         SCHOLARLY_ARTICLE_METADATA_REPRESENTATION_WORKFLOW_ID
@@ -2375,7 +2399,7 @@ def test_bootstrap_seed_version_refresh_repairs_old_arxiv_launch_contract(
         for row in marker_rows
         if isinstance(row.get("text"), str)
     ]
-    assert any(payload.get("seed_version") == "35" for payload in marker_payloads)
+    assert any(payload.get("seed_version") == "36" for payload in marker_payloads)
 
     refreshed_definition = load_workflow_definition_from_vontology(
         ARXIV_PAPER_REPRESENTATION_WORKFLOW_ID

--- a/tests/backend/test_scholarly_metadata_representation_guidance.py
+++ b/tests/backend/test_scholarly_metadata_representation_guidance.py
@@ -21,6 +21,50 @@ def test_missing_tool_retry_prompt_preserves_represented_label_authority() -> No
     assert "get_text_relations_summary" in prompt_text
 
 
+def test_scholarly_outcome_explanation_guidance_preserves_execution_truth() -> None:
+    prompt_text = (
+        _SEED_DIR / "prompt_scholarly_article_outcome_explanation_seed.md"
+    ).read_text(encoding="utf-8")
+
+    lowered = prompt_text.lower()
+    assert "if the workflow was not invoked, say so" in lowered
+    assert "do not describe an internal stage as having stopped" in lowered
+    assert "smallest continuation" in lowered
+    assert "never propose recreating a confirmed effect" in lowered
+    assert "does not establish that the workflow ran" in lowered
+
+
+def test_scholarly_workflow_links_outcome_explanation_prompt_map() -> None:
+    bundle = json.loads(
+        (_SEED_DIR / "paper_representation_workflow_seed_bundle.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    workflow = next(
+        item
+        for item in bundle["workflows"]
+        if item.get("workflow_id")
+        == "#V#scholarly_article_metadata_representation_workflow"
+    )
+    prompt_map_text = next(
+        item["text"]
+        for item in workflow["text_relations"]
+        if item.get("predicate")
+        == "#V#hasWorkflowOutcomeExplanationPromptMapJson"
+    )
+    prompt_map = json.loads(prompt_map_text)
+
+    assert prompt_map["schema_version"] == (
+        "workflow_outcome_explanation_prompt_map.v1"
+    )
+    assert prompt_map["prompt_concept_ids"]["failed"] == (
+        "#V#prompt_scholarly_article_outcome_explanation"
+    )
+    assert prompt_map["prompt_concept_ids"]["default"] == (
+        "#V#prompt_scholarly_article_outcome_explanation"
+    )
+
+
 def test_tool_calling_workflow_has_generic_write_discovery_exemplars() -> None:
     bundle = json.loads(
         (_SEED_DIR / "canonical_workflow_publication_seed_bundle.json").read_text(

--- a/tests/backend/test_workflow_outcome_explanation_prompt_support.py
+++ b/tests/backend/test_workflow_outcome_explanation_prompt_support.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+
+def test_prompt_map_normalisation_rejects_unknown_and_non_concept_entries() -> None:
+    from src.backend.workflows.outcome_explanation_prompt_support import (
+        normalise_workflow_outcome_explanation_prompt_map,
+    )
+
+    result = normalise_workflow_outcome_explanation_prompt_map(
+        {
+            "schema_version": "workflow_outcome_explanation_prompt_map.v1",
+            "prompt_concept_ids": {
+                "failed": "#V#prompt_failed",
+                "partial": "not-a-concept-id",
+                "invented_status": "#V#prompt_invented",
+            },
+        }
+    )
+
+    assert result == {"failed": "#V#prompt_failed"}
+
+
+def test_prompt_selection_uses_exact_status_then_represented_default() -> None:
+    from src.backend.workflows.outcome_explanation_prompt_support import (
+        select_workflow_outcome_explanation_prompt,
+    )
+
+    support = {
+        "workflow_id": "#V#workflow",
+        "source": "text_relation:#V#hasWorkflowOutcomeExplanationPromptMapJson",
+        "prompts": {
+            "failed": {
+                "prompt_concept_id": "#V#prompt_failed",
+                "prompt_text": "Explain this failure.",
+            },
+            "default": {
+                "prompt_concept_id": "#V#prompt_default",
+                "prompt_text": "Explain this outcome.",
+            },
+        },
+    }
+
+    failed = select_workflow_outcome_explanation_prompt(
+        support,
+        outcome_key="failed",
+    )
+    partial = select_workflow_outcome_explanation_prompt(
+        support,
+        outcome_key="partial",
+    )
+    completed = select_workflow_outcome_explanation_prompt(
+        support,
+        outcome_key="completed",
+    )
+
+    assert failed is not None
+    assert failed["matched_prompt_key"] == "failed"
+    assert failed["prompt_concept_id"] == "#V#prompt_failed"
+    assert partial is not None
+    assert partial["matched_prompt_key"] == "default"
+    assert partial["prompt_concept_id"] == "#V#prompt_default"
+    assert completed is None

--- a/tests/backend/test_workflow_turn_capability_service.py
+++ b/tests/backend/test_workflow_turn_capability_service.py
@@ -97,6 +97,21 @@ def test_discovery_exposes_only_executable_routing_eligible_workflows(
             "text_relation:launch_contract",
         ),
     )
+    monkeypatch.setattr(
+        "src.backend.workflows.outcome_explanation_prompt_support."
+        "resolve_workflow_outcome_explanation_prompt_support",
+        lambda workflow_id: {
+            "schema_version": "workflow_outcome_explanation_support.v1",
+            "workflow_id": workflow_id,
+            "source": "text_relation:#V#hasWorkflowOutcomeExplanationPromptMapJson",
+            "prompts": {
+                "failed": {
+                    "prompt_concept_id": "#V#prompt_test_failure_explanation",
+                    "prompt_text": "Explain the verified partial outcome.",
+                }
+            },
+        },
+    )
 
     capabilities, diagnostic = discover_turn_workflow_capabilities(
         "produce the reusable work product",
@@ -137,6 +152,7 @@ def test_discovery_exposes_only_executable_routing_eligible_workflows(
         "find_relations_with_argument",
     ]
     assert catalogue_entry["plan_profile"]["cost_profile"]["declared_step_count"] == 3
+    assert catalogue_entry["outcome_explanation_prompt_keys"] == ["failed"]
     assert diagnostic["status"] == "completed"
     assert diagnostic["match_count"] == 1
     assert diagnostic["candidate_count"] == 3
@@ -558,3 +574,53 @@ def test_workflow_receipt_distinguishes_completion_partial_failure_and_no_start(
     assert durable_timeout["recovery_affordances"][0]["action_type"] == (
         "inspect_pending_workflow_instance"
     )
+
+
+def test_workflow_receipt_projects_represented_outcome_guidance_without_claiming_evidence():
+    from src.backend.services.workflow_turn_capability_service import (
+        WorkflowTurnCapability,
+        normalise_workflow_effect_receipt,
+    )
+
+    capability = WorkflowTurnCapability(
+        name="represented_workflow_test",
+        workflow_id="#V#test_workflow",
+        display_name="Test workflow",
+        description="Produce a represented work product.",
+        relevance_score=0.91,
+        input_schema={"type": "object", "properties": {}},
+        outcome_explanation_prompt_support={
+            "schema_version": "workflow_outcome_explanation_support.v1",
+            "workflow_id": "#V#test_workflow",
+            "source": "text_relation:#V#hasWorkflowOutcomeExplanationPromptMapJson",
+            "prompts": {
+                "failed": {
+                    "prompt_concept_id": "#V#prompt_test_failure_explanation",
+                    "prompt_text": "Name the verified work and unmet postconditions.",
+                },
+                "default": {
+                    "prompt_concept_id": "#V#prompt_test_default_explanation",
+                    "prompt_text": "Explain only what the evidence establishes.",
+                },
+            },
+        },
+    )
+
+    receipt = normalise_workflow_effect_receipt(
+        {
+            "success": True,
+            "instance_id": "instance-failed",
+            "created_new": True,
+            "final_status": "failed",
+        },
+        capability=capability,
+    )
+
+    support = receipt["outcome_explanation_support"]
+    assert support["outcome_key"] == "failed"
+    assert support["matched_prompt_key"] == "failed"
+    assert support["prompt_concept_id"] == "#V#prompt_test_failure_explanation"
+    assert "Name the verified work" in support["prompt_text"]
+    assert "not evidence that the workflow ran" in support["evidence_boundary"]
+    assert receipt["effect_status"] == "failed"
+    assert receipt["instance_id"] == "instance-failed"


### PR DESCRIPTION
Merge decision: ready — the containing turn model receives generic execution-grounded outcome guidance, and an invoked represented workflow may add bounded workflow-owned explanation guidance without changing the underlying telemetry or authority evidence.

## User outcome

When authorised work completes only part of the requested outcome, Von can explain what actually ran, what was verified, what remains, and the exact safe continuation. It no longer needs to infer that a declared workflow “stopped” when the evidence contains only direct tool calls or no workflow invocation.

## Material changes

- Extend ordinary-turn synthesis guidance to separate user-outcome completion from outer turn, attempted tool, effect receipt, and workflow terminal status.
- Require invocation or durable-instance evidence before describing workflow execution or stage progress.
- Preserve actual invocation status, verified sub-effects, remaining postconditions, and typed recovery affordances in cross-turn situation revisions.
- Add optional Vontology-owned `workflow_outcome_explanation_prompt_map.v1` resolution and status-specific prompt selection.
- Project the selected prompt only beside an actual workflow call result, explicitly marked as supplemental non-evidence/non-authority; discovery exposes keys but not prompt bodies.
- Add and canonically read back a scholarly-article example prompt through paper seed bundle version 36.
- Document the generic and represented prompt boundaries.

Jira: [JVNAUTOSCI-2697](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2697)

## Evidence

- `tests/backend/test_adaptive_turn_service.py`: 234 passed.
- `tests/backend/test_paper_representation_workflow_vontology_service.py`: 40 passed, 2 skipped; includes seed publication and canonical prompt read-back.
- Workflow prompt/receipt/guidance tests: 23 passed.
- Focused post-review tests: 6 passed.
- Python 3.11 minimum syntax check: 1,361 files passed.
- JSON parse, compile, focused Ruff/import-order checks, and `git diff --check`: passed.

This supports the affected ordinary-turn and represented-workflow explanation paths. It does not claim broader stochastic model perfection or production deployment.

## Ship boundary

- **Minimum ship criteria:** Generic synthesis distinguishes not-invoked, pending, failed, blocked, and unknown outcomes; workflow-specific guidance is additive, represented, result-adjacent, and non-authoritative; cross-turn recovery state is preserved; affected tests and required CI pass.
- **Stop-ship conditions:** Existing telemetry is removed or changed; workflow-specific prompt content reaches the model before a workflow call result; a prompt is treated as execution/effect/authority evidence; affected exact-path tests or required CI fail.
- **Non-blocking observations:** The six-minute paper integration file repeatedly republishes the eight-workflow seed family; separate Jira work is being created for that test-harness cost. Two existing environment-dependent tests remain skipped.
- **Non-goals:** No universal critic stage, paper-specific failure logic in the generic runtime, telemetry replacement, model-routing change, deployment, or live runtime activation.


[JVNAUTOSCI-2697]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ