### PR TITLE
Recognize narrow Von dependency sudo grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ Homebrew. `--with-ocr` is also available when you want OCR to be mandatory but
 do not authorise package installation; `--install-system-deps` implies that
 strict check.
 
+On a managed Ubuntu/Debian host, an administrator may enable non-interactive
+installation without granting blanket passwordless sudo. Create a root-owned
+rule with `sudo visudo -f /etc/sudoers.d/von-deps`, replacing `<von-user>` with
+the account that runs Von:
+
+```sudoers
+Cmnd_Alias VON_DEPS = /usr/bin/apt-get update, \
+    /usr/bin/apt-get install -y tesseract-ocr tesseract-ocr-eng
+<von-user> ALL=(root) NOPASSWD: VON_DEPS
+```
+
+Keep `VON_DEPS` as an exact, reviewed allowlist when new native dependencies
+are added; do not replace it with unrestricted `apt-get` or `NOPASSWD: ALL`.
+The installer detects this command-specific grant automatically. Without it,
+the ordinary-user local-package route remains available.
+
 ### Windows PowerShell
 
 ```powershell

--- a/setup_py.sh
+++ b/setup_py.sh
@@ -308,16 +308,22 @@ install_tesseract_system_dependency() {
                 echo -e "${RED}Automatic Tesseract installation currently supports apt-based Linux distributions.${NC}"
                 return 1
             fi
+            local apt_get_path
+            apt_get_path=$(command -v apt-get)
             if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
                 echo "Installing Tesseract with apt-get (already running as root)."
-                apt-get update
-                apt-get install -y tesseract-ocr tesseract-ocr-eng
-            elif command_exists sudo && sudo -n true >/dev/null 2>&1; then
+                "$apt_get_path" update
+                "$apt_get_path" install -y tesseract-ocr tesseract-ocr-eng
+            elif command_exists sudo \
+                && sudo -n -l "$apt_get_path" update >/dev/null 2>&1 \
+                && sudo -n -l "$apt_get_path" install -y tesseract-ocr tesseract-ocr-eng >/dev/null 2>&1; then
+                echo "A non-interactive VON_DEPS sudo grant for the exact apt commands is available."
                 echo "Installing Tesseract with: sudo apt-get update"
-                sudo -n apt-get update
+                sudo -n "$apt_get_path" update
                 echo "Installing Tesseract with: sudo apt-get install -y tesseract-ocr tesseract-ocr-eng"
-                sudo -n apt-get install -y tesseract-ocr tesseract-ocr-eng
+                sudo -n "$apt_get_path" install -y tesseract-ocr tesseract-ocr-eng
             else
+                echo "No non-interactive VON_DEPS sudo grant for those exact apt commands was detected."
                 install_tesseract_debian_user_local
             fi
             ;;

--- a/tests/test_setup_ocr_contract.py
+++ b/tests/test_setup_ocr_contract.py
@@ -131,7 +131,12 @@ def test_bash_has_an_explicit_ordinary_user_apt_fallback_and_launcher_path() -> 
         "prepare_tesseract",
     )
 
-    assert "sudo -n true" in system_install
+    assert 'sudo -n -l "$apt_get_path" update' in system_install
+    assert (
+        'sudo -n -l "$apt_get_path" install -y tesseract-ocr tesseract-ocr-eng'
+        in system_install
+    )
+    assert "sudo -n true" not in system_install
     assert "install_tesseract_debian_user_local" in system_install
     assert "apt-get download" in local_install
     assert "dpkg-deb -x" in local_install
@@ -140,6 +145,16 @@ def test_bash_has_an_explicit_ordinary_user_apt_fallback_and_launcher_path() -> 
     assert "TESSDATA_PREFIX" in local_install
     assert 'if [ -x "${HOME}/.local/bin/tesseract" ]' in launcher
     assert 'export PATH="${HOME}/.local/bin:${PATH}"' in launcher
+
+
+def test_readme_documents_narrow_von_deps_sudo_contract() -> None:
+    readme = _read("README.md")
+
+    assert "Cmnd_Alias VON_DEPS" in readme
+    assert "/usr/bin/apt-get update" in readme
+    assert "/usr/bin/apt-get install -y tesseract-ocr tesseract-ocr-eng" in readme
+    assert "NOPASSWD: VON_DEPS" in readme
+    assert "do not replace it with unrestricted `apt-get` or `NOPASSWD: ALL`" in readme
 
 
 def test_unix_final_receipt_qualifies_core_only_and_required_failure() -> None:


### PR DESCRIPTION
## Outcome

Managed Linux hosts can grant a durable `VON_DEPS` passwordless sudo capability without granting blanket sudo or arbitrary package installation.

## Change

- document a command-specific `Cmnd_Alias VON_DEPS` sudoers rule
- probe the exact `apt-get update` and Tesseract install privileges with non-interactive `sudo -l`
- use the sudo route when those exact privileges are present
- retain the ordinary-user distro-package fallback otherwise
- explicitly discourage unrestricted `apt-get` and `NOPASSWD: ALL`

## Validation

- 15 focused OCR contract/verifier tests passed
- Ruff passed
- Bash syntax and diff checks passed

This is a follow-up to #496 prompted by the DGX deployment privilege boundary.