### PR TITLE
Fix capsule copy on slim historical cards

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -15577,8 +15577,9 @@ def history_turn_failure_capsule():
         request.args.get("session_id") or session.get("session_id")
     )
     history_index = request.args.get("history_index", type=int)
-    if not request_id:
-        return jsonify({"error": "request_id required"}), 400
+    # An authenticated browser may have only the exact history location from a
+    # slim history projection. request_id remains an optional integrity
+    # discriminator, not an authority carrier; enforce it whenever supplied.
     if not session_id:
         return jsonify({"error": "session_id required"}), 400
     if history_index is None or history_index < 0:
@@ -15653,9 +15654,10 @@ def history_turn_failure_capsule():
     if not isinstance(compact_debug, Mapping):
         return jsonify({"error": "failure_capsule_not_available"}), 404
     stored_request_id = _progress_str(compact_debug.get("request_id"))
-    if stored_request_id and stored_request_id != request_id:
+    if request_id and stored_request_id and stored_request_id != request_id:
         return jsonify({"error": "request_id does not belong to history_index"}), 403
-    if stored_request_id != request_id:
+    resolved_request_id = request_id or stored_request_id
+    if not resolved_request_id or stored_request_id != resolved_request_id:
         return jsonify({"error": "failure_capsule_not_available"}), 404
 
     capsule = compact_debug.get("turn_failure_capsule")
@@ -15664,7 +15666,8 @@ def history_turn_failure_capsule():
         not isinstance(projected_capsule, Mapping)
         or projected_capsule.get("schema_version")
         != TURN_FAILURE_CAPSULE_SCHEMA_VERSION
-        or _progress_str(projected_capsule.get("request_id")) != request_id
+        or _progress_str(projected_capsule.get("request_id"))
+        != resolved_request_id
         or turn_failure_capsule_size_bytes(projected_capsule)
         > TURN_FAILURE_CAPSULE_MAX_BYTES
     ):

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -37718,7 +37718,7 @@ async function buildLlmDebugClipboardJsonForTurn(turnId) {
         && Number.isInteger(historyLocation.history_index)
         && historyLocation.history_index >= 0
     );
-    const fetchedCapsule = requestId && hasExactHistoryLocation
+    const fetchedCapsule = hasExactHistoryLocation
         ? await fetchTurnFailureCapsule({
             requestId,
             sessionId: historyLocation?.session_id || null,
@@ -38838,13 +38838,21 @@ async function fetchTurnFailureCapsule({
     historyIndex = null
 } = {}) {
     const cleanRequestId = typeof requestId === 'string' ? requestId.trim() : '';
-    if (!cleanRequestId) {
+    const cleanSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    const hasExactHistoryLocation = Boolean(
+        cleanSessionId
+        && Number.isInteger(historyIndex)
+        && historyIndex >= 0
+    );
+    if (!cleanRequestId && !hasExactHistoryLocation) {
         return null;
     }
 
     try {
-        const params = new URLSearchParams({ request_id: cleanRequestId });
-        const cleanSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+        const params = new URLSearchParams();
+        if (cleanRequestId) {
+            params.set('request_id', cleanRequestId);
+        }
         if (cleanSessionId) {
             params.set('session_id', cleanSessionId);
         }
@@ -38862,7 +38870,9 @@ async function fetchTurnFailureCapsule({
         if (!response.ok || !body || typeof body !== 'object') {
             return null;
         }
-        return projectTurnFailureCapsule(body, { expectedRequestId: cleanRequestId });
+        return projectTurnFailureCapsule(body, {
+            expectedRequestId: cleanRequestId || null
+        });
     } catch (error) {
         console.warn('[chatTab] Failed to fetch bounded turn failure capsule:', error);
         return null;

--- a/tests/backend/test_von_history_telemetry_locator_endpoint.py
+++ b/tests/backend/test_von_history_telemetry_locator_endpoint.py
@@ -600,7 +600,6 @@ def test_history_turn_failure_capsule_denies_cross_actor_conversation(
     response = app.test_client().get(
         "/von/history/turn_failure_capsule",
         query_string={
-            "request_id": "req-private",
             "session_id": "private-session",
             "history_index": 2,
         },
@@ -608,6 +607,60 @@ def test_history_turn_failure_capsule_denies_cross_actor_conversation(
 
     assert response.status_code == 403
     assert response.get_json() == {"error": "Not authorised for conversation"}
+
+
+def test_history_turn_failure_capsule_resolves_exact_location_without_request_id(
+    monkeypatch,
+):
+    import src.backend.server.routes.von_routes as von_routes
+
+    stored_request_id = "req-location-only"
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#owner",
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#owner@org"},
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_resolve_history_request_scope_hints",
+        lambda **_kwargs: ("#V#owner@org", "#V#org"),
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_resolve_shared_conversation_owner",
+        lambda **_kwargs: ("#V#owner", None),
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_derive_namespace_for_user_org",
+        lambda *_args, **_kwargs: "#V#owner@org",
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_debug_entry",
+        lambda **_kwargs: {
+            "request_id": stored_request_id,
+            "turn_failure_capsule": _stored_failure_capsule(stored_request_id),
+        },
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+    response = app.test_client().get(
+        "/von/history/turn_failure_capsule",
+        query_string={
+            "session_id": "owner-session",
+            "history_index": 1307,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == _stored_failure_capsule(stored_request_id)
 
 
 def test_history_turn_failure_capsule_denies_wrong_request_for_history_entry(
@@ -708,7 +761,6 @@ def test_history_turn_failure_capsule_legacy_absence_is_typed_404(monkeypatch):
     response = app.test_client().get(
         "/von/history/turn_failure_capsule",
         query_string={
-            "request_id": "legacy-request",
             "session_id": "legacy-session",
             "history_index": 1,
         },

--- a/tests/frontend/chatTabLlmDebugWorkflowExecution.test.js
+++ b/tests/frontend/chatTabLlmDebugWorkflowExecution.test.js
@@ -301,6 +301,45 @@ describe('LLM debug popup workflow execution hook', () => {
         expect(JSON.parse(firstText).mcp_access).toBeUndefined();
     });
 
+    test('location-only historical turn copies its bounded capsule without loading raw diagnostics', async () => {
+        const {
+            __testOnly_buildLlmDebugClipboardJsonForTurn,
+            setLlmDebugDataForTurn
+        } = require(chatTabModulePath);
+        const { fetchWithTimeout } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        fetchWithTimeout.mockResolvedValue({
+            ok: true,
+            json: async () => buildFailureCapsule({ request_id: 'req-location-only' })
+        });
+
+        setLlmDebugDataForTurn('history-location-only', {
+            history_location: {
+                session_id: 'session-location-only',
+                history_index: 1307
+            },
+            timestamp: '2026-08-27T19:01:51.876Z'
+        });
+
+        const jsonText = await __testOnly_buildLlmDebugClipboardJsonForTurn(
+            'history-location-only'
+        );
+
+        expect(JSON.parse(jsonText)).toEqual(expect.objectContaining({
+            schema_version: 'turn_failure_capsule.v1',
+            request_id: 'req-location-only'
+        }));
+        expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+        const [calledUrl] = fetchWithTimeout.mock.calls[0];
+        const parsedUrl = new URL(calledUrl, 'https://example.test');
+        expect(parsedUrl.pathname).toBe('/von/history/turn_failure_capsule');
+        expect(parsedUrl.searchParams.has('request_id')).toBe(false);
+        expect(parsedUrl.searchParams.get('session_id')).toBe('session-location-only');
+        expect(parsedUrl.searchParams.get('history_index')).toBe('1307');
+        expect(String(calledUrl)).not.toContain('/history/debug');
+        expect(String(calledUrl)).not.toContain('/telemetry_locator');
+        expect(String(calledUrl)).not.toContain('/turn_telemetry_access');
+    });
+
     test('capsule projection redacts credential-shaped text and enforces the pretty UTF-8 16 KiB ceiling', async () => {
         const {
             __testOnly_buildLlmDebugClipboardJsonForTurn,


### PR DESCRIPTION
Merge decision: ready — the location-only bounded capsule path and actor-isolation controls pass focused and neighbouring tests; merge after required CI.

## User outcome

Ordinary Copy on a slim historical conversation card retrieves that turn's bounded failure capsule without first loading full Thinking/debug details. This resolves [JVNAUTOSCI-2699](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2699).

## Material changes

- Allow the authenticated bounded-capsule endpoint to resolve the stored request ID from exact session and raw history index when the caller does not have it.
- Keep a supplied request ID as an enforced integrity discriminator.
- Let the Chat history Copy path fetch from exact history location alone.
- Add location-only success, cross-actor denial, legacy absence, and no-raw-diagnostics frontend coverage.

The actor-owned conversation scope, accepted-invite checks, namespace handling, capsule schema/size/redaction projection, and fail-closed mismatch behaviour remain unchanged.

## Evidence

- Reproduced on session `fdb4d06f-4ce0-4f57-94bd-faf3eb8b1686`, raw history index `1307`: ordinary Copy failed without issuing a capsule request; loading Thinking first made Copy succeed.
- Canonical history read confirmed a valid 1,308-byte `turn_failure_capsule.v1` already exists for request `44ed32ad-e901-4511-91a5-f2f78b8239b2`.
- `34 passed`: bounded capsule service, turn debug persistence, history debug, and telemetry/capsule endpoint tests.
- `81 passed`: all Chat-tab frontend suites.
- Ruff fatal/static checks, ESLint, compile check, and `git diff --check` pass.

## Ship boundary

- **Minimum ship criteria:** location-only historical Copy retrieves only the projected capsule; supplied mismatch and cross-actor access fail closed; missing legacy capsules stay unavailable; required CI passes.
- **Stop-ship conditions:** authority scope widens, raw debug is fetched for ordinary Copy, mismatching request IDs are accepted, or capsule schema/size/redaction checks regress.
- **Non-blocking observations:** exact authenticated post-activation replay remains the deployment read-back, not an additional code change.
- **Non-goals:** capsule schema redesign, broad diagnostic persistence, telemetry locator expansion, and Thinking-card hydration changes.


[JVNAUTOSCI-2699]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ