### PR TITLE
docs: describe Von's current architecture accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,361 +1,227 @@
-# Von - AI-Agent System for Academic Research
+# Von
 
-This is the repository for the open source collaborative development of **Von**, initiated by the Strong AI Lab (SAIL) in the Natural Artificial and Organisational Intelligence Institute at the University of Auckland.
+**A provenance-bearing research-team assistant and a platform for testing
+agentic architectures.**
 
-**Von** is an AI-agent system designed to help academic researchers manage knowledge, conduct research, and interact with AI systems in a structured, reliable, and academically rigorous manner. By combining ontology-based knowledge organisation, Von bridges the gap between implicit knowledge in Large Language Models (LLMs) and explicit, verifiable research structures.
+Von is an open-source project initiated by the Strong AI Lab at the University
+of Auckland. Its near-term job is practical: to become a reliably useful
+assistant for research teams, producing recurring scientific and administrative
+work products, taking bounded authorised actions, preserving continuity, and
+failing honestly when it cannot complete the job.
 
-## What is Von?
+Von is also an experimental platform. We are testing whether explicit knowledge,
+behavioural authority, workflows, memory, provenance, and evaluation make an
+agent more reliable, adaptable, and inspectable than a fair simpler system using
+the same models and tools. That is a hypothesis to measure, not an assumption
+that justifies complexity.
 
-Von (or vonNeumarkt) provides researchers with AI-enriched tools that enhance academic workflows through systematic knowledge management and confidence-aware AI assistance. At its core is **Vontology**—an ontology (a formal representation of knowledge that defines concepts, their properties, and relationships) that structures information hierarchically and tracks provenance, ensuring every piece of knowledge is verifiable and contextualised.
+The governing design rule is simple:
 
-**Why ontologies are the missing piece for AI agents:** Modern AI systems face a critical challenge—while LLMs excel at pattern recognition and flexible understanding, they suffer from hallucinations (generating plausible but false information) because they rely on statistical probabilities rather than verifiable facts. The future of reliable AI agents lies in **neuro-symbolic systems** that combine neural networks with symbolic reasoning.
+> Deliver the smallest dependable end-to-end capability that satisfies the
+> user job. Add representation, workflow, memory, telemetry, evaluation, or
+> formal machinery only when the capability or the evidence shows why it is
+> needed.
 
-**Von embodies this neuro-symbolic approach:** LLMs handle unstructured data and natural language understanding, while Vontology provides a factual, logical backbone—a semantic network of concepts and relationships dating back to Aristotelian knowledge organisation. This combination has been shown to reduce hallucinations to near-zero in certain applications by grounding AI responses in explicit, verifiable knowledge structures.
+## What Von is — and is not
 
-**In practice, this means:** Researchers can distinguish certain facts from uncertain AI suggestions, track how information relates across domains, build verifiable knowledge bases that grow more reliable over time, and maintain provenance for every piece of information. Whether you're conducting systematic literature reviews, mapping research networks, or managing complex entities (people, scholarly works, concepts, institutions), Von provides the structured foundation and AI assistance to work more effectively—without the usual risks of AI-generated misinformation.
+Von is not merely an ontology browser, and it is not an LLM hidden behind an
+ever-growing collection of Python rules. It combines several kinds of machinery,
+choosing the smallest adequate path for each capability:
 
+| Need | Usual surface in Von |
+| --- | --- |
+| Interpretation, synthesis, planning, and recovery under ambiguity | Model judgement |
+| Exact algorithms, validation, execution, persistence, and integrations | Code and bounded tools |
+| Durable concepts, relations, prompts, policies, and provenance-bearing knowledge | Vontology and related knowledge stores |
+| Reusable, inspectable, recoverable multi-step behaviour | Von Workflow Language (VWL) |
+| Evolving objectives, referents, assumptions, observations, and outcome criteria | The conversation's shared situation |
+| Raw documents, blobs, traces, events, caches, and transactional data | Fit-for-purpose stores linked by provenance where needed |
+| Claims about success | Proportionate tests, telemetry, effect receipts, and canonical read-back |
 
-## ✨ Key Features
+Vontology is therefore first-class, but not all-consuming. It gives represented
+knowledge and behaviour stable identities, explicit relationships, provenance,
+and revision paths. It does not make every task ontological, and it does not make
+an assertion true merely because the assertion has been represented.
 
-- 🧠 **Vontology Knowledge Organisation** - Hierarchical ontology system for structuring research concepts, entities, and relationships with provenance tracking
-- 📚 **Entity Management System** - Comprehensive tracking of researchers, scholarly works, institutions, and concepts with relationship mapping
-- 📝 **Text Annotation & Extraction** - Systematic annotation of research materials with salient predicate detection via LLM
-- 🔬 **Scholarly Article Integration** - MCP integration (e.g., arXiv MCP server) for searching, importing, and organising academic papers
-- 📊 **Research Workflow Automation** - Template-driven processes for knowledge acquisition, citation management, and systematic reviews
-- 🎯 **Confidence-Aware AI** - All AI-generated content includes confidence levels and uncertainty quantification
+## The reliability claim
 
-## 🚀 How to Start
+An ontology is not a truth machine. It can contain incomplete, stale,
+context-dependent, or false claims. A language model can ignore or misuse good
+evidence. A tool can report success before the intended state exists. A workflow
+can faithfully execute the wrong plan.
 
-### 1. **Prerequisites:**
-- Python 3.10 or higher
-- Node.js 16+ (for frontend)
-- PowerShell 7.x (for Windows)
+Accordingly, Von makes no general claim that combining language models with an
+ontology or another represented layer eliminates errors, or that all
+Von output is verified or calibrated.
 
-Von currently declares a Python 3.11 minimum in `pyproject.toml`. Newer
-interpreters are fine, but before committing Python changes run:
+What this architecture can provide is a better basis for inspection and
+evaluation: identifiable sources, explicit uncertainty where it is available,
+typed knowledge, bounded authority, observable actions, durable receipts,
+recovery paths, and read-back from the system that owns the final state.
+
+A defensible reliability claim must name its scope. For a specified task set,
+release, model and tool profile, we should compare Von with the best fair simpler
+baseline and report the evidence that matters: useful task completion, grounded
+provenance, final world state, unnecessary human intervention, recovery from
+mistakes, latency, and cost. Until such a comparison supports a bounded claim,
+the architectural advantage remains a research question.
+
+## What is in the repository now
+
+The current repository already contains much of the substrate for that
+architecture:
+
+- a browser application centred on persistent, multi-turn conversations, with
+  inspectable shared situations, uploads, tasks, tool progress, and workflow
+  state;
+- model support for local Ollama and configured OpenAI, Gemini, and opt-in
+  OpenRouter providers;
+- an internal Model Context Protocol (MCP) gateway and capability catalogue spanning represented
+  knowledge, retrieval, scholarly sources, web search, tasks, workflows, and
+  configured external services;
+- Vontology concept, relation, text, search, provenance, import, and export
+  surfaces;
+- graph-native VWL definitions compiled into executable workflows, including
+  durable instances, schedules, event bindings, checkpoints, and recovery;
+- a Workflow Studio and feature-gated expert interfaces for Vontology,
+  annotation, import/export, and diagnostics;
+- MongoDB-backed persistence, document/RAG and concept indexing, conversation
+  continuity, traces, telemetry, and replay/evaluation support; and
+- actor- and organisation-scoped authority mechanisms for private data,
+  provider eligibility, and bounded effects.
+
+This list describes implemented substrate, not universal availability or a
+certification claim. A connector may need credentials; a model may need explicit
+actor-scoped eligibility; a workflow may need a published live Vontology
+definition; and a feature may be disabled in a particular deployment. Presence
+in the repository is not proof that every path is ready in every environment.
+
+Von remains research software under active development. Do not treat it as a
+hardened multi-tenant service for adversarial deployment. The current security
+profiles and known limitations are documented in
+[`docs/engineering/security_considerations.md`](docs/engineering/security_considerations.md).
+
+## Repository map
+
+| Path | Role |
+| --- | --- |
+| [`src/backend/server`](src/backend/server) | Flask application, routes, health, and runtime assembly |
+| [`src/backend/services`](src/backend/services) | Domain services and reusable capability support |
+| [`src/backend/integrations/internal_mcp`](src/backend/integrations/internal_mcp) | Internal tool gateway, catalogue, and integration adapters |
+| [`src/backend/workflows`](src/backend/workflows) | VWL loading, execution, durability, telemetry, and authoring support |
+| [`src/frontend/web/von_interface`](src/frontend/web/von_interface) | Browser interface |
+| [`tests`](tests) | Backend, frontend, launcher, replay, and integration tests |
+| [`docs`](docs) | Current guidance, dated evidence, designs, and operational notes |
+
+For claims about present behaviour, live user-visible results and world-state
+read-back outrank prose. Current code and targeted tests outrank dated status
+documents. [`docs/design_index.md`](docs/design_index.md) explains how the
+documentation is classified and which sources govern which questions.
+
+## Quick start
+
+### Requirements
+
+- Git
+- Python 3.11 or newer
+- Node.js and npm; the current locked frontend dependencies require Node
+  20.19+, 22.13+, or 24+
+- MongoDB, either local or Atlas
+- Bash on macOS/Linux, or PowerShell on Windows
+- a usable language-model route, such as local Ollama or an enabled hosted
+  provider
+
+### macOS or Linux
 
 ```bash
-python scripts/check_python_min_syntax.py
-```
-
-This catches syntax that a newer local Python accepts but the minimum supported
-runtime would reject.
-
-### 2. **Installation:**
-
-```powershell
-# Clone the repository
 git clone https://github.com/Strong-AI-Lab/Von.git
 cd Von
-
-# Run automated setup in Windows PowerShell
-# This runs setup_py.ps1 (pdm dependencies, python packages, etc.) and setup_js.ps1 (Javascript dependencies)
-./setup_all.ps1
-
-# Configure VSCode settings
-./setup_all.ps1 -ConfigureVSCode
-
-# Configure VSCode settings and specific Python version (e.g., 3.12)
-./setup_all.ps1 -ConfigureVSCode -PythonVersion 3.12
-
-```
-
-**VSCode workspace policy:** Committed workspace settings in `.vscode/` are intentionally limited to portable testing defaults (pytest/jest and safe test DB settings). Keep personal editor preferences (for example command auto-approve lists, local Jira views, and machine-specific paths) in your **user** VSCode settings, not workspace settings.
-
-If directly running `./setup_all.ps1` does not work, then run each setup script separately:
-
-```powershell
-# Run setup_py.ps1
-# Runs setup_py.ps1, which automatically finds and uses the newest compatible Python 3.10–3.15 version available in your PATH
-./setup_py.ps1 -ConfigureVSCode
-
-# How to specify a specific Python version (e.g., 3.12)
-./setup_py.ps1 -ConfigureVSCode -PythonVersion 3.12
-
-# Then,
-./setup_js.ps1
-```
-
-**For Linux/macOS users:**
-```bash
-# Run the bash setup script
+cp .env.template .env
 ./setup_all.sh
 ```
 
-**Note**: The bash scripts (`setup_all.sh`, `run.sh`) provide basic functionality but lack some advanced features available in the PowerShell versions. See [docs/script_comparison_report.md](docs/script_comparison_report.md) for details.
-
-### 3. **Database Setup**
-
-Von uses MongoDB to store your knowledge base (concepts, entities, relationships).
-
-**MongoDB Installation:**
-MongoDB will be automatically installed during the setup process (via `setup_py.ps1`). If automatic installation fails or you prefer manual installation, download MongoDB Community Edition from https://www.mongodb.com/try/download/community
-
-**Configuration:**
-
-1. **Copy the template:** `cp .env.template .env` (or `.env.template` to `.env`)
-
-2. **Choose your database option** by editing `.env`:
-
-   - **Local MongoDB** (Default):
-     ```bash
-     MONGO_URI=mongodb://localhost:27017/
-     VON_DB_NAME=von_db
-     ```
-     Make sure that MongoDB is running on your local machine.
-
-   - **MongoDB Atlas** (Cloud - Optional for team collaboration):
-     ```bash
-     MONGO_URI=mongodb+srv://YOUR_USERNAME:YOUR_PASSWORD@YOUR_CLUSTER.mongodb.net/
-     VON_DB_NAME=von_db
-     MONGO_PROJECT=Your Project Name
-     ```
-
-     Keep the default `MONGO_ALLOW_LOCAL_FALLBACK=0` so Atlas failures do not
-     silently fall back to an old localhost database. After installing a
-     separately supervised SSH tunnel, expose its loopback listeners through
-     `MONGO_SSH_TUNNEL_FALLBACK_ENDPOINTS`; Von derives its Mongo credentials in
-     memory, discovers the writable forwarded replica member, and probes the
-     direct primary again on later database use after a bounded recovery
-     window. Once connectivity is stable, prefer `VON_MONGO_STRICT_STARTUP=1`
-     and `VON_MONGO_STARTUP_PROBE=1`.
-
-     On macOS, the persistent per-user launchd tunnel and its install, status,
-     and uninstall commands are documented in
-     [`docs/engineering/environment_minimums.md`](docs/engineering/environment_minimums.md#macos-supervised-atlas-ssh-fallback).
-
-Von decides local versus remote MongoDB from the effective `MONGO_URI` host and
-logs either `[Von Database] Connecting to LOCAL MongoDB ...` or
-`[Von Database] Connecting to REMOTE MongoDB ...` in `./logs`.
-
-**Starting with Knowledge:**
-
-By default, you start with an empty knowledge base. You can:
-- Create concepts manually through the Von interface
-- Load sample ontology
-- Build your custom ontology from scratch and import it
-
-You have two options for initializing your knowledge base (note: SAIL members with access to remote SAIL database do not need to do this):
-
-**Option 1: Manual Creation** (Empty Start)
-- Start Von and create concepts through the user interface
-- Build your ontology from scratch with full control
-- Ideal for: Custom domains, specific research needs
-
-**Option 2: Load Sample Base Knowledge** (Quick Start)
-A sample base ontological knowledge with a few concepts and their definition is provided in `./sample_knowledge` folder.
-
-To load the sample knowledge base:
+### Windows PowerShell
 
 ```powershell
-# Ensure you're in the Von root directory
-# 1. Activate Python environment (if not already active)
-.\.venv\Scripts\Activate.ps1   # Windows PowerShell
-# or: source .venv/bin/activate  # Mac/Linux
-
-# 2. Make sure that your local database does not already have corrupted 'von_db' (drop 'von_db' if it exists)
-
-# 3. Run the initialization script
-python src/utilities/init_database.py --full-setup
+git clone https://github.com/Strong-AI-Lab/Von.git
+Set-Location Von
+Copy-Item .env.template .env
+.\setup_all.ps1
 ```
 
-**What this does:**
-- Creates database collections and indexes
-- Loads sample interconnected AI concepts with relationships
-- Sets up proper ontology hierarchy
-- Provides working examples for exploration
+### Configure data and models
 
-**After loading**, start Von normally:
-```powershell
-./run.ps1
+The copied `.env` starts with a local MongoDB configuration:
+
+```dotenv
+MONGO_URI=mongodb://localhost:27017/
+VON_DB_NAME=von_db
 ```
 
-Visit `http://localhost:5000` and explore the pre-loaded concepts in the interface. You can extend this base ontology by adding your own concepts and relationships.
+Run MongoDB locally, or replace `MONGO_URI` with an Atlas connection string.
+Remote database failures do not silently fall back to a possibly stale local
+database unless that fallback is explicitly enabled.
 
-### 4. **LLM Provider Setup**
+For local models, install and run Ollama and configure `OLLAMA_HOSTS_LIST`. For
+hosted providers, set the applicable credential, such as `OPENAI_API_KEY` or
+`GEMINI_API_KEY`, then select an eligible provider and model in Von's settings.
+Never commit `.env`.
 
-**Ollama (Local Models):**
-1. Install Ollama: https://ollama.ai
-2. Pull models: `ollama pull llama3.2` (or your preferred model) or install directly from ollama UI.
-3. Ensure Ollama is running: `ollama serve`
-4. Von will auto-detect available models (if not, select the installed local model in Von's Settings panel)
+### Run Von
 
-**OpenAI:**
-1. Get your own API key from https://platform.openai.com/api-keys
-2. Set `OPENAI_API_KEY` in `.env`
-3. Select OpenAI model in Von's Settings panel
+Before starting Von, make sure the configured MongoDB service and the selected
+local model service, if any, are running.
 
-**Google Gemini:**
-1. Get your own API key from https://ai.google.dev
-2. Set `GEMINI_API_KEY` in `.env` (or `GEMINI_API_KEY_FILE` on a managed host)
-3. Select `gemini-3.7-flash` as the premium Gemini model in Von's Settings panel
+On macOS or Linux:
 
-Von still accepts the legacy `GOOGLE_API_KEY` name for compatibility, but new
-setups should use `GEMINI_API_KEY`. Gemini 3.7 uses a stateless Interactions API
-profile in Von; provider response storage is disabled.
-
-### 5. **UI Feature Flags**
-
-- `VON_EXPERT_TABS_ENABLED=1` enables the expert tabs (Vontology, Import/Export, Annotation) and annotation controls. Default behaviour is disabled unless set.
-- `VON_EXPERT_FOOTER_ENABLED=1` enables the PID/RAG status footer and modal. Default behaviour is disabled unless set.
-
-### 6. **Run:**
-
-**Windows (PowerShell):**
-```powershell
-# Start the server locally
-./run.ps1
-
-# Open browser to http://localhost:5000
-```
-
-**Linux/macOS (Bash):**
 ```bash
-# Start the server locally
 ./run.sh start
-
-# Open browser to http://localhost:5000
+./run.sh status
 ```
 
-### 6A. **Environment Profiles**
-
-**Explicit local minimum:**
+On Windows PowerShell:
 
 ```powershell
-$env:MONGO_URI = 'mongodb://localhost:27017/'
-$env:VON_DB_NAME = 'von_db'
+.\run.ps1 start
+.\run.ps1 status
 ```
 
-**Backend test shell:**
+The launcher reports the effective browser address. Its default is
+`http://localhost:5001` on macOS and `http://localhost:5000` elsewhere. Stop Von
+with `./run.sh stop` or `.\run.ps1 stop`, as appropriate.
 
-```powershell
-$env:VON_DB_NAME = 'test_von_db'
-```
+For the complete environment matrix, hosted deployment settings, feature flags,
+and database recovery options, see
+[`docs/engineering/environment_minimums.md`](docs/engineering/environment_minimums.md).
 
-Use `VON_USE_MOCK_DB=1` only for mock/in-memory test flows. Do not start the
-real server with `VON_DB_NAME=test_von_db`; `run.ps1` blocks that path.
+## Engineering and research documentation
 
-**Minimum sane cloud runtime:**
+- [`AGENTS.md`](AGENTS.md) contains the repository's governing product,
+  architecture, authority, and evidence invariants.
+- [`docs/design_index.md`](docs/design_index.md) routes current manuals, dated
+  implementation records, proposals, and historical material.
+- [The VWL manual](docs/engineering/von_workflow_language_manual.md) defines the
+  represented workflow language and its runtime interfaces.
+- [Agent evaluation and research uptake](docs/engineering/agent_evaluation_and_research_uptake.md)
+  defines the evidence expected for behavioural and architectural claims.
+- [The operational engineering guide](docs/engineering/operational_engineering_guide.md)
+  covers day-to-day development and validation.
 
-```powershell
-$env:MONGO_URI = '<YOUR-ATLAS-URI>'
-$env:VON_DB_NAME = 'von_db'
-$env:MONGO_ALLOW_LOCAL_FALLBACK = '0'
-$env:VON_SKIP_BROWSER_LAUNCH = '1'
-$env:FLASK_SECRET_KEY = '<32+ chars>'
-```
+## Contributing
 
-If cloud browser testing needs Google login, add:
+Contributions are welcome. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) and
+the governing [`AGENTS.md`](AGENTS.md) before changing behaviour. In particular:
 
-```powershell
-$env:GOOGLE_OAUTH_CLIENT_ID = '<YOUR-CLIENT-ID>'
-$env:GOOGLE_OAUTH_CLIENT_SECRET = '<YOUR-CLIENT-SECRET>'
-$env:GOOGLE_OAUTH_REDIRECT_URI = 'https://<your-domain>/von/api/auth/google/callback'
-$env:GOOGLE_OAUTH_STRICT_STARTUP = '1'
-```
+- begin with the user job and the simplest adequate path;
+- preserve provenance and distinguish represented evidence from truth;
+- do not hide durable task-specific semantic policy in incidental code;
+- validate the affected real path at a level proportionate to the claim; and
+- preserve unrelated work and never commit secrets or runtime data.
 
-For the full minimum-env matrix, cloud-development path, and browser-testing
-notes, see [docs/engineering/environment_minimums.md](docs/engineering/environment_minimums.md).
+## Licence and acknowledgements
 
-### 7. **Stop:**
+See [`LICENSE`](LICENSE) for the repository's licence terms.
 
-**Windows (PowerShell):**
-```powershell
-# Stop the local server
-./run.ps1 stop
-```
-
-**Linux/macOS (Bash):**
-```bash
-# Stop the local server
-./run.sh stop
-```
-
-### 8. **Basic Usage:**
--  Browse the Vontology tree to explore knowledge structure
--  Create your first concepts and entities, and make relations between them to construct your own ontological knowledge
--  Configure your preferred LLM provider in Settings (Ollama local models by default)
--  Start a chat conversation with Von's AI assistant
-
-See **[User Guide](USER_GUIDE.md)** for comprehensive guide to Von's features and workflows *(coming soon)*
-
-## 🎯 Quick Usage Examples
-
-### **Ex 1. Systematic Literature Review**
-Von helps researchers conduct comprehensive literature reviews by:
-- Importing papers from arXiv and other sources
-- Organising literature by concepts and relationships
-- Tracking citations and research connections
-- Using AI to identify research gaps and trends
-- Generating confidence-assessed summaries
-
-**Example Workflow:**
-1. Define research concepts in Vontology (e.g., "Causal Reasoning", "Neural Networks")
-2. Import relevant papers via arXiv integration
-3. Annotate papers with salient predicates
-4. Chat with Von to synthesise findings across papers
-5. Export structured bibliography with relationships
-
-### **Ex 2. Research Network Mapping**
-Build comprehensive maps of academic relationships:
-- Track researchers, institutions, and collaborations
-- Map expertise areas and research domains
-- Identify potential collaborators and research trends
-- Understand institutional relationships
-
-**Example Workflow:**
-1. Create Person entities for key researchers
-2. Link researchers to their scholarly works
-3. Use Vontology to classify expertise areas
-4. Visualise collaboration networks
-5. Query Von for collaboration opportunities
-
-### **Ex 3. Knowledge Base Construction**
-Create structured, verifiable knowledge repositories:
-- Build domain-specific ontologies extending Vontology
-- Capture expert knowledge through AI-assisted interviews
-- Track knowledge provenance and confidence
-- Enable team-based knowledge curation
-- Export knowledge in standard formats
-
-**Example Workflow:**
-1. Define domain concepts in Vontology hierarchy
-2. Use knowledge acquisition workflows to gather information
-3. Link entities to concepts with predicates
-4. Validate knowledge with confidence assessment
-5. Share knowledge base with research team
-
-## 🤝 Contributing
-
-We welcome contributions from the community! Von is designed to evolve with academic research needs.
-
-**How to Contribute:**
-1. Read our [Contributing Guidelines](CONTRIBUTING.md)
-2. Browse [open issues](https://github.com/Strong-AI-Lab/Von/issues) or propose new features
-3. Submit pull requests with tests and documentation
-
-**Areas for Contribution (ex):**
-- External MCP server integrations
-- Automatic information extraction for entity creation
-- Domain-specific Vontology extensions
-- Research workflow templates
-- Documentation improvements
-- Frontend improvements
-
-## 📄 Licence
-
-Von is licensed under the **Apache Licence 2.0**. See [LICENSE](LICENSE) for details.
-
-This means you can:
-- ✅ Use Von commercially
-- ✅ Modify and distribute
-- ✅ Use Von in proprietary software
-
-With the requirement to:
-- 📝 Include copyright notice
-- 📝 State significant changes
-- 📝 Include Apache 2.0 licence text
-
-## 🙏 Acknowledgements
-
-Von is developed by the **Strong AI Lab** at the University of Auckland, with contributions from researchers and developers committed to advancing AI-assisted academic research.
+Von was initiated by the Strong AI Lab at the University of Auckland and is
+developed with contributions from researchers and engineers working on useful,
+inspectable, and increasingly dependable AI assistance.


### PR DESCRIPTION
Merge decision: ready — the public README now describes Von's current architecture and research claim accurately, without unsupported hallucination or universal-verification claims.

## User outcome

Readers get an evidence-disciplined account of what Von is, which architectural surfaces it uses, what is implemented now, and how to start it without following stale prerequisites or broken links.

## Material changes

- Reframe Von as a provenance-bearing research-team assistant and platform for testing agentic architectures.
- Explain that Vontology is first-class but not all-consuming, alongside model judgement, bounded tools, VWL, conversation situations, fit-for-purpose stores, telemetry, receipts, and read-back.
- Replace the unsupported hallucination-reduction claim with an evaluable comparison against a fair simpler baseline.
- Distinguish implemented substrate from configured availability and production readiness.
- Correct Python, Node, MongoDB, launcher-port, and cross-platform setup guidance.
- Remove speculative feature examples, promotional absolutes, stale user-guide claims, and a broken documentation link.

## Evidence

- Read the governing `AGENTS.md`, `docs/design_index.md`, and the relevant current architecture, evaluation, workflow, security, and environment guidance.
- Cross-checked current provider, conversation-situation, Vontology, VWL, MCP, persistence, telemetry, and frontend surfaces in code.
- Verified Python and Node requirements against `pyproject.toml` and `package-lock.json`.
- Verified launcher actions and default ports against `run.sh` and `run.ps1`.
- `git diff --check` passed.
- Every local Markdown link target in the rewritten README exists.
- Independent read-only reviews found no remaining material factual overclaim or onboarding blocker after corrections.

No runtime test was run because this changes public Markdown only and makes no runtime-behaviour claim.

## Ship boundary

- **Minimum ship criteria:** Unsupported public claims are absent; current purpose and architecture are accurately bounded; quick-start facts match the repository; local links resolve; the diff is README-only.
- **Stop-ship conditions:** A remaining unsupported reliability claim, a materially false current-capability statement, a broken local link, or setup instructions that contradict current configuration or launchers.
- **Non-blocking observations:** Other older documentation and package metadata contain pre-existing drift; this README does not treat them as current authority.
- **Non-goals:** Runtime changes, model or connector activation, deployment, a broader documentation rewrite, or package-metadata reconciliation.
