### PR TITLE
Make Tesseract OCR setup explicit and verifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ documentation is classified and which sources govern which questions.
 - Bash on macOS/Linux, or PowerShell on Windows
 - a usable language-model route, such as local Ollama or an enabled hosted
   provider
+- Tesseract is optional for core Von, but required for image and scanned-PDF
+  OCR. The setup scripts detect and validate it without installing system
+  software unless you explicitly request that effect.
 
 ### macOS or Linux
 
@@ -140,6 +143,21 @@ cp .env.template .env
 ./setup_all.sh
 ```
 
+If setup reports `OCR STATUS: UNAVAILABLE`, run exactly this command from the
+repository as your ordinary user (do not prefix the whole command with
+`sudo`):
+
+```bash
+./setup_all.sh --install-system-deps
+```
+
+On apt-based Linux, the installer uses passwordless `sudo` only for the
+`apt-get` package operations when available; otherwise it installs the same
+distro packages under the current user's local prefix. On macOS it uses
+Homebrew. `--with-ocr` is also available when you want OCR to be mandatory but
+do not authorise package installation; `--install-system-deps` implies that
+strict check.
+
 ### Windows PowerShell
 
 ```powershell
@@ -148,6 +166,15 @@ Set-Location Von
 Copy-Item .env.template .env
 .\setup_all.ps1
 ```
+
+If setup reports `OCR STATUS: UNAVAILABLE`, run exactly:
+
+```powershell
+.\setup_all.ps1 -InstallSystemDeps
+```
+
+`-InstallSystemDeps` is the only setup option that authorises the Windows
+installer to invoke `winget`; it also makes working OCR mandatory.
 
 ### Configure data and models
 

--- a/run.sh
+++ b/run.sh
@@ -526,6 +526,12 @@ else
 fi
 
 export PYTHONPATH="${ROOT}"
+if [ -x "${HOME}/.local/bin/tesseract" ]; then
+    # setup_all.sh may install the distro Tesseract packages in the ordinary
+    # user's local prefix when sudo is unavailable. Keep that PATH correction
+    # scoped to Von's launcher process rather than changing global shell files.
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
 export PYTHONUNBUFFERED=1
 export PYTHONFAULTHANDLER="${PYTHONFAULTHANDLER:-1}"
 export PYTHONUTF8=1

--- a/scripts/verify_tesseract_ocr.py
+++ b/scripts/verify_tesseract_ocr.py
@@ -1,0 +1,239 @@
+"""Verify that Von's Tesseract-backed English OCR capability really works.
+
+This script deliberately performs more than an executable-presence check.  It
+checks the engine version, requires the exact ``eng`` trained-data language,
+and sends a generated image through Pillow and pytesseract to Tesseract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+SMOKE_TEXT = "VON OCR 42"
+_TESSERACT_VERSION_RE = re.compile(r"^tesseract\s+v?(\S+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    available: bool
+    reason: str
+    detail: str
+    version: str = ""
+
+    def machine_line(self) -> str:
+        if self.available:
+            return (
+                "VON_SETUP_CAPABILITY name=ocr state=available "
+                f"engine=tesseract version={self.version} language=eng smoke=passed"
+            )
+        return (
+            "VON_SETUP_CAPABILITY name=ocr state=unavailable "
+            f"reason={self.reason}"
+        )
+
+    def human_line(self) -> str:
+        if self.available:
+            return (
+                f"Tesseract OCR check passed: version {self.version}; exact 'eng' "
+                f"language data found; smoke recognised '{SMOKE_TEXT}'."
+            )
+        return f"Tesseract OCR check failed ({self.reason}): {self.detail}"
+
+
+def _failure(reason: str, detail: str) -> VerificationResult:
+    return VerificationResult(
+        available=False,
+        reason=reason,
+        detail=_one_line(detail),
+    )
+
+
+def _one_line(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _command_failure_detail(completed: subprocess.CompletedProcess[str]) -> str:
+    output = _one_line(completed.stderr or completed.stdout or "")
+    if output:
+        return f"command exited {completed.returncode}: {output}"
+    return f"command exited {completed.returncode} without diagnostic output"
+
+
+def _run_tesseract(
+    executable: str,
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [executable, *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _parse_version(output: str) -> str | None:
+    first_line = next((line.strip() for line in output.splitlines() if line.strip()), "")
+    match = _TESSERACT_VERSION_RE.match(first_line)
+    return match.group(1) if match is not None else None
+
+
+def _parse_languages(output: str) -> set[str]:
+    return {
+        line.strip()
+        for line in output.splitlines()
+        if line.strip() and not line.lstrip().lower().startswith("list of available languages")
+    }
+
+
+def _render_smoke_image():
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(f"Python dependency is unavailable: {exc.name}") from exc
+
+    font = ImageFont.load_default()
+    probe = Image.new("L", (1, 1), color=255)
+    bounds = ImageDraw.Draw(probe).textbbox((0, 0), SMOKE_TEXT, font=font)
+    margin = 5
+    width = bounds[2] - bounds[0] + (2 * margin)
+    height = bounds[3] - bounds[1] + (2 * margin)
+    image = Image.new("L", (width, height), color=255)
+    ImageDraw.Draw(image).text(
+        (margin - bounds[0], margin - bounds[1]),
+        SMOKE_TEXT,
+        fill=0,
+        font=font,
+    )
+
+    # Pillow 8 exposes LANCZOS directly on Image; newer versions also expose
+    # it under Image.Resampling.  Enlarge the embedded default font so this
+    # check does not depend on platform font packages.
+    resampling = getattr(Image, "Resampling", Image)
+    return image.resize((width * 5, height * 5), resample=resampling.LANCZOS)
+
+
+def _run_ocr_smoke(executable: str) -> tuple[bool, str, str]:
+    try:
+        import pytesseract
+    except ModuleNotFoundError as exc:
+        return (
+            False,
+            "python_dependency_missing",
+            f"Python dependency is unavailable: {exc.name}",
+        )
+
+    try:
+        image = _render_smoke_image()
+    except RuntimeError as exc:
+        return False, "python_dependency_missing", str(exc)
+
+    try:
+        pytesseract.pytesseract.tesseract_cmd = executable
+        recognised = pytesseract.image_to_string(
+            image,
+            lang="eng",
+            config="--psm 7",
+        )
+    except (OSError, RuntimeError) as exc:
+        return (
+            False,
+            "smoke_execution_failed",
+            f"pytesseract smoke raised {type(exc).__name__}: {exc}",
+        )
+
+    normalised = " ".join(re.findall(r"[A-Z0-9]+", recognised.upper()))
+    if normalised != SMOKE_TEXT:
+        actual = normalised or "<empty>"
+        return (
+            False,
+            "smoke_text_mismatch",
+            f"expected '{SMOKE_TEXT}' but Tesseract recognised '{actual}'",
+        )
+    return True, "", ""
+
+
+def verify_tesseract(command: str = "tesseract") -> VerificationResult:
+    executable = shutil.which(command)
+    if executable is None:
+        return _failure(
+            "executable_not_found",
+            f"executable '{command}' was not found on PATH",
+        )
+
+    try:
+        version_check = _run_tesseract(executable, "--version")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _failure(
+            "version_check_failed",
+            f"could not run '{executable} --version': {exc}",
+        )
+    if version_check.returncode != 0:
+        return _failure("version_check_failed", _command_failure_detail(version_check))
+
+    version = _parse_version(version_check.stdout or version_check.stderr)
+    if version is None:
+        return _failure(
+            "version_unrecognised",
+            "'tesseract --version' did not report a recognisable Tesseract version",
+        )
+
+    try:
+        language_check = _run_tesseract(executable, "--list-langs")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _failure(
+            "language_check_failed",
+            f"could not run '{executable} --list-langs': {exc}",
+        )
+    if language_check.returncode != 0:
+        return _failure("language_check_failed", _command_failure_detail(language_check))
+
+    languages = _parse_languages(language_check.stdout)
+    if "eng" not in languages:
+        available = ", ".join(sorted(languages)) or "none"
+        return _failure(
+            "eng_language_missing",
+            f"exact language 'eng' is unavailable; reported languages: {available}",
+        )
+
+    smoke_passed, reason, detail = _run_ocr_smoke(executable)
+    if not smoke_passed:
+        return _failure(reason, detail)
+
+    return VerificationResult(
+        available=True,
+        reason="",
+        detail="",
+        version=version,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tesseract-command",
+        default="tesseract",
+        help="Tesseract command or path to verify. Default: tesseract",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print only the stable machine-readable capability line.",
+    )
+    args = parser.parse_args(argv)
+
+    result = verify_tesseract(args.tesseract_command)
+    print(result.machine_line())
+    if not args.quiet:
+        print(result.human_line())
+    return 0 if result.available else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/setup_all.ps1
+++ b/setup_all.ps1
@@ -28,6 +28,14 @@
 .PARAMETER SkipMongoDB
     Skip MongoDB installation checks (forwarded to setup_py.ps1).
 
+.PARAMETER WithOCR
+    Require image and scanned-PDF OCR support. This validates Tesseract but
+    does not install system software.
+
+.PARAMETER InstallSystemDeps
+    Explicitly authorise installation of required system dependencies. On
+    Windows this currently installs Tesseract with winget and implies -WithOCR.
+
 .EXAMPLES
     ./setup_all.ps1
     ./setup_all.ps1 -ConfigureVSCode
@@ -35,6 +43,8 @@
     ./setup_all.ps1 -SkipPy -Force
     ./setup_all.ps1 -CI -PythonVersion 3.12
     ./setup_all.ps1 -SkipMongoDB -ConfigureVSCode
+    ./setup_all.ps1 -WithOCR
+    ./setup_all.ps1 -InstallSystemDeps
 
 .NOTES
     Exit codes: 0 success, non-zero on any failed phase.
@@ -46,7 +56,9 @@ param(
     [switch]$CI,
     [switch]$ConfigureVSCode,
     [string]$PythonVersion,
-    [switch]$SkipMongoDB
+    [switch]$SkipMongoDB,
+    [switch]$WithOCR,
+    [switch]$InstallSystemDeps
 )
 
 $ErrorActionPreference = 'Stop'
@@ -57,6 +69,43 @@ $start = Get-Date
 function Write-Phase { param([string]$Msg,[ConsoleColor]$Color=[ConsoleColor]::Cyan) Write-Host $Msg -ForegroundColor $Color }
 function Write-Err   { param([string]$Msg) Write-Host $Msg -ForegroundColor Red }
 function Duration($since) { return [int]((Get-Date) - $since).TotalSeconds }
+
+function Write-OcrSummary {
+    param(
+        [ValidateSet('available', 'unavailable', 'failed')]
+        [string]$State,
+        [bool]$Required
+    )
+
+    $requiredText = if ($Required) { 'true' } else { 'false' }
+    Write-Phase '=== OCR Capability Summary ==='
+    switch ($State) {
+        'available' { Write-Host 'OCR AVAILABLE: Tesseract, English language data, and a real OCR smoke test passed.' -ForegroundColor Green }
+        'unavailable' { Write-Host 'OCR UNAVAILABLE: core setup can run, but image and scanned-PDF OCR is not available.' -ForegroundColor Yellow }
+        'failed' { Write-Host 'OCR FAILED: OCR setup or validation did not complete successfully.' -ForegroundColor Red }
+    }
+    Write-Host ("VON_SETUP_CAPABILITY name=ocr state={0} required={1}" -f $State, $requiredText)
+    if ($State -ne 'available') {
+        Write-Host 'NEXT ACTION: .\setup_all.ps1 -InstallSystemDeps' -ForegroundColor Yellow
+        Write-Host 'VON_SETUP_NEXT_ACTION command=".\setup_all.ps1 -InstallSystemDeps"'
+    }
+}
+
+if ($InstallSystemDeps) {
+    $WithOCR = $true
+}
+
+if ($SkipPy -and $WithOCR) {
+    Write-Err 'Invalid options: OCR setup requires the Python phase; do not combine -SkipPy with -WithOCR or -InstallSystemDeps.'
+    Write-OcrSummary -State 'failed' -Required $true
+    Write-Err '=== SETUP: INCOMPLETE (invalid OCR options) ==='
+    Write-Host 'VON_SETUP_RESULT state=incomplete scope=setup reason=invalid_ocr_options'
+    exit 2
+}
+
+# setup_py.ps1 runs in this PowerShell process and publishes its final OCR state
+# here so the unified summary can report optional as well as required outcomes.
+$env:VON_SETUP_OCR_STATE = ''
 
 Write-Phase "=== Von Unified Setup ==="
 Write-Host  ("Root: {0}" -f $root)
@@ -69,6 +118,8 @@ if (-not $SkipPy) {
     if ($Force) { $pyParams['Reset'] = $true }
     if ($PythonVersion) { $pyParams['PythonVersion'] = $PythonVersion }
     if ($SkipMongoDB) { $pyParams['SkipMongoDB'] = $true }
+    if ($WithOCR) { $pyParams['WithOCR'] = $true }
+    if ($InstallSystemDeps) { $pyParams['InstallSystemDeps'] = $true }
     $pyArgsDisplay = ($pyParams.GetEnumerator() | ForEach-Object {
         $arg = '-' + $_.Key
         if ($_.Value -is [string]) { $arg += ' ' + $_.Value }
@@ -82,6 +133,9 @@ if (-not $SkipPy) {
         Write-Phase ("Python setup completed in {0}s" -f (Duration $pyStart)) 'Green'
     } catch {
         Write-Err "Python setup failed: $($_.Exception.Message)"
+        if ($env:VON_SETUP_OCR_STATE -eq 'available' -or -not $env:VON_SETUP_OCR_STATE) {
+            $env:VON_SETUP_OCR_STATE = 'failed'
+        }
         $overallOk = $false
     }
 } else {
@@ -108,10 +162,27 @@ if (-not $SkipJS) {
 }
 
 $elapsed = Duration $start
+$ocrState = $env:VON_SETUP_OCR_STATE
+if ($ocrState -notin @('available', 'unavailable', 'failed')) {
+    $ocrState = if ($SkipPy) { 'unavailable' } else { 'failed' }
+}
+Write-OcrSummary -State $ocrState -Required ([bool]$WithOCR)
+if ($WithOCR -and $ocrState -ne 'available') {
+    $overallOk = $false
+}
+
 if ($overallOk) {
-    Write-Phase ("=== Unified setup SUCCESS in {0}s ===" -f $elapsed) 'Green'
+    if ($ocrState -eq 'available') {
+        Write-Phase ("=== FULL SETUP: COMPLETE in {0}s ===" -f $elapsed) 'Green'
+        Write-Host 'VON_SETUP_RESULT state=complete scope=full'
+    }
+    else {
+        Write-Phase ("=== CORE SETUP: COMPLETE (OCR unavailable) in {0}s ===" -f $elapsed) 'Yellow'
+        Write-Host 'VON_SETUP_RESULT state=complete scope=core reason=ocr_unavailable'
+    }
     exit 0
 } else {
-    Write-Err   ("=== Unified setup FAILED in {0}s (see above) ===" -f $elapsed)
+    Write-Err   ("=== SETUP: INCOMPLETE in {0}s (see above) ===" -f $elapsed)
+    Write-Host 'VON_SETUP_RESULT state=incomplete scope=setup'
     exit 1
 }

--- a/setup_all.sh
+++ b/setup_all.sh
@@ -15,6 +15,9 @@
 #   --configure-vscode  Forwarded to setup_py.sh to configure VS Code settings
 #   --python-version V  Forwarded to setup_py.sh to target a specific Python minor version
 #   --skip-mongodb      Skip MongoDB installation checks (forwarded to setup_py.sh)
+#   --with-ocr          Require working image/scanned-PDF OCR; never installs system packages
+#   --install-system-deps
+#                       Explicitly authorise Tesseract installation; implies --with-ocr
 #   --help, -h          Show this help message
 #
 # EXAMPLES:
@@ -24,6 +27,7 @@
 #   ./setup_all.sh --skip-py --force
 #   ./setup_all.sh --ci --python-version 3.12
 #   ./setup_all.sh --skip-mongodb --configure-vscode
+#   ./setup_all.sh --install-system-deps
 
 set -e
 
@@ -42,6 +46,8 @@ CI=0
 CONFIGURE_VSCODE=0
 PYTHON_VERSION=""
 SKIP_MONGODB=0
+WITH_OCR=0
+INSTALL_SYSTEM_DEPS=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -73,6 +79,15 @@ while [[ $# -gt 0 ]]; do
             SKIP_MONGODB=1
             shift
             ;;
+        --with-ocr)
+            WITH_OCR=1
+            shift
+            ;;
+        --install-system-deps)
+            INSTALL_SYSTEM_DEPS=1
+            WITH_OCR=1
+            shift
+            ;;
         --help|-h)
             grep "^# " "$0" | sed 's/^# //'
             exit 0
@@ -85,8 +100,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ $SKIP_PY -eq 1 ]] && { [[ $WITH_OCR -eq 1 ]] || [[ $INSTALL_SYSTEM_DEPS -eq 1 ]]; }; then
+    echo -e "${RED}Invalid options: OCR setup cannot be combined with --skip-py.${NC}"
+    echo "Run OCR setup as your ordinary user with:"
+    echo "  ./setup_all.sh --install-system-deps"
+    exit 2
+fi
+
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -d "${HOME}/.local/bin" ]]; then
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
 OVERALL_OK=1
 START_TIME=$(date +%s)
 
@@ -115,6 +140,12 @@ if [[ $SKIP_PY -eq 0 ]]; then
     if [[ $SKIP_MONGODB -eq 1 ]]; then
         PY_ARGS="$PY_ARGS --skip-mongodb"
     fi
+    if [[ $WITH_OCR -eq 1 ]]; then
+        PY_ARGS="$PY_ARGS --with-ocr"
+    fi
+    if [[ $INSTALL_SYSTEM_DEPS -eq 1 ]]; then
+        PY_ARGS="$PY_ARGS --install-system-deps"
+    fi
     
     echo -e "${CYAN}[1/2] Python setup starting (args:$PY_ARGS)${NC}"
     PY_START=$(date +%s)
@@ -129,6 +160,28 @@ if [[ $SKIP_PY -eq 0 ]]; then
 else
     echo -e "${YELLOW}[1/2] Python setup skipped (--skip-py)${NC}"
 fi
+
+function final_ocr_check() {
+    local python_cmd=""
+    if [[ -x "$SCRIPT_DIR/.venv/bin/python" ]]; then
+        python_cmd="$SCRIPT_DIR/.venv/bin/python"
+    elif [[ -x "$SCRIPT_DIR/.venv/Scripts/python.exe" ]]; then
+        python_cmd="$SCRIPT_DIR/.venv/Scripts/python.exe"
+    fi
+
+    [[ -n "$python_cmd" ]] && \
+        "$python_cmd" "$SCRIPT_DIR/scripts/verify_tesseract_ocr.py" --quiet
+}
+
+function print_final_ocr_unavailable() {
+    local required="$1"
+    echo "OCR STATUS: UNAVAILABLE"
+    echo "Image and scanned-PDF OCR will not work."
+    echo "NEXT ACTION: ./setup_all.sh --install-system-deps"
+    echo "Run that command from the Von repository as your ordinary user; do not prefix the whole command with sudo."
+    echo "VON_SETUP_CAPABILITY name=ocr state=unavailable required=${required}"
+    echo 'VON_SETUP_NEXT_ACTION command="./setup_all.sh --install-system-deps"'
+}
 
 # JavaScript Phase
 if [[ $SKIP_JS -eq 0 ]]; then
@@ -155,10 +208,28 @@ else
 fi
 
 ELAPSED=$(duration $START_TIME)
-if [[ $OVERALL_OK -eq 1 ]]; then
-    echo -e "${GREEN}=== Unified setup SUCCESS in ${ELAPSED}s ===${NC}"
+OCR_OK=0
+if final_ocr_check; then
+    OCR_OK=1
+fi
+
+if [[ $WITH_OCR -eq 1 ]] && [[ $OCR_OK -eq 0 ]]; then
+    OVERALL_OK=0
+fi
+
+if [[ $OVERALL_OK -eq 1 ]] && [[ $OCR_OK -eq 1 ]]; then
+    echo -e "${GREEN}=== FULL SETUP: COMPLETE in ${ELAPSED}s ===${NC}"
+    echo "OCR STATUS: AVAILABLE (executable, English data, and real OCR smoke passed)"
+    echo "VON_SETUP_CAPABILITY name=ocr state=available required=$([[ $WITH_OCR -eq 1 ]] && echo true || echo false)"
+    exit 0
+elif [[ $OVERALL_OK -eq 1 ]]; then
+    echo -e "${GREEN}=== CORE SETUP: COMPLETE in ${ELAPSED}s ===${NC}"
+    print_final_ocr_unavailable false
     exit 0
 else
-    echo -e "${RED}=== Unified setup FAILED in ${ELAPSED}s (see above) ===${NC}"
+    echo -e "${RED}=== SETUP: INCOMPLETE in ${ELAPSED}s (see above) ===${NC}"
+    if [[ $OCR_OK -eq 0 ]]; then
+        print_final_ocr_unavailable "$([[ $WITH_OCR -eq 1 ]] && echo true || echo false)"
+    fi
     exit 1
 fi

--- a/setup_py.ps1
+++ b/setup_py.ps1
@@ -20,6 +20,14 @@
 .PARAMETER SkipMongoDB
     Optional flag to skip MongoDB installation checks and continue setup.
 
+.PARAMETER WithOCR
+    Require image and scanned-PDF OCR support. This validates Tesseract but
+    does not install system software.
+
+.PARAMETER InstallSystemDeps
+    Explicitly authorise installation of required system dependencies. On
+    Windows this currently installs Tesseract with winget and implies -WithOCR.
+
 .EXAMPLES
     ./setup_py.ps1
     ./setup_py.ps1 -ConfigureVSCode
@@ -27,6 +35,10 @@
     ./setup_py.ps1 -ConfigureVSCode -PythonVersion 3.12
     ./setup_py.ps1 -Reset -ConfigureVSCode -PythonVersion 3.11
     ./setup_py.ps1 -SkipMongoDB -ConfigureVSCode
+    ./setup_py.ps1 -WithOCR
+
+    If OCR is unavailable, use the unified installer exactly as printed:
+    .\setup_all.ps1 -InstallSystemDeps
 #>
 # PSScriptAnalyzer -DisableRule PSUseApprovedVerbs
 param (
@@ -40,8 +52,25 @@ param (
     [string]$PythonVersion,
 
     [Parameter(Mandatory = $false)]
-    [switch]$SkipMongoDB
+    [switch]$SkipMongoDB,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WithOCR,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$InstallSystemDeps
 )
+
+if ($InstallSystemDeps) {
+    $WithOCR = $true
+}
+
+$script:OcrRequired = [bool]$WithOCR
+$script:OcrState = 'unavailable'
+$script:OcrReason = 'not_checked'
+$script:OcrPreflightAvailable = $false
+$script:TesseractExecutable = $null
+$env:VON_SETUP_OCR_STATE = $script:OcrState
 
 # Function to reset the environment
 function Reset-Environment {
@@ -654,71 +683,266 @@ function Install-MongoDB {
     throw "MongoDB installation failed. Run setup with -SkipMongoDB to bypass this check."
 }
 
-# Function to install Tesseract OCR (Windows)
-function Install-Tesseract {
-    Write-Host "Checking for Tesseract OCR installation..." -ForegroundColor Cyan
+# OCR capability helpers. Detection is always read-only; winget is called only
+# when -InstallSystemDeps explicitly authorises a system dependency mutation.
+function Get-TesseractDefaultDirectories {
+    $directories = @()
+    if ($env:ProgramFiles) {
+        $directories += (Join-Path $env:ProgramFiles 'Tesseract-OCR')
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $directories += (Join-Path ${env:ProgramFiles(x86)} 'Tesseract-OCR')
+    }
+    if ($env:LOCALAPPDATA) {
+        $directories += (Join-Path $env:LOCALAPPDATA 'Programs\Tesseract-OCR')
+    }
+    return @($directories | Select-Object -Unique)
+}
 
+function Resolve-TesseractExecutable {
     $tesseractCmd = Get-Command tesseract.exe -ErrorAction SilentlyContinue
     if ($tesseractCmd) {
-        Write-Host "Tesseract OCR is already installed at $($tesseractCmd.Source)" -ForegroundColor Green
-        return
+        return $tesseractCmd.Source
     }
 
-    $defaultDirs = @(
-        "C:\Program Files\Tesseract-OCR",
-        "C:\Program Files (x86)\Tesseract-OCR"
-    )
-    foreach ($dir in $defaultDirs) {
-        $exe = Join-Path $dir "tesseract.exe"
-        if (Test-Path $exe) {
-            Write-Host "Tesseract OCR found at $exe (not in PATH). Adding to PATH for this session." -ForegroundColor Yellow
-            $env:Path = $env:Path + ";" + $dir
-            return
+    foreach ($dir in (Get-TesseractDefaultDirectories)) {
+        $exe = Join-Path $dir 'tesseract.exe'
+        if (Test-Path -LiteralPath $exe) {
+            if (($env:Path -split ';') -notcontains $dir) {
+                $env:Path = $env:Path + ';' + $dir
+            }
+            Write-Host "Tesseract found at $exe (not previously on PATH); added it for this setup session." -ForegroundColor Yellow
+            return $exe
         }
     }
 
-    Write-Host "Tesseract OCR not found. Attempting to install via winget..." -ForegroundColor Yellow
+    return $null
+}
+
+function Test-TesseractEngine {
+    $executable = Resolve-TesseractExecutable
+    if (-not $executable) {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'unavailable'
+            Reason = 'tesseract_executable_not_found'
+            Executable = $null
+            Version = $null
+        }
+    }
+
+    try {
+        $versionOutput = @(& $executable --version 2>&1)
+        $versionExitCode = $LASTEXITCODE
+    }
+    catch {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'failed'
+            Reason = "tesseract_version_invocation_failed: $($_.Exception.Message)"
+            Executable = $executable
+            Version = $null
+        }
+    }
+    if ($versionExitCode -ne 0) {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'failed'
+            Reason = "tesseract_version_exit_$versionExitCode"
+            Executable = $executable
+            Version = $null
+        }
+    }
+
+    try {
+        $languageOutput = @(& $executable --list-langs 2>&1)
+        $languageExitCode = $LASTEXITCODE
+    }
+    catch {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'failed'
+            Reason = "tesseract_language_invocation_failed: $($_.Exception.Message)"
+            Executable = $executable
+            Version = ([string]($versionOutput[0])).Trim()
+        }
+    }
+    if ($languageExitCode -ne 0) {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'failed'
+            Reason = "tesseract_language_exit_$languageExitCode"
+            Executable = $executable
+            Version = ([string]($versionOutput[0])).Trim()
+        }
+    }
+
+    $languages = @($languageOutput | ForEach-Object { ([string]$_).Trim() } | Where-Object { $_ })
+    if ($languages -notcontains 'eng') {
+        return [pscustomobject]@{
+            Available = $false
+            State = 'unavailable'
+            Reason = 'tesseract_english_language_not_found'
+            Executable = $executable
+            Version = ([string]($versionOutput[0])).Trim()
+        }
+    }
+
+    return [pscustomobject]@{
+        Available = $true
+        State = 'available'
+        Reason = 'engine_and_english_language_validated'
+        Executable = $executable
+        Version = ([string]($versionOutput[0])).Trim()
+    }
+}
+
+function Set-OcrState {
+    param(
+        [ValidateSet('available', 'unavailable', 'failed')]
+        [string]$State,
+        [string]$Reason
+    )
+
+    $script:OcrState = $State
+    $script:OcrReason = $Reason
+    $env:VON_SETUP_OCR_STATE = $State
+}
+
+function Write-OcrStatus {
+    $requiredText = if ($script:OcrRequired) { 'true' } else { 'false' }
+    switch ($script:OcrState) {
+        'available' {
+            Write-Host "OCR AVAILABLE: $($script:OcrReason)" -ForegroundColor Green
+        }
+        'unavailable' {
+            Write-Host "OCR UNAVAILABLE: $($script:OcrReason)" -ForegroundColor Yellow
+            if (-not $script:OcrRequired) {
+                Write-Host 'Core setup will continue, but image and scanned-PDF OCR will not be available.' -ForegroundColor Yellow
+            }
+        }
+        'failed' {
+            Write-Host "OCR FAILED: $($script:OcrReason)" -ForegroundColor Red
+            if (-not $script:OcrRequired) {
+                Write-Host 'Core setup will continue, but image and scanned-PDF OCR will not be available.' -ForegroundColor Yellow
+            }
+        }
+    }
+    Write-Host ("VON_SETUP_CAPABILITY name=ocr state={0} required={1}" -f $script:OcrState, $requiredText)
+    if ($script:OcrState -ne 'available') {
+        Write-Host 'NEXT ACTION: .\setup_all.ps1 -InstallSystemDeps' -ForegroundColor Yellow
+        Write-Host 'VON_SETUP_NEXT_ACTION command=".\setup_all.ps1 -InstallSystemDeps"'
+    }
+}
+
+function Install-TesseractSystemDependency {
+    if (-not $InstallSystemDeps) {
+        throw 'Internal setup error: Tesseract installation was requested without -InstallSystemDeps.'
+    }
+
     $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
-    if ($winget) {
+    if (-not $winget) {
+        throw 'winget.exe is unavailable. Install Microsoft App Installer, then run the exact next-action command again.'
+    }
+
+    Write-Host 'Installing Tesseract OCR with winget (explicitly authorised by -InstallSystemDeps)...' -ForegroundColor Cyan
+    try {
+        $wingetOutput = @(& $winget.Source install --id UB-Mannheim.TesseractOCR --exact --silent --accept-package-agreements --accept-source-agreements 2>&1)
+        $wingetExitCode = $LASTEXITCODE
+        foreach ($line in $wingetOutput) {
+            Write-Host ([string]$line)
+        }
+    }
+    catch {
+        throw "winget could not be invoked: $($_.Exception.Message)"
+    }
+
+    if ($wingetExitCode -ne 0) {
+        throw "winget Tesseract installation exited with code $wingetExitCode"
+    }
+}
+
+function Initialize-OcrCapability {
+    Write-Host ''
+    Write-Host '=== OCR Capability Check ===' -ForegroundColor Cyan
+    Write-Host 'Tesseract is optional for core setup and required for image and scanned-PDF OCR.' -ForegroundColor Cyan
+    if ($script:OcrRequired) {
+        Write-Host 'OCR is required for this run.' -ForegroundColor Cyan
+    }
+
+    $engineResult = Test-TesseractEngine
+    if (-not $engineResult.Available -and $InstallSystemDeps) {
+        Write-Host "Tesseract is not usable yet: $($engineResult.Reason)" -ForegroundColor Yellow
         try {
-            & $winget.Source install --id UB-Mannheim.TesseractOCR -e --silent --accept-package-agreements --accept-source-agreements
+            Install-TesseractSystemDependency
         }
         catch {
-            Write-Host "Winget installation failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            Set-OcrState -State 'failed' -Reason $_.Exception.Message
+            Write-OcrStatus
+            throw
         }
-    }
-    else {
-        Write-Host "winget not found. Skipping automatic installation." -ForegroundColor Yellow
+        $engineResult = Test-TesseractEngine
     }
 
-    $tesseractCmd = Get-Command tesseract.exe -ErrorAction SilentlyContinue
-    if ($tesseractCmd) {
-        Write-Host "Tesseract OCR installed at $($tesseractCmd.Source)" -ForegroundColor Green
+    if (-not $engineResult.Available) {
+        Set-OcrState -State $engineResult.State -Reason $engineResult.Reason
+        Write-OcrStatus
+        if ($script:OcrRequired) {
+            throw 'Required OCR capability is unavailable. Run the exact NEXT ACTION command shown above.'
+        }
         return
     }
 
-    foreach ($dir in $defaultDirs) {
-        $exe = Join-Path $dir "tesseract.exe"
-        if (Test-Path $exe) {
-            Write-Host "Tesseract OCR found at $exe after install. Adding to PATH for this session." -ForegroundColor Yellow
-            $env:Path = $env:Path + ";" + $dir
-            return
-        }
+    $script:OcrPreflightAvailable = $true
+    $script:TesseractExecutable = $engineResult.Executable
+    Set-OcrState -State 'available' -Reason "$($engineResult.Version); executable and exact eng language data validated"
+    Write-OcrStatus
+}
+
+function Complete-OcrValidation {
+    if (-not $script:OcrPreflightAvailable) {
+        return
     }
 
-    Write-Host "Tesseract OCR still not detected. Please install manually:" -ForegroundColor Yellow
-    Write-Host "- Windows installer: https://github.com/UB-Mannheim/tesseract/wiki" -ForegroundColor Cyan
-    Write-Host "- Ensure tesseract.exe is on PATH for OCR to work." -ForegroundColor Yellow
+    Write-Host 'Running shared real Pillow + pytesseract OCR smoke test...' -ForegroundColor Cyan
+    $verifier = Join-Path $PSScriptRoot 'scripts\verify_tesseract_ocr.py'
+    if (-not (Test-Path -LiteralPath $verifier)) {
+        Set-OcrState -State 'failed' -Reason 'shared_ocr_verifier_not_found'
+        return
+    }
+
+    try {
+        $smokeOutput = @(& .venv\Scripts\python.exe $verifier --tesseract-command $script:TesseractExecutable 2>&1)
+        $smokeExitCode = $LASTEXITCODE
+        foreach ($line in $smokeOutput) {
+            Write-Host ([string]$line) -ForegroundColor DarkGray
+        }
+    }
+    catch {
+        Set-OcrState -State 'failed' -Reason "ocr_smoke_invocation_failed: $($_.Exception.Message)"
+        return
+    }
+
+    if ($smokeExitCode -ne 0) {
+        Set-OcrState -State 'unavailable' -Reason "shared_pillow_pytesseract_verifier_exit_$smokeExitCode"
+        return
+    }
+
+    $script:OcrState = 'available'
+    $script:OcrReason = 'Tesseract executable, exact eng language data, and Pillow+pytesseract smoke validated'
+    $env:VON_SETUP_OCR_STATE = $script:OcrState
 }
 
 ## Validate parameters and provide an explanatory message
-if (-not $ConfigureVSCode -and -not $Reset -and -not $PythonVersion) {
+if (-not $ConfigureVSCode -and -not $Reset -and -not $PythonVersion -and -not $WithOCR -and -not $InstallSystemDeps) {
     # Check if any action parameter is provided
     Write-Host "No action parameters provided. Please specify one or more of the following parameters:" -ForegroundColor Yellow
     Write-Host ""
     Write-Host "  -Reset            : Resets the environment by removing the .venv and .vscode directories." -ForegroundColor Cyan
     Write-Host "  -ConfigureVSCode  : Configures VS Code settings for the Python environment." -ForegroundColor Cyan
     Write-Host '  -PythonVersion <ver> : Specify the target Python minor version (e.g., "3.12").' -ForegroundColor Cyan
+    Write-Host "  -WithOCR          : Requires OCR and validates it without installing system software." -ForegroundColor Cyan
+    Write-Host "  -InstallSystemDeps: Installs Tesseract with winget and implies -WithOCR." -ForegroundColor Cyan
     Write-Host ""
     Write-Host "Examples:" -ForegroundColor Yellow
     Write-Host "  ./setup_py.ps1 -Reset" -ForegroundColor Green
@@ -726,6 +950,8 @@ if (-not $ConfigureVSCode -and -not $Reset -and -not $PythonVersion) {
     Write-Host ""
     Write-Host "  ./setup_py.ps1 -ConfigureVSCode" -ForegroundColor Green
     Write-Host "      Sets up the Python environment (using detected Python) and configures VS Code." -ForegroundColor Gray
+    Write-Host ""
+    Write-Host 'If OCR is unavailable, run exactly: .\setup_all.ps1 -InstallSystemDeps' -ForegroundColor Yellow
 }
 
 # Check if Reset is set
@@ -733,7 +959,7 @@ if ($Reset) {
     # Renamed from RESET_FLAG
     Reset-Environment
     # Check if ONLY reset was requested
-    if (-not $ConfigureVSCode -and [string]::IsNullOrEmpty($PythonVersion)) {
+    if (-not $ConfigureVSCode -and [string]::IsNullOrEmpty($PythonVersion) -and -not $WithOCR -and -not $InstallSystemDeps) {
         # Renamed from VSCODE_FLAG
         Write-Host "Environment reset complete. Exiting script as no setup flags were provided." -ForegroundColor Green
         exit 0
@@ -742,6 +968,10 @@ if ($Reset) {
 
 # Main script logic
 # Pass the PythonVersion parameter to Initialize-Windows
+
+# Detect OCR before performing the rest of setup. Default setup never invokes
+# winget; a missing optional OCR capability is reported with one exact command.
+Initialize-OcrCapability
 
 # Ensure MongoDB is installed before proceeding (unless skipped)
 if (-not $SkipMongoDB) {
@@ -757,15 +987,6 @@ else {
     Write-Host "Skipping MongoDB installation checks (-SkipMongoDB flag set)." -ForegroundColor Yellow
 }
 
-# Ensure Tesseract OCR is installed for PDF/image OCR support
-try {
-    Install-Tesseract
-}
-catch {
-    Write-Host "Tesseract setup encountered an error: $($_.Exception.Message)" -ForegroundColor Yellow
-    Write-Host "Continuing with Python setup..." -ForegroundColor Yellow
-}
-
 # Ensure .env file exists (create from template if missing)
 New-EnvFile
 
@@ -773,6 +994,17 @@ New-EnvFile
 Install-UvAndArxiv
 
 Initialize-Windows -RequestedPythonVersion $PythonVersion
+
+# The executable/language preflight is necessary but not sufficient: exercise
+# the same Python libraries Von uses against a generated image after PDM install.
+Complete-OcrValidation
+
+Write-Host ''
+Write-Host '=== OCR Capability Summary ===' -ForegroundColor Cyan
+Write-OcrStatus
+if ($script:OcrRequired -and $script:OcrState -ne 'available') {
+    throw 'Required OCR capability failed its final smoke test. Run the exact NEXT ACTION command shown above.'
+}
 
 if ($ConfigureVSCode) {
     # Renamed from VSCODE_FLAG

--- a/setup_py.sh
+++ b/setup_py.sh
@@ -11,6 +11,9 @@
 #   --reset              Remove .venv and .vscode directories and start fresh
 #   --python-version VER Specify target Python minor version (e.g., "3.12")
 #   --skip-mongodb       Skip MongoDB installation checks
+#   --with-ocr           Require working OCR; never installs system packages
+#   --install-system-deps
+#                        Explicitly authorise Tesseract installation; implies --with-ocr
 #   --help, -h           Show this help message
 #
 # EXAMPLES:
@@ -20,6 +23,7 @@
 #   ./setup_py.sh --configure-vscode --python-version 3.12
 #   ./setup_py.sh --reset --configure-vscode --python-version 3.11
 #   ./setup_py.sh --skip-mongodb --configure-vscode
+#   ./setup_all.sh --install-system-deps
 
 set -e
 
@@ -35,6 +39,8 @@ CONFIGURE_VSCODE=0
 RESET=0
 PYTHON_VERSION=""
 SKIP_MONGODB=0
+WITH_OCR=0
+INSTALL_SYSTEM_DEPS=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -54,6 +60,15 @@ while [[ $# -gt 0 ]]; do
             SKIP_MONGODB=1
             shift
             ;;
+        --with-ocr)
+            WITH_OCR=1
+            shift
+            ;;
+        --install-system-deps)
+            INSTALL_SYSTEM_DEPS=1
+            WITH_OCR=1
+            shift
+            ;;
         --help|-h)
             grep "^# " "$0" | sed 's/^# //'
             exit 0
@@ -66,9 +81,299 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -d "${HOME}/.local/bin" ]]; then
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+OCR_BASIC_AVAILABLE=0
+OCR_REASON="not_checked"
+TESS_VERSION=""
+
 # Function to check if command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+print_ocr_unavailable() {
+    local reason="$1"
+    local required="$2"
+    echo ""
+    echo -e "${YELLOW}================================================================${NC}"
+    echo -e "${YELLOW}OCR STATUS: UNAVAILABLE${NC}"
+    echo "Reason: $reason"
+    echo "Image and scanned-PDF OCR will not work."
+    if [[ "$required" == "false" ]]; then
+        echo "Core Von setup will continue without OCR."
+    else
+        echo "OCR was requested, so setup cannot report completion."
+    fi
+    echo ""
+    echo "NEXT ACTION: ./setup_all.sh --install-system-deps"
+    echo "Run that command from the Von repository as your ordinary user."
+    echo "Do not prefix the whole setup command with sudo."
+    echo "VON_SETUP_CAPABILITY name=ocr state=unavailable required=${required}"
+    echo 'VON_SETUP_NEXT_ACTION command="./setup_all.sh --install-system-deps"'
+    echo -e "${YELLOW}================================================================${NC}"
+    echo ""
+}
+
+check_tesseract_basic() {
+    OCR_REASON=""
+    TESS_VERSION=""
+
+    if ! command_exists tesseract; then
+        OCR_REASON="the tesseract executable is not on PATH"
+        return 1
+    fi
+
+    if ! TESS_VERSION=$(tesseract --version 2>/dev/null | head -n1) || [[ -z "$TESS_VERSION" ]]; then
+        OCR_REASON="tesseract --version failed"
+        return 1
+    fi
+
+    local languages
+    if ! languages=$(tesseract --list-langs 2>/dev/null); then
+        OCR_REASON="tesseract --list-langs failed"
+        return 1
+    fi
+    if ! printf '%s\n' "$languages" | grep -qx 'eng'; then
+        OCR_REASON="the required English language data (eng) is missing"
+        return 1
+    fi
+
+    return 0
+}
+
+install_tesseract_debian_user_local() {
+    local command_name
+    for command_name in apt-get apt-cache dpkg dpkg-query dpkg-deb dpkg-architecture; do
+        if ! command_exists "$command_name"; then
+            echo -e "${RED}Cannot perform an ordinary-user install: $command_name is unavailable.${NC}"
+            return 1
+        fi
+    done
+
+    local candidate_version architecture safe_version base_dir target_dir current_link bin_dir
+    candidate_version=$(apt-cache policy tesseract-ocr | awk '/Candidate:/ {print $2; exit}')
+    if [[ -z "$candidate_version" ]] || [[ "$candidate_version" == "(none)" ]]; then
+        echo -e "${RED}No installable tesseract-ocr package is present in the current apt package lists.${NC}"
+        return 1
+    fi
+    architecture=$(dpkg --print-architecture 2>/dev/null || dpkg-architecture -qDEB_HOST_ARCH)
+    safe_version=$(printf '%s' "$candidate_version" | tr '/:+~' '____')
+    base_dir="${XDG_DATA_HOME:-${HOME}/.local/share}/von/system-deps"
+    target_dir="${base_dir}/tesseract-${safe_version}-${architecture}"
+    current_link="${base_dir}/tesseract-current"
+    bin_dir="${HOME}/.local/bin"
+
+    echo -e "${CYAN}sudo is unavailable without a password; installing Ubuntu/Debian Tesseract packages for this ordinary user.${NC}"
+    echo "User-local prefix: $target_dir"
+
+    local download_dir staging_dir
+    download_dir=$(mktemp -d "${TMPDIR:-/tmp}/von-tesseract.XXXXXX") || return 1
+    staging_dir="${download_dir}/root"
+    mkdir -p "$staging_dir"
+
+    local -a packages=( )
+    local -a queue=(tesseract-ocr tesseract-ocr-eng)
+    local -a processed=( )
+    local package status existing already_seen dependency package_candidate
+    while [[ ${#queue[@]} -gt 0 ]]; do
+        package="${queue[0]}"
+        queue=("${queue[@]:1}")
+        [[ "$package" =~ ^[a-z0-9][a-z0-9+.-]*(:[a-z0-9]+)?$ ]] || continue
+        already_seen=0
+        for existing in "${processed[@]}"; do
+            if [[ "$existing" == "$package" ]]; then
+                already_seen=1
+                break
+            fi
+        done
+        [[ $already_seen -eq 1 ]] && continue
+        processed+=("$package")
+
+        # An installed dependency is already resolved by the host linker and
+        # package database; do not recursively download its unrelated subtree.
+        status=$(dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null || true)
+        if [[ "$status" == ii* ]]; then
+            continue
+        fi
+
+        package_candidate=$(apt-cache policy "$package" | awk '/Candidate:/ {print $2; exit}')
+        if [[ -z "$package_candidate" ]] || [[ "$package_candidate" == "(none)" ]]; then
+            echo -e "${RED}No downloadable apt candidate was found for required package $package.${NC}"
+            return 1
+        fi
+        packages+=("$package")
+
+        while IFS= read -r dependency; do
+            [[ -n "$dependency" ]] && queue+=("$dependency")
+        done < <(
+            apt-cache depends --important "$package" 2>/dev/null \
+                | sed -nE 's/^[[:space:]]*(Pre)?Depends:[[:space:]]+([^<[:space:]]+).*$/\2/p'
+        )
+    done
+
+    if [[ ${#packages[@]} -eq 0 ]]; then
+        packages=(tesseract-ocr tesseract-ocr-eng)
+    fi
+
+    echo "Downloading distro packages without administrative privileges: ${packages[*]}"
+    if ! (cd "$download_dir" && apt-get download "${packages[@]}"); then
+        rm -rf -- "$download_dir"
+        echo -e "${RED}The ordinary-user apt package download failed.${NC}"
+        return 1
+    fi
+
+    local deb found_deb=0
+    for deb in "$download_dir"/*.deb; do
+        [[ -f "$deb" ]] || continue
+        found_deb=1
+        if ! dpkg-deb -x "$deb" "$staging_dir"; then
+            rm -rf -- "$download_dir"
+            echo -e "${RED}Failed to extract $(basename "$deb").${NC}"
+            return 1
+        fi
+    done
+    if [[ $found_deb -eq 0 ]] || [[ ! -x "$staging_dir/usr/bin/tesseract" ]]; then
+        rm -rf -- "$download_dir"
+        echo -e "${RED}Downloaded packages did not provide a Tesseract executable.${NC}"
+        return 1
+    fi
+
+    mkdir -p "$base_dir" "$bin_dir"
+    if [[ -e "$target_dir" ]]; then
+        if [[ ! -x "$target_dir/usr/bin/tesseract" ]]; then
+            rm -rf -- "$target_dir"
+            mv "$staging_dir" "$target_dir"
+        fi
+    else
+        mv "$staging_dir" "$target_dir"
+    fi
+    rm -rf -- "$download_dir"
+
+    if [[ -e "$current_link" ]] && [[ ! -L "$current_link" ]]; then
+        echo -e "${RED}Cannot update $current_link because it is not a symbolic link.${NC}"
+        return 1
+    fi
+    ln -sfn "$target_dir" "$current_link"
+
+    local wrapper_path="${bin_dir}/tesseract"
+    if [[ -e "$wrapper_path" ]] || [[ -L "$wrapper_path" ]]; then
+        if ! grep -q '^# Managed by Von setup_all.sh$' "$wrapper_path" 2>/dev/null; then
+            echo -e "${RED}Refusing to replace existing non-Von file: $wrapper_path${NC}"
+            return 1
+        fi
+    fi
+
+    local wrapper_tmp="${bin_dir}/.tesseract.von.$$"
+    cat > "$wrapper_tmp" <<'WRAPPER'
+#!/usr/bin/env sh
+# Managed by Von setup_all.sh
+set -eu
+prefix="${XDG_DATA_HOME:-${HOME}/.local/share}/von/system-deps/tesseract-current"
+architecture="$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || true)"
+library_path="${prefix}/usr/lib"
+if [ -n "$architecture" ]; then
+    library_path="${prefix}/usr/lib/${architecture}:${library_path}"
+fi
+export LD_LIBRARY_PATH="${library_path}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+for candidate in "${prefix}"/usr/share/tesseract-ocr/*/tessdata; do
+    if [ -d "$candidate" ]; then
+        export TESSDATA_PREFIX="${candidate}/"
+        break
+    fi
+done
+exec "${prefix}/usr/bin/tesseract" "$@"
+WRAPPER
+    chmod 0755 "$wrapper_tmp"
+    mv "$wrapper_tmp" "$wrapper_path"
+    export PATH="${bin_dir}:${PATH}"
+    return 0
+}
+
+install_tesseract_system_dependency() {
+    case "$(uname -s 2>/dev/null || true)" in
+        Darwin)
+            if ! command_exists brew; then
+                echo -e "${RED}Homebrew is required to install Tesseract on macOS.${NC}"
+                return 1
+            fi
+            echo "Installing Tesseract with: brew install tesseract"
+            brew install tesseract
+            ;;
+        Linux)
+            if ! command_exists apt-get; then
+                echo -e "${RED}Automatic Tesseract installation currently supports apt-based Linux distributions.${NC}"
+                return 1
+            fi
+            if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+                echo "Installing Tesseract with apt-get (already running as root)."
+                apt-get update
+                apt-get install -y tesseract-ocr tesseract-ocr-eng
+            elif command_exists sudo && sudo -n true >/dev/null 2>&1; then
+                echo "Installing Tesseract with: sudo apt-get update"
+                sudo -n apt-get update
+                echo "Installing Tesseract with: sudo apt-get install -y tesseract-ocr tesseract-ocr-eng"
+                sudo -n apt-get install -y tesseract-ocr tesseract-ocr-eng
+            else
+                install_tesseract_debian_user_local
+            fi
+            ;;
+        *)
+            echo -e "${RED}Automatic Tesseract installation is unsupported on this operating system.${NC}"
+            return 1
+            ;;
+    esac
+}
+
+prepare_tesseract() {
+    echo -e "${CYAN}Checking the Tesseract executable and English language data...${NC}"
+    if check_tesseract_basic; then
+        OCR_BASIC_AVAILABLE=1
+        echo -e "${GREEN}Tesseract basic checks passed: $TESS_VERSION; eng available.${NC}"
+        return 0
+    fi
+
+    print_ocr_unavailable "$OCR_REASON" "$([[ $WITH_OCR -eq 1 ]] && echo true || echo false)"
+    if [[ $INSTALL_SYSTEM_DEPS -eq 0 ]]; then
+        [[ $WITH_OCR -eq 0 ]]
+        return
+    fi
+
+    echo -e "${CYAN}--install-system-deps was provided; installing Tesseract now.${NC}"
+    if ! install_tesseract_system_dependency; then
+        OCR_REASON="the authorised Tesseract installation command failed"
+        print_ocr_unavailable "$OCR_REASON" true
+        return 1
+    fi
+    hash -r
+    if ! check_tesseract_basic; then
+        print_ocr_unavailable "installation completed but verification failed: $OCR_REASON" true
+        return 1
+    fi
+    OCR_BASIC_AVAILABLE=1
+    echo -e "${GREEN}Tesseract installation verified at the executable/language level: $TESS_VERSION; eng available.${NC}"
+}
+
+verify_tesseract_runtime() {
+    local required="$([[ $WITH_OCR -eq 1 ]] && echo true || echo false)"
+    if [[ $OCR_BASIC_AVAILABLE -eq 0 ]]; then
+        print_ocr_unavailable "$OCR_REASON" "$required"
+        [[ $WITH_OCR -eq 0 ]]
+        return
+    fi
+
+    if "$VENV_PYTHON" "$SCRIPT_DIR/scripts/verify_tesseract_ocr.py"; then
+        echo "OCR STATUS: AVAILABLE"
+        echo "VON_SETUP_CAPABILITY name=ocr state=available required=${required}"
+        return 0
+    fi
+
+    OCR_REASON="the real Pillow/pytesseract OCR smoke test failed"
+    print_ocr_unavailable "$OCR_REASON" "$required"
+    [[ $WITH_OCR -eq 0 ]]
 }
 
 # Function to reset environment
@@ -364,7 +669,7 @@ main() {
     if [[ $RESET -eq 1 ]]; then
         reset_environment
         # Check if ONLY reset was requested
-        if [[ $CONFIGURE_VSCODE -eq 0 ]] && [[ -z "$PYTHON_VERSION" ]]; then
+        if [[ $CONFIGURE_VSCODE -eq 0 ]] && [[ -z "$PYTHON_VERSION" ]] && [[ $WITH_OCR -eq 0 ]]; then
             echo -e "${GREEN}Environment reset complete. Exiting as no setup flags were provided.${NC}"
             exit 0
         fi
@@ -387,16 +692,8 @@ main() {
         echo -e "${YELLOW}Skipping MongoDB installation checks (-skip-mongodb flag set).${NC}"
     fi
 
-    echo -e "${CYAN}Checking for Tesseract OCR...${NC}"
-    if command_exists tesseract; then
-        TESS_VERSION=$(tesseract --version | head -n1)
-        echo -e "${GREEN}Tesseract OCR found: $TESS_VERSION${NC}"
-    else
-        echo -e "${YELLOW}Tesseract OCR not found. Please install manually:${NC}"
-        echo -e "  macOS: ${CYAN}brew install tesseract${NC}"
-        echo -e "  Ubuntu/Debian: ${CYAN}sudo apt install tesseract-ocr${NC}"
-        echo -e "  Or see: https://github.com/tesseract-ocr/tesseract"
-        echo -e "${YELLOW}Continuing with Python setup...${NC}"
+    if ! prepare_tesseract; then
+        exit 1
     fi
 
     # Ensure .env file exists
@@ -474,6 +771,10 @@ main() {
         else
             echo -e "${YELLOW}⚠ Some Python packages may not be installed correctly${NC}"
         fi
+    fi
+
+    if ! verify_tesseract_runtime; then
+        exit 1
     fi
 
     # Configure VS Code if requested

--- a/tests/test_setup_ocr_contract.py
+++ b/tests/test_setup_ocr_contract.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UNIX_NEXT_COMMAND = "./setup_all.sh --install-system-deps"
+WINDOWS_NEXT_COMMAND = r".\setup_all.ps1 -InstallSystemDeps"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8-sig")
+
+
+def _bash_function(script: str, name: str, next_name: str) -> str:
+    start = script.index(f"{name}()")
+    end = script.index(f"{next_name}()", start)
+    return script[start:end]
+
+
+def _powershell_function(script: str, name: str, next_marker: str) -> str:
+    start = script.index(f"function {name}")
+    end = script.index(next_marker, start)
+    return script[start:end]
+
+
+@pytest.mark.parametrize("script_name", ["setup_all.sh", "setup_py.sh"])
+def test_bash_help_exposes_ocr_contract_without_starting_setup(
+    script_name: str,
+) -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is required for setup-script contract tests")
+
+    result = subprocess.run(
+        [bash, str(REPO_ROOT / script_name), "--help"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=True,
+    )
+
+    assert "--with-ocr" in result.stdout
+    assert "--install-system-deps" in result.stdout
+    assert UNIX_NEXT_COMMAND in result.stdout
+    assert "Python setup starting" not in result.stdout
+    assert "Installing Tesseract" not in result.stdout
+
+
+def test_every_unavailable_surface_gives_humans_and_agents_the_exact_command() -> None:
+    readme = _read("README.md")
+    setup_all_sh = _read("setup_all.sh")
+    setup_py_sh = _read("setup_py.sh")
+    setup_all_ps1 = _read("setup_all.ps1")
+    setup_py_ps1 = _read("setup_py.ps1")
+
+    assert "If setup reports `OCR STATUS: UNAVAILABLE`" in readme
+    assert f"```bash\n{UNIX_NEXT_COMMAND}\n```" in readme
+    assert f"```powershell\n{WINDOWS_NEXT_COMMAND}\n```" in readme
+
+    for script in (setup_all_sh, setup_py_sh):
+        assert f"NEXT ACTION: {UNIX_NEXT_COMMAND}" in script
+        assert f'VON_SETUP_NEXT_ACTION command="{UNIX_NEXT_COMMAND}"' in script
+        assert "as your ordinary user" in script
+
+    for script in (setup_all_ps1, setup_py_ps1):
+        assert f"NEXT ACTION: {WINDOWS_NEXT_COMMAND}" in script
+        assert f'VON_SETUP_NEXT_ACTION command="{WINDOWS_NEXT_COMMAND}"' in script
+
+
+def test_bash_orchestrator_forwards_both_ocr_options_and_rejects_skip_py() -> None:
+    script = _read("setup_all.sh")
+
+    assert 'PY_ARGS="$PY_ARGS --with-ocr"' in script
+    assert 'PY_ARGS="$PY_ARGS --install-system-deps"' in script
+    assert re.search(
+        r"--install-system-deps\)\s+INSTALL_SYSTEM_DEPS=1\s+WITH_OCR=1",
+        script,
+    )
+
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is required for setup-script contract tests")
+    result = subprocess.run(
+        [
+            bash,
+            str(REPO_ROOT / "setup_all.sh"),
+            "--skip-py",
+            "--install-system-deps",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 2
+    assert UNIX_NEXT_COMMAND in output
+    assert "Python setup starting" not in output
+
+
+def test_bash_package_mutation_is_behind_the_explicit_install_gate() -> None:
+    script = _read("setup_py.sh")
+    prepare = _bash_function(script, "prepare_tesseract", "verify_tesseract_runtime")
+    installer_call = prepare.index("install_tesseract_system_dependency")
+    no_authority_guard = prepare.index("[[ $INSTALL_SYSTEM_DEPS -eq 0 ]]")
+
+    assert no_authority_guard < installer_call
+    assert "--install-system-deps was provided" in prepare
+    assert "brew install tesseract" in script
+    assert "apt-get install -y tesseract-ocr tesseract-ocr-eng" in script
+
+
+def test_bash_has_an_explicit_ordinary_user_apt_fallback_and_launcher_path() -> None:
+    setup = _read("setup_py.sh")
+    launcher = _read("run.sh")
+    local_install = _bash_function(
+        setup,
+        "install_tesseract_debian_user_local",
+        "install_tesseract_system_dependency",
+    )
+    system_install = _bash_function(
+        setup,
+        "install_tesseract_system_dependency",
+        "prepare_tesseract",
+    )
+
+    assert "sudo -n true" in system_install
+    assert "install_tesseract_debian_user_local" in system_install
+    assert "apt-get download" in local_install
+    assert "dpkg-deb -x" in local_install
+    assert "${HOME}/.local/share" in local_install
+    assert "${HOME}/.local/bin" in local_install
+    assert "TESSDATA_PREFIX" in local_install
+    assert 'if [ -x "${HOME}/.local/bin/tesseract" ]' in launcher
+    assert 'export PATH="${HOME}/.local/bin:${PATH}"' in launcher
+
+
+def test_unix_final_receipt_qualifies_core_only_and_required_failure() -> None:
+    script = _read("setup_all.sh")
+
+    assert "=== FULL SETUP: COMPLETE" in script
+    assert "=== CORE SETUP: COMPLETE" in script
+    assert "OCR STATUS: UNAVAILABLE" in script
+    assert "Image and scanned-PDF OCR will not work." in script
+    assert re.search(
+        r"if \[\[ \$WITH_OCR -eq 1 \]\] && \[\[ \$OCR_OK -eq 0 \]\]; then\s+"
+        r"OVERALL_OK=0",
+        script,
+    )
+    assert "VON_SETUP_CAPABILITY name=ocr state=available" in script
+    assert "VON_SETUP_CAPABILITY name=ocr state=unavailable" in script
+
+
+def test_powershell_forwards_flags_and_never_runs_winget_without_authority() -> None:
+    orchestrator = _read("setup_all.ps1")
+    python_setup = _read("setup_py.ps1")
+
+    assert "$pyParams['WithOCR'] = $true" in orchestrator
+    assert "$pyParams['InstallSystemDeps'] = $true" in orchestrator
+    assert re.search(
+        r"if \(\$InstallSystemDeps\)\s*{\s*\$WithOCR = \$true\s*}",
+        orchestrator,
+    )
+    assert re.search(
+        r"if \(\$InstallSystemDeps\)\s*{\s*\$WithOCR = \$true\s*}",
+        python_setup,
+    )
+
+    install = _powershell_function(
+        python_setup,
+        "Install-Tesseract",
+        "## Validate parameters",
+    )
+    winget_call = re.search(r"&\s+\$winget(?:\.Source)?\s+install\b", install)
+    authority_guard = re.search(
+        r"if\s*\(\s*-not\s+\$InstallSystemDeps\s*\)",
+        install,
+        flags=re.IGNORECASE,
+    )
+    assert winget_call, "Install-Tesseract must retain its explicit winget call"
+    assert authority_guard, "winget must be guarded by -InstallSystemDeps"
+    assert authority_guard.start() < winget_call.start()
+
+
+def test_powershell_receipt_cannot_claim_success_when_required_ocr_is_missing() -> None:
+    orchestrator = _read("setup_all.ps1")
+    python_setup = _read("setup_py.ps1")
+
+    assert "OCR UNAVAILABLE: core setup can run" in orchestrator
+    assert "VON_SETUP_CAPABILITY name=ocr state=" in orchestrator
+    assert "real OCR smoke test passed" in orchestrator
+    assert re.search(
+        r"if\s*\(\s*\$WithOCR\s*-and\s*\$ocrState\s*-ne\s*'available'\s*\)\s*"
+        r"{\s*\$overallOk\s*=\s*\$false",
+        orchestrator,
+        flags=re.IGNORECASE,
+    )
+    assert "$env:VON_SETUP_OCR_STATE" in python_setup
+    assert re.search(
+        r"\$script:OcrState\s*=\s*'available'",
+        python_setup,
+        flags=re.IGNORECASE,
+    )
+
+
+def test_shell_syntax_and_powershell_contract_syntax() -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is required for setup-script syntax tests")
+
+    for name in ("setup_all.sh", "setup_py.sh", "run.sh"):
+        subprocess.run(
+            [bash, "-n", str(REPO_ROOT / name)],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=True,
+        )
+
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        # The PowerShell behavioural contract is still covered statically by the
+        # preceding tests on hosts where PowerShell itself is unavailable.
+        assert "param(" in _read("setup_all.ps1")
+        assert "param (" in _read("setup_py.ps1")
+        return
+
+    for name in ("setup_all.ps1", "setup_py.ps1"):
+        path = str(REPO_ROOT / name).replace("'", "''")
+        command = (
+            "$tokens = $null; $errors = $null; "
+            f"[System.Management.Automation.Language.Parser]::ParseFile('{path}', "
+            "[ref]$tokens, [ref]$errors) | Out-Null; "
+            "if ($errors.Count) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }"
+        )
+        subprocess.run(
+            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=20,
+            check=True,
+        )

--- a/tests/test_verify_tesseract_ocr.py
+++ b/tests/test_verify_tesseract_ocr.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+from scripts import verify_tesseract_ocr
+
+
+def _completed(
+    stdout: str,
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+):
+    return SimpleNamespace(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode,
+    )
+
+
+def test_verifier_requires_exact_eng_and_runs_real_image_through_pytesseract(
+    monkeypatch,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    smoke_call: dict[str, object] = {}
+    fake_pytesseract = SimpleNamespace(
+        pytesseract=SimpleNamespace(tesseract_cmd=""),
+    )
+
+    def fake_run(executable: str, *arguments: str):
+        commands.append((executable, *arguments))
+        if arguments == ("--version",):
+            return _completed("tesseract 5.3.4\n leptonica-1.82.0\n")
+        return _completed(
+            'List of available languages in "/usr/share/tesseract-ocr/5/tessdata/" (2):\n'
+            "eng\n"
+            "osd\n"
+        )
+
+    def fake_image_to_string(image, *, lang: str, config: str) -> str:
+        smoke_call.update(image=image, lang=lang, config=config)
+        return "VON OCR 42\n"
+
+    fake_pytesseract.image_to_string = fake_image_to_string
+    monkeypatch.setattr(verify_tesseract_ocr.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(verify_tesseract_ocr, "_run_tesseract", fake_run)
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+
+    result = verify_tesseract_ocr.verify_tesseract()
+
+    assert result.available is True
+    assert result.version == "5.3.4"
+    assert commands == [
+        ("/usr/bin/tesseract", "--version"),
+        ("/usr/bin/tesseract", "--list-langs"),
+    ]
+    assert fake_pytesseract.pytesseract.tesseract_cmd == "/usr/bin/tesseract"
+    assert smoke_call["lang"] == "eng"
+    assert smoke_call["config"] == "--psm 7"
+    assert smoke_call["image"].width > 200
+    assert smoke_call["image"].height > 40
+
+
+def test_similarly_named_language_does_not_satisfy_exact_eng(monkeypatch) -> None:
+    def fake_run(_executable: str, *arguments: str):
+        if arguments == ("--version",):
+            return _completed("tesseract 5.3.4\n")
+        return _completed("List of available languages (2):\nenm\nosd\n")
+
+    monkeypatch.setattr(verify_tesseract_ocr.shutil, "which", lambda _: "/usr/bin/tesseract")
+    monkeypatch.setattr(verify_tesseract_ocr, "_run_tesseract", fake_run)
+
+    result = verify_tesseract_ocr.verify_tesseract()
+
+    assert result.available is False
+    assert result.reason == "eng_language_missing"
+    assert "enm, osd" in result.detail
+
+
+def test_cli_reports_stable_actionable_missing_executable_reason(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(verify_tesseract_ocr.shutil, "which", lambda _: None)
+
+    exit_code = verify_tesseract_ocr.main([])
+
+    assert exit_code == 1
+    assert capsys.readouterr().out.splitlines() == [
+        "VON_SETUP_CAPABILITY name=ocr state=unavailable reason=executable_not_found",
+        "Tesseract OCR check failed (executable_not_found): executable 'tesseract' was not found on PATH",
+    ]
+
+
+def test_smoke_text_mismatch_is_a_typed_failure(monkeypatch) -> None:
+    fake_pytesseract = SimpleNamespace(
+        pytesseract=SimpleNamespace(tesseract_cmd=""),
+        image_to_string=lambda *_args, **_kwargs: "VON OGR 42\n",
+    )
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+
+    passed, reason, detail = verify_tesseract_ocr._run_ocr_smoke("/usr/bin/tesseract")
+
+    assert passed is False
+    assert reason == "smoke_text_mismatch"
+    assert detail == "expected 'VON OCR 42' but Tesseract recognised 'VON OGR 42'"


### PR DESCRIPTION
## Outcome

A naive public-repo install now reports OCR availability honestly and gives one exact recovery command:

- Unix: `./setup_all.sh --install-system-deps`
- Windows: `.\setup_all.ps1 -InstallSystemDeps`

Default setup never installs Tesseract. `--with-ocr` / `-WithOCR` requires it without authorising package installation; the system-dependency option is the only installation gate and implies strict OCR validation.

## Implementation

- reports missing OCR immediately and again in the final qualified core/full/incomplete receipt
- validates the executable, exact `eng` data, and a real Pillow-to-pytesseract smoke
- supports apt, Homebrew, and winget
- provides an ordinary-user apt package extraction route when passwordless sudo is unavailable
- makes Von launcher processes see that user-local Tesseract without editing global shell configuration
- documents the contract in the public quick start

## Validation

- `51 passed` across the focused OCR contract/verifier tests and neighbouring `run.sh` tests
- Python 3.11 minimum syntax check passed for 1,363 files
- Ruff passed for the new Python files
- Bash syntax checks passed
- full local `./setup_all.sh --install-system-deps --skip-js --skip-mongodb` completed with Tesseract 5.5.2, exact English data, and the real smoke

## Deployment boundary

After merge, the DGX ordinary-user checkout will pull public `main` and run the exact printed Unix command. Von itself will not be started and environment/model configuration remains deferred.