### PR TITLE
JVNAUTOSCI-2701: make queued Von work durable and task-linked

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -979,6 +979,7 @@ ROOM_DEVICES_COLLECTION_NAME = "room_devices"
 
 # Server-side persistence for prompts waiting behind active chat turns.
 CHAT_PROMPT_QUEUE_COLLECTION_NAME = "chat_prompt_queue"
+CHAT_PROMPT_QUEUE_COUNTERS_COLLECTION_NAME = "chat_prompt_queue_counters"
 
 # Restart-safe, actor-bound per-window organisation selections.
 WINDOW_SESSION_BINDINGS_COLLECTION_NAME = "window_session_bindings"
@@ -2391,16 +2392,18 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
         coll.create_index(
             [("queue_id", ASCENDING)], name="queue_id_1_unique", unique=True
         )
-    if "scope_status_created_at" not in existing_indexes:
+    if "scope_status_enqueue_sequence" not in existing_indexes:
         coll.create_index(
             [
                 ("user_concept_id", ASCENDING),
                 ("organisation_concept_id", ASCENDING),
                 ("namespace", ASCENDING),
                 ("status", ASCENDING),
+                ("enqueue_sequence", ASCENDING),
                 ("created_at", ASCENDING),
+                ("queue_id", ASCENDING),
             ],
-            name="scope_status_created_at",
+            name="scope_status_enqueue_sequence",
         )
     if "scope_session_status_created_at" not in existing_indexes:
         coll.create_index(
@@ -2421,6 +2424,38 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
             unique=True,
             partialFilterExpression={
                 "active_conversation_key": {"$exists": True, "$type": "string"}
+            },
+        )
+    if "scope_enqueue_submission_id_unique" not in existing_indexes:
+        coll.create_index(
+            [
+                ("user_concept_id", ASCENDING),
+                ("organisation_concept_id", ASCENDING),
+                ("namespace", ASCENDING),
+                ("enqueue_submission_id", ASCENDING),
+            ],
+            name="scope_enqueue_submission_id_unique",
+            unique=True,
+            partialFilterExpression={
+                "enqueue_submission_id": {"$exists": True, "$type": "string"}
+            },
+        )
+    if "active_task_execution_key_unique" not in existing_indexes:
+        coll.create_index(
+            [("active_task_execution_key", ASCENDING)],
+            name="active_task_execution_key_unique",
+            unique=True,
+            partialFilterExpression={
+                "active_task_execution_key": {"$exists": True, "$type": "string"}
+            },
+        )
+    if "handoff_source_queue_id_unique" not in existing_indexes:
+        coll.create_index(
+            [("handoff_source_queue_id", ASCENDING)],
+            name="handoff_source_queue_id_unique",
+            unique=True,
+            partialFilterExpression={
+                "handoff_source_queue_id": {"$exists": True, "$type": "string"}
             },
         )
     if "active_legacy_submission_key_unique" not in existing_indexes:
@@ -2454,15 +2489,75 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
             unique=True,
             partialFilterExpression={"queued_user_slot": {"$exists": True}},
         )
-    if "conversation_status_created_queue" not in existing_indexes:
+    if "conversation_status_enqueue_sequence" not in existing_indexes:
         coll.create_index(
             [
                 ("conversation_key", ASCENDING),
                 ("status", ASCENDING),
+                ("enqueue_sequence", ASCENDING),
                 ("created_at", ASCENDING),
                 ("queue_id", ASCENDING),
             ],
-            name="conversation_status_created_queue",
+            name="conversation_status_enqueue_sequence",
+        )
+    if "dispatch_status_next_enqueue_sequence" not in existing_indexes:
+        coll.create_index(
+            [
+                ("dispatch_mode", ASCENDING),
+                ("status", ASCENDING),
+                ("next_dispatch_at", ASCENDING),
+                ("enqueue_sequence", ASCENDING),
+                ("created_at", ASCENDING),
+                ("queue_id", ASCENDING),
+            ],
+            name="dispatch_status_next_enqueue_sequence",
+        )
+    if "dispatch_status_lease_expiry" not in existing_indexes:
+        coll.create_index(
+            [
+                ("dispatch_mode", ASCENDING),
+                ("status", ASCENDING),
+                ("dispatch_lease_expires_at", ASCENDING),
+            ],
+            name="dispatch_status_lease_expiry",
+        )
+    if "handoff_reconciliation_due" not in existing_indexes:
+        coll.create_index(
+            [
+                ("dispatch_mode", ASCENDING),
+                ("status", ASCENDING),
+                ("dispatch_ready", ASCENDING),
+                ("handoff_reconciliation_next_at", ASCENDING),
+                ("enqueue_sequence", ASCENDING),
+                ("created_at", ASCENDING),
+                ("queue_id", ASCENDING),
+            ],
+            name="handoff_reconciliation_due",
+        )
+    if "task_execution_reconciliation_due" not in existing_indexes:
+        coll.create_index(
+            [
+                ("task_execution_reconciliation_status", ASCENDING),
+                ("task_execution_reconciliation_next_at", ASCENDING),
+                ("task_execution_reconciliation_lease_expires_at", ASCENDING),
+                ("task_execution_reconciliation_pending_at", ASCENDING),
+                ("queue_id", ASCENDING),
+            ],
+            name="task_execution_reconciliation_due",
+        )
+    if "task_launch_reconciliation_due" not in existing_indexes:
+        coll.create_index(
+            [
+                ("dispatch_mode", ASCENDING),
+                ("status", ASCENDING),
+                ("dispatch_ready", ASCENDING),
+                ("task_launch_reconciliation_next_at", ASCENDING),
+                ("task_launch_reconciliation_lease_expires_at", ASCENDING),
+                ("enqueue_sequence", ASCENDING),
+                ("created_at", ASCENDING),
+                ("queue_id", ASCENDING),
+            ],
+            name="task_launch_reconciliation_due",
         )
     if "user_status_created_at" not in existing_indexes:
         coll.create_index(
@@ -2484,6 +2579,13 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
         )
     if "updated_at_-1" not in existing_indexes:
         coll.create_index([("updated_at", DESCENDING)], name="updated_at_-1")
+    if "purge_after_ttl" not in existing_indexes:
+        coll.create_index(
+            [("purge_after", ASCENDING)],
+            name="purge_after_ttl",
+            expireAfterSeconds=0,
+            sparse=True,
+        )
 
 
 def _ensure_window_session_binding_indexes(coll: Collection) -> None:
@@ -2808,6 +2910,15 @@ def get_chat_prompt_queue_collection() -> Collection | None:
             CHAT_PROMPT_QUEUE_COLLECTION_NAME,
             _ensure_chat_prompt_queue_indexes,
         )
+    return None
+
+
+def get_chat_prompt_queue_counters_collection() -> Collection | None:
+    """Return atomic operational counters used to order queued prompts."""
+
+    db = get_db()
+    if db is not None:
+        return db[CHAT_PROMPT_QUEUE_COUNTERS_COLLECTION_NAME]
     return None
 
 

--- a/src/backend/server/routes/task_routes.py
+++ b/src/backend/server/routes/task_routes.py
@@ -12,6 +12,23 @@ from typing import Any
 from flask import Blueprint, jsonify, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
 
+from ...services import chat_history_service, chat_prompt_queue_service
+from ...services.chat_prompt_queue_dispatch_service import (
+    wake_chat_prompt_queue_dispatcher,
+)
+from ...services.conversation_concept_service import get_conversation_concept
+from ...services.conversation_turn_admission_service import build_conversation_key
+from ...services.namespace_service import resolve_canonical_namespace
+from ...services.task_execution_service import (
+    VON_SYSTEM_CONCEPT_ID,
+    InvalidTaskExecutionData,
+    TaskExecutionAccessError,
+    TaskExecutionNotFoundError,
+    TaskExecutionTransitionError,
+    reconcile_task_execution_queue_record,
+    task_execution_concept_id_for_launch,
+    task_execution_enqueue_submission_id_for_launch,
+)
 from ...services.task_external_resource_action_service import (
     TaskExternalResourceActionAccessError,
     TaskExternalResourceActionNotFoundError,
@@ -161,9 +178,14 @@ def _get_current_user_concept_id() -> str | None:
     then falls back to Flask session.
     """
     try:
-        from ...security.access_control import get_effective_user_concept_id
+        from ...security.access_control import (
+            LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+            get_effective_user_concept_id_with_source,
+        )
 
-        user_concept_id = get_effective_user_concept_id()
+        user_concept_id, actor_source = get_effective_user_concept_id_with_source()
+        if actor_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+            user_concept_id = None
     except Exception:
         user_concept_id = session.get("user_concept_id")
 
@@ -187,6 +209,395 @@ def _get_current_org_concept_id() -> str | None:
     if isinstance(org_concept_id, str) and org_concept_id.strip():
         return org_concept_id.strip()
     return None
+
+
+def _get_task_execution_actor_context() -> dict[str, str]:
+    """Resolve the exact trusted actor, organisation, and namespace."""
+
+    actor_concept_id = _get_current_user_concept_id()
+    if not actor_concept_id:
+        raise TaskExecutionAccessError(
+            "not_authenticated",
+            "An authenticated user is required to execute a task",
+        )
+    organisation_concept_id = _get_current_org_concept_id()
+    if not organisation_concept_id:
+        raise TaskExecutionAccessError(
+            "organisation_scope_required",
+            "Select an organisation before executing a task",
+        )
+    namespace = resolve_canonical_namespace(
+        None,
+        actor_concept_id,
+        organisation_concept_id,
+    )
+    if not namespace:
+        raise TaskExecutionAccessError(
+            "namespace_required",
+            "The trusted actor namespace could not be resolved",
+        )
+    return {
+        "actor_concept_id": actor_concept_id,
+        "organisation_concept_id": organisation_concept_id,
+        "namespace": namespace,
+    }
+
+
+def _resolve_task_execution_conversation(
+    *,
+    task: dict[str, Any],
+    actor_context: dict[str, str],
+) -> dict[str, Any]:
+    """Read back the task's actor-owned originating conversation."""
+
+    task_org_id = task.get("organisation_concept_id")
+    if task_org_id != actor_context["organisation_concept_id"]:
+        raise TaskExecutionAccessError(
+            "task_organisation_mismatch",
+            "The task does not belong to the active organisation",
+        )
+    if task.get("assignee_concept_id") != VON_SYSTEM_CONCEPT_ID:
+        raise TaskExecutionAccessError(
+            "task_not_assigned_to_von",
+            "The task must be assigned to Von before it can be executed",
+        )
+    if task.get("created_by_concept_id") != actor_context["actor_concept_id"]:
+        raise TaskExecutionAccessError(
+            "task_creator_mismatch",
+            "Only the task creator can authorise Von to execute this task",
+        )
+    if str(task.get("status") or "").strip().lower() not in {
+        "pending",
+        "in_progress",
+    }:
+        raise TaskExecutionAccessError(
+            "task_not_executable",
+            "Only a pending or in-progress task can be executed",
+        )
+    conversation_id = task.get("originating_conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id.strip():
+        raise TaskExecutionAccessError(
+            "originating_conversation_required",
+            "The task must be associated with an originating conversation",
+        )
+    conversation = get_conversation_concept(conversation_id.strip())
+    if not isinstance(conversation, dict):
+        raise TaskExecutionAccessError(
+            "originating_conversation_unavailable",
+            "The originating conversation is not accessible",
+        )
+    actor_id = actor_context["actor_concept_id"]
+    org_id = actor_context["organisation_concept_id"]
+    namespace = actor_context["namespace"]
+    if conversation.get("owner_concept_id") != actor_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_owner_mismatch",
+            "The originating conversation belongs to a different actor",
+        )
+    conversation_org_id = conversation.get("organisation_concept_id")
+    if conversation_org_id != org_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_organisation_mismatch",
+            "The originating conversation belongs to a different organisation",
+        )
+    conversation_namespace = conversation.get("namespace")
+    if conversation_namespace:
+        canonical_conversation_namespace = resolve_canonical_namespace(
+            conversation_namespace,
+            actor_id,
+            org_id,
+        )
+        if canonical_conversation_namespace != namespace:
+            raise TaskExecutionAccessError(
+                "originating_conversation_namespace_mismatch",
+                "The originating conversation belongs to a different namespace",
+            )
+    session_id = conversation.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise TaskExecutionAccessError(
+            "originating_conversation_session_required",
+            "The originating conversation has no session identifier",
+        )
+    session_id = session_id.strip()
+    task_session_id = task.get("conversation_session_id")
+    if task_session_id and task_session_id != session_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_session_mismatch",
+            "The task and originating conversation session identifiers differ",
+        )
+    if not chat_history_service.has_chat_history_session(
+        actor_id,
+        session_id,
+        namespace=namespace,
+        include_legacy=False,
+    ):
+        raise TaskExecutionAccessError(
+            "originating_conversation_history_unavailable",
+            "The originating conversation history is not available in this scope",
+        )
+    resolved = dict(task)
+    resolved["originating_conversation_id"] = conversation_id.strip()
+    resolved["conversation_session_id"] = session_id
+    resolved["conversation_name"] = (
+        conversation.get("name")
+        or conversation.get("topic")
+        or task.get("conversation_name")
+    )
+    return resolved
+
+
+def _build_task_execution_prompt(task: dict[str, Any]) -> str:
+    """Project the represented task intent into the queued conversation turn."""
+
+    task_id = str(task.get("task_concept_id") or "").strip()
+    title = str(task.get("title") or "Untitled task").strip()
+    description = str(task.get("description") or "").strip()
+    prompt = (
+        "Execute the task assigned to Von.\n"
+        f"Task concept ID: {task_id}\n"
+        f"Title: {title}\n"
+        f"Description: {description}"
+    )
+    return prompt[: chat_prompt_queue_service.MAX_PROMPT_RAW_CHARS]
+
+
+def _enqueue_task_execution(
+    *,
+    scope: dict[str, str],
+    task: dict[str, Any],
+    task_execution_concept_id: str,
+    enqueue_submission_id: str,
+    execution_envelope: dict[str, Any],
+    conversation_key: str,
+) -> dict[str, Any]:
+    """Narrow adapter around the durable server-dispatch queue contract."""
+
+    return chat_prompt_queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw=_build_task_execution_prompt(task),
+        session_id=task["conversation_session_id"],
+        session_name=task.get("conversation_name"),
+        status=chat_prompt_queue_service.STATUS_QUEUED,
+        source="von_task",
+        conversation_key=conversation_key,
+        enqueue_submission_id=enqueue_submission_id,
+        dispatch_mode=chat_prompt_queue_service.DISPATCH_MODE_SERVER,
+        execution_envelope_version=1,
+        execution_envelope=execution_envelope,
+        task_concept_id=task["task_concept_id"],
+        task_execution_concept_id=task_execution_concept_id,
+        server_dispatch_ready=False,
+    )
+
+
+def _task_execution_error_response(exc: Exception) -> ResponseReturnValue:
+    if isinstance(exc, TaskExecutionAccessError):
+        status = 401 if exc.reason_code == "not_authenticated" else 403
+        return jsonify(
+            {
+                "success": False,
+                "error": exc.safe_message,
+                "reason_code": exc.reason_code,
+            }
+        ), status
+    if isinstance(exc, TaskExecutionNotFoundError):
+        return jsonify({"success": False, "error": str(exc)}), 404
+    if isinstance(exc, InvalidTaskExecutionData):
+        return jsonify({"success": False, "error": str(exc)}), 400
+    if isinstance(exc, TaskExecutionTransitionError):
+        return jsonify({"success": False, "error": str(exc)}), 409
+    if isinstance(exc, chat_prompt_queue_service.ChatPromptQueueCapacityReached):
+        return jsonify({"success": False, "error": str(exc)}), 429
+    if isinstance(exc, chat_prompt_queue_service.ChatPromptQueueSubmissionConflict):
+        return jsonify(
+            {
+                "success": False,
+                "error": str(exc),
+                "reason_code": exc.error_code,
+            }
+        ), 409
+    if isinstance(exc, chat_prompt_queue_service.ChatPromptQueueTaskAlreadyActive):
+        return jsonify(
+            {
+                "success": False,
+                "error": str(exc),
+                "reason_code": exc.error_code,
+                "queue_id": exc.queue_id,
+                "task_execution_concept_id": exc.task_execution_concept_id,
+            }
+        ), 409
+    if isinstance(exc, chat_prompt_queue_service.InvalidChatPromptQueueInput):
+        return jsonify({"success": False, "error": str(exc)}), 400
+    if isinstance(exc, chat_prompt_queue_service.ChatPromptQueueUnavailable):
+        return jsonify({"success": False, "error": str(exc)}), 503
+    logger.error("Unexpected task execution error: %s", exc)
+    return jsonify({"success": False, "error": "Internal server error"}), 500
+
+
+@task_bp.route("/<task_concept_id>/execute-with-von", methods=["POST"])
+def execute_task_with_von_route(task_concept_id: str) -> ResponseReturnValue:
+    """Explicitly launch one actor-bound Von execution for a task."""
+
+    task_execution: dict[str, Any] | None = None
+    queue_record: dict[str, Any] | None = None
+    actor_context: dict[str, str] | None = None
+    task: dict[str, Any] | None = None
+    try:
+        actor_context = _get_task_execution_actor_context()
+        # A task point read is not sufficient authority by itself. Bind it to
+        # the trusted creator, active organisation, and actor-owned originating
+        # conversation instead of accepting any request payload scope.
+        task = _resolve_task_execution_conversation(
+            task=dict(get_task(task_concept_id)),
+            actor_context=actor_context,
+        )
+        payload = request.get_json(silent=True)
+        payload = payload if isinstance(payload, dict) else {}
+        requested_session_id = payload.get("originating_session_id")
+        if requested_session_id is not None and requested_session_id != task.get(
+            "conversation_session_id"
+        ):
+            raise TaskExecutionAccessError(
+                "originating_conversation_session_mismatch",
+                "The requested conversation does not match the task",
+            )
+        launch_request_id = payload.get("launch_request_id")
+        if launch_request_id is None:
+            raise InvalidTaskExecutionData("launch_request_id is required")
+        if not isinstance(launch_request_id, str) or not launch_request_id.strip():
+            raise InvalidTaskExecutionData("launch_request_id must be a string")
+        launch_request_id = launch_request_id.strip()
+        if len(launch_request_id) > 200:
+            raise InvalidTaskExecutionData("launch_request_id is too long")
+
+        execution_concept_id = task_execution_concept_id_for_launch(
+            task_concept_id=task["task_concept_id"],
+            creator_concept_id=actor_context["actor_concept_id"],
+            organisation_concept_id=actor_context["organisation_concept_id"],
+            launch_request_id=launch_request_id,
+        )
+        enqueue_submission_id = task_execution_enqueue_submission_id_for_launch(
+            task_concept_id=task["task_concept_id"],
+            creator_concept_id=actor_context["actor_concept_id"],
+            organisation_concept_id=actor_context["organisation_concept_id"],
+            launch_request_id=launch_request_id,
+        )
+        execution_envelope = {
+            "initiation_id": launch_request_id,
+            "turn_kind": "user_message",
+            "workflow_inputs": {
+                "task_concept_id": task["task_concept_id"],
+                "task_execution_concept_id": execution_concept_id,
+                "originating_conversation_concept_id": task[
+                    "originating_conversation_id"
+                ],
+                "conversation_session_id": task["conversation_session_id"],
+                "authority_actor_concept_id": actor_context["actor_concept_id"],
+                "authority_organisation_concept_id": actor_context[
+                    "organisation_concept_id"
+                ],
+                "authority_namespace": actor_context["namespace"],
+                "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
+            },
+        }
+        scope = {
+            "user_concept_id": actor_context["actor_concept_id"],
+            "organisation_concept_id": actor_context["organisation_concept_id"],
+            "namespace": actor_context["namespace"],
+        }
+        conversation_key = build_conversation_key(
+            owner_user_id=actor_context["actor_concept_id"],
+            history_namespace=actor_context["namespace"],
+            conversation_session_id=task["conversation_session_id"],
+        )
+        queue_record = _enqueue_task_execution(
+            scope=scope,
+            task=task,
+            task_execution_concept_id=execution_concept_id,
+            enqueue_submission_id=enqueue_submission_id,
+            execution_envelope=execution_envelope,
+            conversation_key=conversation_key,
+        )
+        queue_replayed = bool(queue_record.get("idempotent_replay"))
+        task_execution = reconcile_task_execution_queue_record(
+            {
+                **queue_record,
+                **scope,
+                "execution_envelope": execution_envelope,
+            }
+        )
+        if (
+            queue_record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
+            and not queue_record.get("dispatch_ready")
+        ):
+            queue_record = chat_prompt_queue_service.activate_server_dispatch_record(
+                scope=scope,
+                queue_id=str(queue_record["queue_id"]),
+                enqueue_submission_id=enqueue_submission_id,
+                task_execution_concept_id=execution_concept_id,
+            )
+            queue_record["idempotent_replay"] = queue_replayed
+        wake_chat_prompt_queue_dispatcher()
+        return jsonify(
+            {
+                "success": True,
+                "task": {
+                    "task_concept_id": task["task_concept_id"],
+                    "title": task.get("title"),
+                    "originating_conversation_id": task[
+                        "originating_conversation_id"
+                    ],
+                    "conversation_session_id": task["conversation_session_id"],
+                    "conversation_name": task.get("conversation_name"),
+                },
+                "task_execution": task_execution,
+                "queue_item": queue_record,
+                "idempotent_replay": queue_replayed,
+            }
+        ), (200 if queue_replayed else 201)
+    except TaskNotFoundError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 404
+    except Exception as exc:  # noqa: BLE001 - preserve route error boundary
+        # Once the unready queue outbox exists, do not delete it on an unknown
+        # projection acknowledgement. The server dispatcher owns durable
+        # reconciliation and the exact client launch ID makes retries safe.
+        if (
+            queue_record
+            and actor_context
+            and task
+            and queue_record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
+            and not queue_record.get("dispatch_ready")
+        ):
+            logger.warning(
+                "Task launch accepted for durable reconciliation queue_id=%s: %s",
+                queue_record.get("queue_id"),
+                exc,
+            )
+            wake_chat_prompt_queue_dispatcher()
+            return jsonify(
+                {
+                    "success": True,
+                    "reconciliation_pending": True,
+                    "warning": "Task execution projection is being reconciled",
+                    "task": {
+                        "task_concept_id": task["task_concept_id"],
+                        "title": task.get("title"),
+                        "originating_conversation_id": task[
+                            "originating_conversation_id"
+                        ],
+                        "conversation_session_id": task[
+                            "conversation_session_id"
+                        ],
+                        "conversation_name": task.get("conversation_name"),
+                    },
+                    "task_execution": None,
+                    "queue_item": queue_record,
+                    "idempotent_replay": bool(
+                        queue_record.get("idempotent_replay")
+                    ),
+                }
+            ), 202
+        return _task_execution_error_response(exc)
 
 
 @task_bp.route("/", methods=["POST"])

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -54,6 +54,11 @@ from ...services.request_progress_service import (
 )
 from ...services import chat_history_service
 from ...services import chat_prompt_queue_service
+from ...services.chat_prompt_queue_dispatch_service import (
+    ChatPromptDispatchOutcome,
+    reconcile_linked_task_execution_terminal,
+    wake_chat_prompt_queue_dispatcher,
+)
 from ...services import conversation_management_service
 from ...services import conversation_search_service
 from ...services.external_conversation_import_service import (
@@ -241,6 +246,88 @@ von_bp = Blueprint("von", __name__, template_folder=_TEMPLATE_DIR)
 _TURN_ADMISSION_CONTEXT_KEY = "von_conversation_turn_admission"
 
 
+def _bound_task_execution_correlation(token: Any) -> dict[str, str] | None:
+    """Return only server-bound task correlation from an admission token."""
+
+    task_id = _normalise_non_empty_text(getattr(token, "task_concept_id", None))
+    execution_id = _normalise_non_empty_text(
+        getattr(token, "task_execution_concept_id", None)
+    )
+    if not task_id and not execution_id:
+        return None
+    correlation = {
+        "request_id": _normalise_non_empty_text(
+            getattr(token, "client_request_id", None)
+        ),
+        "conversation_session_id": _normalise_non_empty_text(
+            getattr(token, "session_id", None)
+        ),
+        "queue_id": _normalise_non_empty_text(getattr(token, "queue_id", None)),
+        "enqueue_submission_id": _normalise_non_empty_text(
+            getattr(token, "enqueue_submission_id", None)
+        ),
+        "task_concept_id": task_id,
+        "task_execution_concept_id": execution_id,
+    }
+    missing = [key for key, value in correlation.items() if not value]
+    if missing:
+        raise RuntimeError(
+            "bound task execution correlation is incomplete: " + ", ".join(missing)
+        )
+    return cast(dict[str, str], correlation)
+
+
+def _stamp_bound_task_execution_turn_projection(
+    llm_debug_info: dict[str, Any],
+    token: Any,
+    *,
+    completion_gate_source: Mapping[str, Any] | None = None,
+) -> None:
+    """Stamp server-owned queue/task identity into the persisted turn record."""
+
+    correlation = _bound_task_execution_correlation(token)
+    if correlation is None:
+        return
+    record = llm_debug_info.get("turn_execution_record")
+    if not isinstance(record, Mapping):
+        raise RuntimeError("task-linked turn has no persistable turn execution record")
+    stamped = dict(record)
+    stamped.update(correlation)
+    stamped["session_id"] = correlation["conversation_session_id"]
+    gate = llm_debug_info.get("completion_gate")
+    if not isinstance(gate, Mapping):
+        gate = llm_debug_info.get("completion_gate_verdict")
+    if not isinstance(gate, Mapping) and isinstance(completion_gate_source, Mapping):
+        gate = completion_gate_source.get("completion_gate")
+        if not isinstance(gate, Mapping):
+            gate = completion_gate_source.get("completion_gate_verdict")
+        if not isinstance(gate, Mapping):
+            gate_fields = {
+                "decision": completion_gate_source.get("completion_gate_decision"),
+                "decision_reason": completion_gate_source.get(
+                    "completion_gate_decision_reason"
+                ),
+                "requires_follow_up": completion_gate_source.get(
+                    "completion_gate_requires_follow_up"
+                ),
+                "safe_to_claim_completion": completion_gate_source.get(
+                    "completion_gate_safe_to_claim_completion"
+                ),
+                "terminal_outcome": completion_gate_source.get(
+                    "completion_gate_terminal_outcome"
+                ),
+                "evidence_payload": completion_gate_source.get(
+                    "completion_gate_evidence_payload"
+                ),
+            }
+            gate = {
+                key: value for key, value in gate_fields.items() if value is not None
+            }
+    if isinstance(gate, Mapping):
+        stamped["completion_gate"] = dict(gate)
+    llm_debug_info["turn_execution_record"] = stamped
+
+
 def _release_request_turn_admission(
     *,
     response: Any | None = None,
@@ -308,6 +395,7 @@ def _release_request_turn_admission(
             status=terminal_status,
             error=error_text,
         )
+        wake_chat_prompt_queue_dispatcher()
     except Exception:
         current_app.logger.exception(
             "[turn_admission] Failed to release queue_id=%s request_id=%s",
@@ -1036,15 +1124,17 @@ def _chat_prompt_queue_error_response(
         response.headers["Retry-After"] = "1"
         return response, 429
     if isinstance(exc, chat_prompt_queue_service.InvalidChatPromptQueueInput):
+        error_code = str(getattr(exc, "error_code", "invalid_input"))
+        status_code = int(getattr(exc, "status_code", 400) or 400)
         return (
             jsonify(
                 {
                     "success": False,
                     "error": str(exc),
-                    "error_code": "invalid_input",
+                    "error_code": error_code,
                 }
             ),
-            400,
+            status_code,
         )
     if isinstance(exc, chat_prompt_queue_service.ConversationTurnAlreadyActive):
         return (
@@ -1180,6 +1270,9 @@ def create_chat_prompt_queue_route():
                     history_namespace=history_namespace,
                     conversation_session_id=session_id,
                 )
+        handoff_source_queue_id = _normalise_non_empty_text(
+            payload.get("handoff_source_queue_id")
+        )
         record = chat_prompt_queue_service.create_queue_record(
             scope=scope,
             prompt_raw=payload.get("prompt_raw"),
@@ -1201,10 +1294,67 @@ def create_chat_prompt_queue_route():
                 else None
             ),
             window_session_id=request.headers.get(_WINDOW_SESSION_HEADER_NAME),
+            enqueue_submission_id=payload.get("enqueue_submission_id"),
+            dispatch_mode=payload.get("dispatch_mode"),
+            execution_envelope_version=payload.get("execution_envelope_version"),
+            execution_envelope=payload.get("execution_envelope"),
+            handoff_source_queue_id=handoff_source_queue_id,
+            server_dispatch_ready=(False if handoff_source_queue_id else None),
         )
-        return jsonify({"success": True, "item": record}), 201
+        idempotent_replay = bool(record.get("idempotent_replay"))
+        if (
+            handoff_source_queue_id
+            and record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
+            and not record.get("dispatch_ready")
+        ):
+            record = chat_prompt_queue_service.complete_server_dispatch_handoff(
+                scope=scope,
+                queue_id=str(record.get("queue_id") or ""),
+                enqueue_submission_id=_normalise_non_empty_text(
+                    record.get("enqueue_submission_id")
+                ),
+            )
+            record["idempotent_replay"] = idempotent_replay
+        if record.get("dispatch_mode") == "server":
+            wake_chat_prompt_queue_dispatcher()
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "item": record,
+                    "idempotent_replay": idempotent_replay,
+                }
+            ),
+            200 if idempotent_replay else 201,
+        )
     except Exception as exc:
         return _chat_prompt_queue_error_response(exc, action="create", scope=scope)
+
+
+@von_bp.route(
+    "/api/chat_prompt_queue/<queue_id>/complete-handoff",
+    methods=["POST"],
+)
+def complete_chat_prompt_queue_handoff_route(queue_id: str):
+    """Retry the server-owned retirement/activation half of a durable handoff."""
+
+    scope = _get_current_chat_prompt_queue_scope()
+    if isinstance(scope, tuple):
+        return scope
+    try:
+        record = chat_prompt_queue_service.complete_server_dispatch_handoff(
+            scope=scope,
+            queue_id=queue_id,
+        )
+        wake_chat_prompt_queue_dispatcher()
+        return jsonify({"success": True, "item": record})
+    except Exception as exc:
+        return _chat_prompt_queue_error_response(
+            exc,
+            action="complete_handoff",
+            queue_id=queue_id,
+            scope=scope,
+        )
 
 
 @von_bp.route("/api/chat_prompt_queue/<queue_id>", methods=["PATCH"])
@@ -1278,6 +1428,28 @@ def cancel_chat_prompt_queue_route(queue_id: str):
             scope=scope,
             queue_id=queue_id,
         )
+        try:
+            reconcile_linked_task_execution_terminal(
+                {
+                    **record,
+                    "user_concept_id": scope.get("user_concept_id"),
+                    "organisation_concept_id": scope.get(
+                        "organisation_concept_id"
+                    ),
+                    "namespace": scope.get("namespace"),
+                },
+                status=chat_prompt_queue_service.STATUS_CANCELLED,
+                source="queue_cancellation",
+            )
+        except Exception as exc:
+            _safe_app_log(
+                "warning",
+                "TaskExecution cancellation reconciliation deferred for %s: %s",
+                queue_id,
+                exc,
+            )
+        finally:
+            wake_chat_prompt_queue_dispatcher()
         return jsonify({"success": True, "item": record})
     except Exception as exc:
         return _chat_prompt_queue_error_response(
@@ -7266,10 +7438,33 @@ def cancel_task(task_id: str):
     queue_id = _normalise_non_empty_text(getattr(status, "queue_id", None))
     if queue_id:
         try:
-            chat_prompt_queue_service.cancel_prompt_record(
+            cancelled_record = chat_prompt_queue_service.cancel_prompt_record(
                 scope=scope,
                 queue_id=queue_id,
             )
+            try:
+                reconcile_linked_task_execution_terminal(
+                    {
+                        **cancelled_record,
+                        "user_concept_id": scope.get("user_concept_id"),
+                        "organisation_concept_id": scope.get(
+                            "organisation_concept_id"
+                        ),
+                        "namespace": scope.get("namespace"),
+                    },
+                    status=chat_prompt_queue_service.STATUS_CANCELLED,
+                    source="background_queue_cancellation",
+                )
+            except Exception as exc:
+                _safe_app_log(
+                    "warning",
+                    "TaskExecution background cancellation reconciliation "
+                    "deferred for %s: %s",
+                    queue_id,
+                    exc,
+                )
+            finally:
+                wake_chat_prompt_queue_dispatcher()
         except chat_prompt_queue_service.ConversationTurnAlreadyActive:
             # The running generate request owns this fence and observes the
             # cancellation flag; its teardown will terminalise the exact
@@ -10709,6 +10904,18 @@ def _submit_generate_background_request(
     background_attempt_id = _normalise_non_empty_text(
         background_payload.get("attempt_id")
     )
+    background_dispatch_reservation_token = _normalise_non_empty_text(
+        background_payload.get("dispatch_reservation_token")
+    )
+    background_enqueue_submission_id = _normalise_non_empty_text(
+        background_payload.get("enqueue_submission_id")
+    )
+    background_task_concept_id = _normalise_non_empty_text(
+        background_payload.get("task_concept_id")
+    )
+    background_task_execution_concept_id = _normalise_non_empty_text(
+        background_payload.get("task_execution_concept_id")
+    )
     background_user_id = _normalise_non_empty_text(actor_scope.get("user_concept_id"))
     background_org_id = _normalise_non_empty_text(
         actor_scope.get("organisation_concept_id")
@@ -10735,6 +10942,94 @@ def _submit_generate_background_request(
     else:
         frozen_session_snapshot.pop(_LEGACY_SUBMISSION_WINDOW_SESSION_KEY, None)
 
+    def _reconcile_unadmitted_background_response(
+        *,
+        generated_response: Any | None = None,
+        exception: BaseException | None = None,
+    ) -> None:
+        # Once admission exists, its exact attempt token owns terminalisation.
+        # This fallback is only for validation/capacity failures that happen
+        # before the durable queue reservation can be upgraded.
+        if getattr(g, _TURN_ADMISSION_CONTEXT_KEY, None) is not None:
+            return
+        if not all(
+            (
+                background_queue_id,
+                background_attempt_id,
+                background_dispatch_reservation_token,
+            )
+        ):
+            return
+
+        retryable = exception is not None
+        error_text = (
+            f"background generate raised {type(exception).__name__}: {exception}"
+            if exception is not None
+            else "background generate ended before turn admission"
+        )
+        if generated_response is not None:
+            status_code = int(getattr(generated_response, "status_code", 500) or 500)
+            payload = None
+            try:
+                payload = generated_response.get_json(silent=True)
+            except Exception:
+                payload = None
+            retryable = status_code in {429, 500, 502, 503, 504}
+            if isinstance(payload, Mapping):
+                retryable = retryable or payload.get("retryable") is True
+                error_text = str(
+                    payload.get("error")
+                    or payload.get("detail")
+                    or f"background generate returned HTTP {status_code}"
+                )
+            else:
+                error_text = f"background generate returned HTTP {status_code}"
+
+        if retryable:
+            released = chat_prompt_queue_service.release_server_dispatch_reservation(
+                queue_id=str(background_queue_id),
+                dispatch_reservation_token=str(background_dispatch_reservation_token),
+                server_instance_id=SERVER_INSTANCE_ID,
+                retry_after_seconds=1.0,
+                error=error_text[:4_000],
+            )
+            if released:
+                wake_chat_prompt_queue_dispatcher()
+            return
+        failed = chat_prompt_queue_service.fail_server_dispatch_reservation(
+            queue_id=str(background_queue_id),
+            dispatch_reservation_token=str(background_dispatch_reservation_token),
+            server_instance_id=SERVER_INSTANCE_ID,
+            error=error_text[:4_000],
+        )
+        if failed:
+            try:
+                reconcile_linked_task_execution_terminal(
+                    {
+                        "queue_id": background_queue_id,
+                        "enqueue_submission_id": background_enqueue_submission_id,
+                        "task_concept_id": background_task_concept_id,
+                        "task_execution_concept_id": (
+                            background_task_execution_concept_id
+                        ),
+                        "user_concept_id": background_user_id,
+                        "organisation_concept_id": background_org_id,
+                        "namespace": background_namespace,
+                    },
+                    status=chat_prompt_queue_service.STATUS_FAILED,
+                    source="background_pre_admission_failure",
+                    error=error_text[:4_000],
+                )
+            except Exception as exc:
+                _safe_app_log(
+                    "warning",
+                    "TaskExecution pre-admission reconciliation deferred for %s: %s",
+                    background_queue_id,
+                    exc,
+                )
+            finally:
+                wake_chat_prompt_queue_dispatcher()
+
     def _run_generate_request_in_background() -> dict[str, Any]:
         with app.test_request_context(
             "/von/generate",
@@ -10747,9 +11042,18 @@ def _submit_generate_background_request(
             session.modified = True
             try:
                 generated = make_response(generate())
+                _reconcile_unadmitted_background_response(generated_response=generated)
                 _release_request_turn_admission(response=generated)
                 return _normalise_background_generate_result(generated)
             except BaseException as exc:
+                try:
+                    _reconcile_unadmitted_background_response(exception=exc)
+                except Exception:
+                    current_app.logger.exception(
+                        "[chat_prompt_dispatch] Failed to reconcile unadmitted "
+                        "queue_id=%s",
+                        background_queue_id,
+                    )
                 _release_request_turn_admission(exception=exc)
                 raise
 
@@ -10802,6 +11106,199 @@ def _submit_generate_background_request(
         ),
         202,
     )
+
+
+def _server_dispatch_retry_after_seconds(response: Any) -> float:
+    raw_header = None
+    try:
+        raw_header = response.headers.get("Retry-After")
+    except Exception:
+        raw_header = None
+    try:
+        return max(0.0, min(float(raw_header), 60.0))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def submit_server_dispatched_chat_prompt(
+    app: Any,
+    record: Mapping[str, Any],
+) -> ChatPromptDispatchOutcome:
+    """Submit one trusted queue reservation through the normal generate path.
+
+    The row is a bounded launch capability issued by the server at enqueue
+    time.  Persisted actor identifiers set the maximum scope, while current
+    organisation membership and the normal generate authorisation checks are
+    evaluated again before execution.  No browser session or model-supplied
+    identity can enlarge that scope.
+    """
+
+    user_concept_id = _normalise_non_empty_text(record.get("user_concept_id"))
+    organisation_concept_id = _normalise_non_empty_text(
+        record.get("organisation_concept_id")
+    )
+    namespace = _normalise_non_empty_text(record.get("namespace"))
+    queue_id = _normalise_non_empty_text(record.get("queue_id"))
+    attempt_id = _normalise_non_empty_text(record.get("attempt_id"))
+    request_id = _normalise_non_empty_text(record.get("client_request_id"))
+    reservation_token = _normalise_non_empty_text(
+        record.get("dispatch_reservation_token")
+    )
+    conversation_session_id = _normalise_non_empty_text(record.get("session_id"))
+    if not all(
+        (
+            user_concept_id,
+            namespace,
+            queue_id,
+            attempt_id,
+            request_id,
+            reservation_token,
+            conversation_session_id,
+        )
+    ):
+        return ChatPromptDispatchOutcome(
+            accepted=False,
+            error="server queue entry is missing its bounded launch identity",
+        )
+
+    expected_namespace = _derive_namespace_for_user_org(
+        user_concept_id,
+        organisation_concept_id,
+    )
+    if expected_namespace != namespace:
+        return ChatPromptDispatchOutcome(
+            accepted=False,
+            error="server queue namespace no longer matches its actor scope",
+        )
+
+    role_in_org: str | None = None
+    if organisation_concept_id:
+        try:
+            from ...services.organisation_membership_service import (
+                resolve_user_organisation_membership,
+            )
+
+            membership = resolve_user_organisation_membership(
+                user_concept_id,
+                organisation_concept_id,
+            )
+        except Exception as exc:
+            return ChatPromptDispatchOutcome(
+                accepted=False,
+                retryable=True,
+                retry_after_seconds=2.0,
+                error=(
+                    "organisation membership could not be revalidated: "
+                    f"{type(exc).__name__}"
+                ),
+            )
+        if not isinstance(membership, Mapping):
+            return ChatPromptDispatchOutcome(
+                accepted=False,
+                error="organisation membership was revoked before dispatch",
+            )
+        role_in_org = _normalise_non_empty_text(membership.get("role")) or "member"
+
+    raw_envelope = record.get("execution_envelope")
+    if not isinstance(raw_envelope, Mapping):
+        return ChatPromptDispatchOutcome(
+            accepted=False,
+            error="server queue entry has no valid execution envelope",
+        )
+    payload = dict(raw_envelope)
+    # These fields are server-owned even if a legacy or malformed envelope
+    # happens to contain names that look like identity/correlation inputs.
+    for key in (
+        "user_id",
+        "organisation_concept_id",
+        "namespace",
+        "background_task_id",
+        "prompt_queue_id",
+        "client_request_id",
+        "attempt_id",
+        "dispatch_reservation_token",
+        "enqueue_submission_id",
+        "task_concept_id",
+        "task_execution_concept_id",
+    ):
+        payload.pop(key, None)
+    payload.update(
+        {
+            "prompt": str(record.get("prompt_raw") or ""),
+            "conversation_session_id": conversation_session_id,
+            "conversation_session_name": record.get("session_name"),
+            "background": True,
+            "prompt_queue_id": queue_id,
+            "client_request_id": request_id,
+            "attempt_id": attempt_id,
+            "dispatch_reservation_token": reservation_token,
+        }
+    )
+    if record.get("task_concept_id") or record.get("task_execution_concept_id"):
+        # Correlation is stamped from the reserved row after envelope fields
+        # with the same names have been removed above.
+        payload.update(
+            {
+                "enqueue_submission_id": record.get("enqueue_submission_id"),
+                "task_concept_id": record.get("task_concept_id"),
+                "task_execution_concept_id": record.get("task_execution_concept_id"),
+            }
+        )
+
+    frozen_session: dict[str, Any] = {
+        "user_concept_id": user_concept_id,
+        "namespace": namespace,
+        "session_id": conversation_session_id,
+    }
+    if organisation_concept_id:
+        frozen_session["organisation_concept_id"] = organisation_concept_id
+        frozen_session["org_id"] = organisation_concept_id
+        frozen_session["role_in_org"] = role_in_org
+
+    with app.test_request_context(
+        "/von/generate",
+        method="POST",
+        json=payload,
+    ):
+        session.clear()
+        session.update(frozen_session)
+        session.modified = True
+        try:
+            response = make_response(generate())
+        except Exception as exc:
+            return ChatPromptDispatchOutcome(
+                accepted=False,
+                retryable=True,
+                retry_after_seconds=1.0,
+                error=f"generate submission raised {type(exc).__name__}: {exc}",
+            )
+
+        response_payload = None
+        try:
+            response_payload = response.get_json(silent=True)
+        except Exception:
+            response_payload = None
+        status_code = int(getattr(response, "status_code", 500) or 500)
+        if status_code == 202 and isinstance(response_payload, Mapping):
+            if response_payload.get("background") is True:
+                return ChatPromptDispatchOutcome(accepted=True)
+
+        retryable = status_code in {429, 500, 502, 503, 504}
+        if isinstance(response_payload, Mapping):
+            retryable = retryable or response_payload.get("retryable") is True
+            error = str(
+                response_payload.get("error")
+                or response_payload.get("detail")
+                or f"generate submission returned HTTP {status_code}"
+            )
+        else:
+            error = f"generate submission returned HTTP {status_code}"
+        return ChatPromptDispatchOutcome(
+            accepted=False,
+            retryable=retryable,
+            retry_after_seconds=_server_dispatch_retry_after_seconds(response),
+            error=error[:4_000],
+        )
 
 
 def _persist_terminal_failure_turn_record_best_effort(
@@ -11545,10 +12042,13 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             raw_active_session_id = effective.get("chat_session_id")
             if isinstance(raw_active_session_id, str) and raw_active_session_id.strip():
                 background_session_id = raw_active_session_id.strip()
-        if background_session_id and chat_history_service.is_external_conversation_read_only(
-            user_id=user_concept_id,
-            session_id=background_session_id,
-            namespace=user_namespace,
+        if (
+            background_session_id
+            and chat_history_service.is_external_conversation_read_only(
+                user_id=user_concept_id,
+                session_id=background_session_id,
+                namespace=user_namespace,
+            )
         ):
             return _external_conversation_read_only_response()
         return _submit_generate_background_request(
@@ -11624,6 +12124,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         if isinstance(raw_prompt_queue_id, str) and raw_prompt_queue_id.strip()
         else None
     )
+    dispatch_reservation_token = _normalise_non_empty_text(
+        data.get("dispatch_reservation_token")
+    )
     try:
         if user_concept_id and history_user_id and history_namespace:
             raw_attempt_id = data.get("attempt_id")
@@ -11655,6 +12158,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 ),
                 queue_id=prompt_queue_id,
                 attempt_id=attempt_id,
+                dispatch_reservation_token=dispatch_reservation_token,
                 window_session_id=legacy_submission_window_session_id,
             )
         else:
@@ -14529,6 +15033,17 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                 )
 
         _refresh_llm_debug_timing_payload(llm_debug_info)
+        admission_token = getattr(g, _TURN_ADMISSION_CONTEXT_KEY, None)
+        if admission_token is not None:
+            _stamp_bound_task_execution_turn_projection(
+                llm_debug_info,
+                admission_token,
+                completion_gate_source=(
+                    tool_progress_snapshot
+                    if isinstance(tool_progress_snapshot, Mapping)
+                    else None
+                ),
+            )
 
         current_app.config["CONTEXT"] = _persist_generate_turn_messages(
             history_user_id=history_user_id,
@@ -15666,8 +16181,7 @@ def history_turn_failure_capsule():
         not isinstance(projected_capsule, Mapping)
         or projected_capsule.get("schema_version")
         != TURN_FAILURE_CAPSULE_SCHEMA_VERSION
-        or _progress_str(projected_capsule.get("request_id"))
-        != resolved_request_id
+        or _progress_str(projected_capsule.get("request_id")) != resolved_request_id
         or turn_failure_capsule_size_bytes(projected_capsule)
         > TURN_FAILURE_CAPSULE_MAX_BYTES
     ):
@@ -17036,10 +17550,13 @@ def reset_context():
                 ),
                 shared_invite=shared_invite,
             )
-            if owner_namespace and chat_history_service.is_external_conversation_read_only(
-                user_id=owner_user_id,
-                session_id=session_id,
-                namespace=owner_namespace,
+            if (
+                owner_namespace
+                and chat_history_service.is_external_conversation_read_only(
+                    user_id=owner_user_id,
+                    session_id=session_id,
+                    namespace=owner_namespace,
+                )
             ):
                 return _external_conversation_read_only_response()
             reset_outcome = chat_history_service.reset_chat_history_conversation_state(
@@ -18108,7 +18625,9 @@ def import_external_conversation_route():
 
     user_concept_id = session.get("user_concept_id")
     if not isinstance(user_concept_id, str) or not user_concept_id.strip():
-        return jsonify({"error": "Not authenticated", "error_code": "not_authenticated"}), 401
+        return jsonify(
+            {"error": "Not authenticated", "error_code": "not_authenticated"}
+        ), 401
 
     upload = request.files.get("file")
     if upload is None:
@@ -18403,7 +18922,9 @@ def continue_external_conversation_route():
 
     user_concept_id = session.get("user_concept_id")
     if not isinstance(user_concept_id, str) or not user_concept_id.strip():
-        return jsonify({"error": "Not authenticated", "error_code": "not_authenticated"}), 401
+        return jsonify(
+            {"error": "Not authenticated", "error_code": "not_authenticated"}
+        ), 401
     data = request.get_json(silent=True) or {}
     source_session_id = data.get("session_id") or data.get("source_session_id")
     if not isinstance(source_session_id, str) or not source_session_id.strip():
@@ -18431,7 +18952,9 @@ def continue_external_conversation_route():
         )
         return jsonify(result), 201
     except ExternalConversationImportError as exc:
-        status_code = 404 if exc.error_code == "external_conversation_not_found" else 409
+        status_code = (
+            404 if exc.error_code == "external_conversation_not_found" else 409
+        )
         return jsonify({"error": str(exc), "error_code": exc.error_code}), status_code
     except WindowSessionOwnershipError:
         return (

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -1313,6 +1313,23 @@ def _start_async_process_shutdown(
 
     def _run_shutdown() -> None:
         try:
+            from ..services.chat_prompt_queue_dispatch_service import (
+                stop_chat_prompt_queue_dispatcher,
+            )
+            from ..services.conversation_turn_admission_service import (
+                conversation_turn_admission_service,
+            )
+
+            stop_chat_prompt_queue_dispatcher(timeout=5.0)
+            conversation_turn_admission_service.shutdown(wait=True, timeout=5.0)
+        except Exception as exc:
+            try:
+                app_logger.warning(
+                    "[shutdown] Chat prompt dispatcher stop error: %s", exc
+                )
+            except Exception:
+                pass
+        try:
             _stop_durable_workflow_system()
         except Exception as exc:
             try:
@@ -1369,6 +1386,41 @@ def _maybe_start_external_conversation_import_worker(app: Flask) -> None:
     except Exception as exc:
         app.logger.warning(
             "[external_conversation_import] Worker startup deferred: %s", exc
+        )
+
+
+def _maybe_start_chat_prompt_queue_dispatcher(app: Flask) -> None:
+    """Resume durable server-dispatch queue rows without browser ownership."""
+
+    if not _env_bool("VON_CHAT_PROMPT_DISPATCHER_ENABLE", True):
+        app.config["CHAT_PROMPT_QUEUE_DISPATCHER_STATE"] = "disabled"
+        return
+    if (_is_running_under_pytest() or _is_agent_test_instance()) and not _env_bool(
+        "VON_CHAT_PROMPT_DISPATCHER_ENABLE_IN_TESTS", False
+    ):
+        app.config["CHAT_PROMPT_QUEUE_DISPATCHER_STATE"] = "skipped_test_runtime"
+        return
+    try:
+        import atexit
+
+        from ..services.chat_prompt_queue_dispatch_service import (
+            configure_chat_prompt_queue_dispatcher,
+            start_chat_prompt_queue_dispatcher,
+            stop_chat_prompt_queue_dispatcher,
+        )
+        from .routes.von_routes import submit_server_dispatched_chat_prompt
+
+        configure_chat_prompt_queue_dispatcher(
+            app=app,
+            submit=submit_server_dispatched_chat_prompt,
+        )
+        start_chat_prompt_queue_dispatcher()
+        atexit.register(stop_chat_prompt_queue_dispatcher)
+        app.config["CHAT_PROMPT_QUEUE_DISPATCHER_STATE"] = "running"
+    except Exception as exc:
+        app.config["CHAT_PROMPT_QUEUE_DISPATCHER_STATE"] = "startup_deferred"
+        app.logger.warning(
+            "[chat_prompt_dispatch] Worker startup deferred: %s", exc
         )
 
 
@@ -1507,6 +1559,7 @@ def create_flask_app(
     _bootstrap_publication_scope_profiles_for_startup(app)
     _configure_durable_workflow_startup(app)
     _maybe_start_external_conversation_import_worker(app)
+    _maybe_start_chat_prompt_queue_dispatcher(app)
     _log_prompt_concept_health(app)
 
     # (Prewarm logic moved below route registrations to avoid early first-request state.)
@@ -3237,11 +3290,33 @@ def _build_health_runtime_authority_projection(app: Flask) -> dict[str, object]:
             "last_refresh_succeeded": None,
         }
 
+    try:
+        from ..services.chat_prompt_queue_dispatch_service import (
+            get_chat_prompt_queue_dispatcher_snapshot,
+        )
+
+        prompt_queue_dispatcher: dict[str, object] = dict(
+            get_chat_prompt_queue_dispatcher_snapshot()
+        )
+        prompt_queue_dispatcher["startup_state"] = app.config.get(
+            "CHAT_PROMPT_QUEUE_DISPATCHER_STATE"
+        )
+    except Exception:
+        prompt_queue_dispatcher = {
+            "schema_version": "chat_prompt_queue_dispatcher.v1",
+            "configured": False,
+            "running": False,
+            "startup_state": app.config.get(
+                "CHAT_PROMPT_QUEUE_DISPATCHER_STATE"
+            ),
+        }
+
     return {
         "schema_version": "health_runtime_authority_projection.v1",
         "mongo": mongo,
         "durable_workflows": durable,
         "model_registry": model_registry,
+        "chat_prompt_queue_dispatcher": prompt_queue_dispatcher,
         "startup_seed_materialisations": (
             _build_startup_seed_materialisations_projection(app)
         ),

--- a/src/backend/services/chat_prompt_queue_dispatch_service.py
+++ b/src/backend/services/chat_prompt_queue_dispatch_service.py
@@ -1,0 +1,731 @@
+"""Server-owned dispatch for durable queued conversation turns.
+
+The Mongo queue owns FIFO, idempotency and the durable conversation fence.
+This module deliberately owns only the small, one-process scheduling loop that
+turns an eligible queue reservation into a background ``/von/generate``
+submission.  Queue rows remain the source of truth across browser and process
+lifetime; the in-process worker is replaceable and may safely restart.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..security.access_control import override_current_actor
+from . import chat_prompt_queue_service, task_execution_service
+from .conversation_turn_admission_service import SERVER_INSTANCE_ID
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_POLL_INTERVAL_SECONDS = 1.0
+_DEFAULT_RETRY_AFTER_SECONDS = 1.0
+_TERMINAL_RETENTION_BACKFILL_BATCH_SIZE = 500
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        return max(0.05, float(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class ChatPromptDispatchOutcome:
+    """Result of submitting one reserved queue row to the execution surface."""
+
+    accepted: bool
+    retryable: bool = False
+    retry_after_seconds: float = _DEFAULT_RETRY_AFTER_SECONDS
+    error: str | None = None
+
+
+def reconcile_linked_task_execution_terminal(
+    record: Mapping[str, Any],
+    *,
+    status: str,
+    source: str,
+    error: str | None = None,
+) -> dict[str, Any] | None:
+    """Apply one exact queue terminal outcome to its internal TaskExecution.
+
+    The queue transition must already have succeeded.  Rows without task links
+    remain ordinary conversation work; partially linked rows are rejected
+    rather than guessed from an execution envelope.
+    """
+
+    queue_id = str(record.get("queue_id") or "").strip()
+    if not queue_id:
+        return None
+    claimed = chat_prompt_queue_service.claim_task_execution_terminal_reconciliation(
+        queue_id=queue_id,
+        server_instance_id=SERVER_INSTANCE_ID,
+    )
+    if claimed is None:
+        return None
+    persisted_status = str(
+        claimed.get("task_execution_reconciliation_queue_status") or ""
+    ).strip()
+    if persisted_status != status:
+        chat_prompt_queue_service.release_task_execution_terminal_reconciliation(
+            queue_id=queue_id,
+            reconciliation_token=str(
+                claimed.get("task_execution_reconciliation_token") or ""
+            ),
+            server_instance_id=SERVER_INSTANCE_ID,
+            error=(
+                "terminal reconciliation status changed before projection: "
+                f"expected {status}, found {persisted_status or 'missing'}"
+            ),
+        )
+        raise RuntimeError("terminal queue status changed before reconciliation")
+    try:
+        return _reconcile_claimed_task_execution_terminal(
+            claimed,
+            source=source,
+            error=error,
+        )
+    except Exception as exc:
+        chat_prompt_queue_service.release_task_execution_terminal_reconciliation(
+            queue_id=queue_id,
+            reconciliation_token=str(
+                claimed.get("task_execution_reconciliation_token") or ""
+            ),
+            server_instance_id=SERVER_INSTANCE_ID,
+            error=f"{type(exc).__name__}: {exc}"[:4_000],
+        )
+        raise
+
+
+def _reconcile_claimed_task_execution_terminal(
+    record: Mapping[str, Any],
+    *,
+    source: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Project and acknowledge one already-claimed durable terminal marker."""
+
+    task_id = str(record.get("task_concept_id") or "").strip()
+    execution_id = str(record.get("task_execution_concept_id") or "").strip()
+    if not task_id and not execution_id:
+        raise RuntimeError("claimed terminal reconciliation has no task link")
+    link = {
+        "task_concept_id": task_id,
+        "task_execution_concept_id": execution_id,
+        "enqueue_submission_id": str(record.get("enqueue_submission_id") or "").strip(),
+        "queue_id": str(record.get("queue_id") or "").strip(),
+        "actor_concept_id": str(record.get("user_concept_id") or "").strip(),
+        "organisation_concept_id": str(
+            record.get("organisation_concept_id") or ""
+        ).strip(),
+    }
+    missing = [key for key, value in link.items() if not value]
+    if missing:
+        raise RuntimeError(
+            "linked queue terminal record is incomplete: " + ", ".join(missing)
+        )
+    with override_current_actor(
+        link["actor_concept_id"], link["organisation_concept_id"]
+    ):
+        execution = task_execution_service.get_task_execution(
+            execution_id,
+            actor_concept_id=link["actor_concept_id"],
+            organisation_concept_id=link["organisation_concept_id"],
+        )
+    for field in (
+        "task_concept_id",
+        "enqueue_submission_id",
+        "queue_id",
+    ):
+        if execution.get(field) != link[field]:
+            raise task_execution_service.TaskExecutionAccessError(
+                "task_execution_queue_link_mismatch",
+                f"The terminal queue record {field} does not match the task execution",
+            )
+    queue_status = str(
+        record.get("task_execution_reconciliation_queue_status")
+        or record.get("status")
+        or ""
+    ).strip()
+    target_status = {
+        chat_prompt_queue_service.STATUS_COMPLETED: (
+            task_execution_service.TASK_EXECUTION_STATUS_COMPLETED
+        ),
+        chat_prompt_queue_service.STATUS_FAILED: (
+            task_execution_service.TASK_EXECUTION_STATUS_FAILED
+        ),
+        chat_prompt_queue_service.STATUS_CANCELLED: (
+            task_execution_service.TASK_EXECUTION_STATUS_CANCELLED
+        ),
+    }.get(queue_status)
+    if target_status is None:
+        raise ValueError("linked TaskExecution requires a terminal queue status")
+    result_error = (
+        error
+        if error is not None
+        else record.get("task_execution_reconciliation_error")
+    )
+    source_clean = str(
+        source
+        or record.get("task_execution_reconciliation_source")
+        or "queue_terminal_reconciliation"
+    ).strip()
+    try:
+        with override_current_actor(
+            link["actor_concept_id"], link["organisation_concept_id"]
+        ):
+            transitioned = task_execution_service.transition_task_execution(
+                execution_id,
+                actor_concept_id=link["actor_concept_id"],
+                organisation_concept_id=link["organisation_concept_id"],
+                enqueue_submission_id=link["enqueue_submission_id"],
+                queue_id=link["queue_id"],
+                status=target_status,
+                result=(
+                    None
+                    if target_status
+                    == task_execution_service.TASK_EXECUTION_STATUS_COMPLETED
+                    else (str(result_error) if result_error is not None else None)
+                ),
+                source=source_clean,
+            )
+    except task_execution_service.TaskExecutionTransitionError:
+        # Queue dismissal may turn an already-failed row into cancelled.  The
+        # execution's first terminal fact remains the honest attempt outcome.
+        with override_current_actor(
+            link["actor_concept_id"], link["organisation_concept_id"]
+        ):
+            refreshed = task_execution_service.get_task_execution(
+                execution_id,
+                actor_concept_id=link["actor_concept_id"],
+                organisation_concept_id=link["organisation_concept_id"],
+            )
+        if (
+            refreshed.get("status")
+            in task_execution_service.TASK_EXECUTION_TERMINAL_STATUSES
+        ):
+            transitioned = refreshed
+        else:
+            raise
+    if transitioned.get("status") not in (
+        target_status,
+        task_execution_service.TASK_EXECUTION_STATUS_FAILED
+        if queue_status == chat_prompt_queue_service.STATUS_CANCELLED
+        else target_status,
+    ):
+        raise task_execution_service.TaskExecutionTransitionError(
+            "TaskExecution terminal read-back does not match the queue outcome"
+        )
+    acknowledged = (
+        chat_prompt_queue_service.acknowledge_task_execution_terminal_reconciliation(
+            queue_id=link["queue_id"],
+            reconciliation_token=str(
+                record.get("task_execution_reconciliation_token") or ""
+            ),
+            server_instance_id=SERVER_INSTANCE_ID,
+            task_execution_concept_id=execution_id,
+            enqueue_submission_id=link["enqueue_submission_id"],
+            queue_status=queue_status,
+        )
+    )
+    if not acknowledged:
+        raise RuntimeError(
+            "TaskExecution terminal projection succeeded but queue acknowledgement "
+            "did not match its exact reconciliation claim"
+        )
+    return transitioned
+
+
+class ChatPromptQueueDispatcher:
+    """Bounded server worker for safe, unclaimed queue entries.
+
+    The callback must merely submit the turn to the existing background
+    generate path.  Admission then upgrades the exact reservation and owns the
+    lease/terminal lifecycle.  An accepted submission is therefore not a claim
+    that the user task or even the turn has completed.
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_interval_seconds: float | None = None,
+    ) -> None:
+        self._poll_interval_seconds = (
+            float(poll_interval_seconds)
+            if poll_interval_seconds is not None
+            else _positive_float_env(
+                "VON_CHAT_PROMPT_DISPATCH_POLL_SECONDS",
+                _DEFAULT_POLL_INTERVAL_SECONDS,
+            )
+        )
+        self._lock = threading.RLock()
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._app: Any | None = None
+        self._submit: (
+            Callable[
+                [Any, Mapping[str, Any]], ChatPromptDispatchOutcome | Mapping[str, Any]
+            ]
+            | None
+        ) = None
+        self._last_error: str | None = None
+        self._accepted_count = 0
+        self._retry_count = 0
+        self._failed_count = 0
+        self._handoff_reconciled_count = 0
+        self._handoff_reconciliation_failed_count = 0
+        self._task_launch_reconciled_count = 0
+        self._task_launch_reconciliation_retry_count = 0
+        self._task_launch_reconciliation_failed_count = 0
+        self._task_execution_reconciled_count = 0
+        self._task_execution_reconciliation_retry_count = 0
+        self._linked_terminal_backfilled_count = 0
+        self._linked_terminal_backfill_complete = False
+        self._terminal_retention_backfilled_count = 0
+        self._terminal_retention_backfill_complete = False
+
+    def configure(
+        self,
+        *,
+        app: Any,
+        submit: Callable[
+            [Any, Mapping[str, Any]], ChatPromptDispatchOutcome | Mapping[str, Any]
+        ],
+    ) -> None:
+        if app is None or not callable(submit):
+            raise ValueError("dispatcher app and submit callback are required")
+        with self._lock:
+            self._app = app
+            self._submit = submit
+
+    @staticmethod
+    def _normalise_outcome(
+        value: ChatPromptDispatchOutcome | Mapping[str, Any],
+    ) -> ChatPromptDispatchOutcome:
+        if isinstance(value, ChatPromptDispatchOutcome):
+            return value
+        if not isinstance(value, Mapping):
+            raise TypeError("dispatch callback returned an invalid outcome")
+        return ChatPromptDispatchOutcome(
+            accepted=bool(value.get("accepted")),
+            retryable=bool(value.get("retryable")),
+            retry_after_seconds=max(
+                0.0,
+                float(value.get("retry_after_seconds") or _DEFAULT_RETRY_AFTER_SECONDS),
+            ),
+            error=(
+                str(value.get("error"))[:4_000]
+                if value.get("error") is not None
+                else None
+            ),
+        )
+
+    def run_once(self) -> bool:
+        """Reserve and submit at most one row; return whether work was found."""
+
+        with self._lock:
+            app = self._app
+            submit = self._submit
+        if app is None or submit is None:
+            raise RuntimeError("chat prompt dispatcher is not configured")
+
+        if self._reconcile_one_linked_terminal():
+            return True
+        if self._reconcile_one_task_launch():
+            return True
+        if self._reconcile_one_handoff():
+            return True
+
+        record = chat_prompt_queue_service.reserve_next_server_dispatch(
+            server_instance_id=SERVER_INSTANCE_ID,
+        )
+        if record is None:
+            return False
+
+        queue_id = str(record.get("queue_id") or "").strip()
+        token = str(record.get("dispatch_reservation_token") or "").strip()
+        if not queue_id or not token:
+            self._last_error = "reserved row omitted its exact dispatch identity"
+            _logger.error("[chat_prompt_dispatch] %s", self._last_error)
+            return True
+
+        try:
+            if record.get("task_execution_concept_id"):
+                # Re-read task authority immediately before model submission;
+                # assignment or cancellation may have changed while queued.
+                task_execution_service.reconcile_task_execution_queue_record(record)
+            outcome = self._normalise_outcome(submit(app, record))
+        except (
+            task_execution_service.InvalidTaskExecutionData,
+            task_execution_service.TaskExecutionAccessError,
+            task_execution_service.TaskExecutionTransitionError,
+        ) as exc:
+            outcome = ChatPromptDispatchOutcome(
+                accepted=False,
+                retryable=False,
+                error=f"task launch is no longer executable: {exc}",
+            )
+        except Exception as exc:  # worker must survive one bad submission
+            outcome = ChatPromptDispatchOutcome(
+                accepted=False,
+                retryable=True,
+                retry_after_seconds=_DEFAULT_RETRY_AFTER_SECONDS,
+                error=f"dispatch submission raised {type(exc).__name__}: {exc}",
+            )
+            _logger.exception(
+                "[chat_prompt_dispatch] Submission failed for queue_id=%s",
+                queue_id,
+            )
+
+        if outcome.accepted:
+            with self._lock:
+                self._accepted_count += 1
+                self._last_error = None
+            return True
+
+        error = outcome.error or "server dispatch was not accepted"
+        if outcome.retryable:
+            released = chat_prompt_queue_service.release_server_dispatch_reservation(
+                queue_id=queue_id,
+                dispatch_reservation_token=token,
+                server_instance_id=SERVER_INSTANCE_ID,
+                retry_after_seconds=outcome.retry_after_seconds,
+                error=error,
+            )
+            with self._lock:
+                self._retry_count += 1
+                self._last_error = error
+            if not released:
+                _logger.info(
+                    "[chat_prompt_dispatch] Reservation changed before retry "
+                    "queue_id=%s",
+                    queue_id,
+                )
+            return True
+
+        failed = chat_prompt_queue_service.fail_server_dispatch_reservation(
+            queue_id=queue_id,
+            dispatch_reservation_token=token,
+            server_instance_id=SERVER_INSTANCE_ID,
+            error=error,
+        )
+        with self._lock:
+            self._failed_count += 1
+            self._last_error = error
+        if not failed:
+            _logger.info(
+                "[chat_prompt_dispatch] Reservation changed before failure queue_id=%s",
+                queue_id,
+            )
+        else:
+            reconcile_linked_task_execution_terminal(
+                record,
+                status=chat_prompt_queue_service.STATUS_FAILED,
+                source="queue_dispatcher",
+                error=error,
+            )
+        return True
+
+    def _reconcile_one_handoff(self) -> bool:
+        """Retire and activate at most one durable legacy queue handoff."""
+
+        try:
+            record = chat_prompt_queue_service.reconcile_next_server_dispatch_handoff()
+        except Exception as exc:  # noqa: BLE001 - the durable row remains retryable
+            with self._lock:
+                self._handoff_reconciliation_failed_count += 1
+                self._last_error = f"{type(exc).__name__}: {exc}"
+            _logger.warning(
+                "[chat_prompt_dispatch] Queue handoff reconciliation deferred: %s",
+                exc,
+            )
+            # The service has durably scheduled the exact handoff retry. Let
+            # this pass continue to unrelated dispatch-ready rows instead of
+            # reporting the blocked handoff as completed work.
+            return False
+        if record is None:
+            return False
+        with self._lock:
+            self._handoff_reconciled_count += 1
+            self._last_error = None
+        return True
+
+    def _reconcile_one_task_launch(self) -> bool:
+        """Project and activate at most one durable task launch outbox."""
+
+        record = chat_prompt_queue_service.claim_task_execution_launch_reconciliation(
+            server_instance_id=SERVER_INSTANCE_ID,
+        )
+        if record is None:
+            return False
+        queue_id = str(record.get("queue_id") or "").strip()
+        token = str(record.get("task_launch_reconciliation_token") or "").strip()
+        try:
+            execution = task_execution_service.reconcile_task_execution_queue_record(
+                record
+            )
+            expected_execution_id = str(
+                record.get("task_execution_concept_id") or ""
+            ).strip()
+            if (
+                execution.get("task_execution_concept_id") != expected_execution_id
+                or execution.get("queue_id") != queue_id
+                or execution.get("enqueue_submission_id")
+                != record.get("enqueue_submission_id")
+            ):
+                raise task_execution_service.TaskExecutionTransitionError(
+                    "TaskExecution launch read-back does not match its queue outbox"
+                )
+            acknowledged = chat_prompt_queue_service.acknowledge_task_execution_launch_reconciliation(
+                queue_id=queue_id,
+                reconciliation_token=token,
+                server_instance_id=SERVER_INSTANCE_ID,
+                task_execution_concept_id=expected_execution_id,
+                enqueue_submission_id=str(record.get("enqueue_submission_id") or ""),
+            )
+            if not acknowledged:
+                raise RuntimeError(
+                    "TaskExecution launch projection succeeded but queue activation "
+                    "did not match its exact reconciliation claim"
+                )
+        except (
+            task_execution_service.InvalidTaskExecutionData,
+            task_execution_service.TaskExecutionAccessError,
+            task_execution_service.TaskExecutionTransitionError,
+        ) as exc:
+            failed = (
+                chat_prompt_queue_service.fail_task_execution_launch_reconciliation(
+                    queue_id=queue_id,
+                    reconciliation_token=token,
+                    server_instance_id=SERVER_INSTANCE_ID,
+                    error=f"{type(exc).__name__}: {exc}"[:4_000],
+                )
+            )
+            with self._lock:
+                self._task_launch_reconciliation_failed_count += 1
+                self._last_error = f"{type(exc).__name__}: {exc}"
+            if not failed:
+                _logger.info(
+                    "[chat_prompt_dispatch] Task launch reconciliation claim "
+                    "changed before permanent failure queue_id=%s",
+                    queue_id,
+                )
+            return True
+        except Exception as exc:  # noqa: BLE001 - durable launch remains retryable
+            released = (
+                chat_prompt_queue_service.release_task_execution_launch_reconciliation(
+                    queue_id=queue_id,
+                    reconciliation_token=token,
+                    server_instance_id=SERVER_INSTANCE_ID,
+                    error=f"{type(exc).__name__}: {exc}"[:4_000],
+                )
+            )
+            with self._lock:
+                self._task_launch_reconciliation_retry_count += 1
+                self._last_error = f"{type(exc).__name__}: {exc}"
+            if not released:
+                _logger.info(
+                    "[chat_prompt_dispatch] Task launch reconciliation claim "
+                    "changed before retry queue_id=%s",
+                    queue_id,
+                )
+            return True
+        with self._lock:
+            self._task_launch_reconciled_count += 1
+            self._last_error = None
+        return True
+
+    def _reconcile_one_linked_terminal(self) -> bool:
+        """Retry at most one durable cross-store terminal projection."""
+
+        record = chat_prompt_queue_service.claim_task_execution_terminal_reconciliation(
+            server_instance_id=SERVER_INSTANCE_ID,
+        )
+        if record is None:
+            return False
+        queue_id = str(record.get("queue_id") or "").strip()
+        token = str(record.get("task_execution_reconciliation_token") or "").strip()
+        try:
+            _reconcile_claimed_task_execution_terminal(record)
+        except Exception as exc:  # noqa: BLE001 - durable marker remains retryable
+            released = chat_prompt_queue_service.release_task_execution_terminal_reconciliation(
+                queue_id=queue_id,
+                reconciliation_token=token,
+                server_instance_id=SERVER_INSTANCE_ID,
+                error=f"{type(exc).__name__}: {exc}"[:4_000],
+            )
+            with self._lock:
+                self._task_execution_reconciliation_retry_count += 1
+                self._last_error = f"{type(exc).__name__}: {exc}"
+            if not released:
+                _logger.info(
+                    "[chat_prompt_dispatch] Terminal reconciliation claim changed "
+                    "before retry queue_id=%s",
+                    queue_id,
+                )
+            return True
+        with self._lock:
+            self._task_execution_reconciled_count += 1
+            self._last_error = None
+        return True
+
+    def _worker_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                if not self._linked_terminal_backfill_complete:
+                    backfilled = chat_prompt_queue_service.backfill_linked_terminal_reconciliation(
+                        batch_size=_TERMINAL_RETENTION_BACKFILL_BATCH_SIZE,
+                    )
+                    with self._lock:
+                        self._linked_terminal_backfilled_count += backfilled
+                        self._linked_terminal_backfill_complete = (
+                            backfilled < _TERMINAL_RETENTION_BACKFILL_BATCH_SIZE
+                        )
+                if not self._terminal_retention_backfill_complete:
+                    backfilled = (
+                        chat_prompt_queue_service.backfill_legacy_terminal_purge_after(
+                            batch_size=_TERMINAL_RETENTION_BACKFILL_BATCH_SIZE,
+                        )
+                    )
+                    with self._lock:
+                        self._terminal_retention_backfilled_count += backfilled
+                        self._terminal_retention_backfill_complete = (
+                            backfilled < _TERMINAL_RETENTION_BACKFILL_BATCH_SIZE
+                        )
+                found = self.run_once()
+                if found:
+                    # Continue immediately so free conversations may dispatch
+                    # concurrently through the bounded background registry.
+                    continue
+            except Exception as exc:  # noqa: BLE001 - worker survives store outages
+                with self._lock:
+                    self._last_error = f"{type(exc).__name__}: {exc}"
+                _logger.warning(
+                    "[chat_prompt_dispatch] Worker iteration deferred: %s",
+                    exc,
+                )
+            self._wake.wait(timeout=self._poll_interval_seconds)
+            self._wake.clear()
+
+    def start(self) -> threading.Thread:
+        with self._lock:
+            if self._app is None or self._submit is None:
+                raise RuntimeError("chat prompt dispatcher is not configured")
+            if self._thread is not None and self._thread.is_alive():
+                return self._thread
+            self._stop.clear()
+            self._wake.clear()
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name="chat-prompt-queue-dispatcher",
+                daemon=True,
+            )
+            self._thread.start()
+            return self._thread
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        self._stop.set()
+        self._wake.set()
+        with self._lock:
+            thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(0.0, float(timeout)))
+
+    def wake(self) -> None:
+        self._wake.set()
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            last_error_sha256 = (
+                hashlib.sha256(self._last_error.encode("utf-8")).hexdigest()
+                if self._last_error
+                else None
+            )
+            return {
+                "schema_version": "chat_prompt_queue_dispatcher.v1",
+                "server_instance_id": SERVER_INSTANCE_ID,
+                "configured": self._app is not None and self._submit is not None,
+                "running": bool(self._thread and self._thread.is_alive()),
+                "accepted_count": self._accepted_count,
+                "retry_count": self._retry_count,
+                "failed_count": self._failed_count,
+                "handoff_reconciled_count": self._handoff_reconciled_count,
+                "handoff_reconciliation_failed_count": (
+                    self._handoff_reconciliation_failed_count
+                ),
+                "task_launch_reconciled_count": self._task_launch_reconciled_count,
+                "task_launch_reconciliation_retry_count": (
+                    self._task_launch_reconciliation_retry_count
+                ),
+                "task_launch_reconciliation_failed_count": (
+                    self._task_launch_reconciliation_failed_count
+                ),
+                "task_execution_reconciled_count": (
+                    self._task_execution_reconciled_count
+                ),
+                "task_execution_reconciliation_retry_count": (
+                    self._task_execution_reconciliation_retry_count
+                ),
+                "linked_terminal_backfilled_count": (
+                    self._linked_terminal_backfilled_count
+                ),
+                "linked_terminal_backfill_complete": (
+                    self._linked_terminal_backfill_complete
+                ),
+                "terminal_retention_backfilled_count": (
+                    self._terminal_retention_backfilled_count
+                ),
+                "terminal_retention_backfill_complete": (
+                    self._terminal_retention_backfill_complete
+                ),
+                "last_error_present": self._last_error is not None,
+                "last_error_sha256": last_error_sha256,
+            }
+
+
+chat_prompt_queue_dispatcher = ChatPromptQueueDispatcher()
+
+
+def configure_chat_prompt_queue_dispatcher(
+    *,
+    app: Any,
+    submit: Callable[
+        [Any, Mapping[str, Any]], ChatPromptDispatchOutcome | Mapping[str, Any]
+    ],
+) -> None:
+    chat_prompt_queue_dispatcher.configure(app=app, submit=submit)
+
+
+def start_chat_prompt_queue_dispatcher() -> threading.Thread:
+    return chat_prompt_queue_dispatcher.start()
+
+
+def stop_chat_prompt_queue_dispatcher(*, timeout: float = 5.0) -> None:
+    chat_prompt_queue_dispatcher.stop(timeout=timeout)
+
+
+def wake_chat_prompt_queue_dispatcher() -> None:
+    chat_prompt_queue_dispatcher.wake()
+
+
+def get_chat_prompt_queue_dispatcher_snapshot() -> dict[str, Any]:
+    return chat_prompt_queue_dispatcher.snapshot()
+
+
+__all__ = [
+    "ChatPromptDispatchOutcome",
+    "ChatPromptQueueDispatcher",
+    "chat_prompt_queue_dispatcher",
+    "configure_chat_prompt_queue_dispatcher",
+    "get_chat_prompt_queue_dispatcher_snapshot",
+    "reconcile_linked_task_execution_terminal",
+    "start_chat_prompt_queue_dispatcher",
+    "stop_chat_prompt_queue_dispatcher",
+    "wake_chat_prompt_queue_dispatcher",
+]

--- a/src/backend/services/chat_prompt_queue_service.py
+++ b/src/backend/services/chat_prompt_queue_service.py
@@ -7,6 +7,8 @@ records, but it does not decide what Von should answer or how workflows run.
 from __future__ import annotations
 
 import hashlib
+import json
+import math
 import os
 import re
 import threading
@@ -18,7 +20,10 @@ from pymongo import ReturnDocument
 from pymongo.collection import Collection
 from pymongo.errors import DuplicateKeyError
 
-from ..db.mongo_client import get_chat_prompt_queue_collection
+from ..db.mongo_client import (
+    get_chat_prompt_queue_collection,
+    get_chat_prompt_queue_counters_collection,
+)
 from .namespace_service import (
     concept_id_to_namespace_slug,
     derive_actor_context_from_namespace,
@@ -39,6 +44,31 @@ MAX_PROMPT_RAW_CHARS = 100_000
 MAX_SESSION_NAME_CHARS = 500
 STALE_IN_PROGRESS_TIMEOUT_SECONDS = 24 * 60 * 60
 RECENT_FAILED_VISIBILITY_SECONDS = 24 * 60 * 60
+DEFAULT_DISPATCH_LEASE_SECONDS = 90
+DEFAULT_HANDOFF_RECONCILIATION_RETRY_SECONDS = 5
+DEFAULT_TASK_EXECUTION_RECONCILIATION_LEASE_SECONDS = 90
+DEFAULT_TERMINAL_RETENTION_SECONDS = 30 * 24 * 60 * 60
+DEFAULT_TERMINAL_BACKFILL_GRACE_SECONDS = 7 * 24 * 60 * 60
+DISPATCH_MODE_SERVER = "server"
+TASK_EXECUTION_RECONCILIATION_PENDING = "pending"
+TASK_EXECUTION_RECONCILIATION_CLAIMED = "claimed"
+TASK_EXECUTION_RECONCILIATION_ACKNOWLEDGED = "acknowledged"
+EXECUTION_ENVELOPE_VERSION = 1
+MAX_EXECUTION_ENVELOPE_CHARS = 100_000
+EXECUTION_ENVELOPE_ALLOWED_FIELDS = frozenset(
+    {
+        "initiation_id",
+        "language",
+        "model",
+        "model_parameters",
+        "model_provider",
+        "presenter_mode",
+        "skip_buttonify",
+        "thinking_card_mode",
+        "turn_kind",
+        "workflow_inputs",
+    }
+)
 STALE_IN_PROGRESS_ADVISORY_REASON = (
     "Prompt queue record has remained in progress for more than 24 hours; "
     "reconcile its exact turn or task receipt before retrying or terminalising it."
@@ -101,6 +131,53 @@ class ChatPromptQueueCapacityReached(ChatPromptQueueError):
         self.limit_kind = limit_kind
 
 
+class ChatPromptQueueSubmissionConflict(InvalidChatPromptQueueInput):
+    """Raised when one enqueue identity is reused for different work."""
+
+    error_code = "enqueue_submission_conflict"
+    status_code = 409
+
+    def __init__(self, message: str, *, queue_id: str | None = None) -> None:
+        super().__init__(message)
+        self.queue_id = queue_id
+
+
+class ChatPromptQueueTaskAlreadyActive(ChatPromptQueueError):
+    """Raised when another active queue row already executes the same task."""
+
+    error_code = "task_execution_already_active"
+    status_code = 409
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        queue_id: str | None = None,
+        task_execution_concept_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.queue_id = queue_id
+        self.task_execution_concept_id = task_execution_concept_id
+
+
+class ChatPromptQueueReconciliationRequired(InvalidChatPromptQueueInput):
+    """Raised when an ambiguous server-owned attempt needs exact evidence."""
+
+    error_code = "server_dispatch_reconciliation_required"
+    status_code = 409
+
+
+class ChatPromptQueueHandoffConflict(InvalidChatPromptQueueInput):
+    """Raised when a queued replacement cannot safely retire its source row."""
+
+    error_code = "queue_handoff_conflict"
+    status_code = 409
+
+    def __init__(self, message: str, *, queue_id: str | None = None) -> None:
+        super().__init__(message)
+        self.queue_id = queue_id
+
+
 _QUEUE_ADMISSION_LOCK = threading.RLock()
 _UNSET = object()
 
@@ -119,9 +196,182 @@ def _foreground_queue_limits() -> tuple[int, int]:
     )
 
 
+def _dispatch_lease_seconds(value: int | None = None) -> int:
+    if value is not None:
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError) as exc:
+            raise InvalidChatPromptQueueInput(
+                "lease_seconds must be a positive integer"
+            ) from exc
+    return _positive_int_env(
+        "VON_CHAT_PROMPT_QUEUE_DISPATCH_LEASE_SECONDS",
+        DEFAULT_DISPATCH_LEASE_SECONDS,
+    )
+
+
+def _turn_lease_seconds(value: int | None = None) -> int:
+    if value is not None:
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError) as exc:
+            raise InvalidChatPromptQueueInput(
+                "lease_seconds must be a positive integer"
+            ) from exc
+    return _positive_int_env(
+        "VON_CHAT_PROMPT_QUEUE_TURN_LEASE_SECONDS",
+        DEFAULT_DISPATCH_LEASE_SECONDS,
+    )
+
+
+def _terminal_retention_seconds() -> int:
+    return _positive_int_env(
+        "VON_CHAT_PROMPT_QUEUE_TERMINAL_RETENTION_SECONDS",
+        DEFAULT_TERMINAL_RETENTION_SECONDS,
+    )
+
+
+def _terminal_backfill_grace_seconds(value: int | None = None) -> int:
+    if value is not None:
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError) as exc:
+            raise InvalidChatPromptQueueInput(
+                "rollout_grace_seconds must be a positive integer"
+            ) from exc
+    return _positive_int_env(
+        "VON_CHAT_PROMPT_QUEUE_TERMINAL_BACKFILL_GRACE_SECONDS",
+        DEFAULT_TERMINAL_BACKFILL_GRACE_SECONDS,
+    )
+
+
+def _terminal_purge_after(completed_at: datetime) -> datetime:
+    return completed_at + timedelta(seconds=_terminal_retention_seconds())
+
+
+def _task_execution_reconciliation_lease_seconds(value: int | None = None) -> int:
+    if value is not None:
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError) as exc:
+            raise InvalidChatPromptQueueInput(
+                "lease_seconds must be a positive integer"
+            ) from exc
+    return _positive_int_env(
+        "VON_TASK_EXECUTION_RECONCILIATION_LEASE_SECONDS",
+        DEFAULT_TASK_EXECUTION_RECONCILIATION_LEASE_SECONDS,
+    )
+
+
+def _has_task_execution_link(doc: Mapping[str, Any] | None) -> bool:
+    if not isinstance(doc, Mapping):
+        return False
+    return any(
+        isinstance(doc.get(field), str) and bool(str(doc.get(field)).strip())
+        for field in ("task_concept_id", "task_execution_concept_id")
+    )
+
+
+def _terminal_reconciliation_update(
+    doc: Mapping[str, Any] | None,
+    *,
+    status: str,
+    error: str | None,
+    source: str,
+    observed_now: datetime,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Build the retention/reconciliation half of one terminal queue CAS.
+
+    A linked queue row cannot acquire a TTL date until its exact TaskExecution
+    terminal projection has been acknowledged.  The pending marker is written
+    in the same Mongo update as the queue terminal state, so a process failure
+    cannot leave a terminal row that looks fully reconciled.
+    """
+
+    if not _has_task_execution_link(doc):
+        return {"purge_after": _terminal_purge_after(observed_now)}, {}
+    return (
+        {
+            "task_execution_reconciliation_status": (
+                TASK_EXECUTION_RECONCILIATION_PENDING
+            ),
+            "task_execution_reconciliation_queue_status": status,
+            "task_execution_reconciliation_error": error,
+            "task_execution_reconciliation_source": source,
+            "task_execution_reconciliation_pending_at": observed_now,
+            "task_execution_reconciliation_updated_at": observed_now,
+        },
+        {
+            "purge_after": "",
+            "task_execution_reconciliation_token": "",
+            "task_execution_reconciliation_owner": "",
+            "task_execution_reconciliation_acquired_at": "",
+            "task_execution_reconciliation_heartbeat_at": "",
+            "task_execution_reconciliation_lease_expires_at": "",
+            "task_execution_reconciliation_next_at": "",
+            "task_execution_reconciliation_last_error": "",
+            "task_execution_reconciled_at": "",
+        },
+    )
+
+
 def _queued_user_slot_key(user_concept_id: str, slot: int) -> str:
     actor_hash = hashlib.sha256(user_concept_id.encode("utf-8")).hexdigest()
     return f"{actor_hash}:{slot}"
+
+
+def _active_task_execution_key(task_concept_id: str) -> str:
+    return hashlib.sha256(task_concept_id.encode("utf-8")).hexdigest()
+
+
+def _enqueue_sort() -> list[tuple[str, int]]:
+    """Sort legacy rows first, then all new rows by their durable sequence."""
+
+    return [("enqueue_sequence", 1), ("created_at", 1), ("queue_id", 1)]
+
+
+def _earlier_enqueue_filter(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Match rows allocated before ``record``, including pre-sequence legacy rows."""
+
+    sequence = record.get("enqueue_sequence")
+    if isinstance(sequence, int) and not isinstance(sequence, bool):
+        return {
+            "$or": [
+                {"enqueue_sequence": {"$exists": False}},
+                {"enqueue_sequence": {"$lt": sequence}},
+            ]
+        }
+    created_at = record.get("created_at") or _now()
+    queue_id = str(record.get("queue_id") or "")
+    return {
+        "enqueue_sequence": {"$exists": False},
+        "$or": [
+            {"created_at": {"$lt": created_at}},
+            {"created_at": created_at, "queue_id": {"$lt": queue_id}},
+        ],
+    }
+
+
+def _raise_if_task_execution_already_active(
+    *,
+    coll: Collection,
+    active_task_execution_key: str | None,
+) -> None:
+    if not active_task_execution_key:
+        return
+    existing = coll.find_one(
+        {"active_task_execution_key": active_task_execution_key},
+        {"queue_id": 1, "task_execution_concept_id": 1},
+    )
+    if not isinstance(existing, Mapping):
+        return
+    raise ChatPromptQueueTaskAlreadyActive(
+        "This task already has an active Von execution",
+        queue_id=str(existing.get("queue_id") or "") or None,
+        task_execution_concept_id=(
+            str(existing.get("task_execution_concept_id") or "") or None
+        ),
+    )
 
 
 def _now() -> datetime:
@@ -151,6 +401,135 @@ def _coerce_scope_value(value: Any, *, field: str, required: bool = True) -> str
     if required and not cleaned:
         raise InvalidChatPromptQueueInput(f"{field} is required")
     return cleaned or None
+
+
+def _normalise_execution_envelope(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise InvalidChatPromptQueueInput("execution_envelope must be an object")
+    invalid_keys = sorted(
+        str(key)
+        for key in value
+        if not isinstance(key, str) or key not in EXECUTION_ENVELOPE_ALLOWED_FIELDS
+    )
+    if invalid_keys:
+        raise InvalidChatPromptQueueInput(
+            "execution_envelope contains invalid keys: " + ", ".join(invalid_keys[:8])
+        )
+    for mapping_field in ("model_parameters", "workflow_inputs"):
+        nested = value.get(mapping_field)
+        if nested is not None and not isinstance(nested, Mapping):
+            raise InvalidChatPromptQueueInput(
+                f"execution_envelope.{mapping_field} must be an object"
+            )
+    try:
+        encoded = json.dumps(
+            dict(value),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput(
+            "execution_envelope must contain JSON values"
+        ) from exc
+    if len(encoded) > MAX_EXECUTION_ENVELOPE_CHARS:
+        raise InvalidChatPromptQueueInput("execution_envelope is too large")
+    decoded = json.loads(encoded)
+    if not isinstance(decoded, dict):  # pragma: no cover - guarded above
+        raise InvalidChatPromptQueueInput("execution_envelope must be an object")
+    return decoded
+
+
+def _enqueue_fingerprint(
+    *,
+    scope: Mapping[str, Any],
+    prompt_raw: str,
+    session_id: str | None,
+    session_name: str | None,
+    conversation_key: str,
+    execution_envelope: Mapping[str, Any],
+    execution_envelope_version: int,
+    task_concept_id: str | None,
+    task_execution_concept_id: str | None,
+    dispatch_ready: bool,
+    handoff_source_queue_id: str | None,
+) -> str:
+    material = {
+        "schema": "chat_prompt_queue_enqueue.v2",
+        "scope": _scope_query(scope),
+        "prompt_raw": prompt_raw,
+        "session_id": session_id,
+        "session_name": session_name,
+        "conversation_key": conversation_key,
+        "execution_envelope": dict(execution_envelope),
+        "execution_envelope_version": execution_envelope_version,
+        "task_concept_id": task_concept_id,
+        "task_execution_concept_id": task_execution_concept_id,
+        "dispatch_ready_at_enqueue": dispatch_ready,
+        "handoff_source_queue_id": handoff_source_queue_id,
+    }
+    encoded = json.dumps(
+        material,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _idempotent_enqueue_result(
+    doc: Mapping[str, Any] | None, *, replayed: bool
+) -> dict[str, Any] | None:
+    record = serialise_queue_record(doc)
+    if record is not None:
+        record["idempotent_replay"] = replayed
+    return record
+
+
+def _find_idempotent_enqueue(
+    *,
+    coll: Collection,
+    scope: Mapping[str, Any],
+    enqueue_submission_id: str,
+    enqueue_fingerprint: str,
+) -> dict[str, Any] | None:
+    existing = coll.find_one(
+        {
+            **_scope_query(scope),
+            "enqueue_submission_id": enqueue_submission_id,
+        }
+    )
+    if not isinstance(existing, Mapping):
+        return None
+    if existing.get("enqueue_fingerprint") != enqueue_fingerprint:
+        raise ChatPromptQueueSubmissionConflict(
+            "enqueue_submission_id was already used for different queue work",
+            queue_id=str(existing.get("queue_id") or "") or None,
+        )
+    return _idempotent_enqueue_result(existing, replayed=True)
+
+
+def _raise_if_handoff_source_already_bound(
+    *,
+    coll: Collection,
+    handoff_source_queue_id: str | None,
+) -> None:
+    if not handoff_source_queue_id:
+        return
+    existing = coll.find_one(
+        {"handoff_source_queue_id": handoff_source_queue_id},
+        {"queue_id": 1},
+    )
+    if not isinstance(existing, Mapping):
+        return
+    raise ChatPromptQueueHandoffConflict(
+        "The handoff source is already bound to another durable replacement",
+        queue_id=str(existing.get("queue_id") or "") or None,
+    )
 
 
 def _normalise_user_concept_id(value: Any) -> str:
@@ -263,6 +642,33 @@ def _collection() -> Collection:
     if coll is None:
         raise ChatPromptQueueUnavailable("chat_prompt_queue collection is unavailable")
     return coll
+
+
+def _next_enqueue_sequence() -> int:
+    """Allocate a durable total order before inserting one new queue row."""
+
+    counters = get_chat_prompt_queue_counters_collection()
+    if counters is None:
+        raise ChatPromptQueueUnavailable(
+            "chat_prompt_queue counter collection is unavailable"
+        )
+    counter = counters.find_one_and_update(
+        {"_id": "global_enqueue_sequence"},
+        {"$inc": {"value": 1}},
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    try:
+        sequence = int((counter or {}).get("value"))
+    except (TypeError, ValueError) as exc:  # pragma: no cover - corrupt store
+        raise ChatPromptQueueUnavailable(
+            "chat_prompt_queue enqueue sequence is invalid"
+        ) from exc
+    if sequence < 1:  # pragma: no cover - corrupt store
+        raise ChatPromptQueueUnavailable(
+            "chat_prompt_queue enqueue sequence is invalid"
+        )
+    return sequence
 
 
 def build_queue_scope(
@@ -539,8 +945,22 @@ def expire_stale_in_progress_records(
             **_compatible_scope_query(scope),
             "status": STATUS_IN_PROGRESS,
             "$or": [
-                {"claimed_at": {"$lte": cutoff}},
-                {"claimed_at": None, "updated_at": {"$lte": cutoff}},
+                {"lease_expires_at": {"$lte": observed_now}},
+                {
+                    "lease_expires_at": {"$exists": False},
+                    "$or": [
+                        {"lease_heartbeat_at": {"$lte": cutoff}},
+                        {
+                            "lease_heartbeat_at": {"$exists": False},
+                            "claimed_at": {"$lte": cutoff},
+                        },
+                        {
+                            "lease_heartbeat_at": {"$exists": False},
+                            "claimed_at": None,
+                            "updated_at": {"$lte": cutoff},
+                        },
+                    ],
+                },
             ],
         },
         {
@@ -581,16 +1001,59 @@ def serialise_queue_record(doc: Mapping[str, Any] | None) -> dict[str, Any] | No
         "completed_at": _serialise_datetime(doc.get("completed_at")),
         "last_error": doc.get("last_error"),
         "source": doc.get("source"),
+        "enqueue_submission_id": doc.get("enqueue_submission_id"),
+        "dispatch_mode": doc.get("dispatch_mode"),
+        "dispatch_ready": doc.get("dispatch_ready"),
+        "handoff_source_queue_id": doc.get("handoff_source_queue_id"),
+        "retired_handoff_source_queue_id": doc.get(
+            "retired_handoff_source_queue_id"
+        ),
+        "handoff_replacement_queue_id": doc.get("handoff_replacement_queue_id"),
+        "handoff_source_retired_at": _serialise_datetime(
+            doc.get("handoff_source_retired_at")
+        ),
+        "handoff_completed_at": _serialise_datetime(doc.get("handoff_completed_at")),
+        "handoff_cancelled_at": _serialise_datetime(doc.get("handoff_cancelled_at")),
+        "handoff_reconciliation_attempted_at": _serialise_datetime(
+            doc.get("handoff_reconciliation_attempted_at")
+        ),
+        "handoff_reconciliation_next_at": _serialise_datetime(
+            doc.get("handoff_reconciliation_next_at")
+        ),
+        "handoff_reconciliation_attempt_count": int(
+            doc.get("handoff_reconciliation_attempt_count") or 0
+        ),
+        "handoff_reconciliation_last_error": doc.get(
+            "handoff_reconciliation_last_error"
+        ),
+        "execution_envelope_version": doc.get("execution_envelope_version"),
+        "task_concept_id": doc.get("task_concept_id"),
+        "task_execution_concept_id": doc.get("task_execution_concept_id"),
         "client_request_id": doc.get("client_request_id"),
         "attempt_id": doc.get("attempt_id"),
         "conversation_key": doc.get("conversation_key"),
         "server_instance_id": doc.get("server_instance_id"),
         "lease_acquired_at": _serialise_datetime(doc.get("lease_acquired_at")),
         "lease_heartbeat_at": _serialise_datetime(doc.get("lease_heartbeat_at")),
+        "lease_expires_at": _serialise_datetime(doc.get("lease_expires_at")),
+        "next_dispatch_at": _serialise_datetime(doc.get("next_dispatch_at")),
+        "purge_after": _serialise_datetime(doc.get("purge_after")),
         "stale_advisory": bool(doc.get("stale_advisory")),
         "stale_advisory_at": _serialise_datetime(doc.get("stale_advisory_at")),
         "stale_advisory_reason": doc.get("stale_advisory_reason"),
         "reconciliation_required": bool(doc.get("reconciliation_required")),
+        "task_execution_reconciliation_status": doc.get(
+            "task_execution_reconciliation_status"
+        ),
+        "task_execution_reconciliation_queue_status": doc.get(
+            "task_execution_reconciliation_queue_status"
+        ),
+        "task_execution_reconciliation_pending_at": _serialise_datetime(
+            doc.get("task_execution_reconciliation_pending_at")
+        ),
+        "task_execution_reconciled_at": _serialise_datetime(
+            doc.get("task_execution_reconciled_at")
+        ),
     }
 
 
@@ -612,7 +1075,7 @@ def list_active_queue_records(
         **_compatible_scope_query(scope),
         "status": {"$in": allowed_statuses},
     }
-    docs = _collection().find(query).sort([("created_at", 1)]).limit(max_limit)
+    docs = _collection().find(query).sort(_enqueue_sort()).limit(max_limit)
     return [
         record for record in (serialise_queue_record(doc) for doc in docs) if record
     ]
@@ -650,10 +1113,671 @@ def list_queue_visibility_records(
 ) -> dict[str, list[dict[str, Any]]]:
     """Return active queue records plus bounded failed records for UI visibility."""
 
-    return {
-        "items": list_active_queue_records(scope=scope),
-        "recent_failed_items": list_recent_failed_queue_records(scope=scope),
+    active = list_active_queue_records(scope=scope)
+    recent_failed = list_recent_failed_queue_records(scope=scope)
+    # The two reads are intentionally bounded and inexpensive, but a record can
+    # become failed between them. Prefer the terminal observation and never make
+    # one canonical queue row appear twice in the UI projection.
+    failed_queue_ids = {
+        str(record.get("queue_id") or "")
+        for record in recent_failed
+        if record.get("queue_id")
     }
+    return {
+        "items": [
+            record
+            for record in active
+            if str(record.get("queue_id") or "") not in failed_queue_ids
+        ],
+        "recent_failed_items": recent_failed,
+    }
+
+
+def backfill_legacy_terminal_purge_after(
+    *,
+    now: datetime | None = None,
+    batch_size: int = 500,
+    rollout_grace_seconds: int | None = None,
+) -> int:
+    """Add bounded TTL dates to legacy terminal rows without surprise expiry."""
+
+    observed_now = now or _now()
+    if observed_now.tzinfo is None:
+        observed_now = observed_now.replace(tzinfo=timezone.utc)
+    else:
+        observed_now = observed_now.astimezone(timezone.utc)
+    try:
+        bounded_batch_size = max(1, min(int(batch_size), 500))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput("batch_size must be an integer") from exc
+    rollout_floor = observed_now + timedelta(
+        seconds=_terminal_backfill_grace_seconds(rollout_grace_seconds)
+    )
+    retention_seconds = _terminal_retention_seconds()
+    coll = _collection()
+    docs = (
+        coll.find(
+            {
+                "status": {"$in": list(TERMINAL_STATUSES)},
+                "purge_after": {"$exists": False},
+                "$and": [
+                    {
+                        "$or": [
+                            {"task_concept_id": {"$exists": False}},
+                            {"task_concept_id": ""},
+                            {"task_concept_id": None},
+                        ]
+                    },
+                    {
+                        "$or": [
+                            {"task_execution_concept_id": {"$exists": False}},
+                            {"task_execution_concept_id": ""},
+                            {"task_execution_concept_id": None},
+                        ]
+                    },
+                ],
+            },
+            {"_id": 1, "queue_id": 1, "status": 1, "completed_at": 1, "updated_at": 1},
+        )
+        .sort([("completed_at", 1), ("updated_at", 1), ("queue_id", 1)])
+        .limit(bounded_batch_size)
+    )
+    modified = 0
+    for doc in docs:
+        terminal_at = doc.get("completed_at") or doc.get("updated_at") or observed_now
+        if not isinstance(terminal_at, datetime):
+            terminal_at = observed_now
+        elif terminal_at.tzinfo is None:
+            terminal_at = terminal_at.replace(tzinfo=timezone.utc)
+        else:
+            terminal_at = terminal_at.astimezone(timezone.utc)
+        purge_after = max(
+            terminal_at + timedelta(seconds=retention_seconds),
+            rollout_floor,
+        )
+        identity_query: dict[str, Any]
+        if doc.get("_id") is not None:
+            identity_query = {"_id": doc["_id"]}
+        else:  # pragma: no cover - Mongo documents always have _id
+            identity_query = {"queue_id": doc.get("queue_id")}
+        result = coll.update_one(
+            {
+                **identity_query,
+                "status": {"$in": list(TERMINAL_STATUSES)},
+                "purge_after": {"$exists": False},
+            },
+            {"$set": {"purge_after": purge_after}},
+        )
+        modified += int(getattr(result, "modified_count", 0) or 0)
+    return modified
+
+
+def backfill_linked_terminal_reconciliation(
+    *,
+    now: datetime | None = None,
+    batch_size: int = 500,
+) -> int:
+    """Fence legacy linked terminal rows from TTL and make them retryable."""
+
+    observed_now = now or _now()
+    try:
+        bounded_batch_size = max(1, min(int(batch_size), 500))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput("batch_size must be an integer") from exc
+    coll = _collection()
+    docs = (
+        coll.find(
+            {
+                "status": {"$in": list(TERMINAL_STATUSES)},
+                "task_execution_reconciliation_status": {"$exists": False},
+                "$or": [
+                    {"task_concept_id": {"$exists": True, "$nin": [None, ""]}},
+                    {
+                        "task_execution_concept_id": {
+                            "$exists": True,
+                            "$nin": [None, ""],
+                        }
+                    },
+                ],
+            },
+            {
+                "_id": 1,
+                "queue_id": 1,
+                "status": 1,
+                "last_error": 1,
+                "completed_at": 1,
+            },
+        )
+        .sort([("completed_at", 1), ("queue_id", 1)])
+        .limit(bounded_batch_size)
+    )
+    modified = 0
+    for doc in docs:
+        pending_at = (
+            doc.get("completed_at")
+            if isinstance(doc.get("completed_at"), datetime)
+            else observed_now
+        )
+        result = coll.update_one(
+            {
+                "_id": doc.get("_id"),
+                "status": doc.get("status"),
+                "task_execution_reconciliation_status": {"$exists": False},
+            },
+            {
+                "$set": {
+                    "task_execution_reconciliation_status": (
+                        TASK_EXECUTION_RECONCILIATION_PENDING
+                    ),
+                    "task_execution_reconciliation_queue_status": doc.get("status"),
+                    "task_execution_reconciliation_error": doc.get("last_error"),
+                    "task_execution_reconciliation_source": (
+                        "legacy_linked_terminal_backfill"
+                    ),
+                    "task_execution_reconciliation_pending_at": pending_at,
+                    "task_execution_reconciliation_updated_at": observed_now,
+                },
+                "$unset": {"purge_after": ""},
+            },
+        )
+        modified += int(getattr(result, "modified_count", 0) or 0)
+    return modified
+
+
+def _internal_task_execution_reconciliation_record(
+    doc: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    record = serialise_queue_record(doc)
+    if record is None or not isinstance(doc, Mapping):
+        return None
+    for field in (
+        "user_concept_id",
+        "organisation_concept_id",
+        "namespace",
+        "task_execution_reconciliation_token",
+        "task_execution_reconciliation_owner",
+        "task_execution_reconciliation_error",
+        "task_execution_reconciliation_source",
+    ):
+        record[field] = doc.get(field)
+    record["task_execution_reconciliation_lease_expires_at"] = _serialise_datetime(
+        doc.get("task_execution_reconciliation_lease_expires_at")
+    )
+    return record
+
+
+def claim_task_execution_terminal_reconciliation(
+    *,
+    server_instance_id: str,
+    queue_id: str | None = None,
+    now: datetime | None = None,
+    lease_seconds: int | None = None,
+) -> dict[str, Any] | None:
+    """Claim one durable linked-terminal projection with an expiring lease."""
+
+    owner = _coerce_scope_value(server_instance_id, field="server_instance_id")
+    queue_id_clean = _coerce_scope_value(
+        queue_id,
+        field="queue_id",
+        required=False,
+    )
+    observed_now = now or _now()
+    query: dict[str, Any] = {
+        "status": {"$in": list(TERMINAL_STATUSES)},
+        "$and": [
+            {
+                "$or": [
+                    {
+                        "task_execution_reconciliation_status": (
+                            TASK_EXECUTION_RECONCILIATION_PENDING
+                        )
+                    },
+                    {
+                        "task_execution_reconciliation_status": (
+                            TASK_EXECUTION_RECONCILIATION_CLAIMED
+                        ),
+                        "task_execution_reconciliation_lease_expires_at": {
+                            "$lte": observed_now
+                        },
+                    },
+                ]
+            },
+            {
+                "$or": [
+                    {"task_execution_reconciliation_next_at": {"$exists": False}},
+                    {
+                        "task_execution_reconciliation_next_at": {
+                            "$lte": observed_now
+                        }
+                    },
+                ]
+            },
+        ],
+    }
+    if queue_id_clean:
+        query["queue_id"] = queue_id_clean
+    token = str(uuid4())
+    doc = _collection().find_one_and_update(
+        query,
+        {
+            "$set": {
+                "task_execution_reconciliation_status": (
+                    TASK_EXECUTION_RECONCILIATION_CLAIMED
+                ),
+                "task_execution_reconciliation_token": token,
+                "task_execution_reconciliation_owner": owner,
+                "task_execution_reconciliation_acquired_at": observed_now,
+                "task_execution_reconciliation_heartbeat_at": observed_now,
+                "task_execution_reconciliation_lease_expires_at": observed_now
+                + timedelta(
+                    seconds=_task_execution_reconciliation_lease_seconds(
+                        lease_seconds
+                    )
+                ),
+                "task_execution_reconciliation_updated_at": observed_now,
+            },
+            "$unset": {
+                "purge_after": "",
+                "task_execution_reconciliation_next_at": "",
+            },
+            "$inc": {"task_execution_reconciliation_attempt_count": 1},
+        },
+        sort=[("task_execution_reconciliation_pending_at", 1), ("queue_id", 1)],
+        return_document=ReturnDocument.AFTER,
+    )
+    return _internal_task_execution_reconciliation_record(doc)
+
+
+def release_task_execution_terminal_reconciliation(
+    *,
+    queue_id: str,
+    reconciliation_token: str,
+    server_instance_id: str,
+    error: str,
+    retry_after_seconds: float = 1.0,
+    now: datetime | None = None,
+) -> bool:
+    """Return an exact failed reconciliation claim to the durable retry queue."""
+
+    try:
+        delay = max(0.0, float(retry_after_seconds))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput(
+            "retry_after_seconds must be a non-negative number"
+        ) from exc
+    if not math.isfinite(delay):
+        raise InvalidChatPromptQueueInput("retry_after_seconds must be finite")
+    observed_now = now or _now()
+    result = _collection().update_one(
+        {
+            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+            "task_execution_reconciliation_status": (
+                TASK_EXECUTION_RECONCILIATION_CLAIMED
+            ),
+            "task_execution_reconciliation_token": _coerce_scope_value(
+                reconciliation_token,
+                field="reconciliation_token",
+            ),
+            "task_execution_reconciliation_owner": _coerce_scope_value(
+                server_instance_id,
+                field="server_instance_id",
+            ),
+        },
+        {
+            "$set": {
+                "task_execution_reconciliation_status": (
+                    TASK_EXECUTION_RECONCILIATION_PENDING
+                ),
+                "task_execution_reconciliation_next_at": observed_now
+                + timedelta(seconds=delay),
+                "task_execution_reconciliation_last_error": _coerce_text(
+                    error,
+                    field="error",
+                    required=True,
+                    max_chars=4_000,
+                ),
+                "task_execution_reconciliation_updated_at": observed_now,
+            },
+            "$unset": {
+                "purge_after": "",
+                "task_execution_reconciliation_token": "",
+                "task_execution_reconciliation_owner": "",
+                "task_execution_reconciliation_acquired_at": "",
+                "task_execution_reconciliation_heartbeat_at": "",
+                "task_execution_reconciliation_lease_expires_at": "",
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def acknowledge_task_execution_terminal_reconciliation(
+    *,
+    queue_id: str,
+    reconciliation_token: str,
+    server_instance_id: str,
+    task_execution_concept_id: str,
+    enqueue_submission_id: str,
+    queue_status: str,
+    now: datetime | None = None,
+) -> bool:
+    """Acknowledge an exact successful TaskExecution projection by queue CAS."""
+
+    if queue_status not in TERMINAL_STATUSES:
+        raise InvalidChatPromptQueueInput("queue_status must be terminal")
+    observed_now = now or _now()
+    result = _collection().update_one(
+        {
+            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+            "status": queue_status,
+            "task_execution_concept_id": _coerce_scope_value(
+                task_execution_concept_id,
+                field="task_execution_concept_id",
+            ),
+            "enqueue_submission_id": _coerce_scope_value(
+                enqueue_submission_id,
+                field="enqueue_submission_id",
+            ),
+            "task_execution_reconciliation_status": (
+                TASK_EXECUTION_RECONCILIATION_CLAIMED
+            ),
+            "task_execution_reconciliation_queue_status": queue_status,
+            "task_execution_reconciliation_token": _coerce_scope_value(
+                reconciliation_token,
+                field="reconciliation_token",
+            ),
+            "task_execution_reconciliation_owner": _coerce_scope_value(
+                server_instance_id,
+                field="server_instance_id",
+            ),
+        },
+        {
+            "$set": {
+                "task_execution_reconciliation_status": (
+                    TASK_EXECUTION_RECONCILIATION_ACKNOWLEDGED
+                ),
+                "task_execution_reconciled_at": observed_now,
+                "task_execution_reconciliation_updated_at": observed_now,
+                # Retention begins only once the cross-store projection is
+                # durably acknowledged, never at the earlier queue terminal CAS.
+                "purge_after": _terminal_purge_after(observed_now),
+            },
+            "$unset": {
+                "task_execution_reconciliation_token": "",
+                "task_execution_reconciliation_owner": "",
+                "task_execution_reconciliation_acquired_at": "",
+                "task_execution_reconciliation_heartbeat_at": "",
+                "task_execution_reconciliation_lease_expires_at": "",
+                "task_execution_reconciliation_next_at": "",
+                "task_execution_reconciliation_last_error": "",
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def _internal_task_launch_reconciliation_record(
+    doc: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    record = serialise_queue_record(doc)
+    if record is None or not isinstance(doc, Mapping):
+        return None
+    for field in (
+        "user_concept_id",
+        "organisation_concept_id",
+        "namespace",
+        "task_launch_reconciliation_token",
+        "task_launch_reconciliation_owner",
+        "task_launch_reconciliation_last_error",
+    ):
+        record[field] = doc.get(field)
+    record["execution_envelope"] = (
+        dict(doc.get("execution_envelope"))
+        if isinstance(doc.get("execution_envelope"), Mapping)
+        else {}
+    )
+    record["task_launch_reconciliation_lease_expires_at"] = _serialise_datetime(
+        doc.get("task_launch_reconciliation_lease_expires_at")
+    )
+    return record
+
+
+def claim_task_execution_launch_reconciliation(
+    *,
+    server_instance_id: str,
+    now: datetime | None = None,
+    lease_seconds: int | None = None,
+) -> dict[str, Any] | None:
+    """Claim one unready task launch outbox with an expiring server lease."""
+
+    owner = _coerce_scope_value(server_instance_id, field="server_instance_id")
+    observed_now = now or _now()
+    token = str(uuid4())
+    doc = _collection().find_one_and_update(
+        {
+            "status": STATUS_QUEUED,
+            "dispatch_mode": DISPATCH_MODE_SERVER,
+            "dispatch_ready": False,
+            "task_concept_id": {"$exists": True, "$nin": [None, ""]},
+            "task_execution_concept_id": {
+                "$exists": True,
+                "$nin": [None, ""],
+            },
+            "$and": [
+                {
+                    "$or": [
+                        {"task_launch_reconciliation_next_at": {"$exists": False}},
+                        {"task_launch_reconciliation_next_at": {"$lte": observed_now}},
+                    ]
+                },
+                {
+                    "$or": [
+                        {"task_launch_reconciliation_token": {"$exists": False}},
+                        {
+                            "task_launch_reconciliation_lease_expires_at": {
+                                "$lte": observed_now
+                            }
+                        },
+                    ]
+                },
+            ],
+        },
+        {
+            "$set": {
+                "task_launch_reconciliation_token": token,
+                "task_launch_reconciliation_owner": owner,
+                "task_launch_reconciliation_acquired_at": observed_now,
+                "task_launch_reconciliation_lease_expires_at": observed_now
+                + timedelta(seconds=_dispatch_lease_seconds(lease_seconds)),
+                "task_launch_reconciliation_updated_at": observed_now,
+            },
+            "$unset": {"task_launch_reconciliation_next_at": ""},
+            "$inc": {"task_launch_reconciliation_attempt_count": 1},
+        },
+        sort=_enqueue_sort(),
+        return_document=ReturnDocument.AFTER,
+    )
+    return _internal_task_launch_reconciliation_record(doc)
+
+
+def release_task_execution_launch_reconciliation(
+    *,
+    queue_id: str,
+    reconciliation_token: str,
+    server_instance_id: str,
+    error: str,
+    retry_after_seconds: float = 1.0,
+    now: datetime | None = None,
+) -> bool:
+    """Release an exact launch projection claim for durable retry."""
+
+    try:
+        delay = max(0.0, float(retry_after_seconds))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput(
+            "retry_after_seconds must be a non-negative number"
+        ) from exc
+    if not math.isfinite(delay):
+        raise InvalidChatPromptQueueInput("retry_after_seconds must be finite")
+    observed_now = now or _now()
+    result = _collection().update_one(
+        {
+            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+            "status": STATUS_QUEUED,
+            "dispatch_ready": False,
+            "task_launch_reconciliation_token": _coerce_scope_value(
+                reconciliation_token,
+                field="reconciliation_token",
+            ),
+            "task_launch_reconciliation_owner": _coerce_scope_value(
+                server_instance_id,
+                field="server_instance_id",
+            ),
+        },
+        {
+            "$set": {
+                "task_launch_reconciliation_next_at": observed_now
+                + timedelta(seconds=delay),
+                "task_launch_reconciliation_last_error": _coerce_text(
+                    error,
+                    field="error",
+                    required=True,
+                    max_chars=4_000,
+                ),
+                "task_launch_reconciliation_updated_at": observed_now,
+            },
+            "$unset": {
+                "task_launch_reconciliation_token": "",
+                "task_launch_reconciliation_owner": "",
+                "task_launch_reconciliation_acquired_at": "",
+                "task_launch_reconciliation_lease_expires_at": "",
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def acknowledge_task_execution_launch_reconciliation(
+    *,
+    queue_id: str,
+    reconciliation_token: str,
+    server_instance_id: str,
+    task_execution_concept_id: str,
+    enqueue_submission_id: str,
+    now: datetime | None = None,
+) -> bool:
+    """Activate one exact task launch after its TaskExecution is read back."""
+
+    observed_now = now or _now()
+    result = _collection().update_one(
+        {
+            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+            "status": STATUS_QUEUED,
+            "dispatch_ready": False,
+            "task_execution_concept_id": _coerce_scope_value(
+                task_execution_concept_id,
+                field="task_execution_concept_id",
+            ),
+            "enqueue_submission_id": _coerce_scope_value(
+                enqueue_submission_id,
+                field="enqueue_submission_id",
+            ),
+            "task_launch_reconciliation_token": _coerce_scope_value(
+                reconciliation_token,
+                field="reconciliation_token",
+            ),
+            "task_launch_reconciliation_owner": _coerce_scope_value(
+                server_instance_id,
+                field="server_instance_id",
+            ),
+        },
+        {
+            "$set": {
+                "dispatch_ready": True,
+                "dispatch_ready_at": observed_now,
+                "task_launch_reconciled_at": observed_now,
+                "updated_at": observed_now,
+            },
+            "$unset": {
+                "task_launch_reconciliation_token": "",
+                "task_launch_reconciliation_owner": "",
+                "task_launch_reconciliation_acquired_at": "",
+                "task_launch_reconciliation_lease_expires_at": "",
+                "task_launch_reconciliation_next_at": "",
+                "task_launch_reconciliation_last_error": "",
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def fail_task_execution_launch_reconciliation(
+    *,
+    queue_id: str,
+    reconciliation_token: str,
+    server_instance_id: str,
+    error: str,
+    now: datetime | None = None,
+) -> bool:
+    """Terminalise a permanently invalid task launch without invoking Von."""
+
+    observed_now = now or _now()
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    token_clean = _coerce_scope_value(
+        reconciliation_token,
+        field="reconciliation_token",
+    )
+    owner_clean = _coerce_scope_value(
+        server_instance_id,
+        field="server_instance_id",
+    )
+    error_clean = _coerce_text(
+        error,
+        field="error",
+        required=True,
+        max_chars=4_000,
+    )
+    coll = _collection()
+    exact_query = {
+        "queue_id": queue_id_clean,
+        "status": STATUS_QUEUED,
+        "dispatch_ready": False,
+        "task_launch_reconciliation_token": token_clean,
+        "task_launch_reconciliation_owner": owner_clean,
+    }
+    existing = coll.find_one(exact_query)
+    reconciliation_set, reconciliation_unset = _terminal_reconciliation_update(
+        existing,
+        status=STATUS_FAILED,
+        error=error_clean,
+        source="task_launch_reconciliation",
+        observed_now=observed_now,
+    )
+    result = coll.update_one(
+        exact_query,
+        {
+            "$set": {
+                "status": STATUS_FAILED,
+                "completed_at": observed_now,
+                "updated_at": observed_now,
+                "last_error": error_clean,
+                **reconciliation_set,
+            },
+            "$unset": {
+                "active_task_execution_key": "",
+                "queued_global_slot": "",
+                "queued_user_slot": "",
+                "task_launch_reconciliation_token": "",
+                "task_launch_reconciliation_owner": "",
+                "task_launch_reconciliation_acquired_at": "",
+                "task_launch_reconciliation_lease_expires_at": "",
+                "task_launch_reconciliation_next_at": "",
+                "task_launch_reconciliation_last_error": "",
+                **reconciliation_unset,
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
 
 
 def create_queue_record(
@@ -669,6 +1793,14 @@ def create_queue_record(
     conversation_key: Any = None,
     legacy_submission_role: str | None = None,
     window_session_id: Any = None,
+    enqueue_submission_id: Any = None,
+    dispatch_mode: Any = None,
+    execution_envelope: Any = None,
+    execution_envelope_version: Any = None,
+    task_concept_id: Any = None,
+    task_execution_concept_id: Any = None,
+    server_dispatch_ready: Any = None,
+    handoff_source_queue_id: Any = None,
 ) -> dict[str, Any]:
     if status not in {STATUS_QUEUED, STATUS_IN_PROGRESS}:
         raise InvalidChatPromptQueueInput("status must be queued or in_progress")
@@ -704,6 +1836,126 @@ def create_queue_record(
         field="conversation_key",
         required=False,
     )
+    enqueue_submission_id_clean = _coerce_scope_value(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+        required=False,
+    )
+    dispatch_mode_clean = _coerce_scope_value(
+        dispatch_mode,
+        field="dispatch_mode",
+        required=False,
+    )
+    task_concept_id_clean = _coerce_scope_value(
+        task_concept_id,
+        field="task_concept_id",
+        required=False,
+    )
+    task_execution_concept_id_clean = _coerce_scope_value(
+        task_execution_concept_id,
+        field="task_execution_concept_id",
+        required=False,
+    )
+    handoff_source_queue_id_clean = _coerce_scope_value(
+        handoff_source_queue_id,
+        field="handoff_source_queue_id",
+        required=False,
+    )
+    if bool(task_concept_id_clean) != bool(task_execution_concept_id_clean):
+        raise InvalidChatPromptQueueInput(
+            "task_concept_id and task_execution_concept_id must be supplied together"
+        )
+    if task_concept_id_clean and dispatch_mode_clean != DISPATCH_MODE_SERVER:
+        raise InvalidChatPromptQueueInput(
+            "task-linked queue records require server dispatch"
+        )
+    if handoff_source_queue_id_clean and dispatch_mode_clean != DISPATCH_MODE_SERVER:
+        raise InvalidChatPromptQueueInput(
+            "handoff_source_queue_id requires server dispatch"
+        )
+    if handoff_source_queue_id_clean and task_concept_id_clean:
+        raise InvalidChatPromptQueueInput(
+            "handoff_source_queue_id cannot be combined with task execution links"
+        )
+    active_task_execution_key = (
+        _active_task_execution_key(task_concept_id_clean)
+        if task_concept_id_clean
+        else None
+    )
+    envelope: dict[str, Any] | None = None
+    envelope_version: int | None = None
+    enqueue_fingerprint: str | None = None
+    dispatch_ready = True
+    if dispatch_mode_clean is not None and dispatch_mode_clean != DISPATCH_MODE_SERVER:
+        raise InvalidChatPromptQueueInput("dispatch_mode must be server")
+    if dispatch_mode_clean == DISPATCH_MODE_SERVER:
+        if status != STATUS_QUEUED:
+            raise InvalidChatPromptQueueInput(
+                "server-dispatched queue records must start queued"
+            )
+        if not enqueue_submission_id_clean:
+            raise InvalidChatPromptQueueInput(
+                "enqueue_submission_id is required for server dispatch"
+            )
+        if not conversation_key_clean:
+            raise InvalidChatPromptQueueInput(
+                "conversation_key is required for server dispatch"
+            )
+        if client_request_id_clean or attempt_id_clean:
+            raise InvalidChatPromptQueueInput(
+                "server dispatch assigns request and attempt identifiers at reservation"
+            )
+        if execution_envelope_version is None:
+            envelope_version = EXECUTION_ENVELOPE_VERSION
+        elif (
+            isinstance(execution_envelope_version, bool)
+            or not isinstance(execution_envelope_version, int)
+            or execution_envelope_version != EXECUTION_ENVELOPE_VERSION
+        ):
+            raise InvalidChatPromptQueueInput(
+                f"execution_envelope_version must be {EXECUTION_ENVELOPE_VERSION}"
+            )
+        else:
+            envelope_version = EXECUTION_ENVELOPE_VERSION
+        envelope = _normalise_execution_envelope(execution_envelope)
+        if server_dispatch_ready is not None:
+            if not isinstance(server_dispatch_ready, bool):
+                raise InvalidChatPromptQueueInput(
+                    "server_dispatch_ready must be a boolean"
+                )
+            dispatch_ready = server_dispatch_ready
+        if handoff_source_queue_id_clean:
+            if server_dispatch_ready is True:
+                raise InvalidChatPromptQueueInput(
+                    "a handoff replacement must remain dispatch-ineligible until its source is retired"
+                )
+            dispatch_ready = False
+        enqueue_fingerprint = _enqueue_fingerprint(
+            scope=scope,
+            prompt_raw=str(prompt),
+            session_id=session_id_clean,
+            session_name=session_name_clean,
+            conversation_key=conversation_key_clean,
+            execution_envelope=envelope,
+            execution_envelope_version=envelope_version,
+            task_concept_id=task_concept_id_clean,
+            task_execution_concept_id=task_execution_concept_id_clean,
+            dispatch_ready=dispatch_ready,
+            handoff_source_queue_id=handoff_source_queue_id_clean,
+        )
+    elif any(
+        value is not None
+        for value in (
+            enqueue_submission_id_clean,
+            execution_envelope,
+            execution_envelope_version,
+            server_dispatch_ready,
+            handoff_source_queue_id_clean,
+        )
+    ):
+        raise InvalidChatPromptQueueInput(
+            "enqueue submission and execution envelope require server dispatch"
+        )
     legacy_role_clean = _coerce_scope_value(
         legacy_submission_role,
         field="legacy_submission_role",
@@ -743,6 +1995,28 @@ def create_queue_record(
         "completed_at": None,
         "last_error": None,
     }
+    if dispatch_mode_clean == DISPATCH_MODE_SERVER:
+        doc.update(
+            {
+                "enqueue_submission_id": enqueue_submission_id_clean,
+                "enqueue_fingerprint": enqueue_fingerprint,
+                "dispatch_mode": DISPATCH_MODE_SERVER,
+                "execution_envelope": envelope,
+                "execution_envelope_version": envelope_version,
+                "dispatch_ready": dispatch_ready,
+                **(
+                    {"handoff_source_queue_id": handoff_source_queue_id_clean}
+                    if handoff_source_queue_id_clean
+                    else {}
+                ),
+            }
+        )
+    if task_concept_id_clean:
+        doc["task_concept_id"] = task_concept_id_clean
+    if task_execution_concept_id_clean:
+        doc["task_execution_concept_id"] = task_execution_concept_id_clean
+    if active_task_execution_key:
+        doc["active_task_execution_key"] = active_task_execution_key
     if active_legacy_submission_key:
         doc["active_legacy_submission_key"] = active_legacy_submission_key
         doc["legacy_submission_queue_seen"] = (
@@ -755,6 +2029,19 @@ def create_queue_record(
             seconds=LEGACY_SUBMISSION_RENDEZVOUS_SECONDS
         )
     coll = _collection()
+    if enqueue_submission_id_clean and enqueue_fingerprint:
+        reusable = _find_idempotent_enqueue(
+            coll=coll,
+            scope=scope,
+            enqueue_submission_id=enqueue_submission_id_clean,
+            enqueue_fingerprint=enqueue_fingerprint,
+        )
+        if reusable is not None:
+            return reusable
+    _raise_if_handoff_source_already_bound(
+        coll=coll,
+        handoff_source_queue_id=handoff_source_queue_id_clean,
+    )
     if active_legacy_submission_key:
         _expire_unpaired_legacy_submissions(coll=coll, now=now)
         reusable = _find_or_join_legacy_submission(
@@ -767,6 +2054,7 @@ def create_queue_record(
         )
         if reusable is not None:
             return reusable
+    doc["enqueue_sequence"] = _next_enqueue_sequence()
     if status == STATUS_QUEUED:
         global_limit, per_user_limit = _foreground_queue_limits()
         user_id = str(doc["user_concept_id"])
@@ -811,6 +2099,23 @@ def create_queue_record(
                     try:
                         coll.insert_one(candidate)
                     except DuplicateKeyError:
+                        if enqueue_submission_id_clean and enqueue_fingerprint:
+                            reusable = _find_idempotent_enqueue(
+                                coll=coll,
+                                scope=scope,
+                                enqueue_submission_id=enqueue_submission_id_clean,
+                                enqueue_fingerprint=enqueue_fingerprint,
+                            )
+                            if reusable is not None:
+                                return reusable
+                        _raise_if_handoff_source_already_bound(
+                            coll=coll,
+                            handoff_source_queue_id=handoff_source_queue_id_clean,
+                        )
+                        _raise_if_task_execution_already_active(
+                            coll=coll,
+                            active_task_execution_key=active_task_execution_key,
+                        )
                         if active_legacy_submission_key:
                             reusable = _find_or_join_legacy_submission(
                                 coll=coll,
@@ -845,6 +2150,23 @@ def create_queue_record(
         try:
             coll.insert_one(doc)
         except DuplicateKeyError:
+            if enqueue_submission_id_clean and enqueue_fingerprint:
+                reusable = _find_idempotent_enqueue(
+                    coll=coll,
+                    scope=scope,
+                    enqueue_submission_id=enqueue_submission_id_clean,
+                    enqueue_fingerprint=enqueue_fingerprint,
+                )
+                if reusable is not None:
+                    return reusable
+            _raise_if_handoff_source_already_bound(
+                coll=coll,
+                handoff_source_queue_id=handoff_source_queue_id_clean,
+            )
+            _raise_if_task_execution_already_active(
+                coll=coll,
+                active_task_execution_key=active_task_execution_key,
+            )
             if active_legacy_submission_key:
                 reusable = _find_or_join_legacy_submission(
                     coll=coll,
@@ -857,10 +2179,626 @@ def create_queue_record(
                 if reusable is not None:
                     return reusable
             raise
-    record = serialise_queue_record(doc)
+    record = (
+        _idempotent_enqueue_result(doc, replayed=False)
+        if enqueue_submission_id_clean
+        else serialise_queue_record(doc)
+    )
     if record is None:  # pragma: no cover - defensive
         raise ChatPromptQueueUnavailable("created queue record could not be serialised")
     return record
+
+
+def activate_server_dispatch_record(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    enqueue_submission_id: str,
+    task_execution_concept_id: str,
+) -> dict[str, Any]:
+    """Make one exactly linked task queue row eligible for server dispatch."""
+
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    enqueue_id = _coerce_scope_value(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+    )
+    execution_id = _coerce_scope_value(
+        task_execution_concept_id,
+        field="task_execution_concept_id",
+    )
+    now = _now()
+    coll = _collection()
+    exact_query = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "status": STATUS_QUEUED,
+        "dispatch_mode": DISPATCH_MODE_SERVER,
+        "enqueue_submission_id": enqueue_id,
+        "task_execution_concept_id": execution_id,
+    }
+    doc = coll.find_one_and_update(
+        {
+            **exact_query,
+            "dispatch_ready": False,
+            "task_launch_reconciliation_token": {"$exists": False},
+        },
+        {
+            "$set": {
+                "dispatch_ready": True,
+                "dispatch_ready_at": now,
+                "updated_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        doc = coll.find_one({**exact_query, "dispatch_ready": True})
+    record = serialise_queue_record(doc)
+    if record is None:
+        raise ChatPromptQueueRecordNotFound(
+            "The linked server-dispatch row could not be activated",
+            error_code="server_dispatch_activation_mismatch",
+        )
+    return record
+
+
+def complete_server_dispatch_handoff(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    enqueue_submission_id: str | None = None,
+) -> dict[str, Any]:
+    """Retire one exact legacy source before activating its server replacement.
+
+    The replacement is inserted with ``dispatch_ready=False`` and carries the
+    durable source identifier.  That makes the two-document handoff safely
+    retryable: a crash can leave work waiting, but cannot make both rows
+    dispatchable.
+    """
+
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    enqueue_id = _coerce_scope_value(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+        required=False,
+    )
+    coll = _collection()
+    replacement_query: dict[str, Any] = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "status": STATUS_QUEUED,
+        "dispatch_mode": DISPATCH_MODE_SERVER,
+        "handoff_source_queue_id": {"$exists": True, "$ne": ""},
+    }
+    if enqueue_id:
+        replacement_query["enqueue_submission_id"] = enqueue_id
+    replacement = coll.find_one(replacement_query)
+    if not isinstance(replacement, Mapping):
+        raise ChatPromptQueueRecordNotFound(
+            "The server-dispatch handoff replacement was not found",
+            error_code="queue_handoff_replacement_not_found",
+        )
+
+    source_queue_id = _coerce_scope_value(
+        replacement.get("handoff_source_queue_id"),
+        field="handoff_source_queue_id",
+    )
+    if source_queue_id == queue_id_clean:
+        raise ChatPromptQueueHandoffConflict(
+            "A queue handoff cannot replace itself"
+        )
+    source = coll.find_one(
+        {
+            **_compatible_scope_query(scope),
+            "queue_id": source_queue_id,
+        }
+    )
+    if not isinstance(source, Mapping):
+        cancel_prompt_record(scope=scope, queue_id=queue_id_clean)
+        raise ChatPromptQueueHandoffConflict(
+            "The handoff source is unavailable for canonical retirement"
+        )
+    if source.get("dispatch_mode") == DISPATCH_MODE_SERVER:
+        cancel_prompt_record(scope=scope, queue_id=queue_id_clean)
+        raise ChatPromptQueueHandoffConflict(
+            "A server-dispatch row cannot be used as a legacy handoff source"
+        )
+    for field in ("prompt_raw", "session_id", "conversation_key"):
+        if source.get(field) != replacement.get(field):
+            cancel_prompt_record(scope=scope, queue_id=queue_id_clean)
+            raise ChatPromptQueueHandoffConflict(
+                f"The handoff source does not match replacement field {field}"
+            )
+
+    try:
+        cancel_prompt_record(
+            scope=scope,
+            queue_id=source_queue_id,
+            handoff_replacement_queue_id=queue_id_clean,
+        )
+    except ConversationTurnAlreadyActive:
+        # A live source may become cancellable later. Leave the replacement
+        # dispatch-ineligible so the scheduled reconciler can retry.
+        raise
+    except ChatPromptQueueHandoffConflict:
+        cancel_prompt_record(scope=scope, queue_id=queue_id_clean)
+        raise
+    except ChatPromptQueueRecordNotFound as exc:
+        cancel_prompt_record(scope=scope, queue_id=queue_id_clean)
+        raise ChatPromptQueueHandoffConflict(
+            "The handoff source already reached a non-cancellable terminal state",
+            queue_id=queue_id_clean,
+        ) from exc
+
+    now = _now()
+    exact_replacement_query = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "status": STATUS_QUEUED,
+        "dispatch_mode": DISPATCH_MODE_SERVER,
+        "handoff_source_queue_id": source_queue_id,
+    }
+    if enqueue_id:
+        exact_replacement_query["enqueue_submission_id"] = enqueue_id
+    activated = coll.find_one_and_update(
+        {**exact_replacement_query, "dispatch_ready": False},
+        {
+            "$set": {
+                "dispatch_ready": True,
+                "handoff_completed_at": now,
+                "updated_at": now,
+            },
+            "$unset": {
+                "handoff_reconciliation_next_at": "",
+                "handoff_reconciliation_last_error": "",
+            },
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if activated is None:
+        activated = coll.find_one({**exact_replacement_query, "dispatch_ready": True})
+    record = serialise_queue_record(activated)
+    if record is None:
+        raise ChatPromptQueueRecordNotFound(
+            "The server-dispatch handoff could not be activated",
+            error_code="queue_handoff_activation_mismatch",
+        )
+    return record
+
+
+def reconcile_next_server_dispatch_handoff(
+    *,
+    now: datetime | None = None,
+    retry_after_seconds: int = DEFAULT_HANDOFF_RECONCILIATION_RETRY_SECONDS,
+) -> dict[str, Any] | None:
+    """Claim and complete at most one due durable legacy handoff.
+
+    Claiming advances ``handoff_reconciliation_next_at`` before touching the
+    source.  A crash therefore delays retry only by the bounded claim window,
+    while a temporarily active source cannot be selected in a tight loop or
+    starve unrelated dispatch-ready work.
+    """
+
+    observed_now = now or _now()
+    try:
+        bounded_retry_seconds = max(1, int(retry_after_seconds))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput(
+            "retry_after_seconds must be an integer"
+        ) from exc
+    next_attempt_at = observed_now + timedelta(seconds=bounded_retry_seconds)
+    coll = _collection()
+    pending = coll.find_one_and_update(
+        {
+            "status": STATUS_QUEUED,
+            "dispatch_mode": DISPATCH_MODE_SERVER,
+            "dispatch_ready": False,
+            "handoff_source_queue_id": {"$exists": True, "$ne": ""},
+            "$or": [
+                {"handoff_reconciliation_next_at": {"$exists": False}},
+                {"handoff_reconciliation_next_at": None},
+                {"handoff_reconciliation_next_at": {"$lte": observed_now}},
+            ],
+        },
+        {
+            "$set": {
+                "handoff_reconciliation_attempted_at": observed_now,
+                "handoff_reconciliation_next_at": next_attempt_at,
+                "updated_at": observed_now,
+            },
+            "$inc": {"handoff_reconciliation_attempt_count": 1},
+            "$unset": {"handoff_reconciliation_last_error": ""},
+        },
+        sort=_enqueue_sort(),
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(pending, Mapping):
+        return None
+    scope = {
+        "user_concept_id": pending.get("user_concept_id"),
+        "organisation_concept_id": pending.get("organisation_concept_id"),
+        "namespace": pending.get("namespace"),
+    }
+    queue_id = str(pending.get("queue_id") or "")
+    try:
+        return complete_server_dispatch_handoff(
+            scope=scope,
+            queue_id=queue_id,
+            enqueue_submission_id=(
+                str(pending.get("enqueue_submission_id") or "") or None
+            ),
+        )
+    except Exception as exc:
+        # Preserve a bounded, inspectable retry schedule only while the exact
+        # replacement remains pending. Deterministic conflicts may already
+        # have cancelled it in ``complete_server_dispatch_handoff``.
+        coll.update_one(
+            {
+                "queue_id": queue_id,
+                "status": STATUS_QUEUED,
+                "dispatch_mode": DISPATCH_MODE_SERVER,
+                "dispatch_ready": False,
+            },
+            {
+                "$set": {
+                    "handoff_reconciliation_next_at": next_attempt_at,
+                    "handoff_reconciliation_last_error": (
+                        f"{type(exc).__name__}: {exc}"
+                    )[:4_000],
+                    "updated_at": observed_now,
+                }
+            },
+        )
+        raise
+
+
+def reserve_next_server_dispatch(
+    *,
+    server_instance_id: str,
+    now: datetime | None = None,
+    lease_seconds: int | None = None,
+    scan_limit: int = 100,
+) -> dict[str, Any] | None:
+    """Reserve the oldest eligible server-owned FIFO head.
+
+    The reservation uses the same unique conversation fence as an admitted
+    turn. ``bind_queue_record_to_turn`` can upgrade only this opaque token, so
+    there is no pre-admission window in which a second turn can enter the same
+    conversation.
+    """
+
+    owner = _coerce_scope_value(
+        server_instance_id,
+        field="server_instance_id",
+    )
+    observed_now = now or _now()
+    lease_duration = _dispatch_lease_seconds(lease_seconds)
+    try:
+        bounded_scan_limit = max(1, min(int(scan_limit), 500))
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput("scan_limit must be an integer") from exc
+    coll = _collection()
+    eligible_query = {
+                "status": STATUS_QUEUED,
+                "dispatch_mode": DISPATCH_MODE_SERVER,
+                "execution_envelope_version": EXECUTION_ENVELOPE_VERSION,
+                "enqueue_submission_id": {"$exists": True, "$ne": ""},
+                "conversation_key": {"$exists": True, "$ne": ""},
+                "dispatch_ready": {"$ne": False},
+                "$and": [
+                    {
+                        "$or": [
+                            {"next_dispatch_at": {"$exists": False}},
+                            {"next_dispatch_at": {"$lte": observed_now}},
+                        ]
+                    },
+                    {
+                        "$or": [
+                            {"dispatch_reservation_token": {"$exists": False}},
+                            {"dispatch_lease_expires_at": {"$lte": observed_now}},
+                        ]
+                    },
+                ],
+            }
+    # Select one eligible head per conversation before applying the scan cap.
+    # Otherwise a long blocked FIFO for one conversation can occupy the whole
+    # candidate window and starve unrelated conversations behind it.
+    candidates = coll.aggregate(
+        [
+            {"$match": eligible_query},
+            {
+                "$sort": {
+                    "enqueue_sequence": 1,
+                    "created_at": 1,
+                    "queue_id": 1,
+                }
+            },
+            {
+                "$group": {
+                    "_id": "$conversation_key",
+                    "candidate": {"$first": "$$ROOT"},
+                }
+            },
+            {"$replaceRoot": {"newRoot": "$candidate"}},
+            {
+                "$sort": {
+                    "enqueue_sequence": 1,
+                    "created_at": 1,
+                    "queue_id": 1,
+                }
+            },
+            {"$limit": bounded_scan_limit},
+        ]
+    )
+    for candidate in candidates:
+        queue_id = str(candidate.get("queue_id") or "")
+        conversation_key = str(candidate.get("conversation_key") or "")
+        if not queue_id or not conversation_key:
+            continue
+        earlier = coll.find_one(
+            {
+                "conversation_key": conversation_key,
+                "status": {"$in": ACTIVE_STATUSES},
+                "queue_id": {"$ne": queue_id},
+                "$and": [_earlier_enqueue_filter(candidate)],
+            },
+            {"_id": 1},
+        )
+        if earlier is not None:
+            continue
+
+        previous_token = candidate.get("dispatch_reservation_token")
+        if previous_token:
+            reservation_guard: dict[str, Any] = {
+                "dispatch_reservation_token": previous_token,
+                "dispatch_lease_expires_at": {"$lte": observed_now},
+                "active_conversation_key": conversation_key,
+            }
+        else:
+            reservation_guard = {
+                "dispatch_reservation_token": {"$exists": False},
+                "active_conversation_key": {"$exists": False},
+            }
+        token = str(uuid4())
+        request_id = str(uuid4())
+        attempt_id = str(uuid4())
+        try:
+            reserved = coll.find_one_and_update(
+                {
+                    "queue_id": queue_id,
+                    "status": STATUS_QUEUED,
+                    "dispatch_mode": DISPATCH_MODE_SERVER,
+                    "execution_envelope_version": EXECUTION_ENVELOPE_VERSION,
+                    "$or": [
+                        {"next_dispatch_at": {"$exists": False}},
+                        {"next_dispatch_at": {"$lte": observed_now}},
+                    ],
+                    **reservation_guard,
+                },
+                {
+                    "$set": {
+                        "active_conversation_key": conversation_key,
+                        "dispatch_reservation_token": token,
+                        "dispatch_owner": owner,
+                        "dispatch_acquired_at": observed_now,
+                        "dispatch_heartbeat_at": observed_now,
+                        "dispatch_lease_expires_at": observed_now
+                        + timedelta(seconds=lease_duration),
+                        "client_request_id": request_id,
+                        "attempt_id": attempt_id,
+                        "updated_at": observed_now,
+                    },
+                    "$unset": {
+                        "next_dispatch_at": "",
+                        "last_dispatch_error": "",
+                    },
+                    "$inc": {"dispatch_count": 1},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            continue
+        record = serialise_queue_record(reserved)
+        if record is None:
+            continue
+        # This capability result is internal to the dispatcher. The general
+        # serializer intentionally never exposes the opaque token or execution
+        # envelope carried across the sessionless dispatch boundary.
+        record["user_concept_id"] = reserved.get("user_concept_id")
+        record["organisation_concept_id"] = reserved.get("organisation_concept_id")
+        record["namespace"] = reserved.get("namespace")
+        record["dispatch_reservation_token"] = token
+        record["dispatch_owner"] = reserved.get("dispatch_owner")
+        record["dispatch_acquired_at"] = _serialise_datetime(
+            reserved.get("dispatch_acquired_at")
+        )
+        record["dispatch_heartbeat_at"] = _serialise_datetime(
+            reserved.get("dispatch_heartbeat_at")
+        )
+        record["dispatch_lease_expires_at"] = _serialise_datetime(
+            reserved.get("dispatch_lease_expires_at")
+        )
+        record["execution_envelope"] = (
+            dict(reserved.get("execution_envelope"))
+            if isinstance(reserved.get("execution_envelope"), Mapping)
+            else {}
+        )
+        return record
+    return None
+
+
+def release_server_dispatch_reservation(
+    *,
+    queue_id: str,
+    dispatch_reservation_token: str,
+    server_instance_id: str,
+    retry_after_seconds: float = 0,
+    error: str | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Release an exact pre-admission reservation back to its FIFO."""
+
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    token = _coerce_scope_value(
+        dispatch_reservation_token,
+        field="dispatch_reservation_token",
+    )
+    owner = _coerce_scope_value(server_instance_id, field="server_instance_id")
+    try:
+        delay = float(retry_after_seconds)
+    except (TypeError, ValueError) as exc:
+        raise InvalidChatPromptQueueInput(
+            "retry_after_seconds must be a non-negative number"
+        ) from exc
+    if not math.isfinite(delay) or delay < 0:
+        raise InvalidChatPromptQueueInput("retry_after_seconds must be a finite number")
+    observed_now = now or _now()
+    set_fields: dict[str, Any] = {
+        "updated_at": observed_now,
+        "next_dispatch_at": observed_now + timedelta(seconds=delay),
+    }
+    error_clean = _coerce_text(
+        error,
+        field="error",
+        required=False,
+        max_chars=4_000,
+    )
+    unset_fields: dict[str, str] = {
+        "active_conversation_key": "",
+        "dispatch_reservation_token": "",
+        "dispatch_owner": "",
+        "dispatch_acquired_at": "",
+        "dispatch_heartbeat_at": "",
+        "dispatch_lease_expires_at": "",
+        "client_request_id": "",
+        "attempt_id": "",
+    }
+    if error_clean is not None:
+        set_fields["last_dispatch_error"] = error_clean
+    else:
+        unset_fields["last_dispatch_error"] = ""
+    result = _collection().update_one(
+        {
+            "queue_id": queue_id_clean,
+            "status": STATUS_QUEUED,
+            "dispatch_mode": DISPATCH_MODE_SERVER,
+            "dispatch_reservation_token": token,
+            "dispatch_owner": owner,
+            "active_conversation_key": {"$exists": True},
+        },
+        {"$set": set_fields, "$unset": unset_fields},
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def heartbeat_server_dispatch_reservation(
+    *,
+    queue_id: str,
+    dispatch_reservation_token: str,
+    server_instance_id: str,
+    now: datetime | None = None,
+    lease_seconds: int | None = None,
+) -> bool:
+    """Renew one exact server dispatch reservation."""
+
+    observed_now = now or _now()
+    result = _collection().update_one(
+        {
+            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+            "status": STATUS_QUEUED,
+            "dispatch_mode": DISPATCH_MODE_SERVER,
+            "dispatch_reservation_token": _coerce_scope_value(
+                dispatch_reservation_token,
+                field="dispatch_reservation_token",
+            ),
+            "dispatch_owner": _coerce_scope_value(
+                server_instance_id,
+                field="server_instance_id",
+            ),
+            "active_conversation_key": {"$exists": True},
+        },
+        {
+            "$set": {
+                "dispatch_heartbeat_at": observed_now,
+                "dispatch_lease_expires_at": observed_now
+                + timedelta(seconds=_dispatch_lease_seconds(lease_seconds)),
+                "updated_at": observed_now,
+            }
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
+
+
+def fail_server_dispatch_reservation(
+    *,
+    queue_id: str,
+    dispatch_reservation_token: str,
+    server_instance_id: str,
+    error: str,
+    now: datetime | None = None,
+) -> bool:
+    """Terminalise an exact reservation that failed before turn admission."""
+
+    observed_now = now or _now()
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    token_clean = _coerce_scope_value(
+        dispatch_reservation_token,
+        field="dispatch_reservation_token",
+    )
+    owner_clean = _coerce_scope_value(
+        server_instance_id,
+        field="server_instance_id",
+    )
+    error_clean = _coerce_text(
+        error,
+        field="error",
+        required=True,
+        max_chars=4_000,
+    )
+    coll = _collection()
+    exact_query = {
+        "queue_id": queue_id_clean,
+        "status": STATUS_QUEUED,
+        "dispatch_mode": DISPATCH_MODE_SERVER,
+        "dispatch_reservation_token": token_clean,
+        "dispatch_owner": owner_clean,
+        "active_conversation_key": {"$exists": True},
+    }
+    existing = coll.find_one(exact_query)
+    reconciliation_set, reconciliation_unset = _terminal_reconciliation_update(
+        existing,
+        status=STATUS_FAILED,
+        error=error_clean,
+        source="server_dispatch_failure",
+        observed_now=observed_now,
+    )
+    result = coll.update_one(
+        exact_query,
+        {
+            "$set": {
+                "status": STATUS_FAILED,
+                "completed_at": observed_now,
+                "updated_at": observed_now,
+                "last_error": error_clean,
+                **reconciliation_set,
+            },
+            "$unset": {
+                "active_conversation_key": "",
+                "active_task_execution_key": "",
+                "dispatch_reservation_token": "",
+                "dispatch_owner": "",
+                "dispatch_acquired_at": "",
+                "dispatch_heartbeat_at": "",
+                "dispatch_lease_expires_at": "",
+                "queued_global_slot": "",
+                "queued_user_slot": "",
+                "next_dispatch_at": "",
+                **reconciliation_unset,
+            },
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
 
 
 def _requeue_with_bounded_slots(
@@ -948,12 +2886,15 @@ def bind_queue_record_to_turn(
     conversation_key: str,
     server_instance_id: str,
     attempt_id: str | None = None,
+    dispatch_reservation_token: str | None = None,
+    lease_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Atomically bind one queued prompt to the executing conversation turn.
 
-    ``active_conversation_key`` exists only for the admitted record. Its unique
-    partial index is the cross-thread/process single-flight fence; the stable
-    ``conversation_key`` remains afterwards for reconciliation.
+    ``active_conversation_key`` is the cross-thread/process single-flight
+    fence. A server dispatcher may reserve it before admission, but only the
+    exact opaque reservation token owned by this server can upgrade that row.
+    The stable ``conversation_key`` remains afterwards for reconciliation.
     """
 
     queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
@@ -968,6 +2909,11 @@ def bind_queue_record_to_turn(
     server_instance_id_clean = _coerce_scope_value(
         server_instance_id,
         field="server_instance_id",
+    )
+    dispatch_reservation_token_clean = _coerce_scope_value(
+        dispatch_reservation_token,
+        field="dispatch_reservation_token",
+        required=False,
     )
     attempt_id_clean = _coerce_scope_value(
         attempt_id,
@@ -993,10 +2939,35 @@ def bind_queue_record_to_turn(
         raise InvalidChatPromptQueueInput(
             "prompt queue record is already bound to a different request"
         )
-    if existing.get("active_conversation_key"):
+    persisted_reservation_token = _coerce_scope_value(
+        existing.get("dispatch_reservation_token"),
+        field="dispatch_reservation_token",
+        required=False,
+    )
+    reservation_upgrade = bool(
+        dispatch_reservation_token_clean
+        and persisted_reservation_token == dispatch_reservation_token_clean
+        and existing.get("dispatch_owner") == server_instance_id_clean
+        and existing.get("status") == STATUS_QUEUED
+    )
+    if existing.get("active_conversation_key") and not reservation_upgrade:
         raise ConversationTurnAlreadyActive(
             "prompt queue record is already executing",
             queue_id=queue_id_clean,
+        )
+    if dispatch_reservation_token_clean and not reservation_upgrade:
+        raise ConversationTurnAlreadyActive(
+            "server dispatch reservation is no longer owned by this request",
+            queue_id=queue_id_clean,
+        )
+    existing_attempt_id = _coerce_scope_value(
+        existing.get("attempt_id"),
+        field="attempt_id",
+        required=False,
+    )
+    if reservation_upgrade and existing_attempt_id != attempt_id_clean:
+        raise InvalidChatPromptQueueInput(
+            "server dispatch reservation belongs to a different attempt"
         )
 
     persisted_conversation_key = _coerce_scope_value(
@@ -1017,19 +2988,12 @@ def bind_queue_record_to_turn(
     # Legacy rows retain their former same-scope session FIFO until first bound.
     session_id = existing.get("session_id")
     if persisted_conversation_key:
-        created_at = existing.get("created_at", now)
         earlier = coll.find_one(
             {
                 "conversation_key": persisted_conversation_key,
                 "status": {"$in": ACTIVE_STATUSES},
                 "queue_id": {"$ne": queue_id_clean},
-                "$or": [
-                    {"created_at": {"$lt": created_at}},
-                    {
-                        "created_at": created_at,
-                        "queue_id": {"$lt": queue_id_clean},
-                    },
-                ],
+                "$and": [_earlier_enqueue_filter(existing)],
             },
             {
                 "queue_id": 1,
@@ -1037,7 +3001,7 @@ def bind_queue_record_to_turn(
                 "organisation_concept_id": 1,
                 "namespace": 1,
             },
-            sort=[("created_at", 1), ("queue_id", 1)],
+            sort=_enqueue_sort(),
         )
         if earlier is not None:
             same_scope_queue_id = (
@@ -1056,10 +3020,10 @@ def bind_queue_record_to_turn(
                 "session_id": session_id,
                 "status": {"$in": ACTIVE_STATUSES},
                 "queue_id": {"$ne": queue_id_clean},
-                "created_at": {"$lt": existing.get("created_at", now)},
+                "$and": [_earlier_enqueue_filter(existing)],
             },
             {"queue_id": 1},
-            sort=[("created_at", 1), ("queue_id", 1)],
+            sort=_enqueue_sort(),
         )
         if earlier is not None:
             raise ConversationTurnAlreadyActive(
@@ -1067,18 +3031,32 @@ def bind_queue_record_to_turn(
                 queue_id=str(earlier.get("queue_id") or "") or None,
             )
 
+    if reservation_upgrade:
+        ownership_guard: dict[str, Any] = {
+            "status": STATUS_QUEUED,
+            "active_conversation_key": conversation_key_clean,
+            "dispatch_reservation_token": dispatch_reservation_token_clean,
+            "dispatch_owner": server_instance_id_clean,
+            "dispatch_lease_expires_at": {"$gt": now},
+        }
+    else:
+        ownership_guard = {
+            "status": {"$in": ACTIVE_STATUSES},
+            "active_conversation_key": {"$exists": False},
+            "dispatch_reservation_token": {"$exists": False},
+        }
+
     try:
         doc = coll.find_one_and_update(
             {
                 **_compatible_scope_query(scope),
                 "queue_id": queue_id_clean,
-                "status": {"$in": ACTIVE_STATUSES},
                 "$or": [
                     {"client_request_id": None},
                     {"client_request_id": request_id_clean},
                     {"client_request_id": {"$exists": False}},
                 ],
-                "active_conversation_key": {"$exists": False},
+                **ownership_guard,
             },
             {
                 "$set": {
@@ -1092,6 +3070,8 @@ def bind_queue_record_to_turn(
                     "claimed_at": now,
                     "lease_acquired_at": now,
                     "lease_heartbeat_at": now,
+                    "lease_expires_at": now
+                    + timedelta(seconds=_turn_lease_seconds(lease_seconds)),
                     "updated_at": now,
                     "completed_at": None,
                     "last_error": None,
@@ -1103,6 +3083,13 @@ def bind_queue_record_to_turn(
                     "stale_advisory_at": "",
                     "stale_advisory_reason": "",
                     "reconciliation_required": "",
+                    "dispatch_reservation_token": "",
+                    "dispatch_owner": "",
+                    "dispatch_acquired_at": "",
+                    "dispatch_heartbeat_at": "",
+                    "dispatch_lease_expires_at": "",
+                    "next_dispatch_at": "",
+                    "last_dispatch_error": "",
                 },
                 "$inc": {"attempt_count": 1},
             },
@@ -1126,21 +3113,39 @@ def heartbeat_bound_turn(
     scope: Mapping[str, Any],
     queue_id: str,
     attempt_id: str,
+    server_instance_id: str | None = None,
+    now: datetime | None = None,
+    lease_seconds: int | None = None,
 ) -> bool:
     """Refresh an exact admitted turn lease without changing its semantics."""
 
-    now = _now()
-    result = _collection().update_one(
-        {
-            **_compatible_scope_query(scope),
-            "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
-            "attempt_id": _coerce_scope_value(attempt_id, field="attempt_id"),
-            "status": STATUS_IN_PROGRESS,
-            "active_conversation_key": {"$exists": True},
-        },
-        {"$set": {"lease_heartbeat_at": now, "updated_at": now}},
+    observed_now = now or _now()
+    owner = _coerce_scope_value(
+        server_instance_id,
+        field="server_instance_id",
+        required=False,
     )
-    return bool(getattr(result, "modified_count", 0))
+    query: dict[str, Any] = {
+        **_compatible_scope_query(scope),
+        "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+        "attempt_id": _coerce_scope_value(attempt_id, field="attempt_id"),
+        "status": STATUS_IN_PROGRESS,
+        "active_conversation_key": {"$exists": True},
+    }
+    if owner:
+        query["server_instance_id"] = owner
+    result = _collection().update_one(
+        query,
+        {
+            "$set": {
+                "lease_heartbeat_at": observed_now,
+                "lease_expires_at": observed_now
+                + timedelta(seconds=_turn_lease_seconds(lease_seconds)),
+                "updated_at": observed_now,
+            }
+        },
+    )
+    return bool(getattr(result, "matched_count", 0))
 
 
 def update_queued_record(
@@ -1153,6 +3158,22 @@ def update_queued_record(
     conversation_key: Any = _UNSET,
 ) -> dict[str, Any]:
     queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    coll = _collection()
+    if (
+        coll.find_one(
+            {
+                **_compatible_scope_query(scope),
+                "queue_id": queue_id_clean,
+                "status": STATUS_QUEUED,
+                "dispatch_mode": DISPATCH_MODE_SERVER,
+            },
+            {"_id": 1},
+        )
+        is not None
+    ):
+        raise InvalidChatPromptQueueInput(
+            "server-dispatched queue records are immutable; cancel and enqueue new work"
+        )
     set_fields: dict[str, Any] = {"updated_at": _now()}
     if prompt_raw is not None:
         set_fields["prompt_raw"] = _coerce_text(
@@ -1182,11 +3203,12 @@ def update_queued_record(
         )
 
     canonical_scope = _scope_query(scope)
-    doc = _collection().find_one_and_update(
+    doc = coll.find_one_and_update(
         {
             **_compatible_scope_query(scope),
             "queue_id": queue_id_clean,
             "status": STATUS_QUEUED,
+            "dispatch_mode": {"$ne": DISPATCH_MODE_SERVER},
         },
         {"$set": {**set_fields, **canonical_scope}},
         return_document=ReturnDocument.AFTER,
@@ -1206,11 +3228,28 @@ def claim_queue_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str, 
     queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
     now = _now()
     canonical_scope = _scope_query(scope)
-    doc = _collection().find_one_and_update(
+    coll = _collection()
+    if (
+        coll.find_one(
+            {
+                **_compatible_scope_query(scope),
+                "queue_id": queue_id_clean,
+                "status": STATUS_QUEUED,
+                "dispatch_mode": DISPATCH_MODE_SERVER,
+            },
+            {"_id": 1},
+        )
+        is not None
+    ):
+        raise InvalidChatPromptQueueInput(
+            "server-dispatched queue records require a server dispatch reservation"
+        )
+    doc = coll.find_one_and_update(
         {
             **_compatible_scope_query(scope),
             "queue_id": queue_id_clean,
             "status": STATUS_QUEUED,
+            "dispatch_mode": {"$ne": DISPATCH_MODE_SERVER},
         },
         {
             "$set": {
@@ -1277,6 +3316,11 @@ def requeue_prompt_record(
             expected_statuses=[STATUS_IN_PROGRESS],
             fallback_message="in-progress prompt was not found",
         )
+    if existing.get("dispatch_mode") == DISPATCH_MODE_SERVER:
+        raise ChatPromptQueueReconciliationRequired(
+            "A server-dispatched attempt cannot be replayed without reconciling "
+            "its exact turn and effect receipts"
+        )
 
     transition_guard: dict[str, Any] = {}
     if existing.get("active_conversation_key"):
@@ -1331,6 +3375,15 @@ def requeue_prompt_record(
             "server_instance_id": "",
             "lease_acquired_at": "",
             "lease_heartbeat_at": "",
+            "lease_expires_at": "",
+            "dispatch_reservation_token": "",
+            "dispatch_owner": "",
+            "dispatch_acquired_at": "",
+            "dispatch_heartbeat_at": "",
+            "dispatch_lease_expires_at": "",
+            "next_dispatch_at": "",
+            "last_dispatch_error": "",
+            "purge_after": "",
             "stale_advisory": "",
             "stale_advisory_at": "",
             "stale_advisory_reason": "",
@@ -1378,37 +3431,68 @@ def finish_prompt_record(
         else {"active_conversation_key": {"$exists": False}}
     )
     coll = _collection()
+    transition_query = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "status": {"$in": ACTIVE_STATUSES},
+        **ownership_guard,
+    }
+    existing_for_terminal = coll.find_one(transition_query)
+    if not attempt_id_clean:
+        existing = existing_for_terminal
+        if (
+            isinstance(existing, Mapping)
+            and existing.get("dispatch_mode") == DISPATCH_MODE_SERVER
+        ):
+            raise ChatPromptQueueReconciliationRequired(
+                "A server-dispatched queue row can only be terminalised by its "
+                "exact admitted attempt"
+            )
+    error_clean = _coerce_text(
+        error,
+        field="error",
+        required=False,
+        max_chars=4_000,
+    )
+    reconciliation_set, reconciliation_unset = _terminal_reconciliation_update(
+        existing_for_terminal,
+        status=status,
+        error=error_clean,
+        source="queue_terminalisation",
+        observed_now=now,
+    )
     doc = coll.find_one_and_update(
-        {
-            **_compatible_scope_query(scope),
-            "queue_id": queue_id_clean,
-            "status": {"$in": ACTIVE_STATUSES},
-            **ownership_guard,
-        },
+        transition_query,
         {
             "$set": {
                 **canonical_scope,
                 "status": status,
                 "updated_at": now,
                 "completed_at": now,
-                "last_error": _coerce_text(
-                    error,
-                    field="error",
-                    required=False,
-                    max_chars=4_000,
-                ),
+                "last_error": error_clean,
+                **reconciliation_set,
             },
             "$unset": {
                 "active_conversation_key": "",
+                "active_task_execution_key": "",
                 "queued_global_slot": "",
                 "queued_user_slot": "",
                 "server_instance_id": "",
                 "lease_acquired_at": "",
                 "lease_heartbeat_at": "",
+                "lease_expires_at": "",
+                "dispatch_reservation_token": "",
+                "dispatch_owner": "",
+                "dispatch_acquired_at": "",
+                "dispatch_heartbeat_at": "",
+                "dispatch_lease_expires_at": "",
+                "next_dispatch_at": "",
+                "last_dispatch_error": "",
                 "stale_advisory": "",
                 "stale_advisory_at": "",
                 "stale_advisory_reason": "",
                 "reconciliation_required": "",
+                **reconciliation_unset,
             },
         },
         return_document=ReturnDocument.AFTER,
@@ -1453,8 +3537,18 @@ def finish_prompt_record(
     return record
 
 
-def cancel_prompt_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str, Any]:
+def cancel_prompt_record(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    handoff_replacement_queue_id: str | None = None,
+) -> dict[str, Any]:
     queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    replacement_queue_id_clean = _coerce_scope_value(
+        handoff_replacement_queue_id,
+        field="handoff_replacement_queue_id",
+        required=False,
+    )
     now = _now()
     canonical_scope = _scope_query(scope)
 
@@ -1462,6 +3556,19 @@ def cancel_prompt_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str
     existing = coll.find_one(
         {**_compatible_scope_query(scope), "queue_id": queue_id_clean}
     )
+    if (
+        replacement_queue_id_clean
+        and isinstance(existing, Mapping)
+        and existing.get("status") == STATUS_CANCELLED
+    ):
+        if existing.get("handoff_replacement_queue_id") == replacement_queue_id_clean:
+            record = serialise_queue_record(existing)
+            if record is not None:
+                return record
+        raise ChatPromptQueueHandoffConflict(
+            "The handoff source was cancelled independently of this replacement",
+            queue_id=replacement_queue_id_clean,
+        )
     if (
         existing is not None
         and existing.get("status") == STATUS_IN_PROGRESS
@@ -1472,18 +3579,75 @@ def cancel_prompt_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str
             queue_id=queue_id_clean,
         )
 
+    reconciliation_set, reconciliation_unset = _terminal_reconciliation_update(
+        existing,
+        status=STATUS_CANCELLED,
+        error=None,
+        source="queue_cancellation",
+        observed_now=now,
+    )
+    if (
+        isinstance(existing, Mapping)
+        and existing.get("status") == STATUS_FAILED
+        and not _has_task_execution_link(existing)
+        and isinstance(existing.get("completed_at"), datetime)
+    ):
+        reconciliation_set["purge_after"] = _terminal_purge_after(
+            existing["completed_at"]
+        )
+    unresolved_handoff_source_id = (
+        str(existing.get("handoff_source_queue_id") or "").strip()
+        if (
+            isinstance(existing, Mapping)
+            and existing.get("status") == STATUS_QUEUED
+            and existing.get("dispatch_mode") == DISPATCH_MODE_SERVER
+            and existing.get("dispatch_ready") is False
+        )
+        else ""
+    )
+    if unresolved_handoff_source_id:
+        # Release the active unique fence immediately while retaining terminal
+        # provenance. A cancelled replacement must not block a safe retry of a
+        # source that the caller deliberately left queued.
+        reconciliation_set.update(
+            {
+                "retired_handoff_source_queue_id": unresolved_handoff_source_id,
+                "handoff_cancelled_at": now,
+            }
+        )
+        reconciliation_unset.update(
+            {
+                "handoff_source_queue_id": "",
+                "handoff_reconciliation_attempted_at": "",
+                "handoff_reconciliation_next_at": "",
+                "handoff_reconciliation_attempt_count": "",
+                "handoff_reconciliation_last_error": "",
+            }
+        )
+    if replacement_queue_id_clean:
+        reconciliation_set.update(
+            {
+                "handoff_replacement_queue_id": replacement_queue_id_clean,
+                "handoff_source_retired_at": now,
+            }
+        )
+
+    cancellable_query: dict[str, Any] = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "$or": [
+            {"status": STATUS_QUEUED},
+            {
+                "status": STATUS_IN_PROGRESS,
+                "active_conversation_key": {"$exists": False},
+            },
+        ],
+    }
+    if replacement_queue_id_clean:
+        cancellable_query["handoff_replacement_queue_id"] = {"$exists": False}
+
     doc = coll.find_one_and_update(
-        {
-            **_compatible_scope_query(scope),
-            "queue_id": queue_id_clean,
-            "$or": [
-                {"status": STATUS_QUEUED},
-                {
-                    "status": STATUS_IN_PROGRESS,
-                    "active_conversation_key": {"$exists": False},
-                },
-            ],
-        },
+        cancellable_query,
         {
             "$set": {
                 **canonical_scope,
@@ -1491,18 +3655,29 @@ def cancel_prompt_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str
                 "updated_at": now,
                 "completed_at": now,
                 "last_error": None,
+                **reconciliation_set,
             },
             "$unset": {
                 "active_conversation_key": "",
+                "active_task_execution_key": "",
                 "queued_global_slot": "",
                 "queued_user_slot": "",
                 "server_instance_id": "",
                 "lease_acquired_at": "",
                 "lease_heartbeat_at": "",
+                "lease_expires_at": "",
+                "dispatch_reservation_token": "",
+                "dispatch_owner": "",
+                "dispatch_acquired_at": "",
+                "dispatch_heartbeat_at": "",
+                "dispatch_lease_expires_at": "",
+                "next_dispatch_at": "",
+                "last_dispatch_error": "",
                 "stale_advisory": "",
                 "stale_advisory_at": "",
                 "stale_advisory_reason": "",
                 "reconciliation_required": "",
+                **reconciliation_unset,
             },
         },
         return_document=ReturnDocument.AFTER,
@@ -1510,21 +3685,50 @@ def cancel_prompt_record(*, scope: Mapping[str, Any], queue_id: str) -> dict[str
     if doc is None:
         # Failed records keep their original completion time and diagnostic
         # evidence when explicitly dismissed.
+        failed_query: dict[str, Any] = {
+            **_compatible_scope_query(scope),
+            "queue_id": queue_id_clean,
+            "status": STATUS_FAILED,
+        }
+        if replacement_queue_id_clean:
+            failed_query["handoff_replacement_queue_id"] = {"$exists": False}
         doc = coll.find_one_and_update(
-            {
-                **_compatible_scope_query(scope),
-                "queue_id": queue_id_clean,
-                "status": STATUS_FAILED,
-            },
+            failed_query,
             {
                 "$set": {
                     **canonical_scope,
                     "status": STATUS_CANCELLED,
                     "updated_at": now,
+                    **reconciliation_set,
+                },
+                "$unset": {
+                    "active_task_execution_key": "",
+                    **reconciliation_unset,
                 }
             },
             return_document=ReturnDocument.AFTER,
         )
+    if doc is None and replacement_queue_id_clean:
+        retired = coll.find_one(
+            {
+                **_compatible_scope_query(scope),
+                "queue_id": queue_id_clean,
+                "status": STATUS_CANCELLED,
+            }
+        )
+        if (
+            isinstance(retired, Mapping)
+            and retired.get("handoff_replacement_queue_id")
+            == replacement_queue_id_clean
+        ):
+            record = serialise_queue_record(retired)
+            if record is not None:
+                return record
+        if isinstance(retired, Mapping):
+            raise ChatPromptQueueHandoffConflict(
+                "The handoff source was cancelled independently of this replacement",
+                queue_id=replacement_queue_id_clean,
+            )
     record = serialise_queue_record(doc)
     if record is None:
         raise _transition_not_found_error(

--- a/src/backend/services/conversation_turn_admission_service.py
+++ b/src/backend/services/conversation_turn_admission_service.py
@@ -20,12 +20,13 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from . import chat_prompt_queue_service
+from . import chat_prompt_queue_service, task_execution_service
 
 _logger = logging.getLogger(__name__)
 
 _TERMINALISATION_RETRY_INITIAL_DELAY_SEC = 0.5
 _TERMINALISATION_RETRY_MAX_DELAY_SEC = 30.0
+_DEFAULT_LEASE_HEARTBEAT_INTERVAL_SEC = 30.0
 _DEFAULT_WAITRESS_THREADS = 32
 _DEFAULT_HTTP_HEADROOM_THREADS = 8
 
@@ -93,6 +94,10 @@ class ConversationTurnAdmissionToken:
     namespace: str | None
     conversation_key: str
     client_request_id: str
+    session_id: str | None = None
+    enqueue_submission_id: str | None = None
+    task_concept_id: str | None = None
+    task_execution_concept_id: str | None = None
     released: bool = False
     pending_terminal_status: str | None = None
     pending_terminal_error: str | None = None
@@ -177,6 +182,63 @@ class ConversationTurnAdmissionService:
         self._terminalisation_retry_condition = threading.Condition(self._lock)
         self._terminalisation_retry_thread: threading.Thread | None = None
         self._terminalisation_retry_shutdown = False
+        try:
+            heartbeat_interval = float(
+                os.getenv(
+                    "VON_TURN_LEASE_HEARTBEAT_SECONDS",
+                    str(_DEFAULT_LEASE_HEARTBEAT_INTERVAL_SEC),
+                )
+            )
+        except (TypeError, ValueError):
+            heartbeat_interval = _DEFAULT_LEASE_HEARTBEAT_INTERVAL_SEC
+        self._lease_heartbeat_interval_sec = max(0.1, heartbeat_interval)
+        self._lease_heartbeat_stop = threading.Event()
+        self._lease_heartbeat_thread: threading.Thread | None = None
+
+    def _ensure_lease_heartbeat_thread_locked(self) -> None:
+        thread = self._lease_heartbeat_thread
+        if thread is not None and thread.is_alive():
+            return
+        self._lease_heartbeat_stop.clear()
+        thread = threading.Thread(
+            target=self._lease_heartbeat_loop,
+            name="conversation_turn_lease_heartbeat",
+            daemon=True,
+        )
+        self._lease_heartbeat_thread = thread
+        thread.start()
+
+    def _lease_heartbeat_loop(self) -> None:
+        while not self._lease_heartbeat_stop.wait(
+            timeout=self._lease_heartbeat_interval_sec
+        ):
+            with self._lock:
+                tokens = [
+                    token
+                    for token in self._active_tokens.values()
+                    if token.queue_id and token.attempt_id and not token.released
+                ]
+            for token in tokens:
+                try:
+                    refreshed = chat_prompt_queue_service.heartbeat_bound_turn(
+                        scope=token.scope,
+                        queue_id=str(token.queue_id),
+                        attempt_id=str(token.attempt_id),
+                        server_instance_id=SERVER_INSTANCE_ID,
+                    )
+                    if not refreshed:
+                        _logger.warning(
+                            "Turn lease heartbeat no longer matched queue_id=%s "
+                            "attempt_id=%s",
+                            token.queue_id,
+                            token.attempt_id,
+                        )
+                except Exception as exc:  # lease outage must not kill execution
+                    _logger.warning(
+                        "Turn lease heartbeat deferred for queue_id=%s: %s",
+                        token.queue_id,
+                        exc,
+                    )
 
     def _ensure_terminalisation_retry_thread_locked(self) -> None:
         thread = self._terminalisation_retry_thread
@@ -255,14 +317,18 @@ class ConversationTurnAdmissionService:
                 )
 
     def shutdown(self, *, wait: bool = True, timeout: float = 2.0) -> None:
-        """Stop this instance's lazy retry worker (primarily for tests)."""
+        """Stop this instance's retry and lease-heartbeat workers."""
 
+        self._lease_heartbeat_stop.set()
         with self._terminalisation_retry_condition:
             self._terminalisation_retry_shutdown = True
             self._terminalisation_retry_condition.notify_all()
-            thread = self._terminalisation_retry_thread
-        if wait and thread is not None and thread is not threading.current_thread():
-            thread.join(timeout=max(0.0, float(timeout)))
+            retry_thread = self._terminalisation_retry_thread
+        heartbeat_thread = self._lease_heartbeat_thread
+        if wait:
+            for thread in (retry_thread, heartbeat_thread):
+                if thread is not None and thread is not threading.current_thread():
+                    thread.join(timeout=max(0.0, float(timeout)))
 
     def _reserve_capacity(self, user_concept_id: str) -> None:
         with self._lock:
@@ -296,6 +362,75 @@ class ConversationTurnAdmissionService:
             else:
                 self._active_by_user.pop(user_concept_id, None)
 
+    @staticmethod
+    def _task_execution_link(
+        token: ConversationTurnAdmissionToken,
+    ) -> dict[str, str] | None:
+        """Return one complete internal task-execution link or reject corruption."""
+
+        raw_link = {
+            "task_concept_id": token.task_concept_id,
+            "task_execution_concept_id": token.task_execution_concept_id,
+            "enqueue_submission_id": token.enqueue_submission_id,
+            "queue_id": token.queue_id,
+            "actor_concept_id": token.user_concept_id,
+            "organisation_concept_id": token.organisation_concept_id,
+        }
+        present = {
+            key: str(value).strip()
+            for key, value in raw_link.items()
+            if isinstance(value, str) and value.strip()
+        }
+        if not any(
+            key in present
+            for key in (
+                "task_concept_id",
+                "task_execution_concept_id",
+            )
+        ):
+            return None
+        missing = [key for key in raw_link if key not in present]
+        if missing:
+            raise RuntimeError(
+                "bound task execution link is incomplete: " + ", ".join(missing)
+            )
+        return present
+
+    @classmethod
+    def _transition_linked_task_execution(
+        cls,
+        token: ConversationTurnAdmissionToken,
+        *,
+        status: str,
+        source: str,
+        result: str | None = None,
+        queue_record: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        link = cls._task_execution_link(token)
+        if link is None:
+            return None
+        if queue_record is not None:
+            for field in (
+                "queue_id",
+                "enqueue_submission_id",
+                "task_concept_id",
+                "task_execution_concept_id",
+            ):
+                if queue_record.get(field) != link[field]:
+                    raise RuntimeError(
+                        f"terminal queue record {field} does not match admission"
+                    )
+        return task_execution_service.transition_task_execution(
+            link["task_execution_concept_id"],
+            actor_concept_id=link["actor_concept_id"],
+            organisation_concept_id=link["organisation_concept_id"],
+            enqueue_submission_id=link["enqueue_submission_id"],
+            queue_id=link["queue_id"],
+            status=status,
+            result=result,
+            source=source,
+        )
+
     def acquire(
         self,
         *,
@@ -307,6 +442,7 @@ class ConversationTurnAdmissionService:
         conversation_key: str,
         queue_id: str | None = None,
         attempt_id: str | None = None,
+        dispatch_reservation_token: str | None = None,
         window_session_id: str | None = None,
     ) -> ConversationTurnAdmissionToken:
         """Acquire capacity and the durable conversation fence without waiting."""
@@ -318,6 +454,7 @@ class ConversationTurnAdmissionService:
         )
         user_id = str(canonical_scope["user_concept_id"] or "")
         self._reserve_capacity(user_id)
+        registered_token: ConversationTurnAdmissionToken | None = None
         try:
             bound_queue_id = str(queue_id or "").strip()
             if not bound_queue_id:
@@ -355,6 +492,7 @@ class ConversationTurnAdmissionService:
                     conversation_key=conversation_key,
                     server_instance_id=SERVER_INSTANCE_ID,
                     attempt_id=attempt_id,
+                    dispatch_reservation_token=dispatch_reservation_token,
                 )
             except chat_prompt_queue_service.ConversationTurnAlreadyActive as exc:
                 raise ConversationTurnActive(
@@ -371,13 +509,53 @@ class ConversationTurnAdmissionService:
                 namespace=canonical_scope.get("namespace"),
                 conversation_key=conversation_key,
                 client_request_id=client_request_id,
+                session_id=session_id,
+                enqueue_submission_id=(
+                    str(bound.get("enqueue_submission_id") or "").strip() or None
+                ),
+                task_concept_id=(
+                    str(bound.get("task_concept_id") or "").strip() or None
+                ),
+                task_execution_concept_id=(
+                    str(bound.get("task_execution_concept_id") or "").strip() or None
+                ),
             )
             with self._lock:
                 self._active_tokens[token.token_id] = token
                 self._reserved_global = max(0, self._reserved_global - 1)
+                self._ensure_lease_heartbeat_thread_locked()
+            registered_token = token
+            try:
+                self._transition_linked_task_execution(
+                    token,
+                    status=task_execution_service.TASK_EXECUTION_STATUS_IN_PROGRESS,
+                    source="queue_admission",
+                    queue_record=bound,
+                )
+            except Exception as exc:
+                # The registered token keeps capacity and the exact queue fence
+                # owned until queue and TaskExecution failure terminalisation
+                # both succeed through the ordinary durable retry path.
+                try:
+                    self.release(
+                        token,
+                        status=chat_prompt_queue_service.STATUS_FAILED,
+                        error=(
+                            "TaskExecution admission transition failed: "
+                            f"{type(exc).__name__}: {exc}"
+                        )[:4_000],
+                    )
+                except Exception:
+                    _logger.exception(
+                        "Failed to terminalise bound task execution after "
+                        "admission transition error queue_id=%s",
+                        token.queue_id,
+                    )
+                raise
             return token
         except Exception:
-            self._release_user_capacity(user_id, reserved=True)
+            if registered_token is None:
+                self._release_user_capacity(user_id, reserved=True)
             raise
 
     def acquire_ephemeral(
@@ -444,14 +622,74 @@ class ConversationTurnAdmissionService:
             error = token.pending_terminal_error
             token.released = True
         try:
+            terminal_record = None
             if token.queue_id:
-                chat_prompt_queue_service.finish_prompt_record(
+                terminal_record = chat_prompt_queue_service.finish_prompt_record(
                     scope=token.scope,
                     queue_id=token.queue_id,
                     status=status,
                     error=error,
                     attempt_id=token.attempt_id,
                 )
+            execution_status = {
+                chat_prompt_queue_service.STATUS_COMPLETED: (
+                    task_execution_service.TASK_EXECUTION_STATUS_COMPLETED
+                ),
+                chat_prompt_queue_service.STATUS_FAILED: (
+                    task_execution_service.TASK_EXECUTION_STATUS_FAILED
+                ),
+                chat_prompt_queue_service.STATUS_CANCELLED: (
+                    task_execution_service.TASK_EXECUTION_STATUS_CANCELLED
+                ),
+            }.get(status)
+            if execution_status is not None:
+                if not (
+                    isinstance(terminal_record, Mapping)
+                    and terminal_record.get("task_execution_reconciliation_status")
+                ):
+                    # Compatibility for legacy terminal writers and isolated
+                    # callers that predate the durable queue marker.
+                    self._transition_linked_task_execution(
+                        token,
+                        status=execution_status,
+                        source="queue_terminalisation",
+                        result=(
+                            error
+                            if execution_status
+                            != task_execution_service.TASK_EXECUTION_STATUS_COMPLETED
+                            else None
+                        ),
+                        queue_record=terminal_record,
+                    )
+                    terminal_record = None
+                # The queue terminal CAS has already persisted a linked
+                # reconciliation marker.  Attempt the projection now for low
+                # latency, but do not keep process capacity or the cleared
+                # conversation fence hostage if the separate TaskExecution
+                # store is unavailable: the server dispatcher owns the durable
+                # retry from this point.
+                try:
+                    from .chat_prompt_queue_dispatch_service import (
+                        reconcile_linked_task_execution_terminal,
+                        wake_chat_prompt_queue_dispatcher,
+                    )
+
+                    if terminal_record is not None:
+                        reconcile_linked_task_execution_terminal(
+                            terminal_record,
+                            status=status,
+                            source="queue_terminalisation",
+                            error=error,
+                        )
+                except Exception as exc:  # noqa: BLE001 - marker is retryable
+                    _logger.warning(
+                        "TaskExecution terminal reconciliation deferred for "
+                        "queue_id=%s: %s",
+                        token.queue_id,
+                        exc,
+                    )
+                finally:
+                    wake_chat_prompt_queue_dispatcher()
         except Exception:
             # Preserve the live token so teardown or an explicit recovery path
             # can retry durable terminalisation. Releasing process capacity
@@ -495,6 +733,13 @@ class ConversationTurnAdmissionService:
                     self._configured_http_threads - self._global_limit,
                 ),
                 "active_user_count": len(self._active_by_user),
+                "lease_heartbeat_running": bool(
+                    self._lease_heartbeat_thread
+                    and self._lease_heartbeat_thread.is_alive()
+                ),
+                "lease_heartbeat_interval_seconds": (
+                    self._lease_heartbeat_interval_sec
+                ),
             }
 
 

--- a/src/backend/services/task_execution_service.py
+++ b/src/backend/services/task_execution_service.py
@@ -1,0 +1,930 @@
+"""Durable execution attempts for Von-assigned task specifications.
+
+``TaskSpecification`` remains the durable work intent.  This service owns one
+``TaskExecution`` concept per explicit launch and records its operational queue
+identity, but deliberately does not infer that a completed queue turn completed
+the task. TaskSpecification completion remains an explicit, separately
+authorised general-task transition backed by work-product evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from pymongo.errors import DuplicateKeyError
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.visibility_predicates import (
+    set_specific_to_org_values,
+    set_specific_to_user_values,
+)
+from .namespace_service import resolve_canonical_namespace
+from .text_value_service import upsert_singleton_text_relation
+
+logger = logging.getLogger(__name__)
+
+TASK_EXECUTION_TYPE_ID = "#V#task_execution"
+VON_SYSTEM_CONCEPT_ID = "#V#von_system"
+
+PREDICATE_EXECUTES_TASK = "#V#executesTask"
+PREDICATE_HAS_EXECUTOR = "#V#hasExecutor"
+PREDICATE_HAS_CREATED_BY = "#V#hasCreatedBy"
+PREDICATE_HAS_ORIGINATING_CONVERSATION = "#V#hasOriginatingConversation"
+PREDICATE_HAS_EXECUTION_STATUS = "#V#hasExecutionStatus"
+PREDICATE_HAS_START_TIME = "#V#hasStartTime"
+PREDICATE_HAS_END_TIME = "#V#hasEndTime"
+PREDICATE_HAS_RESULT = "#V#hasResult"
+PREDICATE_HAS_PROGRESS_NOTE = "#V#hasProgressNote"
+
+TASK_EXECUTION_STATUS_PENDING = "pending"
+TASK_EXECUTION_STATUS_IN_PROGRESS = "in_progress"
+TASK_EXECUTION_STATUS_COMPLETED = "completed"
+TASK_EXECUTION_STATUS_FAILED = "failed"
+TASK_EXECUTION_STATUS_CANCELLED = "cancelled"
+
+TASK_EXECUTION_ACTIVE_STATUSES = frozenset(
+    {TASK_EXECUTION_STATUS_PENDING, TASK_EXECUTION_STATUS_IN_PROGRESS}
+)
+TASK_EXECUTION_TERMINAL_STATUSES = frozenset(
+    {
+        TASK_EXECUTION_STATUS_COMPLETED,
+        TASK_EXECUTION_STATUS_FAILED,
+        TASK_EXECUTION_STATUS_CANCELLED,
+    }
+)
+TASK_EXECUTION_VALID_STATUSES = (
+    TASK_EXECUTION_ACTIVE_STATUSES | TASK_EXECUTION_TERMINAL_STATUSES
+)
+
+_ALLOWED_TRANSITIONS = {
+    TASK_EXECUTION_STATUS_PENDING: {
+        TASK_EXECUTION_STATUS_IN_PROGRESS,
+        TASK_EXECUTION_STATUS_FAILED,
+        TASK_EXECUTION_STATUS_CANCELLED,
+    },
+    TASK_EXECUTION_STATUS_IN_PROGRESS: set(TASK_EXECUTION_TERMINAL_STATUSES),
+}
+
+
+class TaskExecutionError(RuntimeError):
+    """Base error for durable task execution operations."""
+
+
+class InvalidTaskExecutionData(TaskExecutionError, ValueError):
+    """Raised when launch or transition data is malformed."""
+
+
+class TaskExecutionNotFoundError(TaskExecutionError, LookupError):
+    """Raised when an execution is absent or outside the trusted actor scope."""
+
+
+class TaskExecutionAccessError(TaskExecutionError, PermissionError):
+    """Raised when a task or execution does not match the trusted actor scope."""
+
+    def __init__(self, reason_code: str, safe_message: str) -> None:
+        super().__init__(safe_message)
+        self.reason_code = reason_code
+        self.safe_message = safe_message
+
+
+class TaskExecutionTransitionError(TaskExecutionError):
+    """Raised for an invalid or racing lifecycle transition."""
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _required_text(value: Any, *, field: str, max_chars: int = 2_000) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise InvalidTaskExecutionData(f"{field} is required")
+    cleaned = value.strip()
+    if len(cleaned) > max_chars:
+        raise InvalidTaskExecutionData(f"{field} is too long")
+    return cleaned
+
+
+def _concept_id(value: Any, *, field: str) -> str:
+    cleaned = _required_text(value, field=field)
+    if not cleaned.startswith("#V#") or len(cleaned) <= 3:
+        raise InvalidTaskExecutionData(f"{field} must be a #V# concept ID")
+    return cleaned
+
+
+def _json_object(value: Any, *, field: str, max_chars: int = 100_000) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise InvalidTaskExecutionData(f"{field} must be an object")
+    try:
+        encoded = json.dumps(
+            dict(value),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise InvalidTaskExecutionData(f"{field} must contain JSON values") from exc
+    if len(encoded) > max_chars:
+        raise InvalidTaskExecutionData(f"{field} is too large")
+    decoded = json.loads(encoded)
+    if not isinstance(decoded, dict):  # pragma: no cover - guarded above
+        raise InvalidTaskExecutionData(f"{field} must be an object")
+    return decoded
+
+
+def task_execution_concept_id_for_launch(
+    *,
+    task_concept_id: str,
+    creator_concept_id: str,
+    organisation_concept_id: str,
+    launch_request_id: str,
+) -> str:
+    """Return the stable execution identity for one logical launch request."""
+
+    material = "\x1f".join(
+        (
+            _concept_id(task_concept_id, field="task_concept_id"),
+            _concept_id(creator_concept_id, field="creator_concept_id"),
+            _concept_id(organisation_concept_id, field="organisation_concept_id"),
+            _required_text(
+                launch_request_id,
+                field="launch_request_id",
+                max_chars=200,
+            ),
+        )
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:32]
+    return f"#V#task_execution_{digest}"
+
+
+def task_execution_enqueue_submission_id_for_launch(
+    *,
+    task_concept_id: str,
+    creator_concept_id: str,
+    organisation_concept_id: str,
+    launch_request_id: str,
+) -> str:
+    """Return the stable queue idempotency identity for one logical launch."""
+
+    execution_id = task_execution_concept_id_for_launch(
+        task_concept_id=task_concept_id,
+        creator_concept_id=creator_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        launch_request_id=launch_request_id,
+    )
+    return f"task-launch:{execution_id.removeprefix('#V#task_execution_')}"
+
+
+def _metadata(doc: Mapping[str, Any]) -> dict[str, Any]:
+    raw = doc.get("metadata")
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _execution_response(
+    doc: Mapping[str, Any],
+    *,
+    created: bool | None = None,
+) -> dict[str, Any]:
+    metadata = _metadata(doc)
+    result = {
+        "task_execution_concept_id": doc.get("concept_id"),
+        "task_concept_id": metadata.get("task_concept_id"),
+        "status": metadata.get("execution_status"),
+        "creator_concept_id": metadata.get("creator_concept_id"),
+        "executor_concept_id": metadata.get("executor_concept_id"),
+        "organisation_concept_id": metadata.get("organisation_concept_id"),
+        "namespace": metadata.get("namespace"),
+        "originating_conversation_id": metadata.get("originating_conversation_id"),
+        "conversation_session_id": metadata.get("conversation_session_id"),
+        "conversation_name": metadata.get("conversation_name"),
+        "launch_request_id": metadata.get("launch_request_id"),
+        "enqueue_submission_id": metadata.get("enqueue_submission_id"),
+        "queue_id": metadata.get("queue_id"),
+        "execution_envelope_version": metadata.get("execution_envelope_version"),
+        "execution_envelope": metadata.get("execution_envelope"),
+        "progress_note": metadata.get("progress_note"),
+        "result": metadata.get("result"),
+        "started_at": _iso(metadata.get("started_at")),
+        "ended_at": _iso(metadata.get("ended_at")),
+        "task_terminalised_at": _iso(metadata.get("task_terminalised_at")),
+        "created_at": _iso(doc.get("created_at")),
+        "updated_at": _iso(doc.get("updated_at")),
+    }
+    if created is not None:
+        result["created"] = created
+    return result
+
+
+def _task_launch_values(
+    *,
+    task: Mapping[str, Any],
+    creator_concept_id: str,
+    organisation_concept_id: str,
+    namespace: str,
+) -> dict[str, str | None]:
+    task_id = _concept_id(task.get("task_concept_id"), field="task_concept_id")
+    creator_id = _concept_id(creator_concept_id, field="creator_concept_id")
+    org_id = _concept_id(
+        organisation_concept_id,
+        field="organisation_concept_id",
+    )
+    task_org_id = _concept_id(
+        task.get("organisation_concept_id"),
+        field="task.organisation_concept_id",
+    )
+    if task_org_id != org_id:
+        raise TaskExecutionAccessError(
+            "task_organisation_mismatch",
+            "The task does not belong to the active organisation",
+        )
+    if task.get("assignee_concept_id") != VON_SYSTEM_CONCEPT_ID:
+        raise TaskExecutionAccessError(
+            "task_not_assigned_to_von",
+            "The task must be assigned to Von before it can be executed",
+        )
+    if task.get("created_by_concept_id") != creator_id:
+        raise TaskExecutionAccessError(
+            "task_creator_mismatch",
+            "Only the task creator can authorise Von to execute this task",
+        )
+    task_status = str(task.get("status") or "").strip().lower()
+    if task_status not in {"pending", "in_progress"}:
+        raise TaskExecutionAccessError(
+            "task_not_executable",
+            "Only a pending or in-progress task can be executed",
+        )
+    conversation_id = _concept_id(
+        task.get("originating_conversation_id"),
+        field="task.originating_conversation_id",
+    )
+    conversation_session_id = _required_text(
+        task.get("conversation_session_id"),
+        field="task.conversation_session_id",
+    )
+    canonical_namespace = resolve_canonical_namespace(None, creator_id, org_id)
+    supplied_namespace = resolve_canonical_namespace(namespace, creator_id, org_id)
+    if not canonical_namespace or supplied_namespace != canonical_namespace:
+        raise TaskExecutionAccessError(
+            "task_execution_scope_mismatch",
+            "The execution namespace does not match the trusted actor context",
+        )
+    conversation_name_raw = task.get("conversation_name")
+    conversation_name = (
+        conversation_name_raw.strip()
+        if isinstance(conversation_name_raw, str) and conversation_name_raw.strip()
+        else None
+    )
+    return {
+        "task_concept_id": task_id,
+        "creator_concept_id": creator_id,
+        "organisation_concept_id": org_id,
+        "namespace": canonical_namespace,
+        "originating_conversation_id": conversation_id,
+        "conversation_session_id": conversation_session_id,
+        "conversation_name": conversation_name,
+    }
+
+
+def _persist_singleton_text(
+    *,
+    execution_concept_id: str,
+    predicate: str,
+    text: str,
+) -> None:
+    try:
+        upsert_singleton_text_relation(
+            subject_concept_id=execution_concept_id,
+            predicate=predicate,
+            text=text,
+            lang="en-NZ",
+        )
+    except Exception as exc:  # noqa: BLE001 - metadata remains authoritative
+        # The concept metadata remains the operational source of truth.  The
+        # ontology text projection is inspectability support and can be repaired.
+        logger.warning(
+            "Failed to persist TaskExecution text projection %s for %s: %s",
+            predicate,
+            execution_concept_id,
+            exc,
+        )
+
+
+def create_task_execution(
+    *,
+    task: Mapping[str, Any],
+    creator_concept_id: str,
+    organisation_concept_id: str,
+    namespace: str,
+    launch_request_id: str,
+    enqueue_submission_id: str,
+    execution_envelope: Mapping[str, Any],
+    execution_envelope_version: int = 1,
+) -> dict[str, Any]:
+    """Create or reconcile one durable execution for a logical launch."""
+
+    values = _task_launch_values(
+        task=task,
+        creator_concept_id=creator_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace,
+    )
+    launch_id = _required_text(
+        launch_request_id,
+        field="launch_request_id",
+        max_chars=200,
+    )
+    enqueue_id = _required_text(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+        max_chars=200,
+    )
+    if execution_envelope_version != 1:
+        raise InvalidTaskExecutionData("execution_envelope_version must be 1")
+    envelope = _json_object(execution_envelope, field="execution_envelope")
+    execution_concept_id = task_execution_concept_id_for_launch(
+        task_concept_id=str(values["task_concept_id"]),
+        creator_concept_id=str(values["creator_concept_id"]),
+        organisation_concept_id=str(values["organisation_concept_id"]),
+        launch_request_id=launch_id,
+    )
+    now = _now()
+    relationships: dict[str, Any] = {
+        "is_an_instance_of": [TASK_EXECUTION_TYPE_ID],
+        PREDICATE_EXECUTES_TASK: [values["task_concept_id"]],
+        PREDICATE_HAS_EXECUTOR: [VON_SYSTEM_CONCEPT_ID],
+        PREDICATE_HAS_CREATED_BY: [values["creator_concept_id"]],
+        PREDICATE_HAS_ORIGINATING_CONVERSATION: [values["originating_conversation_id"]],
+    }
+    relationships = set_specific_to_user_values(
+        relationships,
+        [str(values["creator_concept_id"])],
+    )
+    relationships = set_specific_to_org_values(
+        relationships,
+        [str(values["organisation_concept_id"])],
+    )
+    metadata: dict[str, Any] = {
+        "concept_type": "task_execution",
+        **values,
+        "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
+        "launch_request_id": launch_id,
+        "enqueue_submission_id": enqueue_id,
+        "queue_id": None,
+        "execution_status": TASK_EXECUTION_STATUS_PENDING,
+        "execution_envelope_version": execution_envelope_version,
+        "execution_envelope": envelope,
+        "status_history": [
+            {
+                "status": TASK_EXECUTION_STATUS_PENDING,
+                "at": now,
+                "source": "explicit_task_launch",
+            }
+        ],
+    }
+    doc = {
+        "concept_id": execution_concept_id,
+        "guid": str(uuid.uuid4()),
+        "relationships": relationships,
+        "metadata": metadata,
+        "created_at": now,
+        "updated_at": now,
+    }
+    created = True
+    try:
+        ConceptsRepository.insert_one(doc)
+    except DuplicateKeyError:
+        created = False
+        existing = ConceptsRepository.find_one({"concept_id": execution_concept_id})
+        if not isinstance(existing, Mapping):
+            raise TaskExecutionNotFoundError(
+                "The existing task execution is not accessible"
+            )
+        existing_metadata = _metadata(existing)
+        exact_fields = {
+            "task_concept_id": values["task_concept_id"],
+            "creator_concept_id": values["creator_concept_id"],
+            "organisation_concept_id": values["organisation_concept_id"],
+            "namespace": values["namespace"],
+            "originating_conversation_id": values["originating_conversation_id"],
+            "conversation_session_id": values["conversation_session_id"],
+            "launch_request_id": launch_id,
+            "enqueue_submission_id": enqueue_id,
+            "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
+            "execution_envelope_version": execution_envelope_version,
+            "execution_envelope": envelope,
+        }
+        if any(
+            existing_metadata.get(key) != value for key, value in exact_fields.items()
+        ):
+            raise TaskExecutionAccessError(
+                "task_execution_identity_conflict",
+                "The launch identity is already bound to different task work",
+            )
+        doc = existing
+    except Exception as exc:
+        raise TaskExecutionError(f"Failed to create task execution: {exc}") from exc
+
+    if created:
+        _persist_singleton_text(
+            execution_concept_id=execution_concept_id,
+            predicate=PREDICATE_HAS_EXECUTION_STATUS,
+            text=TASK_EXECUTION_STATUS_PENDING,
+        )
+    return _execution_response(doc, created=created)
+
+
+def _get_task_execution_doc(
+    task_execution_concept_id: str,
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str,
+) -> dict[str, Any]:
+    execution_id = _concept_id(
+        task_execution_concept_id,
+        field="task_execution_concept_id",
+    )
+    actor_id = _concept_id(actor_concept_id, field="actor_concept_id")
+    org_id = _concept_id(
+        organisation_concept_id,
+        field="organisation_concept_id",
+    )
+    doc = ConceptsRepository.find_one({"concept_id": execution_id})
+    if not isinstance(doc, Mapping):
+        raise TaskExecutionNotFoundError("Task execution not found")
+    metadata = _metadata(doc)
+    if metadata.get("concept_type") != "task_execution":
+        raise TaskExecutionNotFoundError("Task execution not found")
+    if metadata.get("creator_concept_id") != actor_id:
+        raise TaskExecutionAccessError(
+            "task_execution_actor_mismatch",
+            "The task execution belongs to a different actor",
+        )
+    if metadata.get("organisation_concept_id") != org_id:
+        raise TaskExecutionAccessError(
+            "task_execution_organisation_mismatch",
+            "The task execution belongs to a different organisation",
+        )
+    return dict(doc)
+
+
+def get_task_execution(
+    task_execution_concept_id: str,
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str,
+) -> dict[str, Any]:
+    doc = _get_task_execution_doc(
+        task_execution_concept_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+    return _execution_response(doc)
+
+
+def bind_task_execution_queue_record(
+    task_execution_concept_id: str,
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str,
+    enqueue_submission_id: str,
+    queue_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bind the exact durable queue row to its execution attempt."""
+
+    doc = _get_task_execution_doc(
+        task_execution_concept_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+    execution_id = str(doc["concept_id"])
+    metadata = _metadata(doc)
+    enqueue_id = _required_text(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+        max_chars=200,
+    )
+    if metadata.get("enqueue_submission_id") != enqueue_id:
+        raise TaskExecutionAccessError(
+            "task_execution_enqueue_mismatch",
+            "The queue submission does not match the task execution",
+        )
+    queue_id = _required_text(
+        queue_record.get("queue_id"), field="queue_record.queue_id"
+    )
+    queue_execution_id = queue_record.get("task_execution_concept_id")
+    queue_task_id = queue_record.get("task_concept_id")
+    if queue_execution_id != execution_id or queue_task_id != metadata.get(
+        "task_concept_id"
+    ):
+        raise TaskExecutionAccessError(
+            "task_execution_queue_link_mismatch",
+            "The queue record is linked to different task work",
+        )
+    existing_queue_id = metadata.get("queue_id")
+    if existing_queue_id and existing_queue_id != queue_id:
+        raise TaskExecutionTransitionError(
+            "The task execution is already bound to another queue record"
+        )
+    if not existing_queue_id:
+        now = _now()
+        result = ConceptsRepository.update_one(
+            {
+                "concept_id": execution_id,
+                "metadata.enqueue_submission_id": enqueue_id,
+                "metadata.queue_id": None,
+            },
+            {
+                "$set": {
+                    "metadata.queue_id": queue_id,
+                    "metadata.queue_bound_at": now,
+                    "updated_at": now,
+                }
+            },
+        )
+        if int(getattr(result, "modified_count", 0) or 0) == 0:
+            refreshed = _get_task_execution_doc(
+                execution_id,
+                actor_concept_id=actor_concept_id,
+                organisation_concept_id=organisation_concept_id,
+            )
+            if _metadata(refreshed).get("queue_id") != queue_id:
+                raise TaskExecutionTransitionError(
+                    "The task execution queue binding changed concurrently"
+                )
+    return get_task_execution(
+        execution_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+
+
+def reconcile_task_execution_queue_record(
+    queue_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Create/bind the exact TaskExecution projected by a durable queue row.
+
+    The queue row is the launch outbox.  This idempotent projection lets the
+    server recover if it crashes after accepting the queue row but before the
+    corresponding Vontology concept is created or bound.
+    """
+
+    if not isinstance(queue_record, Mapping):
+        raise InvalidTaskExecutionData("queue_record must be an object")
+    task_id = _concept_id(
+        queue_record.get("task_concept_id"),
+        field="queue_record.task_concept_id",
+    )
+    execution_id = _concept_id(
+        queue_record.get("task_execution_concept_id"),
+        field="queue_record.task_execution_concept_id",
+    )
+    actor_id = _concept_id(
+        queue_record.get("user_concept_id"),
+        field="queue_record.user_concept_id",
+    )
+    org_id = _concept_id(
+        queue_record.get("organisation_concept_id"),
+        field="queue_record.organisation_concept_id",
+    )
+    namespace = _required_text(
+        queue_record.get("namespace"),
+        field="queue_record.namespace",
+    )
+    enqueue_id = _required_text(
+        queue_record.get("enqueue_submission_id"),
+        field="queue_record.enqueue_submission_id",
+        max_chars=200,
+    )
+    queue_id = _required_text(
+        queue_record.get("queue_id"),
+        field="queue_record.queue_id",
+    )
+    session_id = _required_text(
+        queue_record.get("session_id"),
+        field="queue_record.session_id",
+    )
+    if queue_record.get("execution_envelope_version") != 1:
+        raise InvalidTaskExecutionData(
+            "queue_record.execution_envelope_version must be 1"
+        )
+    envelope = _json_object(
+        queue_record.get("execution_envelope"),
+        field="queue_record.execution_envelope",
+    )
+    launch_id = _required_text(
+        envelope.get("initiation_id"),
+        field="queue_record.execution_envelope.initiation_id",
+        max_chars=200,
+    )
+    workflow_inputs = envelope.get("workflow_inputs")
+    if not isinstance(workflow_inputs, Mapping):
+        raise InvalidTaskExecutionData(
+            "queue_record.execution_envelope.workflow_inputs must be an object"
+        )
+    expected_values = {
+        "task_concept_id": task_id,
+        "task_execution_concept_id": execution_id,
+        "authority_actor_concept_id": actor_id,
+        "authority_organisation_concept_id": org_id,
+        "authority_namespace": namespace,
+        "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
+        "conversation_session_id": session_id,
+    }
+    for field, expected in expected_values.items():
+        if workflow_inputs.get(field) != expected:
+            raise TaskExecutionAccessError(
+                "task_execution_queue_link_mismatch",
+                f"The queue execution envelope {field} does not match its launch",
+            )
+    expected_execution_id = task_execution_concept_id_for_launch(
+        task_concept_id=task_id,
+        creator_concept_id=actor_id,
+        organisation_concept_id=org_id,
+        launch_request_id=launch_id,
+    )
+    expected_enqueue_id = task_execution_enqueue_submission_id_for_launch(
+        task_concept_id=task_id,
+        creator_concept_id=actor_id,
+        organisation_concept_id=org_id,
+        launch_request_id=launch_id,
+    )
+    if execution_id != expected_execution_id or enqueue_id != expected_enqueue_id:
+        raise TaskExecutionAccessError(
+            "task_execution_queue_identity_mismatch",
+            "The queue identity does not match its logical task launch",
+        )
+
+    # The queue scope and envelope were frozen by the trusted launch route. Bind
+    # that exact actor while re-reading the current TaskSpecification so a
+    # cancelled, completed, reassigned, or moved task cannot start later.
+    from ..security.access_control import override_current_actor
+    from .task_management_service import TaskNotFoundError, get_task
+
+    with override_current_actor(actor_id, org_id):
+        frozen_task = {
+            "task_concept_id": task_id,
+            "status": "pending",
+            "assignee_concept_id": VON_SYSTEM_CONCEPT_ID,
+            "created_by_concept_id": actor_id,
+            "organisation_concept_id": org_id,
+            "originating_conversation_id": workflow_inputs.get(
+                "originating_conversation_concept_id"
+            ),
+            "conversation_session_id": session_id,
+            "conversation_name": queue_record.get("session_name"),
+        }
+        create_task_execution(
+            task=frozen_task,
+            creator_concept_id=actor_id,
+            organisation_concept_id=org_id,
+            namespace=namespace,
+            launch_request_id=launch_id,
+            enqueue_submission_id=enqueue_id,
+            execution_envelope=envelope,
+            execution_envelope_version=1,
+        )
+        bound_execution = bind_task_execution_queue_record(
+            execution_id,
+            actor_concept_id=actor_id,
+            organisation_concept_id=org_id,
+            enqueue_submission_id=enqueue_id,
+            queue_record={
+                **dict(queue_record),
+                "queue_id": queue_id,
+                "task_concept_id": task_id,
+                "task_execution_concept_id": execution_id,
+            },
+        )
+
+        # Re-read after materialising the attempt. If task authority changed
+        # while the launch outbox was pending, the caller can terminalise both
+        # the queue row and this now-durable execution without invoking Von.
+        try:
+            current_task = dict(get_task(task_id))
+        except TaskNotFoundError as exc:
+            raise TaskExecutionAccessError(
+                "task_no_longer_available",
+                "The task is no longer available for execution",
+            ) from exc
+        current_values = _task_launch_values(
+            task=current_task,
+            creator_concept_id=actor_id,
+            organisation_concept_id=org_id,
+            namespace=namespace,
+        )
+        if current_values["conversation_session_id"] != session_id:
+            raise TaskExecutionAccessError(
+                "task_execution_conversation_mismatch",
+                "The task conversation changed before execution",
+            )
+        if workflow_inputs.get(
+            "originating_conversation_concept_id"
+        ) != current_values.get("originating_conversation_id"):
+            raise TaskExecutionAccessError(
+                "task_execution_conversation_mismatch",
+                "The task originating conversation changed before execution",
+            )
+        return bound_execution
+
+
+def transition_task_execution(
+    task_execution_concept_id: str,
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str,
+    enqueue_submission_id: str,
+    queue_id: str | None,
+    status: str,
+    result: str | None = None,
+    progress_note: str | None = None,
+    source: str = "queue_dispatcher",
+) -> dict[str, Any]:
+    """Move one execution attempt without changing its TaskSpecification."""
+
+    doc = _get_task_execution_doc(
+        task_execution_concept_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+    execution_id = str(doc["concept_id"])
+    metadata = _metadata(doc)
+    target_status = _required_text(status, field="status", max_chars=50).lower()
+    if target_status not in TASK_EXECUTION_VALID_STATUSES:
+        raise InvalidTaskExecutionData("Invalid task execution status")
+    enqueue_id = _required_text(
+        enqueue_submission_id,
+        field="enqueue_submission_id",
+        max_chars=200,
+    )
+    if metadata.get("enqueue_submission_id") != enqueue_id:
+        raise TaskExecutionAccessError(
+            "task_execution_enqueue_mismatch",
+            "The queue submission does not match the task execution",
+        )
+    persisted_queue_id = metadata.get("queue_id")
+    queue_id_clean = (
+        _required_text(queue_id, field="queue_id") if queue_id is not None else None
+    )
+    if persisted_queue_id != queue_id_clean:
+        raise TaskExecutionAccessError(
+            "task_execution_queue_mismatch",
+            "The queue record does not match the task execution",
+        )
+    current_status = str(metadata.get("execution_status") or "")
+    if current_status == target_status:
+        return _execution_response(doc)
+    if target_status not in _ALLOWED_TRANSITIONS.get(current_status, set()):
+        raise TaskExecutionTransitionError(
+            f"Cannot transition task execution from {current_status or 'unknown'} "
+            f"to {target_status}"
+        )
+    now = _now()
+    source_clean = _required_text(source, field="source", max_chars=100)
+    set_fields: dict[str, Any] = {
+        "metadata.execution_status": target_status,
+        "updated_at": now,
+    }
+    if target_status == TASK_EXECUTION_STATUS_IN_PROGRESS:
+        set_fields["metadata.started_at"] = now
+    if target_status in TASK_EXECUTION_TERMINAL_STATUSES:
+        set_fields["metadata.ended_at"] = now
+    if result is not None:
+        set_fields["metadata.result"] = _required_text(
+            result,
+            field="result",
+            max_chars=100_000,
+        )
+    if progress_note is not None:
+        set_fields["metadata.progress_note"] = _required_text(
+            progress_note,
+            field="progress_note",
+            max_chars=20_000,
+        )
+    update_result = ConceptsRepository.update_one(
+        {
+            "concept_id": execution_id,
+            "metadata.execution_status": current_status,
+            "metadata.enqueue_submission_id": enqueue_id,
+            "metadata.queue_id": queue_id_clean,
+        },
+        {
+            "$set": set_fields,
+            "$push": {
+                "metadata.status_history": {
+                    "status": target_status,
+                    "at": now,
+                    "source": source_clean,
+                }
+            },
+        },
+    )
+    if int(getattr(update_result, "modified_count", 0) or 0) == 0:
+        refreshed = _get_task_execution_doc(
+            execution_id,
+            actor_concept_id=actor_concept_id,
+            organisation_concept_id=organisation_concept_id,
+        )
+        if _metadata(refreshed).get("execution_status") == target_status:
+            return _execution_response(refreshed)
+        raise TaskExecutionTransitionError(
+            "The task execution state changed concurrently"
+        )
+
+    _persist_singleton_text(
+        execution_concept_id=execution_id,
+        predicate=PREDICATE_HAS_EXECUTION_STATUS,
+        text=target_status,
+    )
+    if target_status == TASK_EXECUTION_STATUS_IN_PROGRESS:
+        _persist_singleton_text(
+            execution_concept_id=execution_id,
+            predicate=PREDICATE_HAS_START_TIME,
+            text=now.isoformat(),
+        )
+    if target_status in TASK_EXECUTION_TERMINAL_STATUSES:
+        _persist_singleton_text(
+            execution_concept_id=execution_id,
+            predicate=PREDICATE_HAS_END_TIME,
+            text=now.isoformat(),
+        )
+    if result is not None:
+        _persist_singleton_text(
+            execution_concept_id=execution_id,
+            predicate=PREDICATE_HAS_RESULT,
+            text=str(set_fields["metadata.result"]),
+        )
+    if progress_note is not None:
+        _persist_singleton_text(
+            execution_concept_id=execution_id,
+            predicate=PREDICATE_HAS_PROGRESS_NOTE,
+            text=str(set_fields["metadata.progress_note"]),
+        )
+    return get_task_execution(
+        execution_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+
+
+def mark_task_execution_dispatch_failed(
+    task_execution_concept_id: str,
+    *,
+    actor_concept_id: str,
+    organisation_concept_id: str,
+    enqueue_submission_id: str,
+    error: str,
+) -> dict[str, Any]:
+    """Record that this attempt failed before any queue row was bound."""
+
+    return transition_task_execution(
+        task_execution_concept_id,
+        actor_concept_id=actor_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        enqueue_submission_id=enqueue_submission_id,
+        queue_id=None,
+        status=TASK_EXECUTION_STATUS_FAILED,
+        result=_required_text(error, field="error", max_chars=4_000),
+        source="queue_enqueue",
+    )
+
+
+__all__ = [
+    "TASK_EXECUTION_ACTIVE_STATUSES",
+    "TASK_EXECUTION_STATUS_CANCELLED",
+    "TASK_EXECUTION_STATUS_COMPLETED",
+    "TASK_EXECUTION_STATUS_FAILED",
+    "TASK_EXECUTION_STATUS_IN_PROGRESS",
+    "TASK_EXECUTION_STATUS_PENDING",
+    "TASK_EXECUTION_TERMINAL_STATUSES",
+    "TASK_EXECUTION_TYPE_ID",
+    "VON_SYSTEM_CONCEPT_ID",
+    "InvalidTaskExecutionData",
+    "TaskExecutionAccessError",
+    "TaskExecutionError",
+    "TaskExecutionNotFoundError",
+    "TaskExecutionTransitionError",
+    "bind_task_execution_queue_record",
+    "create_task_execution",
+    "get_task_execution",
+    "mark_task_execution_dispatch_failed",
+    "reconcile_task_execution_queue_record",
+    "task_execution_concept_id_for_launch",
+    "task_execution_enqueue_submission_id_for_launch",
+    "transition_task_execution",
+]

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -5835,8 +5835,17 @@ function getQueuedChatPromptCountForSession(sessionId = activeChatSessionId) {
     return queuedChatPrompts.filter((entry) => entry?.sessionKey === sessionKey).length;
 }
 
+function getQueuedChatPromptSubmissionInFlight(sessionId = activeChatSessionId) {
+    return queuedChatPromptSubmissionsInFlight.get(
+        getChatRequestSessionKey(sessionId)
+    ) || null;
+}
+
 function isRestartableChatPromptQueueEntry(entry) {
     if (!entry || entry.status !== CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS) {
+        return false;
+    }
+    if (isServerDispatchedChatPromptQueueEntry(entry)) {
         return false;
     }
     if (getLiveChatRequestForPromptQueueRecord(entry.queueId)) {
@@ -5872,7 +5881,7 @@ function getChatPromptQueueCountsForSession(sessionId = activeChatSessionId) {
         failed: 0
     };
     queuedChatPrompts.forEach((entry) => {
-        if (!entry || entry.sessionKey !== sessionKey) {
+        if (!entry || entry.sessionKey !== sessionKey || entry.enqueueFailed === true) {
             return;
         }
         counts.total += 1;
@@ -6016,22 +6025,28 @@ function updateSendButtonForCurrentChatState() {
         return;
     }
     const uploadInFlight = !!getInFlightUploadStateForSession(activeChatSessionId);
+    const queueSubmissionInFlight = !!getQueuedChatPromptSubmissionInFlight(
+        activeChatSessionId
+    );
     const queueCounts = getChatPromptQueueCountsForSession(activeChatSessionId);
     const sessionBusy = hasLiveChatRequestForSession(activeChatSessionId)
         || queueCounts.running > 0
         || queueCounts.queued > 0
         || queueCounts.restartable > 0;
     const readOnly = isExternalConversationReadOnly();
-    sendButton.disabled = uploadInFlight || readOnly;
+    sendButton.disabled = uploadInFlight || queueSubmissionInFlight || readOnly;
+    sendButton.setAttribute('aria-busy', queueSubmissionInFlight ? 'true' : 'false');
     if (readOnly) {
         sendButton.textContent = 'Read-only import';
         sendButton.title = 'Continue this imported snapshot before sending a new message.';
         return;
     }
-    sendButton.textContent = sessionBusy
-        ? 'Queue Prompt'
-        : 'Send Prompt';
-    if (uploadInFlight) {
+    sendButton.textContent = queueSubmissionInFlight
+        ? 'Queueing…'
+        : (sessionBusy ? 'Queue Prompt' : 'Send Prompt');
+    if (queueSubmissionInFlight) {
+        sendButton.title = 'Saving this prompt to the conversation queue.';
+    } else if (uploadInFlight) {
         sendButton.title = ATTACHMENT_UPLOAD_SEND_BLOCK_MESSAGE;
     } else {
         sendButton.removeAttribute('title');
@@ -23722,10 +23737,11 @@ const liveChatRequestsBySession = new Map();
 const finishedThinkingCardsBySession = new Map();
 let queuedChatPrompts = [];
 let queuedChatPromptCounter = 0;
-let queuedChatPromptDrainTimer = null;
-let queuedChatPromptDrainPromise = null;
-let queuedChatPromptDrainRequested = false;
+let chatPromptQueuePollTimerId = null;
+let chatPromptQueuePollInFlight = false;
+let chatPromptQueuePollAbortController = null;
 const queuedChatPromptClaimsInFlight = new Set();
+const queuedChatPromptSubmissionsInFlight = new Map();
 const queuedChatPromptSyncTimers = new Map();
 let chatPromptQueueAdmissionServerInstanceId = null;
 let selectedChatPromptQueueEntryId = null;
@@ -23742,6 +23758,7 @@ const CHAT_PROMPT_QUEUE_STATUS_COMPLETED = 'completed';
 const CHAT_PROMPT_QUEUE_STATUS_FAILED = 'failed';
 const CHAT_PROMPT_QUEUE_STATUS_CANCELLED = 'cancelled';
 const CHAT_PROMPT_QUEUE_SYNC_STORAGE_KEY = 'von:chatPromptQueueChanged:v1';
+const CHAT_PROMPT_QUEUE_POLL_INTERVAL_MS = 2000;
 
 const CHAT_TTS_STORAGE_KEY = 'chatTtsEnabled';
 
@@ -24366,6 +24383,7 @@ function setActiveChatSession(sessionId, sessionName, externalConversation = und
     renderActiveChatSessionFocusChips(activeChatSessionFocus);
 
     if (previousSessionId !== activeChatSessionId) {
+        setSelectedChatPromptQueueEntryId(null);
         chatSessionSelectionGeneration += 1;
         synchroniseLlmExecutionContext({ reason: 'conversation_session_changed' });
         if (activeChatSessionId) {
@@ -24410,6 +24428,7 @@ function setActiveChatSession(sessionId, sessionName, externalConversation = und
     refreshConversationInfoCopyButtonState();
     renderPendingAttachmentState();
     renderActiveUploadUi();
+    renderChatTaskQueuePanel();
     updateExternalConversationUi();
 }
 
@@ -32546,6 +32565,7 @@ function handleRealtimeConnectionsVisibilityChange() {
         clearWorkflowStatusSnapshotRetryTimer();
         stopIncomingInvitePolling();
         stopSharedSessionBadgePolling();
+        stopChatPromptQueuePolling();
         try {
             incomingInviteAbortController?.abort();
         } catch (_) {
@@ -32590,13 +32610,9 @@ function detachChatWorkForOrganisationSwitch() {
     });
 
     queuedChatPrompts = [];
-    if (queuedChatPromptDrainTimer !== null) {
-        clearTimeout(queuedChatPromptDrainTimer);
-        queuedChatPromptDrainTimer = null;
-    }
-    queuedChatPromptDrainPromise = null;
-    queuedChatPromptDrainRequested = false;
+    stopChatPromptQueuePolling();
     queuedChatPromptClaimsInFlight.clear();
+    queuedChatPromptSubmissionsInFlight.clear();
     chatPromptQueueAdmissionServerInstanceId = null;
     for (const timer of queuedChatPromptSyncTimers.values()) {
         clearTimeout(timer);
@@ -32838,13 +32854,21 @@ function handleAuthStatusChangeForChatTab(detail) {
         void refreshWorkflowStatusSnapshot({ silent: true });
         startIncomingInvitePolling();
         startSharedSessionBadgePolling();
+        void refreshChatPromptQueueFromServer({ silent: true });
     } else {
         stopIncomingInvitePolling();
         stopSharedSessionBadgePolling();
+        stopChatPromptQueuePolling();
+        queuedChatPrompts = [];
+        queuedChatPromptSubmissionsInFlight.clear();
+        selectedChatPromptQueueEntryId = null;
+        locallyHiddenChatPromptQueueEntryKeys.clear();
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
     }
 
     scheduleChatSessionTabsRefresh(true);
-    void refreshChatPromptQueueFromServer({ silent: true });
     void loadIncomingInvites({ silent: true });
     publishRealtimeConnectionTelemetry('auth_status_changed');
 }
@@ -33243,6 +33267,7 @@ export function initializeChatTab() {
         stopWorkflowStatusStream('workflow_stream_stopped_unload');
         stopIncomingInvitePolling();
         stopSharedSessionBadgePolling();
+        stopChatPromptQueuePolling();
     }, { once: true });
 
     // JVNAUTOSCI-1040: Initialize task panel
@@ -34256,7 +34281,48 @@ function normaliseChatPromptQueueEntry(rawEntry, fallback = {}) {
         fileCopyConceptId,
         localOnly: queueId ? false : rawEntry.localOnly === true,
         syncError: rawEntry.syncError || null,
+        enqueueFailed: rawEntry.enqueueFailed === true || fallback.enqueueFailed === true,
+        enqueueUnconfirmed: rawEntry.enqueueUnconfirmed === true
+            || fallback.enqueueUnconfirmed === true,
+        deleteInFlight: rawEntry.deleteInFlight === true || fallback.deleteInFlight === true,
+        handoffSourceQueueId: rawEntry.handoff_source_queue_id
+            || rawEntry.handoffSourceQueueId
+            || fallback.handoffSourceQueueId
+            || null,
+        handoffCompletedAt: rawEntry.handoff_completed_at
+            || rawEntry.handoffCompletedAt
+            || fallback.handoffCompletedAt
+            || null,
+        handoffEnqueueSubmissionId: rawEntry.handoffEnqueueSubmissionId
+            || fallback.handoffEnqueueSubmissionId
+            || null,
+        supersededByQueueId: rawEntry.supersededByQueueId
+            || fallback.supersededByQueueId
+            || null,
         lastError: rawEntry.last_error || rawEntry.lastError || null,
+        enqueueSubmissionId: rawEntry.enqueue_submission_id
+            || rawEntry.enqueueSubmissionId
+            || fallback.enqueueSubmissionId
+            || null,
+        dispatchMode: rawEntry.dispatch_mode
+            || rawEntry.dispatchMode
+            || fallback.dispatchMode
+            || null,
+        dispatchReady: typeof rawEntry.dispatch_ready === 'boolean'
+            ? rawEntry.dispatch_ready
+            : (typeof rawEntry.dispatchReady === 'boolean'
+                ? rawEntry.dispatchReady
+                : (typeof fallback.dispatchReady === 'boolean'
+                    ? fallback.dispatchReady
+                    : null)),
+        executionEnvelopeVersion: rawEntry.execution_envelope_version
+            || rawEntry.executionEnvelopeVersion
+            || fallback.executionEnvelopeVersion
+            || null,
+        executionEnvelope: rawEntry.execution_envelope
+            || rawEntry.executionEnvelope
+            || fallback.executionEnvelope
+            || null,
         clientRequestId: rawEntry.client_request_id || rawEntry.clientRequestId || fallback.clientRequestId || null,
         attemptId: rawEntry.attempt_id || rawEntry.attemptId || fallback.attemptId || null,
         serverInstanceId: rawEntry.server_instance_id || rawEntry.serverInstanceId || fallback.serverInstanceId || null,
@@ -34328,6 +34394,20 @@ function isDisplayedChatPromptQueueEntry(entry) {
     return true;
 }
 
+function isChatPromptQueueEntryForSession(
+    entry,
+    sessionId = activeChatSessionId
+) {
+    return Boolean(
+        entry
+        && entry.sessionKey === getChatRequestSessionKey(sessionId)
+    );
+}
+
+function isServerDispatchedChatPromptQueueEntry(entry) {
+    return entry?.dispatchMode === 'server';
+}
+
 function getChatPromptQueueEntryById(entryId) {
     const cleanEntryId = (typeof entryId === 'string' && entryId.trim())
         ? entryId.trim()
@@ -34385,7 +34465,15 @@ function getSelectedChatPromptQueueEntryForSend() {
         : null;
     const selectedId = activeQueueId || selectedChatPromptQueueEntryId;
     const entry = getChatPromptQueueEntryById(selectedId);
-    if (!entry || !isDisplayedChatPromptQueueEntry(entry)) {
+    if (
+        !entry
+        || !isDisplayedChatPromptQueueEntry(entry)
+        || !isChatPromptQueueEntryForSession(entry)
+        || isServerDispatchedChatPromptQueueEntry(entry)
+        || entry.enqueueFailed === true
+        || entry.handoffEnqueueSubmissionId
+        || entry.supersededByQueueId
+    ) {
         return null;
     }
     if (getLiveChatRequestForPromptQueueRecord(entry.queueId)) {
@@ -34479,6 +34567,23 @@ function describeChatPromptQueueApiError(error, fallbackMessage) {
     return fallbackMessage;
 }
 
+function isAmbiguousChatPromptQueueEnqueueError(error) {
+    const status = Number(error?.httpStatus);
+    return !Number.isInteger(status) || status >= 500;
+}
+
+function isCanonicalChatPromptQueueAbsenceError(error) {
+    return error?.errorCode === 'not_found'
+        || (
+            error?.errorCode === 'wrong_state'
+            && error?.details?.current_status === CHAT_PROMPT_QUEUE_STATUS_CANCELLED
+        )
+        || (
+            Number(error?.httpStatus) === 404
+            && error?.errorCode !== 'scope_mismatch'
+        );
+}
+
 function publishChatPromptQueueChange(reason = 'changed') {
     try {
         localStorage.setItem(CHAT_PROMPT_QUEUE_SYNC_STORAGE_KEY, JSON.stringify({
@@ -34501,6 +34606,118 @@ function handleChatPromptQueueStorageEvent(event) {
     void refreshChatPromptQueueFromServer({ silent: true });
 }
 
+function isCanonicalChatPromptQueuePollingEntry(entry) {
+    return Boolean(
+        entry?.queueId
+        && isServerDispatchedChatPromptQueueEntry(entry)
+        && (
+            entry.status === CHAT_PROMPT_QUEUE_STATUS_QUEUED
+            || entry.status === CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS
+        )
+    );
+}
+
+function stopChatPromptQueuePolling({ abortInFlight = true } = {}) {
+    if (chatPromptQueuePollTimerId !== null) {
+        clearTimeout(chatPromptQueuePollTimerId);
+        chatPromptQueuePollTimerId = null;
+    }
+    if (abortInFlight && chatPromptQueuePollAbortController) {
+        const controller = chatPromptQueuePollAbortController;
+        chatPromptQueuePollAbortController = null;
+        chatPromptQueuePollInFlight = false;
+        try {
+            controller.abort();
+        } catch (_) {
+            // Ignore abort races; the controller identity still retires this poll.
+        }
+    }
+}
+
+function syncChatPromptQueuePolling() {
+    const shouldPoll = (
+        pendingChatOrganisationSwitchId === null
+        && isDocumentVisibleForRealtimeConnections()
+        && queuedChatPrompts.some(isCanonicalChatPromptQueuePollingEntry)
+    );
+    if (!shouldPoll) {
+        stopChatPromptQueuePolling();
+        return;
+    }
+    if (chatPromptQueuePollTimerId !== null || chatPromptQueuePollInFlight) {
+        return;
+    }
+    chatPromptQueuePollTimerId = window.setTimeout(async () => {
+        chatPromptQueuePollTimerId = null;
+        const controller = new AbortController();
+        chatPromptQueuePollAbortController = controller;
+        chatPromptQueuePollInFlight = true;
+        try {
+            await refreshChatPromptQueueFromServer({
+                silent: true,
+                pollTriggered: true,
+                signal: controller.signal
+            });
+        } finally {
+            if (chatPromptQueuePollAbortController === controller) {
+                chatPromptQueuePollAbortController = null;
+                chatPromptQueuePollInFlight = false;
+                syncChatPromptQueuePolling();
+            }
+        }
+    }, CHAT_PROMPT_QUEUE_POLL_INTERVAL_MS);
+}
+
+function getChatPromptQueueStatusByIdForSession(entries, sessionId) {
+    const statusById = new Map();
+    const sessionKey = getChatRequestSessionKey(sessionId);
+    entries.forEach((entry) => {
+        if (
+            !entry?.queueId
+            || entry.sessionKey !== sessionKey
+            || !isServerDispatchedChatPromptQueueEntry(entry)
+        ) {
+            return;
+        }
+        statusById.set(entry.queueId, entry.status);
+    });
+    return statusById;
+}
+
+function activeConversationQueueStateChanged(previousEntries, nextEntries) {
+    const sessionId = normaliseHistorySessionId(activeChatSessionId);
+    if (!sessionId) {
+        return false;
+    }
+    const previousStatusById = getChatPromptQueueStatusByIdForSession(
+        previousEntries,
+        sessionId
+    );
+    if (previousStatusById.size === 0) {
+        return false;
+    }
+    const nextStatusById = getChatPromptQueueStatusByIdForSession(
+        nextEntries,
+        sessionId
+    );
+    return Array.from(previousStatusById.entries()).some(([queueId, status]) => (
+        (
+            status === CHAT_PROMPT_QUEUE_STATUS_QUEUED
+            || status === CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS
+        )
+        && nextStatusById.get(queueId) !== status
+    ));
+}
+
+function refreshActiveConversationHistoryAfterQueueChange() {
+    const sessionId = normaliseHistorySessionId(activeChatSessionId);
+    if (!sessionId) {
+        return;
+    }
+    invalidateSessionHistoryCache(sessionId);
+    scheduleSharedHistoryResync(sessionId);
+}
+
 function mergePersistedChatPromptQueueEntry(entry) {
     const normalised = normaliseChatPromptQueueEntry(entry);
     if (!normalised) {
@@ -34508,6 +34725,10 @@ function mergePersistedChatPromptQueueEntry(entry) {
     }
     const existingIndex = queuedChatPrompts.findIndex((candidate) => (
         (normalised.queueId && candidate.queueId === normalised.queueId)
+        || (
+            normalised.enqueueSubmissionId
+            && candidate.enqueueSubmissionId === normalised.enqueueSubmissionId
+        )
         || candidate.id === normalised.id
     ));
     if (existingIndex >= 0) {
@@ -34518,6 +34739,7 @@ function mergePersistedChatPromptQueueEntry(entry) {
     } else {
         queuedChatPrompts.push(normalised);
     }
+    syncChatPromptQueuePolling();
     return normalised;
 }
 
@@ -34526,8 +34748,11 @@ async function refreshChatPromptQueueFromServer(options = {}) {
         return false;
     }
     const organisationGenerationAtStart = chatOrganisationGeneration;
+    const previousEntries = [...queuedChatPrompts];
     try {
-        const data = await fetchChatPromptQueueJson('');
+        const data = await fetchChatPromptQueueJson('', {
+            signal: options.signal
+        });
         if (!isChatOrganisationRequestCurrent(organisationGenerationAtStart)) {
             return false;
         }
@@ -34558,17 +34783,39 @@ async function refreshChatPromptQueueFromServer(options = {}) {
                 ))
                 .filter(Boolean)
             : [];
+        const recentFailedQueueIds = new Set(
+            canonicalRecentFailedEntries
+                .map((entry) => entry?.queueId)
+                .filter(Boolean)
+        );
         const persistedEntries = canonicalPersistedEntries
+            .filter((entry) => !entry?.queueId || !recentFailedQueueIds.has(entry.queueId))
             .filter(isDisplayedChatPromptQueueEntry);
         const recentFailedEntries = canonicalRecentFailedEntries
             .filter(isDisplayedChatPromptQueueEntry);
-        const localOnlyEntries = queuedChatPrompts.filter((entry) => entry?.localOnly === true);
+        const canonicalSubmissionIds = new Set(
+            [...persistedEntries, ...recentFailedEntries]
+                .map((entry) => entry?.enqueueSubmissionId)
+                .filter(Boolean)
+        );
+        const localOnlyEntries = queuedChatPrompts.filter((entry) => (
+            entry?.localOnly === true
+            && (
+                !entry.enqueueSubmissionId
+                || !canonicalSubmissionIds.has(entry.enqueueSubmissionId)
+            )
+        ));
         queuedChatPrompts = [...persistedEntries, ...localOnlyEntries, ...recentFailedEntries];
+        const shouldRefreshActiveHistory = activeConversationQueueStateChanged(
+            previousEntries,
+            queuedChatPrompts
+        );
         renderChatTaskQueuePanel();
         refreshChatSessionTabActivityIndicators();
         updateSendButtonForCurrentChatState();
-        if (!options.skipDrain) {
-            scheduleQueuedChatPromptDrain();
+        syncChatPromptQueuePolling();
+        if (shouldRefreshActiveHistory) {
+            refreshActiveConversationHistoryAfterQueueChange();
         }
         return {
             items: canonicalPersistedEntries,
@@ -34578,30 +34825,101 @@ async function refreshChatPromptQueueFromServer(options = {}) {
         if (!isChatOrganisationRequestCurrent(organisationGenerationAtStart)) {
             return false;
         }
-        if (!options.silent) {
+        if (!options.silent && error?.name !== 'AbortError') {
             console.warn('[chatTab] Unable to load persisted chat prompt queue:', error);
         }
         return false;
+    } finally {
+        syncChatPromptQueuePolling();
     }
 }
 
+function buildChatPromptExecutionEnvelope({
+    fileCopyConceptId = null,
+    turnKind = null,
+    initiationId = null
+} = {}) {
+    const userContext = getUserContext() || {};
+    const localModelRequestFields = buildLocalModelRequestFields(
+        resolveLocalRequestedLlm()
+    );
+    return {
+        ...(turnKind ? { turn_kind: turnKind } : {}),
+        ...(initiationId ? { initiation_id: initiationId } : {}),
+        language: (typeof userContext.language === 'string' && userContext.language.trim())
+            ? userContext.language.trim()
+            : 'en-NZ',
+        ...localModelRequestFields,
+        ...(fileCopyConceptId ? {
+            workflow_inputs: {
+                file_copy_concept_id: fileCopyConceptId
+            }
+        } : {}),
+        presenter_mode: true,
+        skip_buttonify: false,
+        thinking_card_mode: getThinkingCardMode()
+    };
+}
+
 async function createPersistedChatPromptQueueEntry(entry, status = CHAT_PROMPT_QUEUE_STATUS_QUEUED) {
+    const serverDispatch = isServerDispatchedChatPromptQueueEntry(entry);
+    let enqueueSubmissionId = null;
+    if (serverDispatch) {
+        enqueueSubmissionId = (
+            typeof entry?.enqueueSubmissionId === 'string'
+            && entry.enqueueSubmissionId.trim()
+        )
+            ? entry.enqueueSubmissionId.trim()
+            : createClientRequestId();
+        entry.enqueueSubmissionId = enqueueSubmissionId;
+    }
+    const body = {
+        prompt_raw: entry.promptRaw,
+        session_id: entry.sessionId || null,
+        session_name: entry.sessionName || null,
+        status
+    };
+    if (serverDispatch) {
+        Object.assign(body, {
+            enqueue_submission_id: enqueueSubmissionId,
+            dispatch_mode: 'server',
+            execution_envelope_version: 1,
+            execution_envelope: (
+                entry.executionEnvelope
+                && typeof entry.executionEnvelope === 'object'
+                && !Array.isArray(entry.executionEnvelope)
+            )
+                ? entry.executionEnvelope
+                : {}
+        });
+        if (
+            typeof entry?.handoffSourceQueueId === 'string'
+            && entry.handoffSourceQueueId.trim()
+        ) {
+            body.handoff_source_queue_id = entry.handoffSourceQueueId.trim();
+        }
+    } else {
+        Object.assign(body, {
+            client_request_id: entry.clientRequestId || null,
+            attempt_id: entry.attemptId || null
+        });
+    }
     const data = await fetchChatPromptQueueJson('', {
         method: 'POST',
-        body: JSON.stringify({
-            prompt_raw: entry.promptRaw,
-            session_id: entry.sessionId || null,
-            session_name: entry.sessionName || null,
-            client_request_id: entry.clientRequestId || null,
-            attempt_id: entry.attemptId || null,
-            status
-        })
+        body: JSON.stringify(body)
     });
-    return data.item ? normaliseChatPromptQueueEntry(data.item, entry) : null;
+    if (!data.item) {
+        throw new Error('Queue persistence returned no canonical record.');
+    }
+    return normaliseChatPromptQueueEntry(data.item, entry);
 }
 
 async function persistQueuedPromptUpdateNow(entry) {
-    if (!entry?.queueId || entry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED) {
+    if (
+        !entry?.queueId
+        || entry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED
+        || isServerDispatchedChatPromptQueueEntry(entry)
+    ) {
         return entry;
     }
     const existingTimer = queuedChatPromptSyncTimers.get(entry.id);
@@ -34621,7 +34939,11 @@ async function persistQueuedPromptUpdateNow(entry) {
 }
 
 function schedulePersistedQueuedPromptUpdate(entry) {
-    if (!entry?.queueId || entry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED) {
+    if (
+        !entry?.queueId
+        || entry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED
+        || isServerDispatchedChatPromptQueueEntry(entry)
+    ) {
         return;
     }
     const existingTimer = queuedChatPromptSyncTimers.get(entry.id);
@@ -34651,10 +34973,230 @@ async function deletePersistedChatPromptQueueEntry(entry) {
     if (!entry?.queueId) {
         return true;
     }
-    await fetchChatPromptQueueJson(`/${encodeURIComponent(entry.queueId)}`, {
-        method: 'DELETE'
-    });
+    try {
+        await fetchChatPromptQueueJson(`/${encodeURIComponent(entry.queueId)}`, {
+            method: 'DELETE'
+        });
+    } catch (error) {
+        if (!isCanonicalChatPromptQueueAbsenceError(error)) {
+            throw error;
+        }
+    }
     return true;
+}
+
+async function completePersistedChatPromptQueueHandoff(entry) {
+    if (!entry?.queueId) {
+        throw new Error('The canonical handoff queue record is unavailable.');
+    }
+    const data = await fetchChatPromptQueueJson(
+        `/${encodeURIComponent(entry.queueId)}/complete-handoff`,
+        { method: 'POST' }
+    );
+    if (!data.item) {
+        throw new Error('Queue handoff returned no canonical record.');
+    }
+    return normaliseChatPromptQueueEntry(data.item, entry);
+}
+
+function isPendingServerDispatchHandoff(entry) {
+    return Boolean(
+        entry?.handoffSourceQueueId
+        && isServerDispatchedChatPromptQueueEntry(entry)
+        && entry.dispatchReady === false
+        && entry.status === CHAT_PROMPT_QUEUE_STATUS_QUEUED
+    );
+}
+
+async function cancelUnresolvedChatPromptQueueHandoff(entry) {
+    const sourceQueueId = (
+        typeof entry?.handoffSourceQueueId === 'string'
+        && entry.handoffSourceQueueId.trim()
+    )
+        ? entry.handoffSourceQueueId.trim()
+        : null;
+    const enqueueSubmissionId = (
+        typeof entry?.enqueueSubmissionId === 'string'
+        && entry.enqueueSubmissionId.trim()
+    )
+        ? entry.enqueueSubmissionId.trim()
+        : null;
+    if (!sourceQueueId) {
+        throw new Error('The durable handoff source is unavailable.');
+    }
+
+    const data = await fetchChatPromptQueueJson('');
+    const canonicalEntries = [
+        ...(Array.isArray(data?.items) ? data.items : []),
+        ...(Array.isArray(data?.recent_failed_items) ? data.recent_failed_items : [])
+    ]
+        .map((item) => normaliseChatPromptQueueEntry(item))
+        .filter(Boolean);
+    const replacementQueueIds = new Set();
+    if (entry?.queueId && entry.queueId !== sourceQueueId) {
+        replacementQueueIds.add(entry.queueId);
+    }
+    canonicalEntries.forEach((candidate) => {
+        if (
+            candidate.queueId
+            && candidate.queueId !== sourceQueueId
+            && enqueueSubmissionId
+            && candidate.enqueueSubmissionId === enqueueSubmissionId
+        ) {
+            replacementQueueIds.add(candidate.queueId);
+        }
+    });
+
+    // Cancel the dispatch-ineligible replacement first. The durable server
+    // handoff guarantees it cannot start before its exact source is retired.
+    for (const queueId of replacementQueueIds) {
+        await deletePersistedChatPromptQueueEntry({ queueId });
+    }
+    await deletePersistedChatPromptQueueEntry({ queueId: sourceQueueId });
+
+    queuedChatPrompts = queuedChatPrompts.filter((candidate) => (
+        candidate?.queueId !== sourceQueueId
+        && !replacementQueueIds.has(candidate?.queueId)
+        && (
+            !enqueueSubmissionId
+            || candidate?.enqueueSubmissionId !== enqueueSubmissionId
+            || !candidate?.handoffSourceQueueId
+        )
+        && (
+            !enqueueSubmissionId
+            || candidate?.handoffEnqueueSubmissionId !== enqueueSubmissionId
+        )
+    ));
+    if (!getChatPromptQueueEntryById(selectedChatPromptQueueEntryId)) {
+        selectedChatPromptQueueEntryId = null;
+    }
+    publishChatPromptQueueChange('queue_handoff_cancelled');
+    renderChatTaskQueuePanel();
+    refreshChatSessionTabActivityIndicators();
+    updateSendButtonForCurrentChatState();
+}
+
+function ensureAdmissionDeferredSourceQueueEntry(
+    handoffEntry,
+    { replacementQueueId = null, syncError = null } = {}
+) {
+    const sourceQueueId = (
+        typeof handoffEntry?.handoffSourceQueueId === 'string'
+        && handoffEntry.handoffSourceQueueId.trim()
+    )
+        ? handoffEntry.handoffSourceQueueId.trim()
+        : null;
+    if (!sourceQueueId) {
+        return null;
+    }
+    const existingIndex = queuedChatPrompts.findIndex((entry) => (
+        entry?.queueId === sourceQueueId
+    ));
+    const existing = existingIndex >= 0 ? queuedChatPrompts[existingIndex] : {};
+    const sourceEntry = normaliseChatPromptQueueEntry({
+        queue_id: sourceQueueId,
+        prompt_raw: handoffEntry.promptRaw,
+        session_id: handoffEntry.sessionId,
+        session_name: handoffEntry.sessionName,
+        status: CHAT_PROMPT_QUEUE_STATUS_QUEUED,
+        handoffEnqueueSubmissionId: handoffEntry.enqueueSubmissionId,
+        supersededByQueueId: replacementQueueId
+    }, existing);
+    if (!sourceEntry) {
+        return null;
+    }
+    sourceEntry.syncError = syncError || existing.syncError || null;
+    if (existingIndex >= 0) {
+        queuedChatPrompts[existingIndex] = sourceEntry;
+    } else {
+        queuedChatPrompts.push(sourceEntry);
+    }
+    return sourceEntry;
+}
+
+async function retireAdmissionDeferredSourceAfterCanonicalEnqueue(
+    handoffEntry,
+    persistedEntry
+) {
+    const sourceQueueId = (
+        typeof handoffEntry?.handoffSourceQueueId === 'string'
+        && handoffEntry.handoffSourceQueueId.trim()
+    )
+        ? handoffEntry.handoffSourceQueueId.trim()
+        : null;
+    const replacementQueueId = (
+        typeof persistedEntry?.queueId === 'string'
+        && persistedEntry.queueId.trim()
+    )
+        ? persistedEntry.queueId.trim()
+        : null;
+    if (!sourceQueueId || !replacementQueueId || sourceQueueId === replacementQueueId) {
+        return false;
+    }
+
+    if (
+        persistedEntry?.dispatchReady === true
+        && persistedEntry?.handoffSourceQueueId === sourceQueueId
+    ) {
+        // The v2 server handoff activates a replacement only after the exact
+        // source has been cancelled and read back. Do not issue a second
+        // browser-owned cancellation or retain a phantom source row.
+        queuedChatPrompts = queuedChatPrompts.filter((entry) => (
+            entry?.queueId !== sourceQueueId
+        ));
+        publishChatPromptQueueChange('foreground_prompt_replaced_by_server_queue');
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
+        return true;
+    }
+
+    // Keep the source visible and non-dispatchable during the non-atomic
+    // cleanup window. It is removed from the client projection only after the
+    // canonical DELETE acknowledges cancellation.
+    ensureAdmissionDeferredSourceQueueEntry(handoffEntry, {
+        replacementQueueId
+    });
+    renderChatTaskQueuePanel();
+    refreshChatSessionTabActivityIndicators();
+    updateSendButtonForCurrentChatState();
+
+    try {
+        await deletePersistedChatPromptQueueEntry({ queueId: sourceQueueId });
+        queuedChatPrompts = queuedChatPrompts.filter((entry) => (
+            entry?.queueId !== sourceQueueId
+        ));
+        const replacement = queuedChatPrompts.find((entry) => (
+            entry?.queueId === replacementQueueId
+        ));
+        if (replacement) {
+            replacement.handoffSourceQueueId = null;
+        }
+        publishChatPromptQueueChange('foreground_prompt_replaced_by_server_queue');
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
+        return true;
+    } catch (error) {
+        const sourceEntry = ensureAdmissionDeferredSourceQueueEntry(handoffEntry, {
+            replacementQueueId,
+            syncError: describeChatPromptQueueApiError(
+                error,
+                'The prior queue record could not be retired on the server.'
+            )
+        });
+        if (sourceEntry) {
+            sourceEntry.deleteInFlight = false;
+        }
+        console.warn(
+            '[chatTab] Unable to retire foreground queue record after server enqueue:',
+            error
+        );
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
+        return false;
+    }
 }
 
 async function requeuePersistedChatPromptQueueEntry(entry) {
@@ -34684,10 +35226,10 @@ function ensureChatTaskQueuePanel() {
         panel.id = CHAT_TASK_QUEUE_PANEL_ID;
         panel.className = 'chat-task-queue-panel hidden';
         panel.setAttribute('aria-live', 'polite');
-        panel.setAttribute('aria-label', 'Queued tasks');
+        panel.setAttribute('aria-label', 'Queued prompts for this conversation');
         panel.innerHTML = `
             <div class="chat-task-queue-header">
-                <span class="chat-task-queue-title">Queued tasks</span>
+                <span class="chat-task-queue-title">Queued prompts</span>
                 <span id="${CHAT_TASK_QUEUE_COUNT_ID}" class="chat-task-queue-count">0 queued</span>
             </div>
             <div id="${CHAT_TASK_QUEUE_LIST_ID}" class="chat-task-queue-list"></div>
@@ -34732,7 +35274,10 @@ function ensureChatTaskQueuePanel() {
                 return;
             }
             const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
-            if (!queued) {
+            if (!queued || isServerDispatchedChatPromptQueueEntry(queued)) {
+                if (queued) {
+                    target.value = queued.promptRaw;
+                }
                 return;
             }
             queued.promptRaw = target.value;
@@ -34743,6 +35288,115 @@ function ensureChatTaskQueuePanel() {
         panel.addEventListener('click', (event) => {
             const target = event.target;
             if (!(target instanceof HTMLElement)) {
+                return;
+            }
+            const handoffCompleteButton = target.closest('.chat-task-queue-handoff-complete');
+            if (handoffCompleteButton) {
+                const queueId = String(
+                    handoffCompleteButton.getAttribute('data-queue-id') || ''
+                ).trim();
+                const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
+                if (!queued || !isPendingServerDispatchHandoff(queued)) {
+                    return;
+                }
+                handoffCompleteButton.disabled = true;
+                void (async () => {
+                    try {
+                        const completed = await completePersistedChatPromptQueueHandoff(queued);
+                        mergePersistedChatPromptQueueEntry(completed);
+                        await retireAdmissionDeferredSourceAfterCanonicalEnqueue(
+                            queued,
+                            completed
+                        );
+                        publishChatPromptQueueChange('queue_handoff_completed');
+                        renderChatTaskQueuePanel();
+                        refreshChatSessionTabActivityIndicators();
+                        updateSendButtonForCurrentChatState();
+                    } catch (error) {
+                        queued.syncError = describeChatPromptQueueApiError(
+                            error,
+                            'Queue handoff could not be completed on the server.'
+                        );
+                        renderChatTaskQueuePanel();
+                    }
+                })();
+                return;
+            }
+            const handoffCancelButton = target.closest('.chat-task-queue-handoff-cancel');
+            if (handoffCancelButton) {
+                const queueId = String(
+                    handoffCancelButton.getAttribute('data-queue-id') || ''
+                ).trim();
+                const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
+                if (
+                    !queued
+                    || !queued.handoffSourceQueueId
+                    || queued.deleteInFlight === true
+                ) {
+                    return;
+                }
+                queued.deleteInFlight = true;
+                queued.syncError = null;
+                renderChatTaskQueuePanel();
+                void (async () => {
+                    try {
+                        await cancelUnresolvedChatPromptQueueHandoff(queued);
+                    } catch (error) {
+                        queued.deleteInFlight = false;
+                        queued.syncError = describeChatPromptQueueApiError(
+                            error,
+                            'The unresolved queue handoff could not be cancelled.'
+                        );
+                        renderChatTaskQueuePanel();
+                    }
+                })();
+                return;
+            }
+            const enqueueRetryButton = target.closest('.chat-task-queue-enqueue-retry');
+            if (enqueueRetryButton) {
+                const queueId = String(enqueueRetryButton.getAttribute('data-queue-id') || '').trim();
+                const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
+                if (!queued || queued.enqueueFailed !== true) {
+                    return;
+                }
+                enqueueRetryButton.disabled = true;
+                void (async () => {
+                    try {
+                        const persisted = await createPersistedChatPromptQueueEntry(queued);
+                        if (!persisted) {
+                            throw new Error('Queue persistence returned no record.');
+                        }
+                        const index = queuedChatPrompts.findIndex((entry) => entry.id === queued.id);
+                        if (index >= 0) {
+                            queuedChatPrompts[index] = {
+                                ...queued,
+                                ...persisted,
+                                enqueueFailed: false,
+                                enqueueUnconfirmed: false,
+                                syncError: null,
+                                id: persisted.id || queued.id
+                            };
+                        }
+                        await retireAdmissionDeferredSourceAfterCanonicalEnqueue(
+                            queued,
+                            persisted
+                        );
+                        renderChatTaskQueuePanel();
+                        refreshChatSessionTabActivityIndicators();
+                        updateSendButtonForCurrentChatState();
+                        publishChatPromptQueueChange('queued_prompt_retry_saved');
+                        syncChatPromptQueuePolling();
+                    } catch (error) {
+                        queued.enqueueUnconfirmed = isAmbiguousChatPromptQueueEnqueueError(error);
+                        queued.syncError = describeChatPromptQueueApiError(
+                            error,
+                            queued.enqueueUnconfirmed
+                                ? 'Queue acknowledgement was not received. Retry safely to reconcile this exact prompt.'
+                                : 'Prompt was not queued. Retry when queue storage is available.'
+                        );
+                        renderChatTaskQueuePanel();
+                    }
+                })();
                 return;
             }
             const restartButton = target.closest('.chat-task-queue-restart');
@@ -34769,7 +35423,7 @@ function ensureChatTaskQueuePanel() {
                         refreshChatSessionTabActivityIndicators();
                         updateSendButtonForCurrentChatState();
                         publishChatPromptQueueChange('queued_prompt_restarted');
-                        scheduleQueuedChatPromptDrain();
+                        syncChatPromptQueuePolling();
                     } catch (error) {
                         queued.syncError = describeChatPromptQueueApiError(
                             error,
@@ -34823,17 +35477,46 @@ function ensureChatTaskQueuePanel() {
                 return;
             }
             const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
-            queuedChatPrompts = queuedChatPrompts.filter((entry) => entry.id !== queueId);
-            renderChatTaskQueuePanel();
-            refreshChatSessionTabActivityIndicators();
-            updateSendButtonForCurrentChatState();
-            if (queued) {
-                void deletePersistedChatPromptQueueEntry(queued)
-                    .then(() => publishChatPromptQueueChange('queued_prompt_deleted'))
-                    .catch((error) => {
-                        console.warn('[chatTab] Unable to delete persisted queued prompt:', error);
-                    });
+            if (!queued || queued.deleteInFlight === true) {
+                return;
             }
+            if (!queued.queueId) {
+                queuedChatPrompts = queuedChatPrompts.filter((entry) => entry.id !== queueId);
+                renderChatTaskQueuePanel();
+                refreshChatSessionTabActivityIndicators();
+                updateSendButtonForCurrentChatState();
+                return;
+            }
+            queued.deleteInFlight = true;
+            queued.syncError = null;
+            renderChatTaskQueuePanel();
+            void (async () => {
+                try {
+                    await deletePersistedChatPromptQueueEntry(queued);
+                    queuedChatPrompts = queuedChatPrompts.filter((entry) => (
+                        entry.id !== queueId
+                        && entry.queueId !== queued.queueId
+                    ));
+                    if (selectedChatPromptQueueEntryId === queueId) {
+                        selectedChatPromptQueueEntryId = null;
+                    }
+                    publishChatPromptQueueChange('queued_prompt_deleted');
+                } catch (error) {
+                    const retained = queuedChatPrompts.find((entry) => (
+                        entry.id === queueId
+                        || entry.queueId === queued.queueId
+                    )) || queued;
+                    retained.deleteInFlight = false;
+                    retained.syncError = describeChatPromptQueueApiError(
+                        error,
+                        'Queued task could not be deleted on the server.'
+                    );
+                    console.warn('[chatTab] Unable to delete persisted queued prompt:', error);
+                }
+                renderChatTaskQueuePanel();
+                refreshChatSessionTabActivityIndicators();
+                updateSendButtonForCurrentChatState();
+            })();
         });
     }
 
@@ -34853,14 +35536,31 @@ function renderChatTaskQueuePanel() {
     }
 
     const { panel, list, count } = elements;
-    const displayEntries = queuedChatPrompts.filter(isDisplayedChatPromptQueueEntry);
+    const displayEntries = queuedChatPrompts.filter((entry) => (
+        isDisplayedChatPromptQueueEntry(entry)
+        && isChatPromptQueueEntryForSession(entry)
+    ));
     const queueSize = displayEntries.length;
     let runningCount = 0;
     let interruptedCount = 0;
     let failedCount = 0;
     let queuedCount = 0;
+    let enqueueFailedCount = 0;
+    let enqueueUnconfirmedCount = 0;
+    let cleanupPendingCount = 0;
     displayEntries.forEach((entry) => {
-        if (isRunningChatPromptQueueEntry(entry)) {
+        if (
+            entry.supersededByQueueId
+            || entry.handoffEnqueueSubmissionId
+            || isPendingServerDispatchHandoff(entry)
+        ) {
+            cleanupPendingCount += 1;
+        } else if (entry.enqueueFailed === true) {
+            enqueueFailedCount += 1;
+            if (entry.enqueueUnconfirmed === true) {
+                enqueueUnconfirmedCount += 1;
+            }
+        } else if (isRunningChatPromptQueueEntry(entry)) {
             runningCount += 1;
         } else if (isRestartableChatPromptQueueEntry(entry)) {
             interruptedCount += 1;
@@ -34887,6 +35587,22 @@ function renderChatTaskQueuePanel() {
         if (failedCount > 0) {
             countParts.push(failedCount === 1 ? '1 failed' : `${failedCount} failed`);
         }
+        if (enqueueFailedCount > 0) {
+            const definitelyFailedCount = enqueueFailedCount - enqueueUnconfirmedCount;
+            if (enqueueUnconfirmedCount > 0) {
+                countParts.push(enqueueUnconfirmedCount === 1
+                    ? '1 queue unconfirmed'
+                    : `${enqueueUnconfirmedCount} queues unconfirmed`);
+            }
+            if (definitelyFailedCount > 0) {
+                countParts.push(definitelyFailedCount === 1
+                    ? '1 not queued'
+                    : `${definitelyFailedCount} not queued`);
+            }
+        }
+        if (cleanupPendingCount > 0) {
+            countParts.push(cleanupPendingCount === 1 ? '1 handoff pending' : `${cleanupPendingCount} handoffs pending`);
+        }
         count.textContent = countParts.join(', ');
     }
     list.innerHTML = '';
@@ -34903,6 +35619,19 @@ function renderChatTaskQueuePanel() {
         const isRunning = isRunningChatPromptQueueEntry(entry);
         const isInterrupted = isRestartableChatPromptQueueEntry(entry);
         const isFailed = !isRunning && entry.status === CHAT_PROMPT_QUEUE_STATUS_FAILED;
+        const isServerDispatched = isServerDispatchedChatPromptQueueEntry(entry);
+        const isEnqueueFailed = entry.enqueueFailed === true;
+        const isEnqueueUnconfirmed = entry.enqueueUnconfirmed === true;
+        const isSuperseded = Boolean(entry.supersededByQueueId);
+        const isHandoffPendingSource = Boolean(
+            entry.handoffEnqueueSubmissionId
+            && !entry.supersededByQueueId
+        );
+        const isPendingHandoffReplacement = isPendingServerDispatchHandoff(entry);
+        const hasUnresolvedHandoff = Boolean(
+            entry.handoffSourceQueueId
+            && (isEnqueueFailed || isPendingHandoffReplacement)
+        );
         const item = document.createElement('div');
         item.className = 'chat-task-queue-item';
         if (isRunning) {
@@ -34911,6 +35640,8 @@ function renderChatTaskQueuePanel() {
             item.classList.add('chat-task-queue-item-interrupted');
         } else if (isFailed) {
             item.classList.add('chat-task-queue-item-failed');
+        } else if (isEnqueueFailed) {
+            item.classList.add('chat-task-queue-item-enqueue-failed');
         }
         if (entry.id === selectedChatPromptQueueEntryId) {
             item.classList.add('chat-task-queue-item-selected');
@@ -34921,7 +35652,17 @@ function renderChatTaskQueuePanel() {
         const label = document.createElement('div');
         label.className = 'chat-task-queue-item-label';
         const sessionLabel = getQueuedChatPromptSessionLabel(entry);
-        if (isRunning) {
+        if (isSuperseded) {
+            label.textContent = `Superseded • ${sessionLabel}`;
+        } else if (isHandoffPendingSource) {
+            label.textContent = `Handoff pending • ${sessionLabel}`;
+        } else if (isPendingHandoffReplacement) {
+            label.textContent = `Handoff pending • ${sessionLabel}`;
+        } else if (isEnqueueFailed) {
+            label.textContent = isEnqueueUnconfirmed
+                ? `Queue unconfirmed • ${sessionLabel}`
+                : `Not queued • ${sessionLabel}`;
+        } else if (isRunning) {
             label.textContent = `Running • ${sessionLabel}`;
         } else if (isInterrupted) {
             label.textContent = `Interrupted • ${sessionLabel}`;
@@ -34939,13 +35680,41 @@ function renderChatTaskQueuePanel() {
         editor.rows = 2;
         editor.value = entry.promptRaw;
         editor.setAttribute('data-queue-id', entry.id);
-        editor.readOnly = isRunning || isInterrupted || isFailed;
-        editor.setAttribute('aria-label', isRunning ? `Running task ${index + 1}` : (isInterrupted ? `Interrupted task ${index + 1}` : (isFailed ? `Failed task ${index + 1}` : `Queued task ${index + 1}`)));
+        editor.readOnly = isRunning
+            || isInterrupted
+            || isFailed
+            || isServerDispatched
+            || isEnqueueFailed
+            || isSuperseded
+            || isHandoffPendingSource
+            || isPendingHandoffReplacement;
+        editor.setAttribute('aria-label', isEnqueueFailed ? `Prompt not queued ${index + 1}` : (isRunning ? `Running task ${index + 1}` : (isInterrupted ? `Interrupted task ${index + 1}` : (isFailed ? `Failed task ${index + 1}` : (isServerDispatched ? `Server-dispatched queued task ${index + 1}` : `Queued task ${index + 1}`)))));
 
         const actions = document.createElement('div');
         actions.className = 'chat-task-queue-actions';
 
-        if (isInterrupted) {
+        if (isEnqueueFailed) {
+            const retryButton = document.createElement('button');
+            retryButton.type = 'button';
+            retryButton.className = 'btn-mini chat-task-queue-enqueue-retry';
+            retryButton.textContent = isEnqueueUnconfirmed
+                ? 'Reconcile queueing'
+                : 'Retry queueing';
+            retryButton.setAttribute('data-queue-id', entry.id);
+            retryButton.setAttribute('aria-label', `Retry queueing prompt ${index + 1}`);
+            actions.appendChild(retryButton);
+        } else if (isPendingHandoffReplacement) {
+            const retryHandoffButton = document.createElement('button');
+            retryHandoffButton.type = 'button';
+            retryHandoffButton.className = 'btn-mini chat-task-queue-handoff-complete';
+            retryHandoffButton.textContent = 'Complete handoff';
+            retryHandoffButton.setAttribute('data-queue-id', entry.id);
+            retryHandoffButton.setAttribute(
+                'aria-label',
+                `Complete queue handoff ${index + 1}`
+            );
+            actions.appendChild(retryHandoffButton);
+        } else if (isInterrupted) {
             const restartButton = document.createElement('button');
             restartButton.type = 'button';
             restartButton.className = 'btn-mini chat-task-queue-restart';
@@ -34955,11 +35724,30 @@ function renderChatTaskQueuePanel() {
             actions.appendChild(restartButton);
         }
 
-        if (!isRunning && !isFailed) {
+        if (hasUnresolvedHandoff) {
+            const cancelHandoffButton = document.createElement('button');
+            cancelHandoffButton.type = 'button';
+            cancelHandoffButton.className = 'btn-mini chat-task-queue-handoff-cancel';
+            cancelHandoffButton.textContent = entry.deleteInFlight
+                ? 'Cancelling…'
+                : 'Cancel prompt';
+            cancelHandoffButton.disabled = entry.deleteInFlight === true;
+            cancelHandoffButton.setAttribute('data-queue-id', entry.id);
+            cancelHandoffButton.setAttribute(
+                'aria-label',
+                `Cancel unresolved queue handoff ${index + 1}`
+            );
+            actions.appendChild(cancelHandoffButton);
+        }
+
+        if (!isRunning && !isFailed && !isHandoffPendingSource && !hasUnresolvedHandoff) {
             const deleteButton = document.createElement('button');
             deleteButton.type = 'button';
             deleteButton.className = 'btn-mini chat-task-queue-delete';
-            deleteButton.textContent = 'Delete';
+            deleteButton.textContent = entry.deleteInFlight
+                ? (isSuperseded ? 'Cleaning…' : 'Deleting…')
+                : (isSuperseded ? 'Retry cleanup' : 'Delete');
+            deleteButton.disabled = entry.deleteInFlight === true;
             deleteButton.setAttribute('data-queue-id', entry.id);
             deleteButton.setAttribute('aria-label', isInterrupted ? `Delete interrupted task ${index + 1}` : `Delete queued task ${index + 1}`);
             actions.appendChild(deleteButton);
@@ -34980,6 +35768,21 @@ function renderChatTaskQueuePanel() {
             const syncWarning = document.createElement('div');
             syncWarning.className = 'chat-task-queue-sync-warning';
             syncWarning.textContent = entry.syncError;
+            item.appendChild(syncWarning);
+        } else if (isSuperseded) {
+            const syncWarning = document.createElement('div');
+            syncWarning.className = 'chat-task-queue-sync-warning';
+            syncWarning.textContent = 'Server dispatch is canonical; this prior row is retained until cleanup succeeds.';
+            item.appendChild(syncWarning);
+        } else if (isHandoffPendingSource) {
+            const syncWarning = document.createElement('div');
+            syncWarning.className = 'chat-task-queue-sync-warning';
+            syncWarning.textContent = 'This durable row is retained until server queueing is acknowledged.';
+            item.appendChild(syncWarning);
+        } else if (isPendingHandoffReplacement) {
+            const syncWarning = document.createElement('div');
+            syncWarning.className = 'chat-task-queue-sync-warning';
+            syncWarning.textContent = 'The server is safely reconciling this durable queue handoff.';
             item.appendChild(syncWarning);
         }
         if (isFailed && entry.lastError) {
@@ -35005,6 +35808,22 @@ async function queuePromptForLater(promptRaw, options = {}) {
     const sessionName = (typeof options.sessionName === 'string' && options.sessionName.trim())
         ? options.sessionName.trim()
         : null;
+    const enqueueSubmissionId = (
+        typeof options.enqueueSubmissionId === 'string'
+        && options.enqueueSubmissionId.trim()
+    )
+        ? options.enqueueSubmissionId.trim()
+        : createClientRequestId();
+    const fileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
+        options.fileCopyConceptId
+    );
+    const executionEnvelope = (
+        options.executionEnvelope
+        && typeof options.executionEnvelope === 'object'
+        && !Array.isArray(options.executionEnvelope)
+    )
+        ? options.executionEnvelope
+        : buildChatPromptExecutionEnvelope({ fileCopyConceptId });
     const localEntry = normaliseChatPromptQueueEntry({
         id: createQueuedChatPromptId(),
         promptRaw: value,
@@ -35014,15 +35833,21 @@ async function queuePromptForLater(promptRaw, options = {}) {
         sessionKey: getChatRequestSessionKey(sessionId),
         sessionName,
         session_name: sessionName,
-        fileCopyConceptId: normaliseTrustedUploadedFileCopyConceptId(
-            options.fileCopyConceptId
-        ),
-        clientRequestId: (typeof options.clientRequestId === 'string' && options.clientRequestId.trim())
-            ? options.clientRequestId.trim()
+        enqueueSubmissionId,
+        enqueue_submission_id: enqueueSubmissionId,
+        dispatchMode: 'server',
+        dispatch_mode: 'server',
+        executionEnvelopeVersion: 1,
+        execution_envelope_version: 1,
+        executionEnvelope,
+        execution_envelope: executionEnvelope,
+        handoffSourceQueueId: (
+            typeof options.handoffSourceQueueId === 'string'
+            && options.handoffSourceQueueId.trim()
+        )
+            ? options.handoffSourceQueueId.trim()
             : null,
-        attemptId: (typeof options.attemptId === 'string' && options.attemptId.trim())
-            ? options.attemptId.trim()
-            : null,
+        fileCopyConceptId,
         status: CHAT_PROMPT_QUEUE_STATUS_QUEUED,
         localOnly: true
     });
@@ -35048,21 +35873,32 @@ async function queuePromptForLater(promptRaw, options = {}) {
                     id: persisted.id || localEntry.id
                 };
             } else {
-                queuedChatPrompts.push(persisted);
+                mergePersistedChatPromptQueueEntry(persisted);
             }
             renderChatTaskQueuePanel();
             refreshChatSessionTabActivityIndicators();
             updateSendButtonForCurrentChatState();
+            await retireAdmissionDeferredSourceAfterCanonicalEnqueue(
+                localEntry,
+                persisted
+            );
             publishChatPromptQueueChange('queued_prompt_created');
             return persisted;
         }
     } catch (error) {
+        localEntry.enqueueFailed = true;
+        localEntry.enqueueUnconfirmed = isAmbiguousChatPromptQueueEnqueueError(error);
         localEntry.syncError = describeChatPromptQueueApiError(
             error,
-            'Queued locally; server persistence failed.'
+            localEntry.enqueueUnconfirmed
+                ? 'Queue acknowledgement was not received. Retry safely to reconcile this exact prompt.'
+                : 'Prompt was not queued. Retry when queue storage is available.'
         );
         console.warn('[chatTab] Unable to persist queued prompt:', error);
+        ensureAdmissionDeferredSourceQueueEntry(localEntry);
         renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
     }
     return localEntry;
 }
@@ -35073,6 +35909,7 @@ function isChatPromptSessionBusy(sessionId, { includeQueued = false } = {}) {
         || queuedChatPromptClaimsInFlight.has(sessionKey)
         || queuedChatPrompts.some((entry) => (
             entry?.sessionKey === sessionKey
+            && entry.enqueueFailed !== true
             && (
                 entry.status === CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS
                 || (includeQueued && entry.status === CHAT_PROMPT_QUEUE_STATUS_QUEUED)
@@ -35093,7 +35930,11 @@ async function sendQueuedChatPromptEntry(entryId) {
     }
 
     let nextEntry = getChatPromptQueueEntryById(cleanEntryId);
-    if (!nextEntry || isChatPromptSessionBusy(nextEntry.sessionId)) {
+    if (
+        !nextEntry
+        || isServerDispatchedChatPromptQueueEntry(nextEntry)
+        || isChatPromptSessionBusy(nextEntry.sessionId)
+    ) {
         return false;
     }
     const sessionHead = getQueuedChatPromptHeadsBySession().get(nextEntry.sessionKey);
@@ -35105,7 +35946,6 @@ async function sendQueuedChatPromptEntry(entryId) {
         renderChatTaskQueuePanel();
         refreshChatSessionTabActivityIndicators();
         updateSendButtonForCurrentChatState();
-        scheduleQueuedChatPromptDrain();
         return false;
     }
 
@@ -35142,11 +35982,6 @@ async function sendQueuedChatPromptEntry(entryId) {
             queuedChatPrompts[updatedIndex] = nextEntry;
         }
 
-        queuedChatPrompts = queuedChatPrompts.filter((entry) => entry?.id !== cleanEntryId);
-        renderChatTaskQueuePanel();
-        refreshChatSessionTabActivityIndicators();
-        updateSendButtonForCurrentChatState();
-
         // Release the short claim guard before dispatch. handleSendPrompt runs
         // synchronously until it installs the live request for this session.
         queuedChatPromptClaimsInFlight.delete(sessionKey);
@@ -35156,9 +35991,11 @@ async function sendQueuedChatPromptEntry(entryId) {
             sessionId: nextEntry.sessionId || null,
             sessionName: nextEntry.sessionName || null,
             promptQueueRecordId: nextEntry.queueId || null,
+            enqueueSubmissionId: nextEntry.enqueueSubmissionId || null,
             clientRequestId: nextEntry.clientRequestId || null,
             attemptId: nextEntry.attemptId || null,
-            fileCopyConceptId: nextEntry.fileCopyConceptId || null
+            fileCopyConceptId: nextEntry.fileCopyConceptId || null,
+            queuedSourceEntryId: cleanEntryId
         });
         return true;
     } catch (error) {
@@ -35192,68 +36029,6 @@ function getQueuedChatPromptHeadsBySession() {
         }
     });
     return heads;
-}
-
-async function drainQueuedChatPromptsForFreeSessions() {
-    if (pendingChatOrganisationSwitchId !== null) {
-        return false;
-    }
-    const organisationGenerationAtStart = chatOrganisationGeneration;
-    if (queuedChatPrompts.length === 0) {
-        return false;
-    }
-
-    let startedAny = false;
-    while (true) {
-        if (!isChatOrganisationRequestCurrent(organisationGenerationAtStart)) {
-            return startedAny;
-        }
-        const eligibleEntries = Array.from(getQueuedChatPromptHeadsBySession().values())
-            .filter((entry) => (
-                entry.status === CHAT_PROMPT_QUEUE_STATUS_QUEUED
-                && !isChatPromptSessionBusy(entry.sessionId)
-            ));
-        if (eligibleEntries.length === 0) {
-            return startedAny;
-        }
-
-        let startedThisPass = false;
-        for (const entry of eligibleEntries) {
-            if (!isChatOrganisationRequestCurrent(organisationGenerationAtStart)) {
-                return startedAny;
-            }
-            const started = await sendQueuedChatPromptEntry(entry.id);
-            startedAny = startedAny || started;
-            startedThisPass = startedThisPass || started;
-        }
-        if (!startedThisPass) {
-            return startedAny;
-        }
-    }
-}
-
-function scheduleQueuedChatPromptDrain() {
-    queuedChatPromptDrainRequested = true;
-    if (queuedChatPromptDrainTimer !== null || queuedChatPromptDrainPromise !== null) {
-        return;
-    }
-    queuedChatPromptDrainTimer = setTimeout(() => {
-        queuedChatPromptDrainTimer = null;
-        queuedChatPromptDrainRequested = false;
-        const drainPromise = drainQueuedChatPromptsForFreeSessions()
-            .catch((error) => {
-                console.warn('[chatTab] Unable to drain queued prompts:', error);
-            })
-            .finally(() => {
-                if (queuedChatPromptDrainPromise === drainPromise) {
-                    queuedChatPromptDrainPromise = null;
-                }
-                if (queuedChatPromptDrainRequested) {
-                    scheduleQueuedChatPromptDrain();
-                }
-            });
-        queuedChatPromptDrainPromise = drainPromise;
-    }, 0);
 }
 
 async function handleSendPrompt(options = {}) {
@@ -35366,22 +36141,46 @@ async function handleSendPrompt(options = {}) {
 
     if (isChatPromptSessionBusy(targetSessionId, { includeQueued: !fromQueue })) {
         if (fromQueue) {
-            scheduleQueuedChatPromptDrain();
             return;
         }
         if (!promptText) {
             return;
         }
+        const submissionSessionKey = getChatRequestSessionKey(targetSessionId);
+        if (queuedChatPromptSubmissionsInFlight.has(submissionSessionKey)) {
+            return;
+        }
+        const enqueueSubmissionId = createClientRequestId();
+        queuedChatPromptSubmissionsInFlight.set(
+            submissionSessionKey,
+            enqueueSubmissionId
+        );
         const queuedFileCopyConceptId = takePendingUploadedFileCopyConceptId(
             targetSessionId
         );
-        await queuePromptForLater(promptRaw, {
-            sessionId: targetSessionId,
-            sessionName: targetSessionName,
+        const executionEnvelope = buildChatPromptExecutionEnvelope({
             fileCopyConceptId: queuedFileCopyConceptId
         });
         rememberLastSubmittedUserPrompt(promptRaw);
         setPromptComposerValue('', { promptInput });
+        updateSendButtonForCurrentChatState();
+        try {
+            await queuePromptForLater(promptRaw, {
+                sessionId: targetSessionId,
+                sessionName: targetSessionName,
+                fileCopyConceptId: queuedFileCopyConceptId,
+                executionEnvelope,
+                enqueueSubmissionId
+            });
+        } finally {
+            if (
+                queuedChatPromptSubmissionsInFlight.get(submissionSessionKey)
+                === enqueueSubmissionId
+            ) {
+                queuedChatPromptSubmissionsInFlight.delete(submissionSessionKey);
+            }
+            updateSendButtonForCurrentChatState();
+        }
         return;
     }
 
@@ -35398,6 +36197,12 @@ async function handleSendPrompt(options = {}) {
     const attemptId = (typeof options?.attemptId === 'string' && options.attemptId.trim())
         ? options.attemptId.trim()
         : createClientRequestId();
+    const enqueueSubmissionId = (
+        typeof options?.enqueueSubmissionId === 'string'
+        && options.enqueueSubmissionId.trim()
+    )
+        ? options.enqueueSubmissionId.trim()
+        : createClientRequestId();
     const executionContextBinding = synchroniseLlmExecutionContext();
     const explicitFileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
         options?.fileCopyConceptId
@@ -35411,6 +36216,15 @@ async function handleSendPrompt(options = {}) {
     const pendingFileCopyDisplayName = explicitFileCopyConceptId
         ? normalisePendingAttachmentDisplayName(options?.fileCopyDisplayName)
         : (pendingFileCopyBinding?.displayName || null);
+    const turnKind = assistantOpening ? 'assistant_opening' : null;
+    const initiationId = assistantOpening
+        ? String(options?.initiationId || '').trim() || null
+        : null;
+    const executionEnvelope = buildChatPromptExecutionEnvelope({
+        fileCopyConceptId: pendingFileCopyConceptId,
+        turnKind,
+        initiationId
+    });
     const request = {
         abortController: new AbortController(),
         organisationGeneration: chatOrganisationGeneration,
@@ -35418,8 +36232,8 @@ async function handleSendPrompt(options = {}) {
         sessionKey: getChatRequestSessionKey(targetSessionId),
         sessionName: targetSessionName,
         promptRaw,
-        turnKind: assistantOpening ? 'assistant_opening' : null,
-        initiationId: assistantOpening ? String(options?.initiationId || '').trim() || null : null,
+        turnKind,
+        initiationId,
         promptQueueRecordId,
         selectionStart,
         selectionEnd,
@@ -35429,6 +36243,8 @@ async function handleSendPrompt(options = {}) {
         attachmentBindingTransferred: false,
         attachmentBindingReleased: false,
         aborted: false,
+        enqueueSubmissionId,
+        executionEnvelope,
         clientRequestId,
         attemptId,
         executionContextBinding,
@@ -35445,6 +36261,30 @@ async function handleSendPrompt(options = {}) {
         turnOutcome: null,
         thinkingCardMode: loadStoredThinkingCardMode(),
         thinkingCardDisplayState: reduceThinkingCardDisplayState(null, { type: 'reset_for_active' })
+    };
+    const queuedSourceEntryId = (
+        fromQueue
+        && typeof options?.queuedSourceEntryId === 'string'
+        && options.queuedSourceEntryId.trim()
+    )
+        ? options.queuedSourceEntryId.trim()
+        : null;
+    let queuedSourceAcknowledged = false;
+    const acknowledgeQueuedSource = () => {
+        if (!queuedSourceEntryId || queuedSourceAcknowledged) {
+            return;
+        }
+        queuedSourceAcknowledged = true;
+        queuedChatPrompts = queuedChatPrompts.filter((entry) => (
+            entry?.id !== queuedSourceEntryId
+        ));
+        if (selectedChatPromptQueueEntryId === queuedSourceEntryId) {
+            selectedChatPromptQueueEntryId = null;
+        }
+        publishChatPromptQueueChange('legacy_queued_prompt_acknowledged');
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
     };
     request.promptQueueRecordPromise = request.promptQueueRecordId || options?.skipPromptQueueRecord === true
         ? null
@@ -35750,12 +36590,6 @@ async function handleSendPrompt(options = {}) {
 
         // Get user context from localStorage to send to backend
         const userContext = getUserContext();
-        const localRequestedLlm = resolveLocalRequestedLlm();
-        const localModelRequestFields = buildLocalModelRequestFields(localRequestedLlm);
-        // Presenter-mode controls whether the backend produces two-channel output
-        // (screen + spoken). This should be enabled regardless of whether auto-TTS
-        // is enabled, so clicking Speak later never needs to read raw markdown.
-        const presenterMode = true;
 
         // The server queue record is the authoritative admission/correlation
         // carrier. Await its creation before generate; if persistence is
@@ -35804,20 +36638,9 @@ async function handleSendPrompt(options = {}) {
                 ...(request.promptQueueRecordId ? {
                     prompt_queue_id: request.promptQueueRecordId
                 } : {}),
-                ...(request.turnKind ? { turn_kind: request.turnKind } : {}),
-                ...(request.initiationId ? { initiation_id: request.initiationId } : {}),
                 user_id: userContext.user_id,
                 org_id: userContext.org_id,
-                language: userContext.language,
-                ...localModelRequestFields,
-                ...(request.pendingFileCopyConceptId ? {
-                    workflow_inputs: {
-                        file_copy_concept_id: request.pendingFileCopyConceptId
-                    }
-                } : {}),
-                presenter_mode: presenterMode,
-                skip_buttonify: false,
-                thinking_card_mode: getThinkingCardMode()
+                ...request.executionEnvelope
             })
         });
         startToolUseProgressPolling(request);
@@ -35825,6 +36648,7 @@ async function handleSendPrompt(options = {}) {
             onCompleted: async (generateBody) => {
                 request.serverQueueTerminalObserved = true;
                 request.attachmentBindingAccepted = true;
+                acknowledgeQueuedSource();
                 const delivered = deliverSuccessfulResponseData(generateBody, 'task_result');
                 if (delivered) {
                     try {
@@ -35836,6 +36660,7 @@ async function handleSendPrompt(options = {}) {
             },
             onFailed: async (statusPayload, status) => {
                 request.serverQueueTerminalObserved = true;
+                acknowledgeQueuedSource();
                 const delivered = status === 'cancelled'
                     ? deliverCancelledResponseData(statusPayload)
                     : deliverErrorResponseData(
@@ -35893,14 +36718,15 @@ async function handleSendPrompt(options = {}) {
 
         if (response.ok) {
             request.serverQueueTerminalObserved = true;
+            acknowledgeQueuedSource();
             deliverSuccessfulResponseData(data, 'generate_response');
         } else if (
             data?.retryable === true
             || response.status === 429
         ) {
             // Admission backpressure is not a failed user task. Restore the
-            // durable row to queued state and retry after the server's hint;
-            // another conversation can continue independently meanwhile.
+            // durable row to queued state; the server-side dispatcher owns
+            // its next attempt while other conversations remain usable.
             request.admissionDeferred = true;
             request.foregroundDeliveryCompleted = true;
             request.turnOutcome = {
@@ -35908,12 +36734,11 @@ async function handleSendPrompt(options = {}) {
                 phase_label: 'Queued',
                 summary: data?.detail || 'Waiting for this conversation or server capacity.'
             };
-            const responseQueueId = (typeof data?.prompt_queue_id === 'string' && data.prompt_queue_id.trim())
-                ? data.prompt_queue_id.trim()
-                : null;
-            if (!request.promptQueueRecordId && responseQueueId) {
-                request.promptQueueRecordId = responseQueueId;
-            }
+            // Only a row created and read back for this exact request is safe
+            // to retire. An admission error's queue id may identify the turn
+            // currently holding the conversation fence rather than this prompt.
+            const foregroundQueueRecordId = request.promptQueueRecordId;
+            let deferredServerQueueAcknowledged = false;
             if (data?.error === 'window_context_unavailable') {
                 try {
                     await repairCurrentWindowOrganisationBinding();
@@ -35922,64 +36747,31 @@ async function handleSendPrompt(options = {}) {
                 }
             }
             try {
-                if (request.promptQueueRecordId) {
-                    const refreshed = await refreshChatPromptQueueFromServer({
-                        silent: true,
-                        skipDrain: true
-                    });
-                    const canonicalEntry = refreshed
-                        ? refreshed.items.find((entry) => (
-                            entry?.queueId === request.promptQueueRecordId
-                        ))
-                        : null;
-                    const recovered = canonicalEntry?.status === CHAT_PROMPT_QUEUE_STATUS_QUEUED;
-                    if (canonicalEntry) {
-                        // This exact row can be hidden while the retiring live
-                        // request still owns the active conversation UI. Keep
-                        // it locally so it can drain or render after teardown.
-                        mergePersistedChatPromptQueueEntry(canonicalEntry);
-                    }
-                    if (
-                        canonicalEntry
-                        && canonicalEntry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED
-                    ) {
-                        // Another tab/server attempt already owns this exact
-                        // record. Preserve canonical ownership and wait for a
-                        // queue-change signal instead of locally downgrading it.
-                        request.admissionRetrySuppressed = true;
-                    } else if (!recovered) {
-                        mergePersistedChatPromptQueueEntry({
-                            queue_id: request.promptQueueRecordId,
-                            prompt_raw: request.promptRaw,
-                            session_id: request.sessionId,
-                            session_name: request.sessionName,
-                            client_request_id: request.clientRequestId,
-                            attempt_id: request.attemptId,
-                            status: CHAT_PROMPT_QUEUE_STATUS_QUEUED
-                        });
-                    }
-                } else {
-                    const requeued = await queuePromptForLater(request.promptRaw, {
-                        sessionId: request.sessionId,
-                        sessionName: request.sessionName,
-                        clientRequestId: request.clientRequestId,
-                        attemptId: request.attemptId
-                    });
+                const requeued = await queuePromptForLater(request.promptRaw, {
+                    sessionId: request.sessionId,
+                    sessionName: request.sessionName,
+                    fileCopyConceptId: request.pendingFileCopyConceptId,
+                    enqueueSubmissionId: request.enqueueSubmissionId,
+                    executionEnvelope: request.executionEnvelope,
+                    handoffSourceQueueId: foregroundQueueRecordId
+                });
+                if (requeued?.queueId) {
                     request.promptQueueRecordId = requeued?.queueId || null;
+                    deferredServerQueueAcknowledged = true;
+                    request.attachmentBindingTransferred = Boolean(
+                        request.pendingFileCopyConceptId
+                    );
                 }
             } catch (requeueError) {
                 console.info('[chatTab] Admission-deferred row recovery:', requeueError);
             }
-            const retryAfterSeconds = Number.parseInt(
-                response.headers?.get?.('Retry-After') || data?.retry_after_seconds || '1',
-                10
-            );
-            request.admissionRetryAfterMs = Math.max(
-                250,
-                (Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : 1) * 1000
-            );
             if (isRequestVisible()) {
-                showToast('Prompt queued until this conversation is free.', 'info');
+                showToast(
+                    deferredServerQueueAcknowledged
+                        ? 'Prompt queued until this conversation is free.'
+                        : 'Prompt remains durable; retry server queueing from the queue panel.',
+                    'info'
+                );
             }
         } else {
             request.serverQueueTerminalObserved = true;
@@ -36028,10 +36820,9 @@ async function handleSendPrompt(options = {}) {
                 setFinishedThinkingCardForSession(request.sessionId, null);
             }
             setLiveChatRequestForSession(request.sessionId, null);
-            if (request.admissionRetrySuppressed) {
-                renderChatTaskQueuePanel();
-                refreshChatSessionTabActivityIndicators();
-            }
+            renderChatTaskQueuePanel();
+            refreshChatSessionTabActivityIndicators();
+            updateSendButtonForCurrentChatState();
             if (request.sessionId === activeChatSessionId) {
                 void refreshConversationRuntimeCostSnapshot({
                     observeRequestId: request.clientRequestId,
@@ -36045,14 +36836,7 @@ async function handleSendPrompt(options = {}) {
         if (request.serverQueueTerminalObserved) {
             publishChatPromptQueueChange('turn_terminal');
         }
-        if (request.admissionDeferred && !request.admissionRetrySuppressed) {
-            setTimeout(
-                () => scheduleQueuedChatPromptDrain(),
-                request.admissionRetryAfterMs || 1000
-            );
-        } else if (!request.admissionRetrySuppressed) {
-            scheduleQueuedChatPromptDrain();
-        }
+        syncChatPromptQueuePolling();
     }
 }
 
@@ -39794,13 +40578,10 @@ export function __testOnly_resetChatRequestState() {
     renderActiveUploadUi();
     renderPendingAttachmentState();
     queuedChatPrompts = [];
-    if (queuedChatPromptDrainTimer !== null) {
-        clearTimeout(queuedChatPromptDrainTimer);
-        queuedChatPromptDrainTimer = null;
-    }
-    queuedChatPromptDrainPromise = null;
-    queuedChatPromptDrainRequested = false;
+    stopChatPromptQueuePolling();
+    chatPromptQueuePollInFlight = false;
     queuedChatPromptClaimsInFlight.clear();
+    queuedChatPromptSubmissionsInFlight.clear();
     chatPromptQueueAdmissionServerInstanceId = null;
     for (const timer of queuedChatPromptSyncTimers.values()) {
         clearTimeout(timer);

--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -51,12 +51,23 @@ let _selectedTaskGroupIds = new Set();  // Selected ontology-backed task groups.
 let _taskGroupOptions = [];
 const _taskGroupDisplayNameCache = new Map();
 const _taskGroupNameFetchInFlight = new Set();
+let _taskQueueActivity = [];
+let _taskQueueActivityError = '';
+let _taskQueueActivityLoadPromise = null;
+let _taskQueueActivityPollTimerId = null;
+let _taskQueueActivityGeneration = 0;
+let _taskPanelAuthenticated = null;
+const _taskExecutionLaunchesInFlight = new Set();
 
 const TASK_GROUP_STORAGE_KEY_PREFIX = 'von_task_group_filter_v1';
+const TASK_EXECUTION_LAUNCH_STORAGE_KEY_PREFIX = 'von_task_execution_launch_v1';
 const TASK_LIST_LIMIT = '500';
 const GLOBAL_TASK_PAGE_SIZE = 50;
 const TASK_PANEL_LOAD_TELEMETRY_SCHEMA_VERSION = 'task_panel_load_telemetry.v1';
 const TASK_PANEL_ORG_SWITCH_HANDLER_KEY = '__vonTaskPanelOrgSwitchHandler';
+const TASK_PANEL_AUTH_STATUS_HANDLER_KEY = '__vonTaskPanelAuthStatusHandler';
+const TASK_QUEUE_ACTIVITY_LISTENER_KEY = '__vonTaskQueueActivityListener';
+const TASK_QUEUE_ACTIVITY_POLL_INTERVAL_MS = 5000;
 const TASK_EXTERNAL_RESOURCE_ACTION_HREF_PATTERN = /^\/api\/tasks\/[A-Za-z0-9%_-]+\/external-resource-actions\/[A-Za-z0-9._%-]+$/;
 
 // Constants
@@ -156,10 +167,11 @@ async function ensureTaskOrganisationOptionsLoaded() {
     }
 }
 
-function handleTaskPanelOrganisationSwitch(event) {
-    _activeOrganisationConceptId = normaliseTaskConceptId(
-        event?.detail?.organisation_id || '',
-    );
+function resetTaskPanelScopedState(activeOrganisationConceptId, { actorChanged = false } = {}) {
+    _taskQueueActivityGeneration += 1;
+    stopTaskQueueActivityPolling();
+    _taskQueueActivityLoadPromise = null;
+    _activeOrganisationConceptId = activeOrganisationConceptId;
     _globalTaskLoadGeneration += 1;
     _isLoading = false;
     _tasks = [];
@@ -170,15 +182,44 @@ function handleTaskPanelOrganisationSwitch(event) {
     _globalTaskTotal = null;
     _hiddenBulkTaskTotal = 0;
     _hiddenBulkTaskCollections = [];
+    _taskQueueActivity = [];
+    _taskQueueActivityError = '';
+    if (actorChanged) {
+        _taskOrganisationOptions = [];
+        _taskOrganisationOptionsLoaded = false;
+        _taskGroupDisplayNameCache.clear();
+        _taskGroupNameFetchInFlight.clear();
+    }
     loadTaskGroupSelectionFromStorage();
+}
+
+function refreshTaskPanelAfterScopeChange({ allowLoads = true } = {}) {
+    renderTaskList();
+    renderTaskQueueActivity();
+    refreshTaskExecutionButtonStates();
+    updateTaskCountBadge();
+
+    if (!allowLoads) return;
 
     if (_isGlobalTabMode) {
-        renderTaskList();
-        void loadGlobalTasks();
+        void Promise.all([loadGlobalTasks(), loadTaskQueueActivity()]);
     } else if (_isVisible) {
-        renderTaskList();
         void refreshTasks();
     }
+}
+
+function handleTaskPanelOrganisationSwitch(event) {
+    resetTaskPanelScopedState(normaliseTaskConceptId(
+        event?.detail?.organisation_id || '',
+    ));
+    refreshTaskPanelAfterScopeChange();
+}
+
+function handleTaskPanelAuthStatusChange(event) {
+    const authenticated = event?.detail?.authenticated === true;
+    _taskPanelAuthenticated = authenticated;
+    resetTaskPanelScopedState(authenticated ? undefined : '', { actorChanged: true });
+    refreshTaskPanelAfterScopeChange({ allowLoads: authenticated });
 }
 
 function ensureTaskPanelOrganisationSwitchListener() {
@@ -188,6 +229,82 @@ function ensureTaskPanelOrganisationSwitchListener() {
     }
     document[TASK_PANEL_ORG_SWITCH_HANDLER_KEY] = handleTaskPanelOrganisationSwitch;
     document.addEventListener('orgSwitched', handleTaskPanelOrganisationSwitch);
+}
+
+function ensureTaskPanelAuthStatusListener() {
+    const previousHandler = document[TASK_PANEL_AUTH_STATUS_HANDLER_KEY];
+    if (typeof previousHandler === 'function') {
+        document.removeEventListener('authStatusChanged', previousHandler);
+    }
+    document[TASK_PANEL_AUTH_STATUS_HANDLER_KEY] = handleTaskPanelAuthStatusChange;
+    document.addEventListener('authStatusChanged', handleTaskPanelAuthStatusChange);
+}
+
+function isGlobalTaskQueueActivityViewActive() {
+    if (!_isGlobalTabMode || !_globalTasksContainer) return false;
+    if (document.visibilityState === 'hidden') return false;
+    if (document.body?.dataset?.activeTab === 'globalTasksTab') return true;
+    return _globalTasksContainer.closest('.tab-content')?.classList.contains('active') === true;
+}
+
+function hasAcknowledgedTaskLaunch() {
+    return _tasks.some((task) => {
+        const taskId = getTaskId(task);
+        return taskId && getStoredTaskLaunchState(taskId)?.acknowledged === true;
+    });
+}
+
+function shouldObserveTaskQueueActivity() {
+    if (_taskPanelAuthenticated === false) return false;
+    if (document.visibilityState === 'hidden') return false;
+    return isGlobalTaskQueueActivityViewActive() || hasAcknowledgedTaskLaunch();
+}
+
+function stopTaskQueueActivityPolling() {
+    if (_taskQueueActivityPollTimerId === null) return;
+    clearTimeout(_taskQueueActivityPollTimerId);
+    _taskQueueActivityPollTimerId = null;
+}
+
+function syncTaskQueueActivityPolling() {
+    if (!shouldObserveTaskQueueActivity()) {
+        stopTaskQueueActivityPolling();
+        return;
+    }
+    if (_taskQueueActivityPollTimerId !== null || _taskQueueActivityLoadPromise) {
+        return;
+    }
+    _taskQueueActivityPollTimerId = window.setTimeout(async () => {
+        _taskQueueActivityPollTimerId = null;
+        try {
+            await loadTaskQueueActivity();
+        } finally {
+            syncTaskQueueActivityPolling();
+        }
+    }, TASK_QUEUE_ACTIVITY_POLL_INTERVAL_MS);
+}
+
+function handleTaskQueueActivityVisibilityChange() {
+    syncTaskQueueActivityPolling();
+}
+
+function handleTaskQueueActivityTabActivation() {
+    syncTaskQueueActivityPolling();
+}
+
+function ensureTaskQueueActivityPollingListeners() {
+    const previous = document[TASK_QUEUE_ACTIVITY_LISTENER_KEY];
+    if (previous && typeof previous === 'object') {
+        document.removeEventListener('von:tab-activated', previous.tabActivation);
+        document.removeEventListener('visibilitychange', previous.visibilityChange);
+    }
+    const listeners = {
+        tabActivation: handleTaskQueueActivityTabActivation,
+        visibilityChange: handleTaskQueueActivityVisibilityChange,
+    };
+    document[TASK_QUEUE_ACTIVITY_LISTENER_KEY] = listeners;
+    document.addEventListener('von:tab-activated', listeners.tabActivation);
+    document.addEventListener('visibilitychange', listeners.visibilityChange);
 }
 
 function getTaskTypeOptions() {
@@ -577,6 +694,7 @@ export function initializeTaskPanel() {
     }
     loadTaskGroupSelectionFromStorage();
     ensureTaskPanelOrganisationSwitchListener();
+    ensureTaskPanelAuthStatusListener();
     renderTaskGroupFilterControls();
 
     // Set up close button
@@ -641,6 +759,7 @@ export function showTaskPanel(options = {}) {
     if (_panelEl) {
         loadTaskGroupSelectionFromStorage();
         _isGlobalTabMode = false;
+        syncTaskQueueActivityPolling();
         _taskListEl = document.getElementById('taskList') || _taskListEl;
         _panelEl.classList.remove('hidden');
         _panelEl.setAttribute('aria-hidden', 'false');
@@ -697,6 +816,8 @@ async function openGlobalTasks() {
     _taskDetailState = {};
     _selectedTaskId = '';
     ensureTaskPanelOrganisationSwitchListener();
+    ensureTaskPanelAuthStatusListener();
+    ensureTaskQueueActivityPollingListeners();
 
     // Initialize the global tasks container if needed
     if (!_globalTasksContainer) {
@@ -720,7 +841,11 @@ async function openGlobalTasks() {
     renderGlobalTasksTabContent();
     markTaskLoadStage(telemetry, 'shell_rendered', 'Task controls ready');
     renderTaskLoadProgress('Task controls ready', telemetry);
-    await loadGlobalTasks({ telemetry });
+    await Promise.all([
+        loadGlobalTasks({ telemetry }),
+        loadTaskQueueActivity(),
+    ]);
+    syncTaskQueueActivityPolling();
 }
 
 export function showGlobalTasks() {
@@ -800,6 +925,7 @@ function renderGlobalTasksTabContent() {
             <div id="globalTaskSummary" class="global-task-summary" aria-live="polite"></div>
             <div id="globalBulkTaskVisibilityControl" class="bulk-task-visibility-control hidden" aria-live="polite"></div>
             <div id="globalTaskLoadProgress" class="task-load-progress" aria-live="polite"></div>
+            <section id="globalTaskQueueActivity" class="task-detail-section" aria-live="polite"></section>
             <div class="global-tasks-create">
                 <input type="text" id="globalNewTaskTitle" class="task-input" placeholder="Task title...">
                 <textarea id="globalNewTaskDescription" class="task-textarea" placeholder="Task description..." rows="2"></textarea>
@@ -902,7 +1028,9 @@ function renderGlobalTasksTabContent() {
 
     const refreshBtn = _globalTasksContainer.querySelector('#refreshGlobalTasksBtn');
     if (refreshBtn) {
-        refreshBtn.addEventListener('click', () => loadGlobalTasks());
+        refreshBtn.addEventListener('click', () => {
+            void Promise.all([loadGlobalTasks(), loadTaskQueueActivity()]);
+        });
     }
 
     const createBtn = _globalTasksContainer.querySelector('#globalCreateTaskBtn');
@@ -915,6 +1043,7 @@ function renderGlobalTasksTabContent() {
     renderTaskGroupFilterControls();
     renderGlobalTaskSummary();
     renderBulkTaskVisibilityControls();
+    renderTaskQueueActivity();
     renderGlobalTaskInspector();
 }
 
@@ -1290,6 +1419,156 @@ function renderGlobalTaskSummary(filteredTasks = getFilteredTasks()) {
     `;
 }
 
+function normaliseTaskQueueActivityItem(item, kind) {
+    if (!item || typeof item !== 'object') return null;
+    const queueId = typeof item.queue_id === 'string' ? item.queue_id.trim() : '';
+    if (!queueId) return null;
+    return {
+        ...item,
+        queue_id: queueId,
+        activity_kind: kind,
+    };
+}
+
+function getActiveTaskExecutionIdsFromQueueActivity(items = _taskQueueActivity) {
+    return new Set(
+        items
+            .filter((item) => (
+                item?.activity_kind === 'active'
+                && ['queued', 'in_progress'].includes(item?.status)
+                && typeof item?.task_concept_id === 'string'
+                && item.task_concept_id.trim()
+            ))
+            .map((item) => item.task_concept_id.trim()),
+    );
+}
+
+function taskQueueActivitySortValue(item) {
+    const raw = item?.updated_at || item?.created_at || item?.queued_at || '';
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function loadTaskQueueActivity() {
+    if (!_isGlobalTabMode && !hasAcknowledgedTaskLaunch()) return;
+    if (_taskQueueActivityLoadPromise) return _taskQueueActivityLoadPromise;
+    const requestGeneration = _taskQueueActivityGeneration;
+    const loadPromise = (async () => {
+        try {
+            const response = await getJson('/von/api/chat_prompt_queue');
+            if (requestGeneration !== _taskQueueActivityGeneration) return;
+            const active = Array.isArray(response?.items) ? response.items : [];
+            const recentFailed = Array.isArray(response?.recent_failed_items)
+                ? response.recent_failed_items
+                : [];
+            const recentFailedQueueIds = new Set(
+                recentFailed
+                    .map((item) => (
+                        typeof item?.queue_id === 'string' ? item.queue_id.trim() : ''
+                    ))
+                    .filter(Boolean),
+            );
+            const seen = new Set();
+            const normalisedActivity = [
+                ...active
+                    .filter((item) => !recentFailedQueueIds.has(
+                        typeof item?.queue_id === 'string' ? item.queue_id.trim() : '',
+                    ))
+                    .map((item) => normaliseTaskQueueActivityItem(item, 'active')),
+                ...recentFailed.map((item) => normaliseTaskQueueActivityItem(item, 'recent_failed')),
+            ]
+                .filter((item) => {
+                    if (!item || seen.has(item.queue_id)) return false;
+                    seen.add(item.queue_id);
+                    return true;
+                })
+                .sort((left, right) => taskQueueActivitySortValue(right) - taskQueueActivitySortValue(left));
+            _taskQueueActivity = normalisedActivity.slice(0, 12);
+            _taskQueueActivityError = '';
+            reconcileAcknowledgedTaskLaunches(normalisedActivity);
+        } catch (err) {
+            if (requestGeneration !== _taskQueueActivityGeneration) return;
+            console.debug('[taskPanel] Failed to load queue activity:', err);
+            _taskQueueActivity = [];
+            _taskQueueActivityError = 'Queue activity is temporarily unavailable.';
+        }
+        if (requestGeneration !== _taskQueueActivityGeneration) return;
+        renderTaskQueueActivity();
+        refreshTaskExecutionButtonStates();
+    })().finally(() => {
+        if (_taskQueueActivityLoadPromise === loadPromise) {
+            _taskQueueActivityLoadPromise = null;
+            if (requestGeneration === _taskQueueActivityGeneration) {
+                syncTaskQueueActivityPolling();
+            }
+        }
+    });
+    _taskQueueActivityLoadPromise = loadPromise;
+    return loadPromise;
+}
+
+function renderTaskQueueActivity() {
+    const activityEl = _globalTasksContainer?.querySelector('#globalTaskQueueActivity');
+    if (!activityEl) return;
+    if (_taskQueueActivityError) {
+        activityEl.innerHTML = `
+            <h3>Activity</h3>
+            <p class="task-detail-error">${escapeHtml(_taskQueueActivityError)}</p>
+        `;
+        return;
+    }
+    if (_taskQueueActivity.length === 0) {
+        activityEl.innerHTML = `
+            <h3>Activity</h3>
+            <p class="task-empty-inline">No active or recently failed Von work.</p>
+        `;
+        return;
+    }
+    activityEl.innerHTML = `
+        <h3>Activity</h3>
+        <div class="task-timeline">
+            ${_taskQueueActivity.map((item) => {
+                const status = String(item.status || 'queued').trim() || 'queued';
+                const conversationLabel = String(
+                    item.session_name
+                    || (item.session_id ? `Conversation ${String(item.session_id).slice(0, 8)}` : '')
+                    || 'Conversation unavailable',
+                );
+                const taskLabel = String(
+                    item.task_concept_id
+                    || item.prompt_raw
+                    || 'Queued conversation turn',
+                ).trim().slice(0, 160);
+                const conversationControl = item.session_id
+                    ? `<button type="button" class="task-conversation-link task-queue-conversation-link"
+                            data-session-id="${escapeHtml(item.session_id)}"
+                            title="Open conversation: ${escapeHtml(conversationLabel)}">
+                            ${escapeHtml(conversationLabel)}
+                       </button>`
+                    : `<span>${escapeHtml(conversationLabel)}</span>`;
+                return `
+                    <div class="task-timeline-entry" data-queue-id="${escapeHtml(item.queue_id)}">
+                        <div class="task-timeline-marker" aria-hidden="true"></div>
+                        <div class="task-timeline-content">
+                            <strong>${escapeHtml(status.replace(/_/g, ' '))}</strong>
+                            <span>${escapeHtml(taskLabel)}</span>
+                            ${conversationControl}
+                            <time>${escapeHtml(formatDateTimeOrDash(item.updated_at || item.created_at))}</time>
+                        </div>
+                    </div>
+                `;
+            }).join('')}
+        </div>
+    `;
+    activityEl.querySelectorAll('.task-queue-conversation-link').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void openTaskConversation(event.currentTarget.dataset.sessionId);
+        });
+    });
+}
+
 function renderGlobalTaskPagination() {
     const paginationEl = _globalTasksContainer?.querySelector('#globalTaskPagination');
     if (!paginationEl) return;
@@ -1523,6 +1802,286 @@ function renderTaskDiscussButton(task, className = '') {
     const title = String(task?.title || 'this task').trim() || 'this task';
     return `<button type="button" class="task-discuss-btn ${className}" data-concept-id="${escapeHtml(taskId)}"
         data-concept-name="${escapeHtml(title)}" title="Discuss this task with Von">Discuss</button>`;
+}
+
+function canExecuteTaskWithVon(task) {
+    const currentUserId = getCurrentUserConceptId();
+    return Boolean(
+        task
+        && task.assignee_concept_id === '#V#von_system'
+        && task.created_by_concept_id === currentUserId
+        && task.originating_conversation_id
+        && task.conversation_session_id
+        && ['pending', 'in_progress'].includes(task.status),
+    );
+}
+
+function renderTaskExecuteWithVonButton(task, className = '') {
+    if (!canExecuteTaskWithVon(task)) return '';
+    const taskId = String(getTaskId(task) || '').trim();
+    if (!taskId) return '';
+    const conversationLabel = String(
+        task.conversation_name || task.conversation_session_id || 'originating conversation',
+    ).trim();
+    const executionActive = isTaskExecutionLaunchSuppressed(taskId);
+    return `<button type="button" class="task-execute-with-von-btn ${className}"
+        data-task-id="${escapeHtml(taskId)}"
+        title="${executionActive ? 'Von work is already active' : `Execute with Von in ${escapeHtml(conversationLabel)}`}"
+        ${executionActive ? 'disabled aria-busy="true"' : ''}>${executionActive ? 'Von work active' : 'Execute with Von'}</button>`;
+}
+
+function createTaskLaunchRequestId() {
+    if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+        return globalThis.crypto.randomUUID();
+    }
+    return `task-launch-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getTaskExecutionLaunchStorageKey(taskId) {
+    const actorId = getCurrentUserConceptId() || 'unknown-actor';
+    const organisationId = getCurrentOrganisationConceptId() || 'unknown-organisation';
+    return [
+        TASK_EXECUTION_LAUNCH_STORAGE_KEY_PREFIX,
+        encodeURIComponent(actorId),
+        encodeURIComponent(organisationId),
+        encodeURIComponent(taskId),
+    ].join(':');
+}
+
+function getOrCreateTaskLaunchRequestId(taskId) {
+    const storageKey = getTaskExecutionLaunchStorageKey(taskId);
+    try {
+        const existing = localStorage.getItem(storageKey);
+        if (typeof existing === 'string' && existing.trim()) {
+            try {
+                const parsed = JSON.parse(existing);
+                if (
+                    parsed
+                    && typeof parsed === 'object'
+                    && typeof parsed.launch_request_id === 'string'
+                    && parsed.launch_request_id.trim()
+                ) {
+                    return parsed.launch_request_id.trim();
+                }
+            } catch (_) {
+                // Pre-structured values remain valid durable launch identities.
+            }
+            return existing.trim();
+        }
+    } catch (_) {
+        // The request remains idempotent for this page lifetime without storage.
+    }
+    const launchRequestId = createTaskLaunchRequestId();
+    try {
+        localStorage.setItem(storageKey, JSON.stringify({
+            launch_request_id: launchRequestId,
+            acknowledged: false,
+            canonical_active_observed: false,
+        }));
+    } catch (_) {
+        // Storage can be unavailable in private or restricted browser contexts.
+    }
+    return launchRequestId;
+}
+
+function getStoredTaskLaunchState(taskId) {
+    const storageKey = getTaskExecutionLaunchStorageKey(taskId);
+    try {
+        const raw = localStorage.getItem(storageKey);
+        if (typeof raw !== 'string' || !raw.trim()) return null;
+        try {
+            const parsed = JSON.parse(raw);
+            if (
+                parsed
+                && typeof parsed === 'object'
+                && typeof parsed.launch_request_id === 'string'
+                && parsed.launch_request_id.trim()
+            ) {
+                return {
+                    launchRequestId: parsed.launch_request_id.trim(),
+                    acknowledged: parsed.acknowledged === true,
+                    canonicalActiveObserved: (
+                        parsed.canonical_active_observed === true
+                    ),
+                };
+            }
+        } catch (_) {
+            return {
+                launchRequestId: raw.trim(),
+                acknowledged: false,
+                canonicalActiveObserved: false,
+            };
+        }
+    } catch (_) {
+        return null;
+    }
+    return null;
+}
+
+function markTaskLaunchAcknowledged(
+    taskId,
+    launchRequestId,
+    { canonicalActiveObserved = false } = {},
+) {
+    const storageKey = getTaskExecutionLaunchStorageKey(taskId);
+    try {
+        const current = getStoredTaskLaunchState(taskId);
+        if (current?.launchRequestId !== launchRequestId) return;
+        localStorage.setItem(storageKey, JSON.stringify({
+            launch_request_id: launchRequestId,
+            acknowledged: true,
+            canonical_active_observed: (
+                current.canonicalActiveObserved === true
+                || canonicalActiveObserved === true
+            ),
+        }));
+    } catch (_) {
+        // The active queue observer still suppresses duplicate launches.
+    }
+}
+
+function markTaskLaunchCanonicalActiveObserved(taskId, launchState) {
+    if (!launchState?.launchRequestId || launchState.canonicalActiveObserved) return;
+    const storageKey = getTaskExecutionLaunchStorageKey(taskId);
+    try {
+        localStorage.setItem(storageKey, JSON.stringify({
+            launch_request_id: launchState.launchRequestId,
+            acknowledged: launchState.acknowledged === true,
+            canonical_active_observed: true,
+        }));
+    } catch (_) {
+        // Queue activity still suppresses duplicate launches for this page.
+    }
+}
+
+function clearTaskLaunchRequestId(taskId, launchRequestId = null) {
+    const storageKey = getTaskExecutionLaunchStorageKey(taskId);
+    try {
+        const current = getStoredTaskLaunchState(taskId);
+        if (
+            current
+            && (!launchRequestId || current.launchRequestId === launchRequestId)
+        ) {
+            localStorage.removeItem(storageKey);
+        }
+    } catch (_) {
+        // A successful server response is sufficient if cleanup is unavailable.
+    }
+}
+
+function isTaskExecutionLaunchSuppressed(taskId) {
+    if (_taskExecutionLaunchesInFlight.has(taskId)) return true;
+    if (getStoredTaskLaunchState(taskId)?.acknowledged === true) return true;
+    return getActiveTaskExecutionIdsFromQueueActivity().has(taskId);
+}
+
+function reconcileAcknowledgedTaskLaunches(activity = _taskQueueActivity) {
+    const activeTaskIds = getActiveTaskExecutionIdsFromQueueActivity(activity);
+    const terminalTaskIds = new Set(
+        activity
+            .filter((item) => (
+                item?.activity_kind === 'recent_failed'
+                || ['completed', 'failed', 'cancelled'].includes(item?.status)
+            ))
+            .map((item) => (
+                typeof item?.task_concept_id === 'string'
+                    ? item.task_concept_id.trim()
+                    : ''
+            ))
+            .filter(Boolean),
+    );
+    _tasks.forEach((task) => {
+        const taskId = getTaskId(task);
+        const launchState = taskId ? getStoredTaskLaunchState(taskId) : null;
+        if (launchState?.acknowledged !== true) return;
+        if (activeTaskIds.has(taskId)) {
+            markTaskLaunchCanonicalActiveObserved(taskId, launchState);
+            return;
+        }
+        if (
+            terminalTaskIds.has(taskId)
+            || launchState.canonicalActiveObserved === true
+        ) {
+            clearTaskLaunchRequestId(taskId, launchState.launchRequestId);
+        }
+    });
+}
+
+function refreshTaskExecutionButtonStates() {
+    document.querySelectorAll('.task-execute-with-von-btn').forEach((button) => {
+        const taskId = String(button.dataset.taskId || '').trim();
+        const suppressed = taskId && isTaskExecutionLaunchSuppressed(taskId);
+        button.disabled = Boolean(suppressed);
+        button.textContent = suppressed ? 'Von work active' : 'Execute with Von';
+        button.setAttribute('aria-busy', suppressed ? 'true' : 'false');
+    });
+}
+
+function setTaskExecutionButtonsDisabled(taskId, disabled) {
+    document.querySelectorAll('.task-execute-with-von-btn').forEach((button) => {
+        if (button.dataset.taskId !== taskId) return;
+        const suppressed = disabled || isTaskExecutionLaunchSuppressed(taskId);
+        button.disabled = suppressed;
+        button.textContent = disabled
+            ? 'Queuing…'
+            : (suppressed ? 'Von work active' : 'Execute with Von');
+        button.setAttribute('aria-busy', suppressed ? 'true' : 'false');
+    });
+}
+
+async function executeTaskWithVon(taskId) {
+    const cleanedTaskId = String(taskId || '').trim();
+    if (!cleanedTaskId || _taskExecutionLaunchesInFlight.has(cleanedTaskId)) return;
+    _taskExecutionLaunchesInFlight.add(cleanedTaskId);
+    setTaskExecutionButtonsDisabled(cleanedTaskId, true);
+    const launchRequestId = getOrCreateTaskLaunchRequestId(cleanedTaskId);
+    const scopeGenerationAtStart = _taskQueueActivityGeneration;
+    try {
+        const response = await postJson(
+            `/api/tasks/${encodeURIComponent(cleanedTaskId)}/execute-with-von`,
+            { launch_request_id: launchRequestId },
+        );
+        if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
+        const queueStatus = String(response?.queue_item?.status || '').trim().toLowerCase();
+        if (['completed', 'failed', 'cancelled'].includes(queueStatus)) {
+            // A retry after a lost response can replay an attempt that already
+            // reached terminal state. Do not leave the local launch fence set
+            // when no active queue row can ever be observed to clear it.
+            clearTaskLaunchRequestId(cleanedTaskId, launchRequestId);
+        } else {
+            markTaskLaunchAcknowledged(cleanedTaskId, launchRequestId, {
+                canonicalActiveObserved: ['queued', 'in_progress'].includes(queueStatus),
+            });
+        }
+        const conversationName = response?.task?.conversation_name;
+        if (queueStatus === 'completed') {
+            showToast(
+                conversationName
+                    ? `Von work already completed in ${conversationName}`
+                    : 'Von work already completed',
+                'success',
+            );
+        } else if (queueStatus === 'failed') {
+            showToast('Von work failed; the task can be retried', 'error');
+        } else if (queueStatus === 'cancelled') {
+            showToast('Von work was cancelled; the task can be retried', 'info');
+        } else {
+            showToast(
+                conversationName
+                    ? `Von work queued in ${conversationName}`
+                    : 'Von work queued',
+                'success',
+            );
+        }
+        await loadTaskQueueActivity();
+    } catch (err) {
+        if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
+        console.error('[taskPanel] Failed to execute task with Von:', err);
+        showToast('Failed to queue Von task execution', 'error');
+    } finally {
+        _taskExecutionLaunchesInFlight.delete(cleanedTaskId);
+        setTaskExecutionButtonsDisabled(cleanedTaskId, false);
+    }
 }
 
 function normaliseTaskConceptId(value) {
@@ -2254,6 +2813,7 @@ function renderTaskInspector(task, detailState) {
                 <div class="task-inspector-badges">
                     <span class="task-status-badge">${escapeHtml(getStatusInfo(detailTask.status).label)}</span>
                     <span class="task-priority-chip">${escapeHtml(getPriorityInfo(detailTask.priority).label)}</span>
+                    ${renderTaskExecuteWithVonButton(detailTask, 'task-inspector-execute-btn')}
                     ${renderTaskDiscussButton(detailTask, 'task-inspector-discuss-btn')}
                 </div>
             </div>
@@ -2606,6 +3166,7 @@ function renderTaskItem(task) {
                     🔗 ${linksCount}
                 </span>
                 <div class="task-actions">
+                    ${renderTaskExecuteWithVonButton(task)}
                     ${renderTaskDiscussButton(task)}
                     <button class="task-detail-toggle-btn" data-task-id="${taskId}" title="${_isGlobalTabMode ? 'Inspect task details' : 'Show task details'}">
                         ${_isGlobalTabMode ? 'Inspect' : (detailState.expanded ? 'Hide details' : 'Details')}
@@ -2810,6 +3371,19 @@ async function addTaskAttachment(taskId, panelEl) {
     await loadTaskDetails(taskId, { refreshList: true });
 }
 
+async function openTaskConversation(sessionId) {
+    const cleanedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    if (!cleanedSessionId) return;
+    activateTab('chatTab');
+    try {
+        const { switchToChatSession } = await import('../chatTab.js');
+        await switchToChatSession(cleanedSessionId);
+    } catch (err) {
+        console.warn('[taskPanel] Failed to switch to conversation:', err);
+        showToast('Could not open conversation', 'error');
+    }
+}
+
 /**
  * Attach event listeners to task items.
  */
@@ -2822,6 +3396,14 @@ function attachTaskEventListeners() {
     if (roots.length === 0) return;
 
     roots.forEach((root) => {
+        root.querySelectorAll('.task-execute-with-von-btn').forEach((button) => {
+            button.addEventListener('click', async (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                await executeTaskWithVon(event.currentTarget.dataset.taskId);
+            });
+        });
+
         root.querySelectorAll('.task-concept-link').forEach((btn) => {
             btn.addEventListener('click', (e) => {
                 e.preventDefault();
@@ -2949,16 +3531,7 @@ function attachTaskEventListeners() {
                 e.preventDefault();
                 e.stopPropagation();
                 const sessionId = e.currentTarget.dataset.sessionId;
-                if (sessionId) {
-                    activateTab('chatTab');
-                    try {
-                        const { switchToChatSession } = await import('../chatTab.js');
-                        await switchToChatSession(sessionId);
-                    } catch (err) {
-                        console.warn('[taskPanel] Failed to switch to conversation:', err);
-                        showToast('Could not open conversation', 'error');
-                    }
-                }
+                await openTaskConversation(sessionId);
             });
         });
 
@@ -3007,6 +3580,7 @@ async function handleCreateTask() {
     const titleInput = document.getElementById('newTaskTitle');
     const descInput = document.getElementById('newTaskDescription');
     const prioritySelect = document.getElementById('newTaskPriority');
+    const assigneeSelect = document.getElementById('newTaskAssignee');
 
     if (!titleInput || !descInput) return;
 
@@ -3031,6 +3605,10 @@ async function handleCreateTask() {
             priority: prioritySelect?.value || 'medium',
         };
 
+        if (assigneeSelect?.value === '#V#von_system') {
+            payload.assignee_concept_id = '#V#von_system';
+        }
+
         // Link to current conversation if available
         if (_currentSessionId) {
             payload.session_id = _currentSessionId;
@@ -3042,6 +3620,7 @@ async function handleCreateTask() {
         titleInput.value = '';
         descInput.value = '';
         if (prioritySelect) prioritySelect.value = 'medium';
+        if (assigneeSelect) assigneeSelect.value = '';
 
         showToast('Task created', 'success');
 

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -221,9 +221,9 @@
       </div>
     </div>
 
-    <section id="chatTaskQueuePanel" class="chat-task-queue-panel hidden" aria-live="polite" aria-label="Queued tasks">
+    <section id="chatTaskQueuePanel" class="chat-task-queue-panel hidden" aria-live="polite" aria-label="Queued prompts for this conversation">
       <div class="chat-task-queue-header">
-        <span class="chat-task-queue-title">Queued tasks</span>
+        <span class="chat-task-queue-title">Queued prompts</span>
         <span id="chatTaskQueueCount" class="chat-task-queue-count">0 queued</span>
       </div>
       <div id="chatTaskQueueList" class="chat-task-queue-list"></div>
@@ -387,6 +387,10 @@
         <textarea id="newTaskDescription" class="task-textarea" rows="2"
           placeholder="Task description…" aria-label="Task description" maxlength="2000"></textarea>
         <div class="task-create-row">
+          <select id="newTaskAssignee" class="task-select" aria-label="Assignee">
+            <option value="" selected>Unassigned</option>
+            <option value="#V#von_system">Assign to Von</option>
+          </select>
           <select id="newTaskPriority" class="task-select" aria-label="Priority">
             <option value="low">🟢 Low</option>
             <option value="medium" selected>🟡 Medium</option>

--- a/tests/backend/test_chat_prompt_queue_dispatch_service.py
+++ b/tests/backend/test_chat_prompt_queue_dispatch_service.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask, jsonify, request, session
+
+from src.backend.services import chat_prompt_queue_dispatch_service as dispatch_service
+from src.backend.services import task_execution_service
+
+
+@pytest.fixture(autouse=True)
+def isolate_dispatcher_queue_reconciliation(monkeypatch):
+    """Keep dispatch-unit tests independent from a live queue database."""
+
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_terminal_reconciliation",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "backfill_linked_terminal_reconciliation",
+        lambda **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_launch_reconciliation",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reconcile_next_server_dispatch_handoff",
+        lambda: None,
+    )
+
+
+def _reserved_record() -> dict[str, object]:
+    return {
+        "queue_id": "queue-1",
+        "dispatch_reservation_token": "reservation-1",
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": None,
+        "namespace": "#V#user",
+        "session_id": "session-1",
+        "session_name": "Conversation one",
+        "prompt_raw": "Continue this work",
+        "client_request_id": "request-1",
+        "attempt_id": "attempt-1",
+        "execution_envelope": {"language": "en-NZ"},
+    }
+
+
+def test_dispatcher_leaves_accepted_reservation_for_admission(
+    monkeypatch,
+) -> None:
+    reserved = _reserved_record()
+    released: list[dict[str, object]] = []
+    failed: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: dict(reserved),
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "release_server_dispatch_reservation",
+        lambda **kwargs: released.append(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **kwargs: failed.append(kwargs) or True,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, record: dispatch_service.ChatPromptDispatchOutcome(
+            accepted=record["queue_id"] == "queue-1"
+        ),
+    )
+
+    assert dispatcher.run_once() is True
+    assert released == []
+    assert failed == []
+    assert dispatcher.snapshot()["accepted_count"] == 1
+
+
+def test_blocked_handoff_falls_through_to_unrelated_ready_dispatch(
+    monkeypatch,
+) -> None:
+    reserved = _reserved_record()
+    submissions: list[str] = []
+
+    def defer_blocked_handoff():
+        raise dispatch_service.chat_prompt_queue_service.ConversationTurnAlreadyActive(
+            "legacy source is still executing",
+            queue_id="source-active",
+        )
+
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reconcile_next_server_dispatch_handoff",
+        defer_blocked_handoff,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: dict(reserved),
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, record: (
+            submissions.append(str(record["queue_id"]))
+            or dispatch_service.ChatPromptDispatchOutcome(accepted=True)
+        ),
+    )
+
+    assert dispatcher.run_once() is True
+    assert submissions == ["queue-1"]
+    snapshot = dispatcher.snapshot()
+    assert snapshot["handoff_reconciliation_failed_count"] == 1
+    assert snapshot["accepted_count"] == 1
+
+
+def test_dispatcher_releases_exact_retryable_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: _reserved_record(),
+    )
+    released: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "release_server_dispatch_reservation",
+        lambda **kwargs: released.append(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **_kwargs: False,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, _record: dispatch_service.ChatPromptDispatchOutcome(
+            accepted=False,
+            retryable=True,
+            retry_after_seconds=3,
+            error="capacity",
+        ),
+    )
+
+    assert dispatcher.run_once() is True
+    assert released == [
+        {
+            "queue_id": "queue-1",
+            "dispatch_reservation_token": "reservation-1",
+            "server_instance_id": dispatch_service.SERVER_INSTANCE_ID,
+            "retry_after_seconds": 3,
+            "error": "capacity",
+        }
+    ]
+
+
+def test_dispatcher_terminalises_non_retryable_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: _reserved_record(),
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "release_server_dispatch_reservation",
+        lambda **_kwargs: False,
+    )
+    failed: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **kwargs: failed.append(kwargs) or True,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, _record: {
+            "accepted": False,
+            "retryable": False,
+            "error": "authority revoked",
+        },
+    )
+
+    assert dispatcher.run_once() is True
+    assert failed == [
+        {
+            "queue_id": "queue-1",
+            "dispatch_reservation_token": "reservation-1",
+            "server_instance_id": dispatch_service.SERVER_INSTANCE_ID,
+            "error": "authority revoked",
+        }
+    ]
+
+
+def test_dispatcher_terminalises_exact_linked_execution_only_after_queue_cas(
+    monkeypatch,
+) -> None:
+    record = _reserved_record()
+    record.update(
+        {
+            "organisation_concept_id": "#V#org",
+            "enqueue_submission_id": "enqueue-1",
+            "task_concept_id": "#V#task_1",
+            "task_execution_concept_id": "#V#task_execution_1",
+        }
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: dict(record),
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **_kwargs: True,
+    )
+    claimed = {
+        **record,
+        "status": "failed",
+        "task_execution_reconciliation_status": "claimed",
+        "task_execution_reconciliation_queue_status": "failed",
+        "task_execution_reconciliation_token": "terminal-claim-1",
+        "task_execution_reconciliation_error": "authority revoked",
+    }
+    claim_calls = 0
+
+    def _claim(**_kwargs):
+        nonlocal claim_calls
+        claim_calls += 1
+        return dict(claimed) if claim_calls == 2 else None
+
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_terminal_reconciliation",
+        _claim,
+    )
+    acknowledgements: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "acknowledge_task_execution_terminal_reconciliation",
+        lambda **kwargs: acknowledgements.append(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "get_task_execution",
+        lambda *_args, **_kwargs: {
+            "task_concept_id": "#V#task_1",
+            "enqueue_submission_id": "enqueue-1",
+            "queue_id": "queue-1",
+            "status": "pending",
+        },
+    )
+    transitions: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "transition_task_execution",
+        lambda execution_id, **kwargs: (
+            transitions.append((execution_id, kwargs)) or {"status": kwargs["status"]}
+        ),
+    )
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "reconcile_task_execution_queue_record",
+        lambda _record: {
+            "task_execution_concept_id": "#V#task_execution_1",
+            "task_concept_id": "#V#task_1",
+            "enqueue_submission_id": "enqueue-1",
+            "queue_id": "queue-1",
+            "status": "pending",
+        },
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, _record: dispatch_service.ChatPromptDispatchOutcome(
+            accepted=False,
+            error="authority revoked",
+        ),
+    )
+
+    assert dispatcher.run_once() is True
+    assert transitions == [
+        (
+            "#V#task_execution_1",
+            {
+                "actor_concept_id": "#V#user",
+                "organisation_concept_id": "#V#org",
+                "enqueue_submission_id": "enqueue-1",
+                "queue_id": "queue-1",
+                "status": task_execution_service.TASK_EXECUTION_STATUS_FAILED,
+                "result": "authority revoked",
+                "source": "queue_dispatcher",
+            },
+        )
+    ]
+    assert acknowledgements == [
+        {
+            "queue_id": "queue-1",
+            "reconciliation_token": "terminal-claim-1",
+            "server_instance_id": dispatch_service.SERVER_INSTANCE_ID,
+            "task_execution_concept_id": "#V#task_execution_1",
+            "enqueue_submission_id": "enqueue-1",
+            "queue_status": "failed",
+        }
+    ]
+
+
+def test_dispatcher_does_not_terminalise_linked_execution_after_lost_queue_cas(
+    monkeypatch,
+) -> None:
+    record = _reserved_record()
+    record.update(
+        {
+            "organisation_concept_id": "#V#org",
+            "enqueue_submission_id": "enqueue-1",
+            "task_concept_id": "#V#task_1",
+            "task_execution_concept_id": "#V#task_execution_1",
+        }
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: dict(record),
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **_kwargs: False,
+    )
+    transition = MagicMock()
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "transition_task_execution",
+        transition,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, _record: dispatch_service.ChatPromptDispatchOutcome(
+            accepted=False,
+            error="authority revoked",
+        ),
+    )
+
+    assert dispatcher.run_once() is True
+    transition.assert_not_called()
+
+
+def test_dispatcher_retries_durable_terminal_marker_after_projection_failure(
+    monkeypatch,
+) -> None:
+    from src.backend.security.access_control import (
+        get_effective_organisation_concept_id,
+        get_effective_user_concept_id_with_source,
+    )
+
+    base_claim = {
+        "queue_id": "queue-terminal-retry",
+        "status": "failed",
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": "#V#org",
+        "enqueue_submission_id": "enqueue-terminal-retry",
+        "task_concept_id": "#V#task_retry",
+        "task_execution_concept_id": "#V#task_execution_retry",
+        "task_execution_reconciliation_status": "claimed",
+        "task_execution_reconciliation_queue_status": "failed",
+        "task_execution_reconciliation_error": "turn failed",
+    }
+    claims = iter(
+        [
+            {**base_claim, "task_execution_reconciliation_token": "claim-1"},
+            {**base_claim, "task_execution_reconciliation_token": "claim-2"},
+        ]
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_terminal_reconciliation",
+        lambda **_kwargs: next(claims),
+    )
+    released: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "release_task_execution_terminal_reconciliation",
+        lambda **kwargs: released.append(kwargs) or True,
+    )
+    acknowledged: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "acknowledge_task_execution_terminal_reconciliation",
+        lambda **kwargs: acknowledged.append(kwargs) or True,
+    )
+
+    def _get_execution(*_args, **_kwargs):
+        assert get_effective_user_concept_id_with_source()[0] == "#V#user"
+        assert get_effective_organisation_concept_id() == "#V#org"
+        return {
+            "task_concept_id": "#V#task_retry",
+            "enqueue_submission_id": "enqueue-terminal-retry",
+            "queue_id": "queue-terminal-retry",
+            "status": "in_progress",
+        }
+
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "get_task_execution",
+        _get_execution,
+    )
+    transition_attempts = 0
+
+    def _transition(_execution_id, **kwargs):
+        nonlocal transition_attempts
+        assert get_effective_user_concept_id_with_source()[0] == "#V#user"
+        assert get_effective_organisation_concept_id() == "#V#org"
+        transition_attempts += 1
+        if transition_attempts == 1:
+            raise RuntimeError("task execution store unavailable")
+        return {"status": kwargs["status"]}
+
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "transition_task_execution",
+        _transition,
+    )
+    reserve = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        reserve,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(app=object(), submit=lambda *_args: {"accepted": True})
+
+    assert dispatcher.run_once() is True
+    assert dispatcher.run_once() is True
+    assert transition_attempts == 2
+    assert released[0]["reconciliation_token"] == "claim-1"
+    assert acknowledged[0]["reconciliation_token"] == "claim-2"
+    assert dispatcher.snapshot()["task_execution_reconciliation_retry_count"] == 1
+    assert dispatcher.snapshot()["task_execution_reconciled_count"] == 1
+    reserve.assert_not_called()
+
+
+def test_dispatcher_projects_and_activates_durable_task_launch_before_dispatch(
+    monkeypatch,
+) -> None:
+    claim = {
+        "queue_id": "queue-launch",
+        "status": "queued",
+        "dispatch_ready": False,
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": "#V#org",
+        "namespace": "#V#user@org",
+        "session_id": "session-launch",
+        "enqueue_submission_id": "enqueue-launch",
+        "task_concept_id": "#V#task_launch",
+        "task_execution_concept_id": "#V#task_execution_launch",
+        "task_launch_reconciliation_token": "launch-claim-1",
+        "execution_envelope_version": 1,
+        "execution_envelope": {"initiation_id": "launch-1"},
+    }
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_launch_reconciliation",
+        lambda **_kwargs: dict(claim),
+    )
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "reconcile_task_execution_queue_record",
+        lambda record: {
+            "task_execution_concept_id": record["task_execution_concept_id"],
+            "queue_id": record["queue_id"],
+            "enqueue_submission_id": record["enqueue_submission_id"],
+            "status": "pending",
+        },
+    )
+    acknowledgements: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "acknowledge_task_execution_launch_reconciliation",
+        lambda **kwargs: acknowledgements.append(kwargs) or True,
+    )
+    reserve = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        reserve,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(app=object(), submit=lambda *_args: {"accepted": True})
+
+    assert dispatcher.run_once() is True
+    assert acknowledgements == [
+        {
+            "queue_id": "queue-launch",
+            "reconciliation_token": "launch-claim-1",
+            "server_instance_id": dispatch_service.SERVER_INSTANCE_ID,
+            "task_execution_concept_id": "#V#task_execution_launch",
+            "enqueue_submission_id": "enqueue-launch",
+        }
+    ]
+    assert dispatcher.snapshot()["task_launch_reconciled_count"] == 1
+    reserve.assert_not_called()
+
+
+def test_dispatcher_retries_unknown_launch_projection_and_fails_revoked_launch(
+    monkeypatch,
+) -> None:
+    base_claim = {
+        "queue_id": "queue-launch-retry",
+        "status": "queued",
+        "dispatch_ready": False,
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": "#V#org",
+        "namespace": "#V#user@org",
+        "session_id": "session-launch",
+        "enqueue_submission_id": "enqueue-launch-retry",
+        "task_concept_id": "#V#task_launch_retry",
+        "task_execution_concept_id": "#V#task_execution_launch_retry",
+        "execution_envelope_version": 1,
+        "execution_envelope": {"initiation_id": "launch-retry"},
+    }
+    claims = iter(
+        [
+            {**base_claim, "task_launch_reconciliation_token": "claim-1"},
+            {**base_claim, "task_launch_reconciliation_token": "claim-2"},
+        ]
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "claim_task_execution_launch_reconciliation",
+        lambda **_kwargs: next(claims),
+    )
+    attempts = 0
+
+    def _reconcile(_record):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("task store temporarily unavailable")
+        raise task_execution_service.TaskExecutionAccessError(
+            "task_not_executable",
+            "The task was cancelled",
+        )
+
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "reconcile_task_execution_queue_record",
+        _reconcile,
+    )
+    released: list[dict[str, object]] = []
+    failed: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "release_task_execution_launch_reconciliation",
+        lambda **kwargs: released.append(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_task_execution_launch_reconciliation",
+        lambda **kwargs: failed.append(kwargs) or True,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(app=object(), submit=lambda *_args: {"accepted": True})
+
+    assert dispatcher.run_once() is True
+    assert dispatcher.run_once() is True
+    assert released[0]["reconciliation_token"] == "claim-1"
+    assert "temporarily unavailable" in str(released[0]["error"])
+    assert failed[0]["reconciliation_token"] == "claim-2"
+    assert "The task was cancelled" in str(failed[0]["error"])
+    snapshot = dispatcher.snapshot()
+    assert snapshot["task_launch_reconciliation_retry_count"] == 1
+    assert snapshot["task_launch_reconciliation_failed_count"] == 1
+
+
+def test_dispatcher_revalidates_task_authority_before_model_submission(
+    monkeypatch,
+) -> None:
+    record = {
+        **_reserved_record(),
+        "organisation_concept_id": "#V#org",
+        "enqueue_submission_id": "enqueue-revoked",
+        "task_concept_id": "#V#task_revoked",
+        "task_execution_concept_id": "#V#task_execution_revoked",
+    }
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: dict(record),
+    )
+    monkeypatch.setattr(
+        dispatch_service.task_execution_service,
+        "reconcile_task_execution_queue_record",
+        MagicMock(
+            side_effect=task_execution_service.TaskExecutionAccessError(
+                "task_not_executable",
+                "The task was completed while queued",
+            )
+        ),
+    )
+    failed: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "fail_server_dispatch_reservation",
+        lambda **kwargs: failed.append(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        dispatch_service,
+        "reconcile_linked_task_execution_terminal",
+        MagicMock(),
+    )
+    submit = MagicMock()
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(app=object(), submit=submit)
+
+    assert dispatcher.run_once() is True
+    submit.assert_not_called()
+    assert failed[0]["queue_id"] == "queue-1"
+    assert "no longer executable" in str(failed[0]["error"])
+
+
+def test_worker_backfills_terminal_retention_in_bounded_batches(monkeypatch) -> None:
+    batches = iter([500, 3])
+    observed_batch_sizes: list[int] = []
+
+    def _backfill(*, batch_size: int) -> int:
+        observed_batch_sizes.append(batch_size)
+        return next(batches)
+
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "backfill_legacy_terminal_purge_after",
+        _backfill,
+    )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "reserve_next_server_dispatch",
+        lambda **_kwargs: None,
+    )
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher(poll_interval_seconds=0.01)
+    dispatcher.configure(
+        app=object(),
+        submit=lambda _app, _record: dispatch_service.ChatPromptDispatchOutcome(
+            accepted=True
+        ),
+    )
+    dispatcher.start()
+    for _ in range(100):
+        if dispatcher.snapshot()["terminal_retention_backfill_complete"]:
+            break
+        dispatcher._wake.wait(0.01)
+    dispatcher.stop(timeout=1)
+
+    assert observed_batch_sizes == [500, 500]
+    assert dispatcher.snapshot()["terminal_retention_backfilled_count"] == 503
+    assert dispatcher.snapshot()["terminal_retention_backfill_complete"] is True
+
+
+def test_generate_submission_uses_frozen_actor_scope_and_exact_reservation(
+    monkeypatch,
+) -> None:
+    from src.backend.server.routes import von_routes
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+    captured: dict[str, object] = {}
+
+    def _fake_generate():
+        captured["payload"] = request.get_json()
+        captured["session"] = dict(session)
+        return jsonify(
+            {
+                "background": True,
+                "task_id": "request-1",
+                "status": "pending",
+            }
+        ), 202
+
+    monkeypatch.setattr(von_routes, "generate", _fake_generate)
+    record = _reserved_record()
+    record.update(
+        {
+            "enqueue_submission_id": "enqueue-1",
+            "task_concept_id": "#V#task_1",
+            "task_execution_concept_id": "#V#task_execution_1",
+        }
+    )
+    record["execution_envelope"] = {
+        "language": "en-NZ",
+        "user_id": "#V#attacker",
+        "prompt_queue_id": "wrong-queue",
+        "enqueue_submission_id": "attacker-enqueue",
+        "task_concept_id": "#V#attacker_task",
+        "task_execution_concept_id": "#V#attacker_execution",
+    }
+
+    outcome = von_routes.submit_server_dispatched_chat_prompt(app, record)
+
+    assert outcome.accepted is True
+    assert captured["payload"] == {
+        "language": "en-NZ",
+        "prompt": "Continue this work",
+        "conversation_session_id": "session-1",
+        "conversation_session_name": "Conversation one",
+        "background": True,
+        "prompt_queue_id": "queue-1",
+        "client_request_id": "request-1",
+        "attempt_id": "attempt-1",
+        "dispatch_reservation_token": "reservation-1",
+        "enqueue_submission_id": "enqueue-1",
+        "task_concept_id": "#V#task_1",
+        "task_execution_concept_id": "#V#task_execution_1",
+    }
+    assert captured["session"] == {
+        "user_concept_id": "#V#user",
+        "namespace": "#V#user",
+        "session_id": "session-1",
+    }
+
+
+def test_generate_submission_rejects_scope_namespace_mismatch() -> None:
+    from src.backend.server.routes import von_routes
+
+    app = Flask(__name__)
+    record = _reserved_record()
+    record["namespace"] = "#V#another_user"
+
+    outcome = von_routes.submit_server_dispatched_chat_prompt(app, record)
+
+    assert outcome.accepted is False
+    assert outcome.retryable is False
+    assert "namespace" in str(outcome.error)
+
+
+def _task_admission_token():
+    return SimpleNamespace(
+        task_concept_id="#V#task_1",
+        task_execution_concept_id="#V#task_execution_1",
+        enqueue_submission_id="enqueue-1",
+        queue_id="queue-1",
+        client_request_id="request-1",
+        session_id="session-1",
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+
+
+def test_turn_projection_task_correlation_is_stamped_from_admission_token() -> None:
+    from src.backend.server.routes import von_routes
+
+    debug = {
+        "turn_execution_record": {
+            "request_id": "untrusted-request",
+            "session_id": "untrusted-session",
+            "queue_id": "untrusted-queue",
+            "task_concept_id": "#V#untrusted_task",
+        },
+    }
+
+    von_routes._stamp_bound_task_execution_turn_projection(
+        debug,
+        _task_admission_token(),
+        completion_gate_source={
+            "completion_gate_safe_to_claim_completion": True,
+            "completion_gate_requires_follow_up": False,
+        },
+    )
+
+    assert debug["turn_execution_record"] == {
+        "request_id": "request-1",
+        "session_id": "session-1",
+        "conversation_session_id": "session-1",
+        "queue_id": "queue-1",
+        "enqueue_submission_id": "enqueue-1",
+        "task_concept_id": "#V#task_1",
+        "task_execution_concept_id": "#V#task_execution_1",
+        "completion_gate": {
+            "safe_to_claim_completion": True,
+            "requires_follow_up": False,
+        },
+    }
+
+
+def test_queue_turn_completion_does_not_infer_task_specification_completion() -> None:
+    from src.backend.server.routes import von_routes
+
+    assert not hasattr(
+        von_routes,
+        "_terminalise_task_specification_from_verified_turn",
+    )
+    assert not hasattr(
+        task_execution_service,
+        "terminalise_task_from_execution_evidence",
+    )
+
+
+def test_queue_cancellation_terminalises_linked_execution(monkeypatch) -> None:
+    from src.backend.server.routes import von_routes
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+    scope = {
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": "#V#org",
+        "namespace": "#V#user@org",
+    }
+    cancelled = {
+        "queue_id": "queue-1",
+        "status": "cancelled",
+        "enqueue_submission_id": "enqueue-1",
+        "task_concept_id": "#V#task_1",
+        "task_execution_concept_id": "#V#task_execution_1",
+    }
+    monkeypatch.setattr(
+        von_routes,
+        "_get_current_chat_prompt_queue_scope",
+        lambda: dict(scope),
+    )
+    monkeypatch.setattr(
+        von_routes.chat_prompt_queue_service,
+        "cancel_prompt_record",
+        lambda **_kwargs: dict(cancelled),
+    )
+    reconcile = MagicMock()
+    monkeypatch.setattr(
+        von_routes,
+        "reconcile_linked_task_execution_terminal",
+        reconcile,
+    )
+
+    with app.test_request_context("/von/api/chat_prompt_queue/queue-1"):
+        response = von_routes.cancel_chat_prompt_queue_route("queue-1")
+
+    assert response.get_json()["item"] == cancelled
+    reconcile.assert_called_once_with(
+        {**cancelled, **scope},
+        status="cancelled",
+        source="queue_cancellation",
+    )

--- a/tests/backend/test_chat_prompt_queue_routes.py
+++ b/tests/backend/test_chat_prompt_queue_routes.py
@@ -383,3 +383,117 @@ def test_queue_routes_cannot_release_a_live_server_bound_turn(client) -> None:
         status=chat_prompt_queue_service.STATUS_COMPLETED,
         attempt_id="attempt-live",
     )
+
+
+def test_legacy_routes_cannot_complete_or_replay_server_dispatch_rows(client) -> None:
+    created_response = client.post(
+        "/von/api/chat_prompt_queue",
+        json={
+            "prompt_raw": "Server owns this turn",
+            "session_id": "session-server-owned",
+            "enqueue_submission_id": "submission-server-owned",
+            "dispatch_mode": "server",
+            "execution_envelope_version": 1,
+            "execution_envelope": {"language": "en-NZ"},
+        },
+    )
+    assert created_response.status_code == 201
+    created = created_response.get_json()["item"]
+
+    false_finish = client.post(
+        f"/von/api/chat_prompt_queue/{created['queue_id']}/finish",
+        json={"status": "completed"},
+    )
+    assert false_finish.status_code == 409
+    assert (
+        false_finish.get_json()["error_code"]
+        == "server_dispatch_reconciliation_required"
+    )
+
+    reservation = chat_prompt_queue_service.reserve_next_server_dispatch(
+        server_instance_id=SERVER_INSTANCE_ID,
+    )
+    assert reservation is not None
+    scope = chat_prompt_queue_service.build_queue_scope(
+        user_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        namespace="#V#test_user@test_org",
+    )
+    chat_prompt_queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=created["queue_id"],
+        client_request_id=reservation["client_request_id"],
+        attempt_id=reservation["attempt_id"],
+        conversation_key=created["conversation_key"],
+        server_instance_id=SERVER_INSTANCE_ID,
+        dispatch_reservation_token=reservation["dispatch_reservation_token"],
+    )
+
+    ambiguous_replay = client.post(
+        f"/von/api/chat_prompt_queue/{created['queue_id']}/requeue"
+    )
+    assert ambiguous_replay.status_code == 409
+    assert (
+        ambiguous_replay.get_json()["error_code"]
+        == "server_dispatch_reconciliation_required"
+    )
+
+
+def test_server_handoff_route_links_replays_and_rejects_second_replacement(
+    client,
+) -> None:
+    source_response = client.post(
+        "/von/api/chat_prompt_queue",
+        json={
+            "prompt_raw": "Preserve this exact prompt",
+            "session_id": "session-handoff",
+            "session_name": "Handoff conversation",
+        },
+    )
+    assert source_response.status_code == 201
+    source = source_response.get_json()["item"]
+    replacement_payload = {
+        "prompt_raw": "Preserve this exact prompt",
+        "session_id": "session-handoff",
+        "session_name": "Handoff conversation",
+        "enqueue_submission_id": "submission-handoff-route",
+        "dispatch_mode": "server",
+        "execution_envelope_version": 1,
+        "execution_envelope": {"language": "en-NZ"},
+        "handoff_source_queue_id": source["queue_id"],
+    }
+
+    created_response = client.post(
+        "/von/api/chat_prompt_queue",
+        json=replacement_payload,
+    )
+    replay_response = client.post(
+        "/von/api/chat_prompt_queue",
+        json=replacement_payload,
+    )
+    conflicting_response = client.post(
+        "/von/api/chat_prompt_queue",
+        json={
+            **replacement_payload,
+            "enqueue_submission_id": "submission-handoff-route-conflict",
+        },
+    )
+
+    assert created_response.status_code == 201
+    created = created_response.get_json()["item"]
+    assert created["dispatch_ready"] is True
+    assert created["handoff_source_queue_id"] == source["queue_id"]
+    assert created["handoff_completed_at"] is not None
+    assert replay_response.status_code == 200
+    assert replay_response.get_json()["item"]["queue_id"] == created["queue_id"]
+    assert replay_response.get_json()["idempotent_replay"] is True
+    assert conflicting_response.status_code == 409
+    assert conflicting_response.get_json()["error_code"] == "queue_handoff_conflict"
+
+    scope = chat_prompt_queue_service.build_queue_scope(
+        user_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        namespace="#V#test_user@test_org",
+    )
+    queue_rows = chat_prompt_queue_service.list_active_queue_records(scope=scope)
+    assert [row["queue_id"] for row in queue_rows] == [created["queue_id"]]

--- a/tests/backend/test_chat_prompt_queue_service.py
+++ b/tests/backend/test_chat_prompt_queue_service.py
@@ -19,6 +19,40 @@ def mock_db(monkeypatch: pytest.MonkeyPatch):
     mongo_client.close_connection()
 
 
+def _create_server_queue_record(
+    *,
+    scope: dict[str, str | None],
+    submission_id: str,
+    prompt: str = "Queued server task",
+    conversation_key: str = "conversation-server",
+    session_id: str = "session-server",
+    execution_envelope: dict[str, object] | None = None,
+    task_concept_id: str | None = None,
+    task_execution_concept_id: str | None = None,
+    dispatch_ready: bool | None = None,
+    handoff_source_queue_id: str | None = None,
+) -> dict[str, object]:
+    return queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw=prompt,
+        session_id=session_id,
+        session_name="Server queue",
+        conversation_key=conversation_key,
+        enqueue_submission_id=submission_id,
+        dispatch_mode=queue_service.DISPATCH_MODE_SERVER,
+        execution_envelope=(
+            execution_envelope
+            if execution_envelope is not None
+            else {"language": "en-NZ", "skip_buttonify": True}
+        ),
+        execution_envelope_version=queue_service.EXECUTION_ENVELOPE_VERSION,
+        task_concept_id=task_concept_id,
+        task_execution_concept_id=task_execution_concept_id,
+        server_dispatch_ready=dispatch_ready,
+        handoff_source_queue_id=handoff_source_queue_id,
+    )
+
+
 def test_queue_record_lifecycle_restores_active_items_only() -> None:
     scope = queue_service.build_queue_scope(
         user_concept_id="#V#user",
@@ -177,7 +211,7 @@ def test_shared_conversation_fifo_crosses_scopes_and_orders_timestamp_ties(
             conversation_key="canonical-shared-key",
         ),
     ]
-    earlier, later = sorted(records, key=lambda item: item["queue_id"])
+    earlier, later = records
     scope_by_queue_id = {
         records[0]["queue_id"]: owner_scope,
         records[1]["queue_id"]: invitee_scope,
@@ -216,6 +250,32 @@ def test_shared_conversation_fifo_crosses_scopes_and_orders_timestamp_ties(
         )["status"]
         == queue_service.STATUS_IN_PROGRESS
     )
+
+
+def test_active_queue_projection_matches_fifo_when_timestamps_tie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(queue_service, "_now", lambda: fixed_now)
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    created = [
+        queue_service.create_queue_record(
+            scope=scope,
+            prompt_raw=f"Prompt {index}",
+            session_id="session-tied",
+            conversation_key="conversation-tied",
+        )
+        for index in range(3)
+    ]
+
+    projected = queue_service.list_active_queue_records(scope=scope)
+    assert [record["queue_id"] for record in projected] == [
+        record["queue_id"] for record in created
+    ]
 
 
 def test_queued_backlog_is_bounded_per_user_across_organisations(
@@ -993,3 +1053,1444 @@ def test_cancel_prompt_record_still_rejects_completed_records() -> None:
 
     assert exc_info.value.error_code == "wrong_state"
     assert exc_info.value.details["current_status"] == queue_service.STATUS_COMPLETED
+
+
+def test_visibility_projection_prefers_terminal_observation_for_same_queue_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = queue_service.build_queue_scope(user_concept_id="#V#user")
+    monkeypatch.setattr(
+        queue_service,
+        "list_active_queue_records",
+        lambda **_kwargs: [{"queue_id": "queue-race", "status": "queued"}],
+    )
+    monkeypatch.setattr(
+        queue_service,
+        "list_recent_failed_queue_records",
+        lambda **_kwargs: [{"queue_id": "queue-race", "status": "failed"}],
+    )
+
+    assert queue_service.list_queue_visibility_records(scope=scope) == {
+        "items": [],
+        "recent_failed_items": [
+            {"queue_id": "queue-race", "status": "failed"}
+        ],
+    }
+
+
+def test_server_enqueue_is_idempotent_by_canonical_submission_fingerprint() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    envelope = {
+        "workflow_inputs": {"file_copy_concept_id": "#V#file-copy"},
+        "model_parameters": {"temperature": 0.2, "max_tokens": 400},
+        "model_provider": "gemini",
+        "model": "gemini-3.7-flash",
+    }
+    created = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-1",
+        execution_envelope=envelope,
+        task_concept_id="#V#task-1",
+        task_execution_concept_id="#V#task-execution-1",
+    )
+    replayed = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-1",
+        execution_envelope={
+            "model": "gemini-3.7-flash",
+            "model_provider": "gemini",
+            "model_parameters": {"max_tokens": 400, "temperature": 0.2},
+            "workflow_inputs": {"file_copy_concept_id": "#V#file-copy"},
+        },
+        task_concept_id="#V#task-1",
+        task_execution_concept_id="#V#task-execution-1",
+    )
+
+    assert created["queue_id"] == replayed["queue_id"]
+    assert created["idempotent_replay"] is False
+    assert replayed["idempotent_replay"] is True
+    assert created["task_concept_id"] == "#V#task-1"
+    assert created["task_execution_concept_id"] == "#V#task-execution-1"
+    assert "execution_envelope" not in created
+
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": created["queue_id"]})
+    assert persisted is not None
+    assert persisted["execution_envelope"] == envelope
+    assert coll.count_documents({"enqueue_submission_id": "submission-1"}) == 1
+
+    with pytest.raises(queue_service.ChatPromptQueueSubmissionConflict) as exc_info:
+        _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-1",
+            prompt="Different work",
+            execution_envelope=envelope,
+            task_concept_id="#V#task-1",
+            task_execution_concept_id="#V#task-execution-1",
+        )
+    assert exc_info.value.error_code == "enqueue_submission_conflict"
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.queue_id == created["queue_id"]
+
+    with pytest.raises(queue_service.ChatPromptQueueTaskAlreadyActive) as active:
+        _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-2",
+            execution_envelope=envelope,
+            task_concept_id="#V#task-1",
+            task_execution_concept_id="#V#task-execution-2",
+        )
+    assert active.value.error_code == "task_execution_already_active"
+    assert active.value.queue_id == created["queue_id"]
+    assert active.value.task_execution_concept_id == "#V#task-execution-1"
+
+
+def test_server_handoff_enqueue_replays_exact_replacement() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Retry this exact prompt",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+
+    created = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-exact",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+    replayed = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-exact",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+
+    assert created["queue_id"] == replayed["queue_id"]
+    assert created["idempotent_replay"] is False
+    assert replayed["idempotent_replay"] is True
+    assert created["dispatch_ready"] is False
+    assert created["handoff_source_queue_id"] == source["queue_id"]
+
+
+def test_concurrent_distinct_handoffs_bind_one_replacement_to_source() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Retry this exact prompt",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    source_queue_id = str(source["queue_id"])
+    barrier = threading.Barrier(2)
+
+    def create_replacement(index: int) -> tuple[str, str | None]:
+        barrier.wait()
+        try:
+            record = _create_server_queue_record(
+                scope=scope,
+                submission_id=f"submission-handoff-race-{index}",
+                prompt="Retry this exact prompt",
+                handoff_source_queue_id=source_queue_id,
+            )
+            return "created", str(record["queue_id"])
+        except queue_service.ChatPromptQueueHandoffConflict as exc:
+            return "handoff_conflict", exc.queue_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(create_replacement, range(2)))
+
+    assert sorted(outcome[0] for outcome in outcomes) == [
+        "created",
+        "handoff_conflict",
+    ]
+    assert len({outcome[1] for outcome in outcomes}) == 1
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    assert coll.count_documents({"handoff_source_queue_id": source_queue_id}) == 1
+
+
+def test_cancelling_unready_handoff_releases_source_fence_for_safe_retry() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Retry this exact prompt",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    first = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-cancelled",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+
+    cancelled = queue_service.cancel_prompt_record(
+        scope=scope,
+        queue_id=str(first["queue_id"]),
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-retry",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+
+    assert cancelled["status"] == queue_service.STATUS_CANCELLED
+    assert cancelled["handoff_source_queue_id"] is None
+    assert cancelled["retired_handoff_source_queue_id"] == source["queue_id"]
+    assert replacement["queue_id"] != first["queue_id"]
+    assert replacement["handoff_source_queue_id"] == source["queue_id"]
+
+
+def test_handoff_completion_retires_source_before_dispatch_activation() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Retry this exact prompt",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-complete",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+
+    completed = queue_service.complete_server_dispatch_handoff(
+        scope=scope,
+        queue_id=str(replacement["queue_id"]),
+    )
+
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted_source = coll.find_one({"queue_id": source["queue_id"]})
+    assert persisted_source is not None
+    assert persisted_source["status"] == queue_service.STATUS_CANCELLED
+    assert completed["dispatch_ready"] is True
+    assert completed["handoff_completed_at"] is not None
+    assert persisted_source["handoff_replacement_queue_id"] == replacement["queue_id"]
+
+    replayed = queue_service.complete_server_dispatch_handoff(
+        scope=scope,
+        queue_id=str(replacement["queue_id"]),
+    )
+    assert replayed["queue_id"] == replacement["queue_id"]
+    assert replayed["dispatch_ready"] is True
+
+
+def test_independently_cancelled_source_cannot_activate_handoff_replacement() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Do not override cancellation",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-pre-cancelled",
+        prompt="Do not override cancellation",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+    queue_service.cancel_prompt_record(
+        scope=scope,
+        queue_id=str(source["queue_id"]),
+    )
+
+    with pytest.raises(queue_service.ChatPromptQueueHandoffConflict) as exc_info:
+        queue_service.complete_server_dispatch_handoff(
+            scope=scope,
+            queue_id=str(replacement["queue_id"]),
+        )
+
+    assert exc_info.value.error_code == "queue_handoff_conflict"
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted_source = coll.find_one({"queue_id": source["queue_id"]})
+    persisted_replacement = coll.find_one({"queue_id": replacement["queue_id"]})
+    assert persisted_source is not None
+    assert "handoff_replacement_queue_id" not in persisted_source
+    assert persisted_replacement is not None
+    assert persisted_replacement["status"] == queue_service.STATUS_CANCELLED
+    assert persisted_replacement.get("dispatch_ready") is False
+    assert "handoff_source_queue_id" not in persisted_replacement
+
+
+def test_concurrent_user_cancellation_never_coexists_with_handoff_activation() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Race exact cancellation",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-cancel-race",
+        prompt="Race exact cancellation",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+    barrier = threading.Barrier(2)
+
+    def user_cancel() -> str:
+        barrier.wait()
+        try:
+            queue_service.cancel_prompt_record(
+                scope=scope,
+                queue_id=str(source["queue_id"]),
+            )
+            return "user_cancelled"
+        except queue_service.ChatPromptQueueError:
+            return "handoff_won"
+
+    def complete_handoff() -> str:
+        barrier.wait()
+        try:
+            queue_service.complete_server_dispatch_handoff(
+                scope=scope,
+                queue_id=str(replacement["queue_id"]),
+            )
+            return "activated"
+        except queue_service.ChatPromptQueueHandoffConflict:
+            return "conflict"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        user_future = executor.submit(user_cancel)
+        handoff_future = executor.submit(complete_handoff)
+        user_outcome = user_future.result()
+        handoff_outcome = handoff_future.result()
+
+    assert (user_outcome, handoff_outcome) in {
+        ("user_cancelled", "conflict"),
+        ("handoff_won", "activated"),
+    }
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted_source = coll.find_one({"queue_id": source["queue_id"]})
+    persisted_replacement = coll.find_one({"queue_id": replacement["queue_id"]})
+    assert persisted_source is not None
+    assert persisted_replacement is not None
+    if handoff_outcome == "activated":
+        assert (
+            persisted_source.get("handoff_replacement_queue_id")
+            == replacement["queue_id"]
+        )
+        assert persisted_replacement["dispatch_ready"] is True
+    else:
+        assert "handoff_replacement_queue_id" not in persisted_source
+        assert persisted_replacement["status"] == queue_service.STATUS_CANCELLED
+
+
+def test_blocked_handoff_is_backed_off_and_does_not_hide_ready_work() -> None:
+    fixed_now = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    source = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Retry this exact prompt",
+        session_id="session-server",
+        conversation_key="conversation-server",
+    )
+    queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=str(source["queue_id"]),
+        client_request_id="request-active-source",
+        attempt_id="attempt-active-source",
+        conversation_key="conversation-server",
+        server_instance_id="server-active-source",
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-handoff-blocked",
+        prompt="Retry this exact prompt",
+        handoff_source_queue_id=str(source["queue_id"]),
+    )
+    ready = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-ready-unrelated",
+        prompt="Independent prompt",
+        conversation_key="conversation-independent",
+        session_id="session-independent",
+    )
+
+    with pytest.raises(queue_service.ConversationTurnAlreadyActive):
+        queue_service.reconcile_next_server_dispatch_handoff(
+            now=fixed_now,
+            retry_after_seconds=10,
+        )
+    assert (
+        queue_service.reconcile_next_server_dispatch_handoff(
+            now=fixed_now + timedelta(seconds=5),
+            retry_after_seconds=10,
+        )
+        is None
+    )
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-dispatcher",
+        now=fixed_now,
+    )
+
+    assert reservation is not None
+    assert reservation["queue_id"] == ready["queue_id"]
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": replacement["queue_id"]})
+    assert persisted is not None
+    assert persisted["handoff_reconciliation_attempt_count"] == 1
+    assert persisted["handoff_reconciliation_next_at"].replace(
+        tzinfo=timezone.utc
+    ) == (fixed_now + timedelta(seconds=10))
+    assert "ConversationTurnAlreadyActive" in persisted[
+        "handoff_reconciliation_last_error"
+    ]
+
+
+def test_task_launch_fence_releases_only_after_queue_terminal_state() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    first = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-task-first",
+        task_concept_id="#V#task-fenced",
+        task_execution_concept_id="#V#task-execution-first",
+        dispatch_ready=False,
+    )
+
+    with pytest.raises(queue_service.ChatPromptQueueTaskAlreadyActive):
+        _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-task-second",
+            task_concept_id="#V#task-fenced",
+            task_execution_concept_id="#V#task-execution-second",
+            dispatch_ready=False,
+        )
+
+    queue_service.cancel_prompt_record(
+        scope=scope,
+        queue_id=str(first["queue_id"]),
+    )
+    replacement = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-task-second",
+        task_concept_id="#V#task-fenced",
+        task_execution_concept_id="#V#task-execution-second",
+        dispatch_ready=False,
+    )
+    assert replacement["queue_id"] != first["queue_id"]
+
+
+def test_concurrent_distinct_launches_create_one_active_task_attempt() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    barrier = threading.Barrier(2)
+
+    def launch(index: int) -> tuple[str, str | None]:
+        barrier.wait()
+        try:
+            record = _create_server_queue_record(
+                scope=scope,
+                submission_id=f"submission-race-{index}",
+                task_concept_id="#V#task-race",
+                task_execution_concept_id=f"#V#task-execution-race-{index}",
+                dispatch_ready=False,
+            )
+            return "created", str(record["queue_id"])
+        except queue_service.ChatPromptQueueTaskAlreadyActive as exc:
+            return "already_active", exc.queue_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(launch, range(2)))
+
+    assert sorted(outcome[0] for outcome in outcomes) == [
+        "already_active",
+        "created",
+    ]
+    assert len({outcome[1] for outcome in outcomes}) == 1
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    assert coll.count_documents({"task_concept_id": "#V#task-race"}) == 1
+
+
+def test_concurrent_server_enqueue_replays_one_durable_record() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    barrier = threading.Barrier(8)
+
+    def create_once(_index: int) -> dict[str, object]:
+        barrier.wait()
+        return _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-concurrent",
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        records = list(executor.map(create_once, range(8)))
+
+    assert len({record["queue_id"] for record in records}) == 1
+    assert sum(record["idempotent_replay"] is False for record in records) == 1
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    assert coll.count_documents({"enqueue_submission_id": "submission-concurrent"}) == 1
+
+
+def test_server_enqueue_rejects_non_allowlisted_or_legacy_mixed_payloads() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+
+    with pytest.raises(queue_service.InvalidChatPromptQueueInput, match="invalid keys"):
+        _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-invalid",
+            execution_envelope={"user_id": "#V#other"},
+        )
+    with pytest.raises(
+        queue_service.InvalidChatPromptQueueInput,
+        match="require server dispatch",
+    ):
+        queue_service.create_queue_record(
+            scope=scope,
+            prompt_raw="Legacy must remain browser owned",
+            enqueue_submission_id="submission-without-mode",
+        )
+    with pytest.raises(
+        queue_service.InvalidChatPromptQueueInput,
+        match="assigns request and attempt",
+    ):
+        queue_service.create_queue_record(
+            scope=scope,
+            prompt_raw="Server assigns execution identities",
+            session_id="session-server",
+            conversation_key="conversation-server",
+            enqueue_submission_id="submission-client-request",
+            dispatch_mode=queue_service.DISPATCH_MODE_SERVER,
+            execution_envelope={},
+            execution_envelope_version=queue_service.EXECUTION_ENVELOPE_VERSION,
+            client_request_id="client-request-must-not-be-reused",
+        )
+    with pytest.raises(
+        queue_service.InvalidChatPromptQueueInput,
+        match="cannot be combined with task execution links",
+    ):
+        _create_server_queue_record(
+            scope=scope,
+            submission_id="submission-mixed-handoff-task",
+            task_concept_id="#V#task-mixed",
+            task_execution_concept_id="#V#task-execution-mixed",
+            handoff_source_queue_id="queue-legacy-source",
+        )
+
+    immutable = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-immutable",
+    )
+    with pytest.raises(
+        queue_service.InvalidChatPromptQueueInput,
+        match="immutable",
+    ):
+        queue_service.update_queued_record(
+            scope=scope,
+            queue_id=str(immutable["queue_id"]),
+            prompt_raw="Mutated after idempotent enqueue",
+        )
+    with pytest.raises(
+        queue_service.InvalidChatPromptQueueInput,
+        match="server dispatch reservation",
+    ):
+        queue_service.claim_queue_record(
+            scope=scope,
+            queue_id=str(immutable["queue_id"]),
+        )
+
+
+def test_server_dispatch_rows_reject_legacy_finish_and_ambiguous_replay() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-exact-terminal-only",
+    )
+
+    with pytest.raises(
+        queue_service.ChatPromptQueueReconciliationRequired,
+        match="exact admitted attempt",
+    ) as finish_error:
+        queue_service.finish_prompt_record(
+            scope=scope,
+            queue_id=str(queued["queue_id"]),
+            status=queue_service.STATUS_COMPLETED,
+        )
+    assert finish_error.value.status_code == 409
+
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-old",
+    )
+    assert reservation is not None
+    queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        client_request_id=str(reservation["client_request_id"]),
+        attempt_id=str(reservation["attempt_id"]),
+        conversation_key="conversation-server",
+        server_instance_id="server-old",
+        dispatch_reservation_token=str(
+            reservation["dispatch_reservation_token"]
+        ),
+    )
+    with pytest.raises(
+        queue_service.ChatPromptQueueReconciliationRequired,
+        match="cannot be replayed",
+    ):
+        queue_service.requeue_prompt_record(
+            scope=scope,
+            queue_id=str(queued["queue_id"]),
+            current_server_instance_id="server-new",
+        )
+
+
+def test_task_linked_server_row_dispatches_only_after_exact_activation() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-awaiting-task-link",
+        task_concept_id="#V#task-1",
+        task_execution_concept_id="#V#task-execution-1",
+        dispatch_ready=False,
+    )
+    assert queued["dispatch_ready"] is False
+    assert (
+        queue_service.reserve_next_server_dispatch(server_instance_id="server-a")
+        is None
+    )
+
+    activated = queue_service.activate_server_dispatch_record(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        enqueue_submission_id="submission-awaiting-task-link",
+        task_execution_concept_id="#V#task-execution-1",
+    )
+    replayed_activation = queue_service.activate_server_dispatch_record(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        enqueue_submission_id="submission-awaiting-task-link",
+        task_execution_concept_id="#V#task-execution-1",
+    )
+    assert activated["dispatch_ready"] is True
+    assert replayed_activation["queue_id"] == queued["queue_id"]
+    assert (
+        queue_service.reserve_next_server_dispatch(server_instance_id="server-a")
+        is not None
+    )
+
+
+def test_task_launch_outbox_lease_blocks_route_activation_and_reclaims_exactly() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-launch-reconcile",
+        task_concept_id="#V#task-launch-reconcile",
+        task_execution_concept_id="#V#task-execution-launch-reconcile",
+        dispatch_ready=False,
+    )
+    observed_now = datetime.now(timezone.utc)
+    first = queue_service.claim_task_execution_launch_reconciliation(
+        server_instance_id="reconciler-a",
+        now=observed_now,
+        lease_seconds=10,
+    )
+    assert first is not None
+    assert first["queue_id"] == queued["queue_id"]
+    assert first["execution_envelope"] == {
+        "language": "en-NZ",
+        "skip_buttonify": True,
+    }
+    assert (
+        queue_service.claim_task_execution_launch_reconciliation(
+            server_instance_id="reconciler-b",
+            now=observed_now + timedelta(seconds=5),
+        )
+        is None
+    )
+    with pytest.raises(queue_service.ChatPromptQueueRecordNotFound):
+        queue_service.activate_server_dispatch_record(
+            scope=scope,
+            queue_id=str(queued["queue_id"]),
+            enqueue_submission_id="submission-launch-reconcile",
+            task_execution_concept_id="#V#task-execution-launch-reconcile",
+        )
+
+    reclaimed = queue_service.claim_task_execution_launch_reconciliation(
+        server_instance_id="reconciler-b",
+        now=observed_now + timedelta(seconds=11),
+        lease_seconds=10,
+    )
+    assert reclaimed is not None
+    assert reclaimed["queue_id"] == queued["queue_id"]
+    assert (
+        reclaimed["task_launch_reconciliation_token"]
+        != first["task_launch_reconciliation_token"]
+    )
+    assert not queue_service.acknowledge_task_execution_launch_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(first["task_launch_reconciliation_token"]),
+        server_instance_id="reconciler-a",
+        task_execution_concept_id="#V#task-execution-launch-reconcile",
+        enqueue_submission_id="submission-launch-reconcile",
+        now=observed_now + timedelta(seconds=12),
+    )
+    assert queue_service.acknowledge_task_execution_launch_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(reclaimed["task_launch_reconciliation_token"]),
+        server_instance_id="reconciler-b",
+        task_execution_concept_id="#V#task-execution-launch-reconcile",
+        enqueue_submission_id="submission-launch-reconcile",
+        now=observed_now + timedelta(seconds=12),
+    )
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": queued["queue_id"]})
+    assert persisted is not None
+    assert persisted["dispatch_ready"] is True
+    assert "task_launch_reconciliation_token" not in persisted
+
+
+def test_task_launch_outbox_release_then_permanent_failure_is_terminal() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-launch-failure",
+        task_concept_id="#V#task-launch-failure",
+        task_execution_concept_id="#V#task-execution-launch-failure",
+        dispatch_ready=False,
+    )
+    observed_now = datetime.now(timezone.utc)
+    first = queue_service.claim_task_execution_launch_reconciliation(
+        server_instance_id="reconciler-a",
+        now=observed_now,
+    )
+    assert first is not None
+    assert queue_service.release_task_execution_launch_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(first["task_launch_reconciliation_token"]),
+        server_instance_id="reconciler-a",
+        error="temporary projection failure",
+        retry_after_seconds=3,
+        now=observed_now,
+    )
+    assert (
+        queue_service.claim_task_execution_launch_reconciliation(
+            server_instance_id="reconciler-b",
+            now=observed_now + timedelta(seconds=2),
+        )
+        is None
+    )
+    retry = queue_service.claim_task_execution_launch_reconciliation(
+        server_instance_id="reconciler-b",
+        now=observed_now + timedelta(seconds=3),
+    )
+    assert retry is not None
+    assert queue_service.fail_task_execution_launch_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(retry["task_launch_reconciliation_token"]),
+        server_instance_id="reconciler-b",
+        error="task authority was revoked",
+        now=observed_now + timedelta(seconds=3),
+    )
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": queued["queue_id"]})
+    assert persisted is not None
+    assert persisted["status"] == queue_service.STATUS_FAILED
+    assert persisted["task_execution_reconciliation_status"] == "pending"
+    assert "active_task_execution_key" not in persisted
+    assert "purge_after" not in persisted
+
+
+def test_server_dispatch_reservation_upgrades_exact_token_and_preserves_fifo() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    first = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-first",
+        prompt="First",
+    )
+    second = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-second",
+        prompt="Second",
+    )
+    observed_now = datetime.now(timezone.utc)
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    coll.update_one(
+        {"queue_id": first["queue_id"]},
+        {"$set": {"created_at": observed_now - timedelta(seconds=1)}},
+    )
+    coll.update_one(
+        {"queue_id": second["queue_id"]},
+        {"$set": {"created_at": observed_now}},
+    )
+
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a",
+        now=observed_now,
+        lease_seconds=60,
+    )
+    assert reservation is not None
+    assert reservation["queue_id"] == first["queue_id"]
+    assert reservation["user_concept_id"] == "#V#user"
+    assert reservation["organisation_concept_id"] == "#V#org"
+    assert reservation["namespace"] == "#V#user@org"
+    assert reservation["execution_envelope"] == {
+        "language": "en-NZ",
+        "skip_buttonify": True,
+    }
+    token = str(reservation["dispatch_reservation_token"])
+    assert token
+    assert (
+        queue_service.reserve_next_server_dispatch(
+            server_instance_id="server-b",
+            now=observed_now,
+        )
+        is None
+    )
+    visible = queue_service.list_active_queue_records(scope=scope)
+    assert "dispatch_reservation_token" not in visible[0]
+    assert "execution_envelope" not in visible[0]
+
+    assert not queue_service.heartbeat_server_dispatch_reservation(
+        queue_id=str(first["queue_id"]),
+        dispatch_reservation_token="wrong-token",
+        server_instance_id="server-a",
+        now=observed_now + timedelta(seconds=10),
+    )
+    assert queue_service.heartbeat_server_dispatch_reservation(
+        queue_id=str(first["queue_id"]),
+        dispatch_reservation_token=token,
+        server_instance_id="server-a",
+        now=observed_now + timedelta(seconds=10),
+        lease_seconds=60,
+    )
+
+    with pytest.raises(queue_service.ConversationTurnAlreadyActive):
+        queue_service.bind_queue_record_to_turn(
+            scope=scope,
+            queue_id=str(first["queue_id"]),
+            client_request_id=str(reservation["client_request_id"]),
+            attempt_id=str(reservation["attempt_id"]),
+            conversation_key="conversation-server",
+            server_instance_id="server-a",
+            dispatch_reservation_token="wrong-token",
+        )
+    bound = queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=str(first["queue_id"]),
+        client_request_id=str(reservation["client_request_id"]),
+        attempt_id=str(reservation["attempt_id"]),
+        conversation_key="conversation-server",
+        server_instance_id="server-a",
+        dispatch_reservation_token=token,
+        lease_seconds=60,
+    )
+    assert bound["status"] == queue_service.STATUS_IN_PROGRESS
+    assert bound["lease_expires_at"] is not None
+
+    persisted = coll.find_one({"queue_id": first["queue_id"]})
+    assert persisted is not None
+    assert "dispatch_reservation_token" not in persisted
+    assert persisted["active_conversation_key"] == "conversation-server"
+
+    queue_service.finish_prompt_record(
+        scope=scope,
+        queue_id=str(first["queue_id"]),
+        attempt_id=str(reservation["attempt_id"]),
+        status=queue_service.STATUS_COMPLETED,
+    )
+    next_reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-b",
+        now=observed_now + timedelta(seconds=11),
+    )
+    assert next_reservation is not None
+    assert next_reservation["queue_id"] == second["queue_id"]
+
+
+def test_blocked_fifo_does_not_starve_an_unrelated_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(queue_service, "_now", lambda: fixed_now)
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    first_conversation = [
+        _create_server_queue_record(
+            scope=scope,
+            submission_id=f"submission-blocked-{index}",
+            conversation_key="conversation-blocked",
+            session_id="session-blocked",
+        )
+        for index in range(3)
+    ]
+    independent = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-independent",
+        conversation_key="conversation-independent",
+        session_id="session-independent",
+    )
+
+    first = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a",
+        scan_limit=2,
+    )
+    assert first is not None
+    assert first["queue_id"] == first_conversation[0]["queue_id"]
+
+    second = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a",
+        scan_limit=2,
+    )
+    assert second is not None
+    assert second["queue_id"] == independent["queue_id"]
+
+    assert queue_service.fail_server_dispatch_reservation(
+        queue_id=str(first["queue_id"]),
+        dispatch_reservation_token=str(first["dispatch_reservation_token"]),
+        server_instance_id="server-a",
+        error="bounded test completion",
+    )
+    third = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-b",
+        scan_limit=2,
+    )
+    assert third is not None
+    assert third["queue_id"] == first_conversation[1]["queue_id"]
+
+
+def test_server_dispatch_release_backoff_and_terminal_failure_retention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_CHAT_PROMPT_QUEUE_TERMINAL_RETENTION_SECONDS", "60")
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    legacy = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Browser-owned legacy task",
+        conversation_key="legacy-conversation",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-release",
+        conversation_key="dispatch-conversation",
+    )
+    observed_now = datetime.now(timezone.utc)
+
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a",
+        now=observed_now,
+        lease_seconds=30,
+    )
+    assert reservation is not None
+    assert reservation["queue_id"] == queued["queue_id"]
+    assert reservation["queue_id"] != legacy["queue_id"]
+    assert queue_service.release_server_dispatch_reservation(
+        queue_id=str(queued["queue_id"]),
+        dispatch_reservation_token=str(reservation["dispatch_reservation_token"]),
+        server_instance_id="server-a",
+        retry_after_seconds=10,
+        error="background capacity",
+        now=observed_now,
+    )
+    assert not queue_service.heartbeat_server_dispatch_reservation(
+        queue_id=str(queued["queue_id"]),
+        dispatch_reservation_token=str(reservation["dispatch_reservation_token"]),
+        server_instance_id="server-a",
+        now=observed_now + timedelta(seconds=1),
+    )
+    assert (
+        queue_service.reserve_next_server_dispatch(
+            server_instance_id="server-b",
+            now=observed_now + timedelta(seconds=5),
+        )
+        is None
+    )
+
+    retried = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-b",
+        now=observed_now + timedelta(seconds=11),
+    )
+    assert retried is not None
+    assert retried["queue_id"] == queued["queue_id"]
+    assert (
+        retried["dispatch_reservation_token"]
+        != reservation["dispatch_reservation_token"]
+    )
+    assert retried["client_request_id"] != reservation["client_request_id"]
+    assert retried["attempt_id"] != reservation["attempt_id"]
+    assert queue_service.fail_server_dispatch_reservation(
+        queue_id=str(queued["queue_id"]),
+        dispatch_reservation_token=str(retried["dispatch_reservation_token"]),
+        server_instance_id="server-b",
+        error="authority_revoked",
+        now=observed_now + timedelta(seconds=11),
+    )
+
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": queued["queue_id"]})
+    assert persisted is not None
+    assert persisted["status"] == queue_service.STATUS_FAILED
+    assert persisted["last_error"] == "authority_revoked"
+    assert (persisted["purge_after"] - persisted["completed_at"]).total_seconds() == 60
+    assert "active_conversation_key" not in persisted
+    assert "dispatch_reservation_token" not in persisted
+    assert "purge_after" not in (coll.find_one({"queue_id": legacy["queue_id"]}) or {})
+
+
+def test_linked_terminal_marker_survives_process_loss_until_exact_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_CHAT_PROMPT_QUEUE_TERMINAL_RETENTION_SECONDS", "60")
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-terminal-reconciliation",
+        task_concept_id="#V#task_1",
+        task_execution_concept_id="#V#task_execution_1",
+    )
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a"
+    )
+    assert reservation is not None
+    queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        client_request_id=str(reservation["client_request_id"]),
+        attempt_id=str(reservation["attempt_id"]),
+        conversation_key="conversation-server",
+        server_instance_id="server-a",
+        dispatch_reservation_token=str(reservation["dispatch_reservation_token"]),
+    )
+
+    terminal = queue_service.finish_prompt_record(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        attempt_id=str(reservation["attempt_id"]),
+        status=queue_service.STATUS_COMPLETED,
+    )
+    assert terminal["task_execution_reconciliation_status"] == "pending"
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    persisted = coll.find_one({"queue_id": queued["queue_id"]})
+    assert persisted is not None
+    assert "purge_after" not in persisted
+
+    observed_now = datetime.now(timezone.utc)
+    first_claim = queue_service.claim_task_execution_terminal_reconciliation(
+        server_instance_id="reconciler-a",
+        now=observed_now,
+        lease_seconds=10,
+    )
+    assert first_claim is not None
+    assert (
+        queue_service.claim_task_execution_terminal_reconciliation(
+            server_instance_id="reconciler-b",
+            now=observed_now + timedelta(seconds=5),
+        )
+        is None
+    )
+    reclaimed = queue_service.claim_task_execution_terminal_reconciliation(
+        server_instance_id="reconciler-b",
+        now=observed_now + timedelta(seconds=11),
+        lease_seconds=10,
+    )
+    assert reclaimed is not None
+    assert reclaimed["queue_id"] == queued["queue_id"]
+    assert (
+        reclaimed["task_execution_reconciliation_token"]
+        != first_claim["task_execution_reconciliation_token"]
+    )
+    assert not queue_service.acknowledge_task_execution_terminal_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(
+            first_claim["task_execution_reconciliation_token"]
+        ),
+        server_instance_id="reconciler-a",
+        task_execution_concept_id="#V#task_execution_1",
+        enqueue_submission_id="submission-terminal-reconciliation",
+        queue_status=queue_service.STATUS_COMPLETED,
+        now=observed_now + timedelta(seconds=12),
+    )
+    assert queue_service.acknowledge_task_execution_terminal_reconciliation(
+        queue_id=str(queued["queue_id"]),
+        reconciliation_token=str(reclaimed["task_execution_reconciliation_token"]),
+        server_instance_id="reconciler-b",
+        task_execution_concept_id="#V#task_execution_1",
+        enqueue_submission_id="submission-terminal-reconciliation",
+        queue_status=queue_service.STATUS_COMPLETED,
+        now=observed_now + timedelta(seconds=12),
+    )
+    acknowledged = coll.find_one({"queue_id": queued["queue_id"]})
+    assert acknowledged is not None
+    assert acknowledged["task_execution_reconciliation_status"] == "acknowledged"
+    assert (
+        acknowledged["purge_after"] - acknowledged["task_execution_reconciled_at"]
+    ).total_seconds() == 60
+
+
+def test_linked_pre_admission_failure_and_cancellation_defer_retention() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    failed_row = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-linked-failure",
+        conversation_key="conversation-linked-failure",
+        task_concept_id="#V#task_failure",
+        task_execution_concept_id="#V#task_execution_failure",
+    )
+    reservation = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-a"
+    )
+    assert reservation is not None
+    assert queue_service.fail_server_dispatch_reservation(
+        queue_id=str(failed_row["queue_id"]),
+        dispatch_reservation_token=str(reservation["dispatch_reservation_token"]),
+        server_instance_id="server-a",
+        error="authority revoked",
+    )
+    cancelled_row = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-linked-cancel",
+        conversation_key="conversation-linked-cancel",
+        task_concept_id="#V#task_cancel",
+        task_execution_concept_id="#V#task_execution_cancel",
+    )
+    queue_service.cancel_prompt_record(
+        scope=scope,
+        queue_id=str(cancelled_row["queue_id"]),
+    )
+
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    for queue_id, expected_status in (
+        (failed_row["queue_id"], queue_service.STATUS_FAILED),
+        (cancelled_row["queue_id"], queue_service.STATUS_CANCELLED),
+    ):
+        persisted = coll.find_one({"queue_id": queue_id})
+        assert persisted is not None
+        assert persisted["status"] == expected_status
+        assert persisted["task_execution_reconciliation_status"] == "pending"
+        assert "purge_after" not in persisted
+
+
+def test_linked_terminal_backfill_removes_ttl_before_general_retention_backfill() -> None:
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    observed_now = datetime.now(timezone.utc)
+    coll.insert_one(
+        {
+            "queue_id": "legacy-linked-terminal",
+            "status": queue_service.STATUS_FAILED,
+            "task_concept_id": "#V#task_legacy",
+            "task_execution_concept_id": "#V#task_execution_legacy",
+            "last_error": "legacy failure",
+            "completed_at": observed_now - timedelta(days=2),
+            "updated_at": observed_now - timedelta(days=2),
+            "purge_after": observed_now + timedelta(days=1),
+        }
+    )
+
+    assert queue_service.backfill_linked_terminal_reconciliation(now=observed_now) == 1
+    assert queue_service.backfill_legacy_terminal_purge_after(now=observed_now) == 0
+    persisted = coll.find_one({"queue_id": "legacy-linked-terminal"})
+    assert persisted is not None
+    assert persisted["task_execution_reconciliation_status"] == "pending"
+    assert "purge_after" not in persisted
+
+
+def test_expired_server_dispatch_reservation_is_reclaimed_by_exact_cas() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = _create_server_queue_record(
+        scope=scope,
+        submission_id="submission-expired-lease",
+    )
+    observed_now = datetime.now(timezone.utc)
+    first = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-old",
+        now=observed_now,
+        lease_seconds=10,
+    )
+    assert first is not None
+    reclaimed = queue_service.reserve_next_server_dispatch(
+        server_instance_id="server-new",
+        now=observed_now + timedelta(seconds=11),
+        lease_seconds=10,
+    )
+    assert reclaimed is not None
+    assert reclaimed["queue_id"] == queued["queue_id"]
+    assert (
+        reclaimed["dispatch_reservation_token"] != first["dispatch_reservation_token"]
+    )
+    assert not queue_service.release_server_dispatch_reservation(
+        queue_id=str(queued["queue_id"]),
+        dispatch_reservation_token=str(first["dispatch_reservation_token"]),
+        server_instance_id="server-old",
+    )
+    with pytest.raises(queue_service.ChatPromptQueueError):
+        queue_service.bind_queue_record_to_turn(
+            scope=scope,
+            queue_id=str(queued["queue_id"]),
+            client_request_id=str(first["client_request_id"]),
+            attempt_id=str(first["attempt_id"]),
+            conversation_key="conversation-server",
+            server_instance_id="server-old",
+            dispatch_reservation_token=str(first["dispatch_reservation_token"]),
+        )
+
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    coll.update_one(
+        {"queue_id": queued["queue_id"]},
+        {"$set": {"dispatch_lease_expires_at": observed_now - timedelta(seconds=1)}},
+    )
+    with pytest.raises(queue_service.ConversationTurnAlreadyActive):
+        queue_service.bind_queue_record_to_turn(
+            scope=scope,
+            queue_id=str(queued["queue_id"]),
+            client_request_id=str(reclaimed["client_request_id"]),
+            attempt_id=str(reclaimed["attempt_id"]),
+            conversation_key="conversation-server",
+            server_instance_id="server-new",
+            dispatch_reservation_token=str(reclaimed["dispatch_reservation_token"]),
+        )
+
+
+def test_admitted_lease_heartbeat_controls_stale_advisory() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Long-running turn",
+        conversation_key="conversation-long",
+    )
+    bound = queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        client_request_id="request-long",
+        attempt_id="attempt-long",
+        conversation_key="conversation-long",
+        server_instance_id="server-a",
+        lease_seconds=60,
+    )
+    assert bound["lease_expires_at"] is not None
+    observed_now = datetime.now(timezone.utc)
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    coll.update_one(
+        {"queue_id": queued["queue_id"]},
+        {
+            "$set": {
+                "claimed_at": observed_now - timedelta(days=2),
+                "lease_heartbeat_at": observed_now,
+                "lease_expires_at": observed_now + timedelta(seconds=30),
+            }
+        },
+    )
+
+    assert (
+        queue_service.expire_stale_in_progress_records(
+            scope=scope,
+            now=observed_now,
+        )
+        == 0
+    )
+    assert not queue_service.heartbeat_bound_turn(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        attempt_id="attempt-long",
+        server_instance_id="server-b",
+        now=observed_now + timedelta(seconds=5),
+    )
+    assert queue_service.heartbeat_bound_turn(
+        scope=scope,
+        queue_id=str(queued["queue_id"]),
+        attempt_id="attempt-long",
+        server_instance_id="server-a",
+        now=observed_now + timedelta(seconds=5),
+        lease_seconds=60,
+    )
+
+    coll.update_one(
+        {"queue_id": queued["queue_id"]},
+        {"$set": {"lease_expires_at": observed_now - timedelta(seconds=1)}},
+    )
+    assert (
+        queue_service.expire_stale_in_progress_records(
+            scope=scope,
+            now=observed_now,
+        )
+        == 1
+    )
+    stale = coll.find_one({"queue_id": queued["queue_id"]})
+    assert stale is not None
+    assert stale["stale_advisory"] is True
+    assert stale["reconciliation_required"] is True
+
+
+def test_legacy_terminal_purge_backfill_is_bounded_and_has_rollout_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_CHAT_PROMPT_QUEUE_TERMINAL_RETENTION_SECONDS", "60")
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    observed_now = datetime.now(timezone.utc)
+    old_terminal_at = observed_now - timedelta(days=60)
+    for queue_id, status in (
+        ("legacy-completed", queue_service.STATUS_COMPLETED),
+        ("legacy-failed", queue_service.STATUS_FAILED),
+    ):
+        coll.insert_one(
+            {
+                "queue_id": queue_id,
+                **scope,
+                "prompt_raw": queue_id,
+                "status": status,
+                "created_at": old_terminal_at,
+                "updated_at": old_terminal_at,
+                "completed_at": old_terminal_at,
+            }
+        )
+    coll.insert_one(
+        {
+            "queue_id": "legacy-active",
+            **scope,
+            "prompt_raw": "must never get TTL",
+            "status": queue_service.STATUS_IN_PROGRESS,
+            "created_at": old_terminal_at,
+            "updated_at": old_terminal_at,
+            "completed_at": None,
+        }
+    )
+
+    assert (
+        queue_service.backfill_legacy_terminal_purge_after(
+            now=observed_now,
+            batch_size=1,
+            rollout_grace_seconds=7 * 24 * 60 * 60,
+        )
+        == 1
+    )
+    assert coll.count_documents({"purge_after": {"$exists": True}}) == 1
+    assert (
+        queue_service.backfill_legacy_terminal_purge_after(
+            now=observed_now,
+            batch_size=500,
+            rollout_grace_seconds=7 * 24 * 60 * 60,
+        )
+        == 1
+    )
+    terminals = list(
+        coll.find({"status": {"$in": list(queue_service.TERMINAL_STATUSES)}})
+    )
+    assert len(terminals) == 2
+    for terminal in terminals:
+        assert terminal["purge_after"] >= terminal["completed_at"] + timedelta(
+            seconds=60
+        )
+        # BSON stores millisecond precision, so allow the sub-millisecond part
+        # of the supplied clock to be truncated by mongomock.
+        assert terminal["purge_after"] >= (
+            observed_now.replace(tzinfo=None)
+            + timedelta(days=7)
+            - timedelta(milliseconds=1)
+        )
+    active = coll.find_one({"queue_id": "legacy-active"})
+    assert active is not None
+    assert "purge_after" not in active

--- a/tests/backend/test_conversation_turn_admission_service.py
+++ b/tests/backend/test_conversation_turn_admission_service.py
@@ -7,7 +7,9 @@ import pytest
 
 from src.backend.db import mongo_client
 from src.backend.services import chat_prompt_queue_service as queue_service
+from src.backend.services import task_execution_service
 from src.backend.services.conversation_turn_admission_service import (
+    SERVER_INSTANCE_ID,
     ConversationTurnActive,
     ConversationTurnAdmissionService,
     ConversationTurnCapacityReached,
@@ -104,6 +106,190 @@ def test_distinct_conversations_run_concurrently_and_release_exactly() -> None:
     assert service.snapshot()["active_global"] == 1
     service.release(second, status=queue_service.STATUS_COMPLETED)
     assert service.snapshot()["active_global"] == 0
+
+
+def test_active_durable_turn_renews_its_exact_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VON_TURN_LEASE_HEARTBEAT_SECONDS", "0.01")
+    scope = _scope()
+    service = ConversationTurnAdmissionService(per_user_limit=1, global_limit=1)
+    observed = threading.Event()
+    calls: list[dict[str, object]] = []
+    original_heartbeat = queue_service.heartbeat_bound_turn
+
+    def _heartbeat(**kwargs):
+        calls.append(kwargs)
+        observed.set()
+        return original_heartbeat(**kwargs)
+
+    monkeypatch.setattr(queue_service, "heartbeat_bound_turn", _heartbeat)
+    token = service.acquire(
+        scope=scope,
+        prompt_raw="heartbeat",
+        session_id="conversation-heartbeat",
+        session_name=None,
+        client_request_id="request-heartbeat",
+        conversation_key=_key("conversation-heartbeat"),
+        queue_id=_queued(scope, "conversation-heartbeat", "heartbeat"),
+    )
+    try:
+        assert observed.wait(timeout=1.0)
+        assert calls[-1] == {
+            "scope": token.scope,
+            "queue_id": token.queue_id,
+            "attempt_id": token.attempt_id,
+            "server_instance_id": SERVER_INSTANCE_ID,
+        }
+        assert service.snapshot()["lease_heartbeat_running"] is True
+    finally:
+        service.release(token, status=queue_service.STATUS_COMPLETED)
+        service.shutdown(wait=True)
+
+
+def _bound_task_queue_record(*, status: str = queue_service.STATUS_IN_PROGRESS):
+    return {
+        "queue_id": "queue-task-1",
+        "status": status,
+        "attempt_id": "attempt-task-1",
+        "enqueue_submission_id": "enqueue-task-1",
+        "task_concept_id": "#V#task_1",
+        "task_execution_concept_id": "#V#task_execution_1",
+    }
+
+
+@pytest.mark.parametrize(
+    ("queue_status", "execution_status"),
+    [
+        (
+            queue_service.STATUS_COMPLETED,
+            task_execution_service.TASK_EXECUTION_STATUS_COMPLETED,
+        ),
+        (
+            queue_service.STATUS_FAILED,
+            task_execution_service.TASK_EXECUTION_STATUS_FAILED,
+        ),
+        (
+            queue_service.STATUS_CANCELLED,
+            task_execution_service.TASK_EXECUTION_STATUS_CANCELLED,
+        ),
+    ],
+)
+def test_linked_task_execution_follows_exact_admission_and_terminal_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    queue_status: str,
+    execution_status: str,
+) -> None:
+    scope = _scope()
+    transitions: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        queue_service,
+        "bind_queue_record_to_turn",
+        lambda **_kwargs: _bound_task_queue_record(),
+    )
+    monkeypatch.setattr(
+        queue_service,
+        "finish_prompt_record",
+        lambda **kwargs: _bound_task_queue_record(status=kwargs["status"]),
+    )
+    monkeypatch.setattr(
+        task_execution_service,
+        "transition_task_execution",
+        lambda execution_id, **kwargs: (
+            transitions.append({"execution_id": execution_id, **kwargs})
+            or {"status": kwargs["status"]}
+        ),
+    )
+    service = ConversationTurnAdmissionService(per_user_limit=1, global_limit=1)
+
+    token = service.acquire(
+        scope=scope,
+        prompt_raw="complete linked work",
+        session_id="conversation-task",
+        session_name=None,
+        client_request_id="request-task-1",
+        conversation_key=_key("conversation-task"),
+        queue_id="queue-task-1",
+        attempt_id="attempt-task-1",
+    )
+    terminal_error = None if queue_status == queue_service.STATUS_COMPLETED else "ended"
+    service.release(token, status=queue_status, error=terminal_error)
+
+    assert token.enqueue_submission_id == "enqueue-task-1"
+    assert [call["status"] for call in transitions] == [
+        task_execution_service.TASK_EXECUTION_STATUS_IN_PROGRESS,
+        execution_status,
+    ]
+    assert all(call["queue_id"] == "queue-task-1" for call in transitions)
+    assert all(
+        call["enqueue_submission_id"] == "enqueue-task-1" for call in transitions
+    )
+    assert transitions[-1]["result"] == terminal_error
+    assert service.snapshot()["active_global"] == 0
+    service.shutdown()
+
+
+def test_task_execution_admission_failure_terminalises_bound_attempt_before_capacity_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = _scope()
+    terminal_calls: list[dict[str, object]] = []
+    transitions: list[str] = []
+    monkeypatch.setattr(
+        queue_service,
+        "bind_queue_record_to_turn",
+        lambda **_kwargs: _bound_task_queue_record(),
+    )
+
+    def _transition(_execution_id: str, **kwargs):
+        transitions.append(kwargs["status"])
+        if kwargs["status"] == task_execution_service.TASK_EXECUTION_STATUS_IN_PROGRESS:
+            raise RuntimeError("concept persistence unavailable")
+        return {"status": kwargs["status"]}
+
+    monkeypatch.setattr(
+        task_execution_service,
+        "transition_task_execution",
+        _transition,
+    )
+
+    def _finish(**kwargs):
+        terminal_calls.append(kwargs)
+        return _bound_task_queue_record(status=kwargs["status"])
+
+    monkeypatch.setattr(queue_service, "finish_prompt_record", _finish)
+    service = ConversationTurnAdmissionService(per_user_limit=1, global_limit=1)
+
+    with pytest.raises(RuntimeError, match="concept persistence unavailable"):
+        service.acquire(
+            scope=scope,
+            prompt_raw="fail linked admission",
+            session_id="conversation-task",
+            session_name=None,
+            client_request_id="request-task-1",
+            conversation_key=_key("conversation-task"),
+            queue_id="queue-task-1",
+            attempt_id="attempt-task-1",
+        )
+
+    assert terminal_calls == [
+        {
+            "scope": scope,
+            "queue_id": "queue-task-1",
+            "status": queue_service.STATUS_FAILED,
+            "error": (
+                "TaskExecution admission transition failed: RuntimeError: "
+                "concept persistence unavailable"
+            ),
+            "attempt_id": "attempt-task-1",
+        }
+    ]
+    assert transitions == [
+        task_execution_service.TASK_EXECUTION_STATUS_IN_PROGRESS,
+        task_execution_service.TASK_EXECUTION_STATUS_FAILED,
+    ]
+    assert service.snapshot()["active_global"] == 0
+    service.shutdown()
 
 
 def test_legacy_queue_first_converges_with_generate_admission() -> None:

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -519,6 +519,105 @@ def test_chat_prompt_queue_indexes_include_active_legacy_submission_fence() -> N
     ]
 
 
+def test_chat_prompt_queue_indexes_support_idempotent_dispatch_and_retention() -> None:
+    coll = mongomock.MongoClient().db.chat_prompt_queue_dispatch_indexes
+
+    mc._ensure_chat_prompt_queue_indexes(coll)
+
+    indexes = {index["name"]: index for index in coll.list_indexes()}
+    submission = indexes["scope_enqueue_submission_id_unique"]
+    assert list(submission["key"].items()) == [
+        ("user_concept_id", mc.ASCENDING),
+        ("organisation_concept_id", mc.ASCENDING),
+        ("namespace", mc.ASCENDING),
+        ("enqueue_submission_id", mc.ASCENDING),
+    ]
+    assert submission["unique"] is True
+    assert submission["partialFilterExpression"] == {
+        "enqueue_submission_id": {"$exists": True, "$type": "string"}
+    }
+    active_task = indexes["active_task_execution_key_unique"]
+    assert list(active_task["key"].items()) == [
+        ("active_task_execution_key", mc.ASCENDING)
+    ]
+    assert active_task["unique"] is True
+    assert active_task["partialFilterExpression"] == {
+        "active_task_execution_key": {"$exists": True, "$type": "string"}
+    }
+    handoff_source = indexes["handoff_source_queue_id_unique"]
+    assert list(handoff_source["key"].items()) == [
+        ("handoff_source_queue_id", mc.ASCENDING)
+    ]
+    assert handoff_source["unique"] is True
+    assert handoff_source["partialFilterExpression"] == {
+        "handoff_source_queue_id": {"$exists": True, "$type": "string"}
+    }
+    assert list(indexes["scope_status_enqueue_sequence"]["key"].items()) == [
+        ("user_concept_id", mc.ASCENDING),
+        ("organisation_concept_id", mc.ASCENDING),
+        ("namespace", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("enqueue_sequence", mc.ASCENDING),
+        ("created_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(
+        indexes["conversation_status_enqueue_sequence"]["key"].items()
+    ) == [
+        ("conversation_key", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("enqueue_sequence", mc.ASCENDING),
+        ("created_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(
+        indexes["dispatch_status_next_enqueue_sequence"]["key"].items()
+    ) == [
+        ("dispatch_mode", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("next_dispatch_at", mc.ASCENDING),
+        ("enqueue_sequence", mc.ASCENDING),
+        ("created_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(indexes["dispatch_status_lease_expiry"]["key"].items()) == [
+        ("dispatch_mode", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("dispatch_lease_expires_at", mc.ASCENDING),
+    ]
+    assert list(indexes["handoff_reconciliation_due"]["key"].items()) == [
+        ("dispatch_mode", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("dispatch_ready", mc.ASCENDING),
+        ("handoff_reconciliation_next_at", mc.ASCENDING),
+        ("enqueue_sequence", mc.ASCENDING),
+        ("created_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(indexes["task_launch_reconciliation_due"]["key"].items()) == [
+        ("dispatch_mode", mc.ASCENDING),
+        ("status", mc.ASCENDING),
+        ("dispatch_ready", mc.ASCENDING),
+        ("task_launch_reconciliation_next_at", mc.ASCENDING),
+        ("task_launch_reconciliation_lease_expires_at", mc.ASCENDING),
+        ("enqueue_sequence", mc.ASCENDING),
+        ("created_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(indexes["task_execution_reconciliation_due"]["key"].items()) == [
+        ("task_execution_reconciliation_status", mc.ASCENDING),
+        ("task_execution_reconciliation_next_at", mc.ASCENDING),
+        ("task_execution_reconciliation_lease_expires_at", mc.ASCENDING),
+        ("task_execution_reconciliation_pending_at", mc.ASCENDING),
+        ("queue_id", mc.ASCENDING),
+    ]
+    assert list(indexes["purge_after_ttl"]["key"].items()) == [
+        ("purge_after", mc.ASCENDING)
+    ]
+    assert indexes["purge_after_ttl"]["expireAfterSeconds"] == 0
+    assert indexes["purge_after_ttl"]["sparse"] is True
+
+
 def test_window_session_binding_indexes_support_owner_cleanup_and_expiry() -> None:
     coll = mongomock.MongoClient().db.window_session_binding_indexes
 

--- a/tests/backend/test_task_execute_with_von_routes.py
+++ b/tests/backend/test_task_execute_with_von_routes.py
@@ -1,0 +1,482 @@
+"""Route tests for the explicit actor-bound task execution launch."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+from src.backend.db import mongo_client
+from src.backend.server.routes.task_routes import task_bp
+from src.backend.services import task_execution_service
+
+
+def _build_client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret"
+    app.register_blueprint(task_bp, url_prefix="/api/tasks")
+    return app.test_client()
+
+
+def _task(
+    *,
+    creator: str = "#V#alice",
+    assignee: str = "#V#von_system",
+    status: str = "pending",
+) -> dict:
+    return {
+        "task_concept_id": "#V#task_prepare_brief",
+        "title": "Prepare brief",
+        "description": "Prepare and read back the research brief.",
+        "status": status,
+        "assignee_concept_id": assignee,
+        "created_by_concept_id": creator,
+        "organisation_concept_id": "#V#research_lab",
+        "originating_conversation_id": "#V#conversation_1",
+        "conversation_session_id": "session-1",
+        "conversation_name": "Research planning",
+    }
+
+
+def _conversation() -> dict:
+    return {
+        "conversation_concept_id": "#V#conversation_1",
+        "session_id": "session-1",
+        "name": "Research planning",
+        "owner_concept_id": "#V#alice",
+        "organisation_concept_id": "#V#research_lab",
+        "namespace": "#V#alice@research_lab",
+    }
+
+
+def _set_actor(client, *, include_org: bool = True) -> None:
+    with client.session_transaction() as session:
+        session["user_concept_id"] = "#V#alice"
+        if include_org:
+            session["org_id"] = "#V#research_lab"
+
+
+def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> None:
+    client = _build_client()
+    _set_actor(client)
+    queue_call: dict = {}
+    reconciliation_call: dict = {}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_conversation_concept",
+        lambda _conversation_id: _conversation(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+
+    def _create_queue_record(**kwargs):
+        queue_call.update(kwargs)
+        return {
+            "queue_id": "queue-1",
+            "status": "queued",
+            "session_id": kwargs["session_id"],
+            "session_name": kwargs["session_name"],
+            "enqueue_submission_id": kwargs["enqueue_submission_id"],
+            "task_concept_id": kwargs["task_concept_id"],
+            "task_execution_concept_id": kwargs["task_execution_concept_id"],
+            "idempotent_replay": False,
+            "dispatch_ready": kwargs["server_dispatch_ready"],
+        }
+
+    def _reconcile_execution(record):
+        reconciliation_call.update(record)
+        return {
+            "task_execution_concept_id": record["task_execution_concept_id"],
+            "task_concept_id": "#V#task_prepare_brief",
+            "status": "pending",
+            "queue_id": record["queue_id"],
+            "enqueue_submission_id": record["enqueue_submission_id"],
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        _create_queue_record,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        _reconcile_execution,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.activate_server_dispatch_record",
+        lambda **_kwargs: {
+            **_create_queue_record(**queue_call),
+            "dispatch_ready": True,
+        },
+    )
+    wake_dispatcher = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        wake_dispatcher,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()["task_execution"]["queue_id"] == "queue-1"
+    assert reconciliation_call["user_concept_id"] == "#V#alice"
+    assert reconciliation_call["organisation_concept_id"] == "#V#research_lab"
+    assert reconciliation_call["session_id"] == "session-1"
+    assert queue_call["source"] == "von_task"
+    assert queue_call["dispatch_mode"] == "server"
+    assert queue_call["server_dispatch_ready"] is False
+    assert queue_call["execution_envelope"]["turn_kind"] == "user_message"
+    assert (
+        queue_call["execution_envelope"]["workflow_inputs"]["authority_namespace"]
+        == "#V#alice@research_lab"
+    )
+    assert queue_call["task_concept_id"] == "#V#task_prepare_brief"
+    assert "client_request_id" not in queue_call
+    wake_dispatcher.assert_called_once_with()
+
+
+def test_execute_with_von_replays_an_already_linked_launch_without_rebinding(
+    monkeypatch,
+) -> None:
+    client = _build_client()
+    _set_actor(client)
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_conversation_concept",
+        lambda _conversation_id: _conversation(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    execution_id = "#V#task_execution_replayed"
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        lambda **kwargs: {
+            "queue_id": "queue-original",
+            "status": "in_progress",
+            "dispatch_mode": "server",
+            "dispatch_ready": True,
+            "enqueue_submission_id": kwargs["enqueue_submission_id"],
+            "task_concept_id": "#V#task_prepare_brief",
+            "task_execution_concept_id": kwargs["task_execution_concept_id"],
+            "idempotent_replay": True,
+        },
+    )
+    reconcile = MagicMock(
+        return_value={
+            "task_execution_concept_id": execution_id,
+            "task_concept_id": "#V#task_prepare_brief",
+            "status": "in_progress",
+            "queue_id": "queue-original",
+        }
+    )
+    activate = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        reconcile,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.activate_server_dispatch_record",
+        activate,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        MagicMock(),
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-replayed"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["idempotent_replay"] is True
+    reconcile.assert_called_once()
+    activate.assert_not_called()
+
+
+def test_execute_with_von_requires_authenticated_actor(monkeypatch) -> None:
+    client = _build_client()
+    get_task = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        get_task,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["reason_code"] == "not_authenticated"
+    get_task.assert_not_called()
+
+
+def test_execute_with_von_rejects_legacy_identity_header_actor(monkeypatch) -> None:
+    client = _build_client()
+    get_task = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id_with_source",
+        lambda: ("#V#alice", "legacy_identity_header"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        get_task,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+        headers={"X-User-Concept-ID": "#V#alice"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["reason_code"] == "not_authenticated"
+    get_task.assert_not_called()
+
+
+def test_execute_with_von_deliberately_requires_active_org_scope(monkeypatch) -> None:
+    client = _build_client()
+    _set_actor(client, include_org=False)
+    get_task = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        get_task,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["reason_code"] == "organisation_scope_required"
+    get_task.assert_not_called()
+
+
+def test_execute_with_von_rejects_non_creator_even_when_task_is_visible(
+    monkeypatch,
+) -> None:
+    client = _build_client()
+    _set_actor(client)
+    create_queue = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(creator="#V#bob"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        create_queue,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["reason_code"] == "task_creator_mismatch"
+    create_queue.assert_not_called()
+
+
+def test_execute_with_von_rejects_terminal_task(monkeypatch) -> None:
+    client = _build_client()
+    _set_actor(client)
+    create_queue = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(status="completed"),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        create_queue,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["reason_code"] == "task_not_executable"
+    create_queue.assert_not_called()
+
+
+def test_execute_with_von_requires_client_launch_identity(monkeypatch) -> None:
+    client = _build_client()
+    _set_actor(client)
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_conversation_concept",
+        lambda _conversation_id: _conversation(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "launch_request_id is required"
+
+
+def test_task_execution_lifecycle_is_not_publicly_browser_mutable() -> None:
+    client = _build_client()
+    _set_actor(client)
+
+    for suffix in ("in-progress", "terminal", "terminalise-task"):
+        response = client.post(
+            f"/api/tasks/executions/%23V%23task_execution_1/{suffix}",
+            json={},
+        )
+        assert response.status_code == 404
+
+
+def test_durable_queue_is_not_relabelled_failed_when_execution_binding_needs_reconciliation(
+    monkeypatch,
+) -> None:
+    client = _build_client()
+    _set_actor(client)
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: _task(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_conversation_concept",
+        lambda _conversation_id: _conversation(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        lambda **kwargs: {
+            "queue_id": "queue-durable",
+            "status": "queued",
+            "dispatch_ready": False,
+            "task_concept_id": kwargs["task_concept_id"],
+            "task_execution_concept_id": kwargs["task_execution_concept_id"],
+            "enqueue_submission_id": kwargs["enqueue_submission_id"],
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        MagicMock(side_effect=RuntimeError("execution binding must be reconciled")),
+    )
+    wake = MagicMock()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        wake,
+    )
+
+    response = client.post(
+        "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+        json={"launch_request_id": "launch-bind-reconcile"},
+    )
+
+    assert response.status_code == 202
+    assert response.get_json()["reconciliation_pending"] is True
+    assert response.get_json()["queue_item"]["status"] == "queued"
+    wake.assert_called_once_with()
+
+
+def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DB_NAME", "test_task_execute_with_von_end_to_end")
+    mongo_client.close_connection()
+    client = _build_client()
+    _set_actor(client)
+    task = _task()
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_task",
+        lambda _task_id: dict(task),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.task_management_service.get_task",
+        lambda _task_id: dict(task),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.get_conversation_concept",
+        lambda _conversation_id: _conversation(),
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        task_execution_service,
+        "_persist_singleton_text",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        lambda: None,
+    )
+
+    try:
+        first = client.post(
+            "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+            json={"launch_request_id": "launch-end-to-end"},
+        )
+        replay = client.post(
+            "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+            json={"launch_request_id": "launch-end-to-end"},
+        )
+        duplicate = client.post(
+            "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
+            json={"launch_request_id": "launch-distinct"},
+        )
+
+        assert first.status_code == 201
+        assert replay.status_code == 200
+        assert replay.get_json()["idempotent_replay"] is True
+        assert duplicate.status_code == 409
+        assert duplicate.get_json()["reason_code"] == ("task_execution_already_active")
+        first_payload = first.get_json()
+        assert first_payload["queue_item"]["dispatch_ready"] is True
+        assert (
+            first_payload["task_execution"]["queue_id"]
+            == (first_payload["queue_item"]["queue_id"])
+        )
+
+        queue = mongo_client.get_chat_prompt_queue_collection()
+        assert queue is not None
+        assert queue.count_documents({"task_concept_id": task["task_concept_id"]}) == 1
+        executions = mongo_client.get_db()["concepts"]
+        assert (
+            executions.count_documents(
+                {
+                    "relationships.is_an_instance_of": (
+                        task_execution_service.TASK_EXECUTION_TYPE_ID
+                    )
+                }
+            )
+            == 1
+        )
+    finally:
+        mongo_client.close_connection()

--- a/tests/backend/test_task_execution_service.py
+++ b/tests/backend/test_task_execution_service.py
@@ -1,0 +1,354 @@
+"""Focused tests for durable TaskExecution attempt semantics."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.backend.services import task_execution_service as service
+
+
+def _task() -> dict:
+    return {
+        "task_concept_id": "#V#task_prepare_brief",
+        "title": "Prepare brief",
+        "description": "Prepare and read back the research brief.",
+        "status": "pending",
+        "assignee_concept_id": "#V#von_system",
+        "created_by_concept_id": "#V#alice",
+        "organisation_concept_id": "#V#research_lab",
+        "originating_conversation_id": "#V#conversation_1",
+        "conversation_session_id": "session-1",
+        "conversation_name": "Research planning",
+    }
+
+
+def _execution_doc(
+    *, status: str = "pending", queue_id: str | None = "queue-1"
+) -> dict:
+    return {
+        "concept_id": "#V#task_execution_1",
+        "relationships": {"is_an_instance_of": ["#V#task_execution"]},
+        "metadata": {
+            "concept_type": "task_execution",
+            "task_concept_id": "#V#task_prepare_brief",
+            "creator_concept_id": "#V#alice",
+            "executor_concept_id": "#V#von_system",
+            "organisation_concept_id": "#V#research_lab",
+            "namespace": "#V#alice@research_lab",
+            "originating_conversation_id": "#V#conversation_1",
+            "conversation_session_id": "session-1",
+            "conversation_name": "Research planning",
+            "launch_request_id": "launch-1",
+            "enqueue_submission_id": "enqueue-1",
+            "queue_id": queue_id,
+            "execution_status": status,
+            "execution_envelope_version": 1,
+            "execution_envelope": {
+                "turn_kind": "task_execution",
+                "workflow_inputs": {},
+            },
+        },
+    }
+
+
+def test_create_task_execution_preserves_user_authority_and_von_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inserted: dict = {}
+    text_projection = MagicMock()
+
+    def _insert(doc: dict) -> None:
+        inserted.update(deepcopy(doc))
+
+    monkeypatch.setattr(service.ConceptsRepository, "insert_one", _insert)
+    monkeypatch.setattr(service, "upsert_singleton_text_relation", text_projection)
+
+    execution = service.create_task_execution(
+        task=_task(),
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        namespace="#V#alice@research_lab",
+        launch_request_id="launch-1",
+        enqueue_submission_id="enqueue-1",
+        execution_envelope={
+            "turn_kind": "task_execution",
+            "workflow_inputs": {"task_concept_id": "#V#task_prepare_brief"},
+        },
+    )
+
+    assert execution["created"] is True
+    assert execution["creator_concept_id"] == "#V#alice"
+    assert execution["executor_concept_id"] == "#V#von_system"
+    assert execution["status"] == "pending"
+    assert inserted["relationships"]["#V#hasCreatedBy"] == ["#V#alice"]
+    assert inserted["relationships"]["#V#hasExecutor"] == ["#V#von_system"]
+    assert inserted["relationships"]["#V#executesTask"] == ["#V#task_prepare_brief"]
+    assert inserted["metadata"]["enqueue_submission_id"] == "enqueue-1"
+    text_projection.assert_called_once()
+
+
+def test_logical_launch_is_stable_but_retry_launch_gets_new_execution() -> None:
+    common = {
+        "task_concept_id": "#V#task_prepare_brief",
+        "creator_concept_id": "#V#alice",
+        "organisation_concept_id": "#V#research_lab",
+    }
+    first = service.task_execution_concept_id_for_launch(
+        **common,
+        launch_request_id="launch-1",
+    )
+    replay = service.task_execution_concept_id_for_launch(
+        **common,
+        launch_request_id="launch-1",
+    )
+    retry = service.task_execution_concept_id_for_launch(
+        **common,
+        launch_request_id="launch-2",
+    )
+
+    assert first == replay
+    assert retry != first
+    assert service.task_execution_enqueue_submission_id_for_launch(
+        **common,
+        launch_request_id="launch-1",
+    ) == service.task_execution_enqueue_submission_id_for_launch(
+        **common,
+        launch_request_id="launch-1",
+    )
+
+
+def test_duplicate_logical_launch_reuses_persisted_execution_and_enqueue_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inserted: dict = {}
+
+    def _insert_first(doc: dict) -> None:
+        inserted.update(deepcopy(doc))
+
+    monkeypatch.setattr(service.ConceptsRepository, "insert_one", _insert_first)
+    monkeypatch.setattr(service, "upsert_singleton_text_relation", MagicMock())
+    first = service.create_task_execution(
+        task=_task(),
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        namespace="#V#alice@research_lab",
+        launch_request_id="launch-1",
+        enqueue_submission_id="enqueue-first",
+        execution_envelope={"turn_kind": "user_message", "workflow_inputs": {}},
+    )
+
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "insert_one",
+        MagicMock(side_effect=service.DuplicateKeyError("duplicate execution")),
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        MagicMock(return_value=inserted),
+    )
+    replay = service.create_task_execution(
+        task=_task(),
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        namespace="#V#alice@research_lab",
+        launch_request_id="launch-1",
+        enqueue_submission_id="enqueue-first",
+        execution_envelope={"turn_kind": "user_message", "workflow_inputs": {}},
+    )
+
+    assert replay["created"] is False
+    assert replay["task_execution_concept_id"] == first["task_execution_concept_id"]
+    assert replay["enqueue_submission_id"] == "enqueue-first"
+
+
+def test_duplicate_logical_launch_rejects_changed_queue_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = _execution_doc(status="pending", queue_id=None)
+    existing["metadata"]["execution_envelope"] = {
+        "turn_kind": "user_message",
+        "workflow_inputs": {},
+    }
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "insert_one",
+        MagicMock(side_effect=service.DuplicateKeyError("duplicate execution")),
+    )
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        MagicMock(return_value=existing),
+    )
+
+    with pytest.raises(
+        service.TaskExecutionAccessError,
+        match="launch identity is already bound",
+    ):
+        service.create_task_execution(
+            task=_task(),
+            creator_concept_id="#V#alice",
+            organisation_concept_id="#V#research_lab",
+            namespace="#V#alice@research_lab",
+            launch_request_id="launch-1",
+            enqueue_submission_id="different-enqueue",
+            execution_envelope={"turn_kind": "user_message", "workflow_inputs": {}},
+        )
+
+
+def test_execution_transition_does_not_complete_task_specification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pending = _execution_doc(status="pending")
+    in_progress = _execution_doc(status="in_progress")
+    find_one = MagicMock(side_effect=[pending, in_progress])
+    update_one = MagicMock(return_value=SimpleNamespace(modified_count=1))
+
+    monkeypatch.setattr(service.ConceptsRepository, "find_one", find_one)
+    monkeypatch.setattr(service.ConceptsRepository, "update_one", update_one)
+    monkeypatch.setattr(service, "upsert_singleton_text_relation", MagicMock())
+
+    result = service.transition_task_execution(
+        "#V#task_execution_1",
+        actor_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        enqueue_submission_id="enqueue-1",
+        queue_id="queue-1",
+        status="in_progress",
+    )
+
+    assert result["status"] == "in_progress"
+    update_one.assert_called_once()
+
+
+def test_queue_outbox_reconciliation_creates_and_binds_exact_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution_id = service.task_execution_concept_id_for_launch(
+        task_concept_id="#V#task_prepare_brief",
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        launch_request_id="launch-1",
+    )
+    enqueue_id = service.task_execution_enqueue_submission_id_for_launch(
+        task_concept_id="#V#task_prepare_brief",
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        launch_request_id="launch-1",
+    )
+    envelope = {
+        "initiation_id": "launch-1",
+        "turn_kind": "user_message",
+        "workflow_inputs": {
+            "task_concept_id": "#V#task_prepare_brief",
+            "task_execution_concept_id": execution_id,
+            "originating_conversation_concept_id": "#V#conversation_1",
+            "conversation_session_id": "session-1",
+            "authority_actor_concept_id": "#V#alice",
+            "authority_organisation_concept_id": "#V#research_lab",
+            "authority_namespace": "#V#alice@research_lab",
+            "executor_concept_id": "#V#von_system",
+        },
+    }
+    create = MagicMock(
+        return_value={
+            "task_execution_concept_id": execution_id,
+            "enqueue_submission_id": enqueue_id,
+        }
+    )
+    bind = MagicMock(return_value={"task_execution_concept_id": execution_id})
+    monkeypatch.setattr(
+        "src.backend.services.task_management_service.get_task",
+        lambda _task_id: _task(),
+    )
+    monkeypatch.setattr(service, "create_task_execution", create)
+    monkeypatch.setattr(service, "bind_task_execution_queue_record", bind)
+
+    result = service.reconcile_task_execution_queue_record(
+        {
+            "queue_id": "queue-1",
+            "task_concept_id": "#V#task_prepare_brief",
+            "task_execution_concept_id": execution_id,
+            "user_concept_id": "#V#alice",
+            "organisation_concept_id": "#V#research_lab",
+            "namespace": "#V#alice@research_lab",
+            "enqueue_submission_id": enqueue_id,
+            "session_id": "session-1",
+            "execution_envelope_version": 1,
+            "execution_envelope": envelope,
+        }
+    )
+
+    assert result["task_execution_concept_id"] == execution_id
+    create.assert_called_once()
+    bind.assert_called_once()
+
+
+def test_queue_outbox_reconciliation_rejects_task_cancelled_after_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution_id = service.task_execution_concept_id_for_launch(
+        task_concept_id="#V#task_prepare_brief",
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        launch_request_id="launch-1",
+    )
+    enqueue_id = service.task_execution_enqueue_submission_id_for_launch(
+        task_concept_id="#V#task_prepare_brief",
+        creator_concept_id="#V#alice",
+        organisation_concept_id="#V#research_lab",
+        launch_request_id="launch-1",
+    )
+    cancelled = _task()
+    cancelled["status"] = "cancelled"
+    monkeypatch.setattr(
+        "src.backend.services.task_management_service.get_task",
+        lambda _task_id: cancelled,
+    )
+    create = MagicMock(
+        return_value={
+            "task_execution_concept_id": execution_id,
+            "enqueue_submission_id": enqueue_id,
+        }
+    )
+    bind = MagicMock(return_value={"task_execution_concept_id": execution_id})
+    monkeypatch.setattr(service, "create_task_execution", create)
+    monkeypatch.setattr(service, "bind_task_execution_queue_record", bind)
+
+    with pytest.raises(
+        service.TaskExecutionAccessError,
+        match="pending or in-progress",
+    ):
+        service.reconcile_task_execution_queue_record(
+            {
+                "queue_id": "queue-1",
+                "task_concept_id": "#V#task_prepare_brief",
+                "task_execution_concept_id": execution_id,
+                "user_concept_id": "#V#alice",
+                "organisation_concept_id": "#V#research_lab",
+                "namespace": "#V#alice@research_lab",
+                "enqueue_submission_id": enqueue_id,
+                "session_id": "session-1",
+                "execution_envelope_version": 1,
+                "execution_envelope": {
+                    "initiation_id": "launch-1",
+                    "turn_kind": "user_message",
+                    "workflow_inputs": {
+                        "task_concept_id": "#V#task_prepare_brief",
+                        "task_execution_concept_id": execution_id,
+                        "originating_conversation_concept_id": "#V#conversation_1",
+                        "conversation_session_id": "session-1",
+                        "authority_actor_concept_id": "#V#alice",
+                        "authority_organisation_concept_id": "#V#research_lab",
+                        "authority_namespace": "#V#alice@research_lab",
+                        "executor_concept_id": "#V#von_system",
+                    },
+                },
+            }
+        )
+    create.assert_called_once()
+    bind.assert_called_once()

--- a/tests/frontend/chatAttachmentWorkflowInput.test.js
+++ b/tests/frontend/chatAttachmentWorkflowInput.test.js
@@ -772,13 +772,14 @@ describe('chat attachment workflow input binding', () => {
         });
     }, 15000);
 
-    test('queued prompts carry only the attachment bound to that prompt', async () => {
+    test('server-queued prompts carry only the attachment bound to that prompt', async () => {
         const {
             __testOnly_uploadFilesToVon,
             sendMessage
         } = require(chatTabModulePath);
         const fileCopyConceptId = '#V#uploaded_file_copy_attachment_queue_test';
         const generateBodies = [];
+        const queuePostBodies = [];
         let resolveFirstGenerate;
         let queueCounter = 0;
         const queueRecords = new Map();
@@ -804,13 +805,12 @@ describe('chat attachment workflow input binding', () => {
             }
             if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
                 const body = JSON.parse(options.body || '{}');
+                queuePostBodies.push(body);
                 queueCounter += 1;
                 const queueId = `queue-${queueCounter}`;
                 queueRecords.set(queueId, {
+                    ...body,
                     queue_id: queueId,
-                    prompt_raw: body.prompt_raw,
-                    session_id: body.session_id,
-                    session_name: body.session_name,
                     status: body.status || 'queued'
                 });
                 return Promise.resolve({
@@ -902,14 +902,19 @@ describe('chat attachment workflow input binding', () => {
         });
         await firstSend;
 
-        for (let attempt = 0; attempt < 40 && generateBodies.length < 3; attempt += 1) {
+        for (let attempt = 0; attempt < 40 && queuePostBodies.length < 3; attempt += 1) {
             await new Promise((resolve) => setTimeout(resolve, 10));
         }
 
-        expect(generateBodies).toHaveLength(3);
+        // Only the foreground turn is browser-owned. The two deferred turns
+        // remain durable server-dispatch rows, including their frozen and
+        // prompt-specific attachment envelopes.
+        expect(generateBodies).toHaveLength(1);
         expect(generateBodies[0]).not.toHaveProperty('workflow_inputs');
-        expect(generateBodies[1]).not.toHaveProperty('workflow_inputs');
-        expect(generateBodies[2].workflow_inputs).toEqual({
+        expect(queuePostBodies).toHaveLength(3);
+        expect(queuePostBodies[0]).not.toHaveProperty('execution_envelope');
+        expect(queuePostBodies[1].execution_envelope).not.toHaveProperty('workflow_inputs');
+        expect(queuePostBodies[2].execution_envelope.workflow_inputs).toEqual({
             file_copy_concept_id: fileCopyConceptId
         });
     }, 15000);

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -135,7 +135,7 @@ describe('chat task queue', () => {
         }
     });
 
-    test('keeps same-session prompts FIFO while the first turn is active', async () => {
+    test('persists a same-session prompt while a turn is active and leaves dispatch to the backend', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const { sendMessage } = require(chatTabModulePath);
 
@@ -147,6 +147,7 @@ describe('chat task queue', () => {
         });
 
         const generateBodies = [];
+        const queueBodies = [];
         let resolveFirstGenerate = null;
 
         global.fetch = jest.fn((url, options = {}) => {
@@ -162,6 +163,23 @@ describe('chat task queue', () => {
                 return Promise.resolve({
                     ok: true,
                     json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+
+            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                const body = JSON.parse(options.body || '{}');
+                queueBodies.push(body);
+                return Promise.resolve({
+                    ok: true,
+                    status: 201,
+                    json: async () => ({
+                        success: true,
+                        item: {
+                            ...body,
+                            queue_id: `queue-${queueBodies.length}`,
+                            status: 'queued'
+                        }
+                    })
                 });
             }
 
@@ -206,6 +224,7 @@ describe('chat task queue', () => {
 
         const queuedEditor = document.querySelector('.chat-task-queue-edit');
         expect(queuedEditor).toBeTruthy();
+        expect(queuedEditor.readOnly).toBe(true);
         queuedEditor.value = 'Second edited';
         queuedEditor.dispatchEvent(new Event('input', { bubbles: true }));
 
@@ -216,16 +235,196 @@ describe('chat task queue', () => {
         await flushMicrotasks();
         await flushMicrotasks();
 
-        expect(generateBodies).toHaveLength(2);
-        expect(generateBodies[1].prompt).toBe('Second edited');
-        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+        expect(generateBodies).toHaveLength(1);
+        expect(queueBodies.map((body) => body.prompt_raw)).toEqual([
+            'First request',
+            'Second draft'
+        ]);
+        expect(queueBodies[0]).toMatchObject({
+            client_request_id: expect.any(String),
+            attempt_id: expect.any(String)
+        });
+        expect(queueBodies[0]).not.toHaveProperty('enqueue_submission_id');
+        expect(queueBodies[0]).not.toHaveProperty('dispatch_mode');
+        expect(queueBodies[1]).toMatchObject({
+            enqueue_submission_id: expect.any(String),
+            dispatch_mode: 'server',
+            execution_envelope_version: 1,
+            execution_envelope: {
+                language: 'en-NZ',
+                presenter_mode: true,
+                skip_buttonify: false,
+                thinking_card_mode: expect.any(String)
+            }
+        });
+        expect(queueBodies[1]).not.toHaveProperty('client_request_id');
+        expect(queueBodies[1]).not.toHaveProperty('attempt_id');
+        expect(queuedEditor.value).toBe('Second draft');
+        expect(document.querySelector('.chat-task-queue-item')).toBeTruthy();
+        expect(global.fetch.mock.calls.some(([, options]) => options?.method === 'PATCH')).toBe(false);
+        expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/claim'))).toBe(false);
+        expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/finish'))).toBe(false);
+    }, 15000);
+
+    test('guards one enqueue save per session while preserving a newly typed draft', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const {
+            __testOnly_setLiveChatRequestForSession,
+            sendMessage,
+        } = require(chatTabModulePath);
+
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ'
+        });
+        __testOnly_setLiveChatRequestForSession('session-1', {
+            promptQueueRecordId: 'queue-active',
+            promptRaw: 'Active turn'
+        });
+
+        const queueBodies = [];
+        let resolveFirstQueuePost = null;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                const body = JSON.parse(options.body || '{}');
+                queueBodies.push(body);
+                const response = {
+                    ok: true,
+                    status: 201,
+                    json: async () => ({
+                        success: true,
+                        item: {
+                            ...body,
+                            queue_id: `queue-${queueBodies.length}`,
+                            status: 'queued'
+                        }
+                    })
+                };
+                if (queueBodies.length === 1) {
+                    return new Promise((resolve) => {
+                        resolveFirstQueuePost = () => resolve(response);
+                    });
+                }
+                return Promise.resolve(response);
+            }
+            return Promise.resolve({ ok: true, status: 200, json: async () => ({ success: true }) });
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        const sendButton = document.getElementById('sendButton');
+        promptInput.value = 'First queued prompt';
+        const firstQueuePromise = sendMessage();
+
+        expect(queueBodies).toHaveLength(1);
+        expect(promptInput.value).toBe('');
+        expect(sendButton.disabled).toBe(true);
+        expect(sendButton.textContent).toBe('Queueing…');
+
+        promptInput.value = 'A new draft typed during persistence';
+        await sendMessage();
+        expect(queueBodies).toHaveLength(1);
+        expect(promptInput.value).toBe('A new draft typed during persistence');
+
+        expect(resolveFirstQueuePost).toBeTruthy();
+        resolveFirstQueuePost();
+        await firstQueuePromise;
+
+        expect(promptInput.value).toBe('A new draft typed during persistence');
+        expect(queueBodies[0].enqueue_submission_id).toEqual(expect.any(String));
+
+        await sendMessage();
+        expect(queueBodies).toHaveLength(2);
+        expect(queueBodies[1].prompt_raw).toBe('A new draft typed during persistence');
+        expect(queueBodies[1].enqueue_submission_id).toEqual(expect.any(String));
+        expect(queueBodies[1].enqueue_submission_id)
+            .not.toBe(queueBodies[0].enqueue_submission_id);
+    }, 15000);
+
+    test('marks an ambiguous save as unconfirmed and retries the same immutable submission', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const {
+            __testOnly_setLiveChatRequestForSession,
+            sendMessage,
+        } = require(chatTabModulePath);
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ'
+        });
+        __testOnly_setLiveChatRequestForSession('session-1', {
+            promptQueueRecordId: 'queue-active',
+            promptRaw: 'Active turn'
+        });
+
+        const queueBodies = [];
+        let resolveFailedPost = null;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                const body = JSON.parse(options.body || '{}');
+                queueBodies.push(body);
+                if (queueBodies.length === 1) {
+                    return new Promise((resolve) => {
+                        resolveFailedPost = () => resolve({
+                            ok: false,
+                            status: 503,
+                            json: async () => ({
+                                success: false,
+                                error_code: 'backend_unavailable'
+                            })
+                        });
+                    });
+                }
+                return Promise.resolve({
+                    ok: true,
+                    status: 201,
+                    json: async () => ({
+                        success: true,
+                        item: {
+                            ...body,
+                            queue_id: 'queue-after-retry',
+                            status: 'queued'
+                        }
+                    })
+                });
+            }
+            return Promise.resolve({ ok: true, status: 200, json: async () => ({ success: true }) });
+        });
+
+        const promptInput = document.getElementById('promptInput');
+        promptInput.value = 'Prompt whose queue save fails';
+        const queuePromise = sendMessage();
+        promptInput.value = 'New draft preserved during failure';
+        expect(resolveFailedPost).toBeTruthy();
+        resolveFailedPost();
+        await queuePromise;
+
+        expect(promptInput.value).toBe('New draft preserved during failure');
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queue unconfirmed');
+        expect(document.querySelector('.chat-task-queue-item-label')?.textContent)
+            .toBe('Queue unconfirmed • Current');
+        expect(document.querySelector('.chat-task-queue-sync-warning')?.textContent)
+            .toBe('Queue storage is temporarily unavailable.');
+        expect(document.querySelector('.chat-task-queue-edit')?.readOnly).toBe(true);
+
+        document.querySelector('.chat-task-queue-enqueue-retry').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(queueBodies).toHaveLength(2);
+        expect(queueBodies[1]).toEqual(queueBodies[0]);
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queued');
+        expect(document.querySelector('.chat-task-queue-item-label')?.textContent)
+            .toBe('Next up • Current');
+        expect(global.fetch.mock.calls.some(([url]) => String(url).startsWith('/von/generate'))).toBe(false);
+        expect(global.fetch.mock.calls.some(([, options]) => options?.method === 'PATCH')).toBe(false);
     }, 15000);
 
     test.each([
         [409, 'conversation_turn_active', false],
         [429, 'turn_capacity_reached', false],
         [409, 'window_context_unavailable', true],
-    ])('retries retryable HTTP %i %s admission without client-owned transitions', async (status, errorCode, expectsWindowRepair) => {
+    ])('leaves retryable HTTP %i %s admission queued for the server dispatcher', async (status, errorCode, expectsWindowRepair) => {
         const { getUserContext, postJson } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const { sendMessage } = require(chatTabModulePath);
 
@@ -245,7 +444,7 @@ describe('chat task queue', () => {
 
         const fetchCalls = [];
         const generateBodies = [];
-        let queueRecord = null;
+        const queueBodies = [];
         global.fetch = jest.fn((url, options = {}) => {
             fetchCalls.push({ url, options });
 
@@ -268,13 +467,12 @@ describe('chat task queue', () => {
 
             if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'POST') {
                 const body = JSON.parse(options.body || '{}');
-                queueRecord = {
-                    queue_id: 'queue-retry-contract',
-                    prompt_raw: body.prompt_raw,
-                    session_id: body.session_id,
-                    session_name: body.session_name,
-                    client_request_id: body.client_request_id,
-                    attempt_id: body.attempt_id,
+                queueBodies.push(body);
+                const queueRecord = {
+                    ...body,
+                    queue_id: body.dispatch_mode === 'server'
+                        ? 'queue-server-retry'
+                        : 'queue-direct-retry',
                     status: 'queued'
                 };
                 return Promise.resolve({
@@ -284,50 +482,22 @@ describe('chat task queue', () => {
                 });
             }
 
-            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
-                return Promise.resolve({
-                    ok: true,
-                    status: 200,
-                    json: async () => ({ success: true, items: queueRecord ? [queueRecord] : [] })
-                });
-            }
-
-            if (url === '/von/api/chat_prompt_queue/queue-retry-contract' && options.method === 'PATCH') {
-                const body = JSON.parse(options.body || '{}');
-                queueRecord = { ...queueRecord, ...body, status: 'queued' };
-                return Promise.resolve({
-                    ok: true,
-                    status: 200,
-                    json: async () => ({ success: true, item: queueRecord })
-                });
-            }
-
             if (url === '/von/generate') {
                 const body = JSON.parse(options.body || '{}');
                 generateBodies.push(body);
                 lifecycleEvents.push(`generate:${generateBodies.length}`);
-                if (generateBodies.length === 1) {
-                    return Promise.resolve({
-                        ok: false,
-                        status,
-                        headers: { get: (name) => name === 'Retry-After' ? '0' : null },
-                        json: async () => ({
-                            error: errorCode,
-                            detail: 'Retry this queued turn.',
-                            retryable: true,
-                            ...(errorCode === 'window_context_unavailable' ? {} : {
-                                prompt_queue_id: 'queue-retry-contract'
-                            }),
-                            retry_after_seconds: 0
-                        })
-                    });
-                }
                 return Promise.resolve({
-                    ok: true,
-                    status: 200,
+                    ok: false,
+                    status,
+                    headers: { get: (name) => name === 'Retry-After' ? '0' : null },
                     json: async () => ({
-                        response: 'Retried response',
-                        llm_debug: { model: 'gpt-5.2' }
+                        error: errorCode,
+                        detail: 'Retry this queued turn.',
+                        retryable: true,
+                        ...(errorCode === 'window_context_unavailable' ? {} : {
+                            prompt_queue_id: 'queue-direct-retry'
+                        }),
+                        retry_after_seconds: 0
                     })
                 });
             }
@@ -338,37 +508,53 @@ describe('chat task queue', () => {
         document.getElementById('promptInput').value = 'Retry this exact turn';
         await expect(sendMessage()).resolves.toBeUndefined();
 
-        for (let attempt = 0; attempt < 80 && generateBodies.length < 2; attempt += 1) {
-            await new Promise((resolve) => setTimeout(resolve, 10));
-        }
         await flushMicrotasks();
 
-        expect(generateBodies).toHaveLength(2);
-        expect(generateBodies[1]).toMatchObject({
-            prompt: 'Retry this exact turn',
-            prompt_queue_id: 'queue-retry-contract',
-            client_request_id: generateBodies[0].client_request_id,
-            attempt_id: generateBodies[0].attempt_id
-        });
+        expect(generateBodies).toHaveLength(1);
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queued');
         expect(fetchCalls.filter((call) => (
             call.url === '/von/api/chat_prompt_queue'
             && (call.options.method || 'GET') === 'POST'
-        ))).toHaveLength(1);
+        ))).toHaveLength(2);
+        expect(queueBodies[0]).toMatchObject({
+            client_request_id: generateBodies[0].client_request_id,
+            attempt_id: generateBodies[0].attempt_id
+        });
+        expect(queueBodies[0]).not.toHaveProperty('dispatch_mode');
+        expect(queueBodies[0]).not.toHaveProperty('enqueue_submission_id');
+        expect(queueBodies[1]).toMatchObject({
+            dispatch_mode: 'server',
+            enqueue_submission_id: expect.any(String),
+            execution_envelope_version: 1,
+            execution_envelope: expect.objectContaining({
+                language: 'en-NZ',
+                presenter_mode: true,
+                skip_buttonify: false,
+                thinking_card_mode: expect.any(String)
+            })
+        });
+        expect(queueBodies[1]).not.toHaveProperty('client_request_id');
+        expect(queueBodies[1]).not.toHaveProperty('attempt_id');
+        expect(fetchCalls.some((call) => (
+            call.url === '/von/api/chat_prompt_queue/queue-direct-retry'
+            && call.options.method === 'DELETE'
+        ))).toBe(true);
         expect(fetchCalls.some((call) => /\/(claim|requeue|finish)$/.test(String(call.url)))).toBe(false);
         if (expectsWindowRepair) {
             expect(postJson).toHaveBeenCalledWith('/von/api/session/set_organisation', {
                 organisation_concept_id: 'org'
             });
-            expect(lifecycleEvents.indexOf('repair:/von/api/session/set_organisation'))
-                .toBeLessThan(lifecycleEvents.indexOf('generate:2'));
         } else {
             expect(postJson).not.toHaveBeenCalled();
         }
     }, 15000);
 
-    test('repairs an expired window context before retrying the initial queue write', async () => {
+    test('reuses the immutable server enqueue identity after window-context repair', async () => {
         const { getUserContext, postJson } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
-        const { sendMessage } = require(chatTabModulePath);
+        const {
+            __testOnly_setLiveChatRequestForSession,
+            sendMessage,
+        } = require(chatTabModulePath);
         getUserContext.mockReturnValue({
             user_id: 'user',
             org_id: 'org-a',
@@ -378,10 +564,15 @@ describe('chat task queue', () => {
         postJson.mockResolvedValue({ success: true });
 
         const events = [];
+        const enqueueSubmissionIds = [];
+        const queueBodies = [];
         let queuePostCount = 0;
         global.fetch = jest.fn((url, options = {}) => {
             if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                const body = JSON.parse(options.body || '{}');
+                queueBodies.push(body);
                 queuePostCount += 1;
+                enqueueSubmissionIds.push(body.enqueue_submission_id);
                 events.push(`queue-post-${queuePostCount}`);
                 if (queuePostCount === 1) {
                     return Promise.resolve({
@@ -393,7 +584,6 @@ describe('chat task queue', () => {
                         })
                     });
                 }
-                const body = JSON.parse(options.body || '{}');
                 return Promise.resolve({
                     ok: true,
                     status: 201,
@@ -403,19 +593,12 @@ describe('chat task queue', () => {
                             queue_id: 'queue-after-window-repair',
                             prompt_raw: body.prompt_raw,
                             session_id: body.session_id,
-                            client_request_id: body.client_request_id,
-                            attempt_id: body.attempt_id,
+                            enqueue_submission_id: body.enqueue_submission_id,
+                            dispatch_mode: body.dispatch_mode,
+                            execution_envelope_version: body.execution_envelope_version,
                             status: 'queued'
                         }
                     })
-                });
-            }
-            if (url === '/von/generate') {
-                events.push('generate');
-                return Promise.resolve({
-                    ok: true,
-                    status: 200,
-                    json: async () => ({ response: 'Repaired response' })
                 });
             }
             if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
@@ -431,6 +614,10 @@ describe('chat task queue', () => {
             return { success: true };
         });
 
+        __testOnly_setLiveChatRequestForSession('session-1', {
+            promptQueueRecordId: 'queue-active',
+            promptRaw: 'Active turn'
+        });
         document.getElementById('promptInput').value = 'Repair before persistence';
         await sendMessage();
 
@@ -438,83 +625,73 @@ describe('chat task queue', () => {
         expect(postJson).toHaveBeenCalledWith('/von/api/session/set_organisation', {
             organisation_concept_id: 'org-a'
         });
-        expect(events).toEqual(['queue-post-1', 'repair', 'queue-post-2', 'generate']);
+        expect(enqueueSubmissionIds[0]).toEqual(expect.any(String));
+        expect(enqueueSubmissionIds[1]).toBe(enqueueSubmissionIds[0]);
+        expect(queueBodies[0]).toEqual(queueBodies[1]);
+        expect(queueBodies[0]).toMatchObject({
+            dispatch_mode: 'server',
+            execution_envelope_version: 1,
+            execution_envelope: expect.objectContaining({
+                language: 'en-NZ',
+                presenter_mode: true,
+                thinking_card_mode: expect.any(String)
+            })
+        });
+        expect(queueBodies[0]).not.toHaveProperty('client_request_id');
+        expect(queueBodies[0]).not.toHaveProperty('attempt_id');
+        expect(events).toEqual(['queue-post-1', 'repair', 'queue-post-2']);
     }, 15000);
 
-    test('preserves a canonical current-server owner after deferred admission without retrying locally', async () => {
-        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
-        const { sendMessage } = require(chatTabModulePath);
-        getUserContext.mockReturnValue({
-            user_id: 'user',
-            org_id: 'org',
-            language: 'en-NZ'
-        });
-
-        let queueRecord = null;
-        const generateBodies = [];
+    test('does not execute a selected server-dispatch row in the browser', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+            sendMessage,
+        } = require(chatTabModulePath);
+        const originalAlert = window.alert;
+        window.alert = jest.fn();
+        const fetchCalls = [];
         global.fetch = jest.fn((url, options = {}) => {
-            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
-                const body = JSON.parse(options.body || '{}');
-                queueRecord = {
-                    queue_id: 'queue-owned-by-current-server',
-                    prompt_raw: body.prompt_raw,
-                    session_id: body.session_id,
-                    session_name: body.session_name,
-                    client_request_id: body.client_request_id,
-                    attempt_id: body.attempt_id,
-                    status: 'queued'
-                };
-                return Promise.resolve({
-                    ok: true,
-                    status: 201,
-                    json: async () => ({ success: true, item: queueRecord })
-                });
-            }
+            fetchCalls.push({ url, options });
             if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
-                queueRecord = {
-                    ...queueRecord,
-                    status: 'in_progress',
-                    server_instance_id: 'server-current'
-                };
                 return Promise.resolve({
                     ok: true,
                     status: 200,
                     json: async () => ({
                         success: true,
-                        turn_admission: { server_instance_id: 'server-current' },
-                        items: [queueRecord]
+                        items: [{
+                            queue_id: 'queue-server-owned',
+                            prompt_raw: 'Already owned by the server dispatcher',
+                            status: 'queued',
+                            session_id: 'session-1',
+                            session_name: 'Current',
+                            enqueue_submission_id: 'enqueue-server-owned',
+                            dispatch_mode: 'server',
+                            execution_envelope_version: 1
+                        }]
                     })
                 });
-            }
-            if (url === '/von/generate') {
-                generateBodies.push(JSON.parse(options.body || '{}'));
-                return Promise.resolve({
-                    ok: false,
-                    status: 409,
-                    headers: { get: () => '0' },
-                    json: async () => ({
-                        error: 'conversation_turn_active',
-                        retryable: true,
-                        prompt_queue_id: 'queue-owned-by-current-server',
-                        retry_after_seconds: 0
-                    })
-                });
-            }
-            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
-                return Promise.resolve({ ok: true, json: async () => ({ history_length: 0 }) });
             }
             return Promise.resolve({ ok: true, status: 200, json: async () => ({ success: true }) });
         });
 
-        document.getElementById('promptInput').value = 'Already owned elsewhere';
-        await sendMessage();
-        await new Promise((resolve) => setTimeout(resolve, 400));
+        try {
+            await __testOnly_refreshChatPromptQueueFromServer();
+            const editor = document.querySelector('.chat-task-queue-edit');
+            expect(editor).toBeTruthy();
+            expect(editor.readOnly).toBe(true);
+            editor.focus();
+            editor.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 
-        expect(generateBodies).toHaveLength(1);
-        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 running');
-        expect(document.querySelector('.chat-task-queue-item-running')).toBeTruthy();
-        expect(document.querySelector('.chat-task-queue-restart')).toBeNull();
-        expect(document.querySelector('.chat-task-queue-delete')).toBeNull();
+            await sendMessage();
+
+            expect(window.alert).toHaveBeenCalledWith('Please enter a prompt.');
+            expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate'))).toBe(false);
+            expect(fetchCalls.some(({ url }) => String(url).endsWith('/claim'))).toBe(false);
+            expect(fetchCalls.some(({ url }) => String(url).endsWith('/finish'))).toBe(false);
+            expect(fetchCalls.some(({ options }) => options?.method === 'PATCH')).toBe(false);
+        } finally {
+            window.alert = originalAlert;
+        }
     }, 15000);
 
     test('deleting a queued prompt prevents queued execution', async () => {
@@ -599,7 +776,7 @@ describe('chat task queue', () => {
         expect(document.getElementById('chatTaskQueuePanel')?.classList.contains('hidden')).toBe(true);
     }, 15000);
 
-    test('does not let a focused later prompt bypass the same-session FIFO head', async () => {
+    test('does not dispatch a focused later legacy row ahead of the same-session head', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const {
             __testOnly_refreshChatPromptQueueFromServer,
@@ -736,22 +913,21 @@ describe('chat task queue', () => {
         await flushMicrotasks();
         await flushMicrotasks();
 
-        expect(generateBodies[0].prompt).toBe('First queued');
-        expect(generateBodies[0].conversation_session_id).toBe('session-1');
+        expect(generateBodies).toHaveLength(0);
+        expect(document.querySelectorAll('.chat-task-queue-item')).toHaveLength(2);
         expect(fetchCalls.some((call) => (
             String(call.url) === '/von/api/chat_prompt_queue'
             && (call.options.method || 'GET') === 'POST'
         ))).toBe(false);
         expect(fetchCalls.some((call) => String(call.url).endsWith('/claim'))).toBe(false);
-        expect(generateBodies[0].prompt_queue_id).toBe('queue-1');
+        expect(fetchCalls.some((call) => String(call.url).endsWith('/finish'))).toBe(false);
     }, 15000);
 
-    test('starts an off-session selected prompt without switching the visible conversation', async () => {
+    test('projects queue rows only into their conversation while retaining actor-wide tab activity', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const {
             __testOnly_refreshChatPromptQueueFromServer,
             __testOnly_setSessionTabsCache,
-            sendMessage,
         } = require(chatTabModulePath);
 
         getUserContext.mockReturnValue({
@@ -760,6 +936,7 @@ describe('chat task queue', () => {
             language: 'en-NZ',
             gmail_profile: null
         });
+        document.body.insertAdjacentHTML('afterbegin', '<div id="chatSessionTabs"></div>');
         __testOnly_setSessionTabsCache([
             { session_id: 'session-1', session_name: 'Current' },
             { session_id: 'session-2', session_name: 'Target' }
@@ -767,7 +944,6 @@ describe('chat task queue', () => {
 
         const fetchCalls = [];
         const generateBodies = [];
-        let resolveGenerate = null;
         global.fetch = jest.fn((url, options = {}) => {
             fetchCalls.push({ url, options });
 
@@ -866,31 +1042,13 @@ describe('chat task queue', () => {
             }
 
             if (typeof url === 'string' && url.startsWith('/von/generate')) {
-                const parsed = JSON.parse(options.body || '{}');
-                generateBodies.push(parsed);
-                return new Promise((resolve) => {
-                    resolveGenerate = () => resolve({
-                        ok: true,
-                        json: async () => ({
-                            response: 'Off-session response',
-                            llm_debug: { model: 'gpt-5.2' }
-                        })
-                    });
-                });
+                generateBodies.push(JSON.parse(options.body || '{}'));
             }
 
             return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
         });
 
         await __testOnly_refreshChatPromptQueueFromServer();
-        const queuedEditor = document.querySelector('.chat-task-queue-edit');
-        expect(queuedEditor).toBeTruthy();
-        queuedEditor.focus();
-        queuedEditor.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
-
-        await sendMessage();
-        await flushMicrotasks();
-        await flushMicrotasks();
 
         const setSessionIndex = fetchCalls.findIndex((call) => (
             String(call.url) === '/von/api/session/set_chat_session'
@@ -898,20 +1056,16 @@ describe('chat task queue', () => {
         const generateIndex = fetchCalls.findIndex((call) => String(call.url).startsWith('/von/generate'));
         expect(setSessionIndex).toBe(-1);
         expect(fetchCalls.some((call) => String(call.url).endsWith('/claim'))).toBe(false);
-        expect(generateIndex).toBeGreaterThanOrEqual(0);
-        expect(generateBodies[0].conversation_session_id).toBe('session-2');
-        expect(generateBodies[0].prompt_queue_id).toBe('queue-off-session');
-        expect(document.getElementById('scrollableField')?.textContent)
-            .not.toContain('Off-session selected queued');
-        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden')).toBe('true');
-
-        expect(resolveGenerate).toBeTruthy();
-        resolveGenerate();
-        await flushMicrotasks();
-        await flushMicrotasks();
+        expect(generateIndex).toBe(-1);
+        expect(generateBodies).toHaveLength(0);
+        expect(document.querySelector('.chat-task-queue-edit')).toBeNull();
+        expect(document.getElementById('chatTaskQueuePanel')?.classList.contains('hidden')).toBe(true);
+        expect(document.querySelector(
+            '#chatSessionTabs [data-session-id="session-2"] .chat-session-tab-activity'
+        )?.textContent).toBe('Queued');
     }, 15000);
 
-    test('restores interrupted persisted prompts and restarts them explicitly', async () => {
+    test('requeues interrupted persisted prompts without browser-side dispatch', async () => {
         const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const {
             __testOnly_refreshChatPromptQueueFromServer,
@@ -1025,22 +1179,25 @@ describe('chat task queue', () => {
         await new Promise((resolve) => setTimeout(resolve, 20));
         await flushMicrotasks();
 
-        expect(generateBodies).toHaveLength(1);
-        expect(generateBodies[0].prompt).toBe('Recovered task');
-        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+        expect(generateBodies).toHaveLength(0);
+        expect(document.querySelector('.chat-task-queue-item-label')?.textContent)
+            .toBe('Next up • Recovered');
+        expect(document.querySelector('.chat-task-queue-item')).toBeTruthy();
+        expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/claim'))).toBe(false);
+        expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/finish'))).toBe(false);
     }, 15000);
 
-    test('keeps off-session running queue records visible while current-session prompts wait', async () => {
+    test('keeps off-session queue activity on its tab, not in the active composer panel', async () => {
         const {
             __testOnly_refreshChatPromptQueueFromServer,
-            __testOnly_setLiveChatRequestForSession,
         } = require(chatTabModulePath);
 
-        __testOnly_setLiveChatRequestForSession('session-2', {
-            promptQueueRecordId: 'queue-running',
-            promptRaw: 'Background task'
-        });
-
+        document.body.insertAdjacentHTML('afterbegin', '<div id="chatSessionTabs"></div>');
+        const { __testOnly_setSessionTabsCache } = require(chatTabModulePath);
+        __testOnly_setSessionTabsCache([
+            { session_id: 'session-1', session_name: 'Current' },
+            { session_id: 'session-2', session_name: 'Background' }
+        ]);
         global.fetch = jest.fn((url) => {
             if (typeof url === 'string' && url === '/von/api/chat_prompt_queue') {
                 return Promise.resolve({
@@ -1053,7 +1210,10 @@ describe('chat task queue', () => {
                                 prompt_raw: 'Background task',
                                 status: 'in_progress',
                                 session_id: 'session-2',
-                                session_name: 'Background'
+                                session_name: 'Background',
+                                enqueue_submission_id: 'enqueue-running',
+                                dispatch_mode: 'server',
+                                execution_envelope_version: 1
                             },
                             {
                                 queue_id: 'queue-waiting',
@@ -1072,14 +1232,14 @@ describe('chat task queue', () => {
 
         await __testOnly_refreshChatPromptQueueFromServer();
 
-        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 running, 1 queued');
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queued');
         const labels = Array.from(document.querySelectorAll('.chat-task-queue-item-label'))
             .map((node) => node.textContent);
-        expect(labels).toEqual(['Running • Background', 'Next up • Current']);
-        const runningItem = document.querySelector('.chat-task-queue-item-running');
-        expect(runningItem?.querySelector('.chat-task-queue-delete')).toBeNull();
-        expect(runningItem?.querySelector('.chat-task-queue-dismiss')).toBeNull();
-        expect(runningItem?.querySelector('.chat-task-queue-restart')).toBeNull();
+        expect(labels).toEqual(['Next up • Current']);
+        expect(document.querySelector('.chat-task-queue-item-running')).toBeNull();
+        expect(document.querySelector(
+            '#chatSessionTabs [data-session-id="session-2"] .chat-session-tab-activity'
+        )?.textContent).toBe('Running');
     }, 15000);
 
     test('treats a current-server turn from another tab as running until canonical refresh removes it', async () => {
@@ -1126,7 +1286,71 @@ describe('chat task queue', () => {
         expect(document.getElementById('sendButton').textContent).toBe('Send Prompt');
     }, 15000);
 
-    test('a cross-tab queue signal refreshes canonical state and unblocks the next same-session turn', async () => {
+    test('polls server-owned queue work and refreshes active history after its row disappears', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+        const fetchCalls = [];
+        let queueGetCount = 0;
+
+        jest.useFakeTimers();
+        try {
+            global.fetch = jest.fn((url, options = {}) => {
+                fetchCalls.push({ url, options });
+                if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
+                    queueGetCount += 1;
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            success: true,
+                            items: queueGetCount === 1 ? [{
+                                queue_id: 'queue-polled',
+                                prompt_raw: 'Server-dispatched prompt',
+                                status: 'queued',
+                                session_id: 'session-1',
+                                session_name: 'Current',
+                                enqueue_submission_id: 'enqueue-polled',
+                                dispatch_mode: 'server',
+                                execution_envelope_version: 1
+                            }] : []
+                        })
+                    });
+                }
+                if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            history: [],
+                            segments_returned: 1,
+                            total_segments: 1
+                        })
+                    });
+                }
+                return Promise.resolve({ ok: true, status: 200, json: async () => ({ success: true }) });
+            });
+
+            await __testOnly_refreshChatPromptQueueFromServer();
+            expect(queueGetCount).toBe(1);
+            expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queued');
+
+            await jest.advanceTimersByTimeAsync(2000);
+
+            expect(queueGetCount).toBe(2);
+            expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+            expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/history?'))).toBe(true);
+            expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate'))).toBe(false);
+            expect(fetchCalls.some(({ url }) => /\/(claim|finish)$/.test(String(url)))).toBe(false);
+
+            await jest.advanceTimersByTimeAsync(4000);
+            expect(queueGetCount).toBe(2);
+        } finally {
+            jest.useRealTimers();
+        }
+    }, 15000);
+
+    test('a cross-tab queue signal refreshes canonical state without dispatching in the browser', async () => {
         const {
             __testOnly_handleChatPromptQueueStorageEvent,
             __testOnly_refreshChatPromptQueueFromServer,
@@ -1202,19 +1426,13 @@ describe('chat task queue', () => {
         __testOnly_handleChatPromptQueueStorageEvent({
             key: 'von:chatPromptQueueChanged:v1'
         });
-        for (let attempt = 0; attempt < 30 && generateBodies.length === 0; attempt += 1) {
-            await new Promise((resolve) => setTimeout(resolve, 10));
-        }
+        await flushMicrotasks();
+        await flushMicrotasks();
 
-        expect(generateBodies).toHaveLength(1);
-        expect(generateBodies[0]).toMatchObject({
-            prompt: 'Run after the other tab finishes',
-            prompt_queue_id: 'queue-next-after-other-tab',
-            client_request_id: 'request-next',
-            attempt_id: 'attempt-next',
-            conversation_session_id: 'session-1'
-        });
+        expect(generateBodies).toHaveLength(0);
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 queued');
         expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/claim'))).toBe(false);
+        expect(global.fetch.mock.calls.some(([url]) => String(url).endsWith('/finish'))).toBe(false);
     }, 15000);
 
     test('shows recent failed persisted prompts without rerunning them', async () => {
@@ -1506,7 +1724,7 @@ describe('chat task queue', () => {
         expect(document.querySelector('.chat-task-queue-item-failed')).toBeNull();
     }, 15000);
 
-    test('shows a precise persisted update failure reason before server admission', async () => {
+    test('shows a precise persisted update failure for an editable legacy row', async () => {
         const {
             __testOnly_refreshChatPromptQueueFromServer,
         } = require(chatTabModulePath);
@@ -1545,11 +1763,449 @@ describe('chat task queue', () => {
         });
 
         await __testOnly_refreshChatPromptQueueFromServer();
-        await flushMicrotasks();
+        const editor = document.querySelector('.chat-task-queue-edit');
+        editor.value = 'Edited queued task';
+        editor.dispatchEvent(new Event('input', { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 350));
         await flushMicrotasks();
 
         expect(document.querySelector('.chat-task-queue-sync-warning')?.textContent).toBe(
             'This queued task belongs to a different browser or organisation scope.'
         );
+    }, 15000);
+
+    test('retains a canonical queued row and surfaces the error when DELETE fails', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        items: [{
+                            queue_id: 'queue-delete-retained',
+                            prompt_raw: 'Keep me until cancellation is acknowledged',
+                            status: 'queued',
+                            session_id: 'session-1',
+                            session_name: 'Current'
+                        }]
+                    })
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue/queue-delete-retained') {
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    json: async () => ({
+                        success: false,
+                        error: 'queue backend unavailable',
+                        error_code: 'backend_unavailable'
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        const deleteButton = document.querySelector('.chat-task-queue-delete');
+        expect(deleteButton).toBeTruthy();
+        deleteButton.click();
+
+        expect(document.querySelector('[data-queue-id="queue-delete-retained"]')).toBeTruthy();
+        expect(document.querySelector('.chat-task-queue-delete').disabled).toBe(true);
+
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(document.querySelector('[data-queue-id="queue-delete-retained"]')).toBeTruthy();
+        expect(document.querySelector('.chat-task-queue-delete').disabled).toBe(false);
+        expect(document.querySelector('.chat-task-queue-sync-warning')?.textContent).toBe(
+            'Queue storage is temporarily unavailable.'
+        );
+    }, 15000);
+
+    test('treats a DELETE not-found response as canonical absence', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        items: [{
+                            queue_id: 'queue-already-absent',
+                            prompt_raw: 'Already cancelled elsewhere',
+                            status: 'queued',
+                            session_id: 'session-1',
+                            session_name: 'Current'
+                        }]
+                    })
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue/queue-already-absent') {
+                return Promise.resolve({
+                    ok: false,
+                    status: 404,
+                    json: async () => ({
+                        success: false,
+                        error: 'cancellable prompt was not found',
+                        error_code: 'not_found'
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        document.querySelector('.chat-task-queue-delete').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(document.querySelector('[data-queue-id="queue-already-absent"]')).toBeNull();
+        expect(document.getElementById('chatTaskQueuePanel')?.classList.contains('hidden')).toBe(true);
+    }, 15000);
+
+    test('renders one terminal row when active and failed projections overlap', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                success: true,
+                items: [{
+                    queue_id: 'queue-transition-race',
+                    prompt_raw: 'Transitioning row',
+                    status: 'queued',
+                    session_id: 'session-1',
+                    session_name: 'Current'
+                }],
+                recent_failed_items: [{
+                    queue_id: 'queue-transition-race',
+                    prompt_raw: 'Transitioning row',
+                    status: 'failed',
+                    session_id: 'session-1',
+                    session_name: 'Current',
+                    last_error: 'Canonical terminal failure'
+                }]
+            })
+        }));
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+
+        expect(document.querySelectorAll('.chat-task-queue-item')).toHaveLength(1);
+        expect(document.querySelector('.chat-task-queue-item-label')?.textContent)
+            .toBe('Failed • Current');
+        expect(document.getElementById('chatTaskQueueCount')?.textContent).toBe('1 failed');
+    }, 15000);
+
+    test('cancels an unresolved replacement before its legacy source', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+        const deleteOrder = [];
+        let queueReads = 0;
+        const replacement = {
+            queue_id: 'queue-handoff-replacement',
+            prompt_raw: 'Cancel this unresolved handoff',
+            status: 'queued',
+            session_id: 'session-1',
+            session_name: 'Current',
+            dispatch_mode: 'server',
+            dispatch_ready: false,
+            enqueue_submission_id: 'submission-handoff-cancel',
+            handoff_source_queue_id: 'queue-handoff-source'
+        };
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
+                queueReads += 1;
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        items: queueReads <= 2 ? [replacement] : [],
+                        recent_failed_items: []
+                    })
+                });
+            }
+            if (options.method === 'DELETE') {
+                deleteOrder.push(String(url));
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true, item: { status: 'cancelled' } })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        document.querySelector('.chat-task-queue-handoff-cancel').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(deleteOrder).toEqual([
+            '/von/api/chat_prompt_queue/queue-handoff-replacement',
+            '/von/api/chat_prompt_queue/queue-handoff-source'
+        ]);
+        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+    }, 15000);
+
+    test('retains a manually sent legacy row until generate acknowledges it', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+            sendMessage,
+        } = require(chatTabModulePath);
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        let resolveGenerate = null;
+        const generateBodies = [];
+        const queued = {
+            queue_id: 'queue-manual-legacy',
+            prompt_raw: 'Manually dispatch this legacy prompt',
+            status: 'queued',
+            session_id: 'session-1',
+            session_name: 'Current'
+        };
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'GET') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true, items: [queued] })
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue/queue-manual-legacy' && options.method === 'PATCH') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true, item: queued })
+                });
+            }
+            if (url === '/von/generate') {
+                generateBodies.push(JSON.parse(options.body || '{}'));
+                return new Promise((resolve) => {
+                    resolveGenerate = () => resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ response: 'Acknowledged response' })
+                    });
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ html: '' })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        const editor = document.querySelector('.chat-task-queue-edit');
+        editor.focus();
+        editor.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        await sendMessage();
+        await flushMicrotasks();
+
+        expect(resolveGenerate).toBeTruthy();
+        expect(generateBodies).toHaveLength(1);
+        expect(generateBodies[0].prompt_queue_id).toBe('queue-manual-legacy');
+        expect(document.querySelector('[data-queue-id="queue-manual-legacy"]')).toBeTruthy();
+
+        resolveGenerate();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(document.querySelector('[data-queue-id="queue-manual-legacy"]')).toBeNull();
+    }, 15000);
+
+    test('retains the exact foreground row until an admission-deferred server enqueue is acknowledged', async () => {
+        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const { sendMessage } = require(chatTabModulePath);
+
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+
+        const events = [];
+        const serverQueueBodies = [];
+        const generateBodies = [];
+        let serverQueuePostCount = 0;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ html: '' })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ history_length: 0, authenticated: true })
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue' && (options.method || 'GET') === 'POST') {
+                const body = JSON.parse(options.body || '{}');
+                if (body.dispatch_mode !== 'server') {
+                    events.push('direct-post');
+                    return Promise.resolve({
+                        ok: true,
+                        status: 201,
+                        json: async () => ({
+                            success: true,
+                            item: {
+                                ...body,
+                                queue_id: 'queue-direct-handoff',
+                                status: 'queued'
+                            }
+                        })
+                    });
+                }
+                serverQueuePostCount += 1;
+                serverQueueBodies.push(body);
+                events.push(`server-post-${serverQueuePostCount}`);
+                if (serverQueuePostCount === 1) {
+                    return Promise.reject(new TypeError('response lost after enqueue'));
+                }
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        idempotent_replay: true,
+                        item: {
+                            ...body,
+                            queue_id: 'queue-server-handoff',
+                            status: 'queued'
+                        }
+                    })
+                });
+            }
+            if (url === '/von/generate') {
+                events.push('generate');
+                generateBodies.push(JSON.parse(options.body || '{}'));
+                return Promise.resolve({
+                    ok: false,
+                    status: 429,
+                    headers: { get: () => '0' },
+                    json: async () => ({
+                        error: 'turn_capacity_reached',
+                        detail: 'Try this turn later.',
+                        retryable: true,
+                        prompt_queue_id: 'queue-direct-handoff'
+                    })
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue/queue-direct-handoff') {
+                events.push('delete-source');
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    json: async () => ({
+                        success: false,
+                        error: 'queue backend unavailable',
+                        error_code: 'backend_unavailable'
+                    })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        document.getElementById('promptInput').value = 'Preserve this exact prompt';
+        await sendMessage();
+        await flushMicrotasks();
+
+        expect(events).toEqual(['direct-post', 'generate', 'server-post-1']);
+        expect(events).not.toContain('delete-source');
+        expect(document.querySelectorAll('.chat-task-queue-item-label'))
+            .toHaveLength(2);
+        expect(Array.from(document.querySelectorAll('.chat-task-queue-item-label'))
+            .map((element) => element.textContent)).toEqual(expect.arrayContaining([
+            'Queue unconfirmed • Current',
+            'Handoff pending • Current'
+        ]));
+        expect(document.querySelectorAll('.chat-task-queue-delete')).toHaveLength(0);
+
+        document.querySelector('.chat-task-queue-enqueue-retry').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(serverQueueBodies).toHaveLength(2);
+        expect(serverQueueBodies[1].enqueue_submission_id)
+            .toBe(serverQueueBodies[0].enqueue_submission_id);
+        expect(events).toEqual([
+            'direct-post',
+            'generate',
+            'server-post-1',
+            'server-post-2',
+            'delete-source'
+        ]);
+        expect(generateBodies).toHaveLength(1);
+        expect(Array.from(document.querySelectorAll('.chat-task-queue-item-label'))
+            .map((element) => element.textContent)).toEqual(expect.arrayContaining([
+            'Next up • Current',
+            'Superseded • Current'
+        ]));
+        const supersededItem = Array.from(document.querySelectorAll('.chat-task-queue-item'))
+            .find((item) => item.querySelector('.chat-task-queue-item-label')?.textContent
+                === 'Superseded • Current');
+        expect(supersededItem).toBeTruthy();
+        expect(supersededItem.querySelector('.chat-task-queue-edit').readOnly).toBe(true);
+        expect(supersededItem.querySelector('.chat-task-queue-sync-warning').textContent).toBe(
+            'Queue storage is temporarily unavailable.'
+        );
+        expect(supersededItem.querySelector('.chat-task-queue-delete').textContent)
+            .toBe('Retry cleanup');
     }, 15000);
 });

--- a/tests/frontend/taskPanelExecuteWithVon.test.js
+++ b/tests/frontend/taskPanelExecuteWithVon.test.js
@@ -1,0 +1,284 @@
+/** @jest-environment jsdom */
+
+const taskPanelModulePath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+const toastModulePath = '../../src/frontend/web/von_interface/static/js/utils/toast.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    getUserContext: jest.fn(() => ({
+        user_id: '#V#alice',
+        org_id: '#V#research_lab',
+    })),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn(),
+}));
+
+function task(overrides = {}) {
+    return {
+        task_concept_id: '#V#task_prepare_brief',
+        title: 'Prepare brief',
+        description: 'Prepare and read back the research brief.',
+        status: 'pending',
+        priority: 'medium',
+        assignee_concept_id: '#V#von_system',
+        created_by_concept_id: '#V#alice',
+        organisation_concept_id: '#V#research_lab',
+        originating_conversation_id: '#V#conversation_1',
+        conversation_session_id: 'session-1',
+        conversation_name: 'Research planning',
+        task_type_ids: [],
+        ...overrides,
+    };
+}
+
+function queueResponse() {
+    return {
+        success: true,
+        items: [{
+            queue_id: 'queue-1',
+            status: 'queued',
+            task_concept_id: '#V#task_prepare_brief',
+            task_execution_concept_id: '#V#task_execution_1',
+            session_id: 'session-1',
+            session_name: 'Research planning',
+            updated_at: '2026-09-01T12:00:00Z',
+        }],
+        recent_failed_items: [],
+    };
+}
+
+async function flushRenderQueue() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('explicit Execute with Von task control', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.spyOn(console, 'debug').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        localStorage.clear();
+        document.body.innerHTML = `
+            <div id="globalTasksContainer"></div>
+            <span id="taskCountBadge" class="hidden"></span>
+            <span id="globalTaskCountBadge" class="hidden"></span>
+        `;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('launches from the global inspector, disables in flight, and refreshes observer activity', async () => {
+        const { getJson, postJson } = require(apiServiceModulePath);
+        const queuedTask = task();
+        let resolveLaunch;
+        let queueActivityLoads = 0;
+        postJson.mockImplementation(() => new Promise((resolve) => {
+            resolveLaunch = resolve;
+        }));
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve({ task_types: [], task_sources: [], defaults: {} });
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({ organisations: [] });
+            }
+            if (url === '/von/api/chat_prompt_queue') {
+                queueActivityLoads += 1;
+                return Promise.resolve(
+                    queueActivityLoads === 1
+                        ? { success: true, items: [], recent_failed_items: [] }
+                        : queueResponse(),
+                );
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                return Promise.resolve({
+                    tasks: [queuedTask],
+                    count: 1,
+                    offset: 0,
+                    has_more: false,
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        const inspectorButton = document.querySelector(
+            '#globalTaskInspector .task-execute-with-von-btn',
+        );
+        expect(inspectorButton).toBeTruthy();
+        expect(inspectorButton.title).toContain('Research planning');
+        expect(document.querySelector('#globalTaskQueueActivity').textContent).toContain(
+            'No active or recently failed Von work',
+        );
+        expect(document.querySelector('#globalTaskQueueActivity .task-delete-btn')).toBeNull();
+
+        inspectorButton.click();
+        await Promise.resolve();
+        expect(inspectorButton.disabled).toBe(true);
+        expect(inspectorButton.textContent).toBe('Queuing…');
+        expect(postJson).toHaveBeenCalledTimes(1);
+        const [url, payload] = postJson.mock.calls[0];
+        expect(url).toBe('/api/tasks/%23V%23task_prepare_brief/execute-with-von');
+        expect(typeof payload.launch_request_id).toBe('string');
+        expect(payload.launch_request_id.length).toBeGreaterThan(8);
+
+        resolveLaunch({
+            success: true,
+            task: { conversation_name: 'Research planning' },
+            task_execution: { status: 'pending' },
+            queue_item: { status: 'queued' },
+        });
+        await flushRenderQueue();
+
+        expect(inspectorButton.disabled).toBe(true);
+        expect(inspectorButton.textContent).toBe('Von work active');
+        expect(require(toastModulePath).showToast).toHaveBeenCalledWith(
+            'Von work queued in Research planning',
+            'success',
+        );
+        expect(getJson.mock.calls.filter(([url]) => url === '/von/api/chat_prompt_queue')).toHaveLength(2);
+        expect(localStorage.length).toBe(1);
+    });
+
+    test.each([
+        ['completed', 'Von work already completed in Research planning', 'success'],
+        ['failed', 'Von work failed; the task can be retried', 'error'],
+        ['cancelled', 'Von work was cancelled; the task can be retried', 'info'],
+    ])(
+        'reuses a durable launch identity after a lost response and clears a %s replay',
+        async (terminalStatus, expectedMessage, expectedToastType) => {
+            const { getJson, postJson } = require(apiServiceModulePath);
+            getJson.mockImplementation((url) => {
+                if (url === '/api/tasks/taxonomy') {
+                    return Promise.resolve({ task_types: [], task_sources: [], defaults: {} });
+                }
+                if (url === '/von/api/organisations/my_organisations') {
+                    return Promise.resolve({ organisations: [] });
+                }
+                if (url === '/von/api/chat_prompt_queue') {
+                    return Promise.resolve({ success: true, items: [], recent_failed_items: [] });
+                }
+                if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                    return Promise.resolve({
+                        tasks: [task()], count: 1, offset: 0, has_more: false,
+                    });
+                }
+                return Promise.resolve({});
+            });
+            postJson
+                .mockRejectedValueOnce(new Error('response lost'))
+                .mockResolvedValueOnce({
+                    success: true,
+                    task: { conversation_name: 'Research planning' },
+                    task_execution: { status: terminalStatus },
+                    queue_item: { status: terminalStatus },
+                });
+
+            const { showGlobalTasks } = require(taskPanelModulePath);
+            await showGlobalTasks();
+            await flushRenderQueue();
+
+            document.querySelector('.task-execute-with-von-btn').click();
+            await flushRenderQueue();
+            const firstLaunchId = postJson.mock.calls[0][1].launch_request_id;
+            expect(localStorage.length).toBe(1);
+
+            document.querySelector('.task-execute-with-von-btn').click();
+            await flushRenderQueue();
+            expect(postJson.mock.calls[1][1].launch_request_id).toBe(firstLaunchId);
+            expect(localStorage.length).toBe(0);
+            expect(document.querySelector('.task-execute-with-von-btn').disabled).toBe(false);
+            expect(require(toastModulePath).showToast).toHaveBeenLastCalledWith(
+                expectedMessage,
+                expectedToastType,
+            );
+        },
+    );
+
+    test('can create a conversation-associated task assigned to Von', async () => {
+        const { getJson, postJson } = require(apiServiceModulePath);
+        document.body.innerHTML = `
+            <div id="taskPanel" class="hidden">
+                <input id="newTaskTitle" />
+                <textarea id="newTaskDescription"></textarea>
+                <select id="newTaskAssignee">
+                    <option value="">Unassigned</option>
+                    <option value="#V#von_system">Assign to Von</option>
+                </select>
+                <select id="newTaskPriority"><option value="medium">Medium</option></select>
+                <button id="createTaskBtn">Create Task</button>
+                <button id="closeTaskPanel">Close</button>
+                <button id="refreshTasksBtn">Refresh</button>
+                <select id="taskStatusFilter"><option value="all">All</option></select>
+                <select id="taskPriorityFilter"><option value="all">All</option></select>
+                <input id="taskQueryFilter" />
+                <select id="taskViewMode"><option value="board">Board</option></select>
+                <div id="taskList"></div>
+            </div>
+        `;
+        getJson.mockResolvedValue({ tasks: [] });
+        postJson.mockResolvedValue({ task_concept_id: '#V#created_task' });
+
+        const { initializeTaskPanel, setCurrentSession } = require(taskPanelModulePath);
+        initializeTaskPanel();
+        await setCurrentSession('session-1');
+        document.getElementById('newTaskTitle').value = 'Prepare brief';
+        document.getElementById('newTaskDescription').value = 'Prepare the brief.';
+        document.getElementById('newTaskAssignee').value = '#V#von_system';
+        document.getElementById('createTaskBtn').click();
+        await flushRenderQueue();
+
+        expect(postJson).toHaveBeenCalledWith('/api/tasks/', {
+            title: 'Prepare brief',
+            description: 'Prepare the brief.',
+            priority: 'medium',
+            assignee_concept_id: '#V#von_system',
+            session_id: 'session-1',
+        });
+    });
+
+    test('does not offer execution for a task not authorised by this actor', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve({ task_types: [], task_sources: [], defaults: {} });
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({ organisations: [] });
+            }
+            if (url === '/von/api/chat_prompt_queue') {
+                return Promise.resolve({ success: true, items: [], recent_failed_items: [] });
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                return Promise.resolve({
+                    tasks: [task({ created_by_concept_id: '#V#bob' })],
+                    count: 1,
+                    offset: 0,
+                    has_more: false,
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+        await flushRenderQueue();
+
+        expect(document.querySelector('.task-execute-with-von-btn')).toBeNull();
+    });
+});

--- a/tests/frontend/taskPanelQueueActivityPolling.test.js
+++ b/tests/frontend/taskPanelQueueActivityPolling.test.js
@@ -1,0 +1,163 @@
+/** @jest-environment jsdom */
+
+const taskPanelModulePath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const apiServiceModulePath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    deleteJson: jest.fn(),
+    getJson: jest.fn(),
+    getUserContext: jest.fn(() => ({
+        user_id: '#V#alice',
+        org_id: '#V#research_lab',
+    })),
+    patchJson: jest.fn(),
+    postJson: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({
+    activateTab: jest.fn(),
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({
+    showToast: jest.fn(),
+}));
+
+function queueResponse(status, updatedAt) {
+    return {
+        success: true,
+        items: [{
+            queue_id: 'queue-observed',
+            status,
+            task_concept_id: '#V#task_observed',
+            task_execution_concept_id: '#V#execution_observed',
+            session_id: 'session-observed',
+            session_name: 'Observed conversation',
+            updated_at: updatedAt,
+        }],
+        recent_failed_items: [],
+    };
+}
+
+describe('global task queue activity polling', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+        jest.spyOn(console, 'debug').mockImplementation(() => {});
+        document.body.innerHTML = `
+            <div id="globalTasksTab" class="tab-content active">
+                <div id="globalTasksContainer"></div>
+            </div>
+            <span id="taskCountBadge" class="hidden"></span>
+            <span id="globalTaskCountBadge" class="hidden"></span>
+        `;
+        document.body.dataset.activeTab = 'globalTasksTab';
+    });
+
+    afterEach(async () => {
+        document.body.dataset.activeTab = 'chatTab';
+        document.dispatchEvent(new CustomEvent('von:tab-activated', {
+            detail: { tabId: 'chatTab' },
+        }));
+        await jest.runOnlyPendingTimersAsync();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    test('refreshes observer-only activity while open and stops after leaving the tab', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        let queueReads = 0;
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve({ task_types: [], task_sources: [], defaults: {} });
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({ organisations: [] });
+            }
+            if (url === '/von/api/chat_prompt_queue') {
+                queueReads += 1;
+                return Promise.resolve(queueReads === 1
+                    ? queueResponse('queued', '2026-09-01T12:00:00Z')
+                    : queueResponse('in_progress', '2026-09-01T12:00:05Z'));
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                return Promise.resolve({
+                    tasks: [],
+                    count: 0,
+                    offset: 0,
+                    has_more: false,
+                });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        await showGlobalTasks();
+
+        expect(queueReads).toBe(1);
+        expect(document.querySelector('#globalTaskQueueActivity').textContent)
+            .toContain('queued');
+
+        await jest.advanceTimersByTimeAsync(4999);
+        expect(queueReads).toBe(1);
+        await jest.advanceTimersByTimeAsync(1);
+        expect(queueReads).toBe(2);
+        expect(document.querySelector('#globalTaskQueueActivity').textContent)
+            .toContain('in progress');
+
+        document.body.dataset.activeTab = 'chatTab';
+        document.querySelector('#globalTasksTab').classList.remove('active');
+        document.dispatchEvent(new CustomEvent('von:tab-activated', {
+            detail: { tabId: 'chatTab' },
+        }));
+        await jest.advanceTimersByTimeAsync(15000);
+
+        expect(queueReads).toBe(2);
+        expect(getJson.mock.calls.some(([url]) => (
+            String(url).includes('/claim')
+            || String(url).includes('/finish')
+            || String(url).includes('/requeue')
+        ))).toBe(false);
+    });
+
+    test('discards the previous actor response and stops polling after logout', async () => {
+        const { getJson } = require(apiServiceModulePath);
+        let resolveOldActorQueue;
+        let queueReads = 0;
+        getJson.mockImplementation((url) => {
+            if (url === '/api/tasks/taxonomy') {
+                return Promise.resolve({ task_types: [], task_sources: [], defaults: {} });
+            }
+            if (url === '/von/api/organisations/my_organisations') {
+                return Promise.resolve({ organisations: [] });
+            }
+            if (url === '/von/api/chat_prompt_queue') {
+                queueReads += 1;
+                return new Promise((resolve) => {
+                    resolveOldActorQueue = resolve;
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/api/tasks/?')) {
+                return Promise.resolve({ tasks: [], count: 0, offset: 0, has_more: false });
+            }
+            return Promise.resolve({});
+        });
+
+        const { showGlobalTasks } = require(taskPanelModulePath);
+        const opening = showGlobalTasks();
+        for (let attempt = 0; attempt < 10 && !resolveOldActorQueue; attempt += 1) {
+            await Promise.resolve();
+        }
+        expect(queueReads).toBe(1);
+
+        document.dispatchEvent(new CustomEvent('authStatusChanged', {
+            detail: { authenticated: false },
+        }));
+        resolveOldActorQueue(queueResponse('queued', '2026-09-01T12:00:00Z'));
+        await opening;
+
+        expect(document.querySelector('#globalTaskQueueActivity').textContent)
+            .toContain('No active or recently failed Von work');
+        await jest.advanceTimersByTimeAsync(15000);
+        expect(queueReads).toBe(1);
+    });
+});


### PR DESCRIPTION
Merge decision: ready — queued Von work is conversation-local in the composer, accepted idempotently, and executed by a durable server worker; explicit Von-assigned tasks create correlated TaskExecution attempts without conflating operational queue rows with TaskSpecifications.

## User outcome

Queued prompts no longer appear beside every conversation, duplicate retries resolve to one canonical submission, and queued work no longer depends on the originating browser remaining open. An authenticated user can explicitly assign a conversation-associated task to Von and launch a durable, actor-scoped execution attempt.

## Material changes

- Filter the composer-adjacent queue projection to the exact conversation while retaining actor-wide activity and badges.
- Add immutable enqueue identities, exact replay/mismatch semantics, deterministic FIFO sequencing, per-conversation reservations, leases/heartbeats, terminal reconciliation, and bounded TTL retention.
- Move v2 queue draining to a restartable server dispatcher; retain legacy rows for explicit/manual recovery rather than ambiguously replaying them.
- Add durable, cancellation-safe legacy-to-server handoff with exact replacement markers and retry backoff that cannot starve unrelated work.
- Represent TaskSpecification, TaskExecution, operational queue/admission, and effect evidence as linked but distinct lifecycle layers.
- Add explicit Execute with Von controls for trusted creator-owned tasks assigned to #V#von_system and associated with an accessible originating conversation.
- Bind task launch, queue row, request/attempt, actor, organisation, namespace, and conversation; project exact terminal outcomes to TaskExecution without falsely completing TaskSpecification.
- Reconcile login/logout and organisation changes so stale actor-scoped responses cannot render or suppress controls.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2701

## Evidence

- Focused backend queue/dispatch/admission/TaskExecution/index suite: 135 passed.
- Adjacent backend task-route, health/startup, and internal queue-tool suite: 49 passed.
- Handoff concurrency tests repeated 20 times without failure.
- Affected frontend attachment, queue, abort, conversation deletion, and Task-panel suite: 79 passed.
- Frontend static lint and Node syntax checks passed.
- New Python modules/tests pass Ruff and Python compilation; staged diff checks passed.
- Full frontend run: 525 passed; nine failures in four unrelated suites reproduce on clean main with the same signatures. The one candidate-caused stale attachment test was updated to assert the new server-owned dispatch contract and passes.
- Independent backend, TaskExecution, and frontend reliability reviews recommend merge.

No live model turn was invoked: the temporary repository-wide Sol restriction was respected. Route integration and jsdom paths cover the affected acceptance boundary without activation.

## Ship boundary

- **Minimum ship criteria:** exact conversation projection; duplicate-safe enqueue; browser-independent server dispatch; one-conversation single flight; exact cancellation/handoff semantics; actor/org/namespace isolation; explicit task-to-execution linkage; truthful terminal state; bounded retention.
- **Stop-ship conditions:** duplicate canonical rows for one intent, cross-scope disclosure/mutation, concurrent turns in one conversation, browser-dependent dispatch, replay after independent cancellation, stale actor response publication, or queue completion falsely completing TaskSpecification.
- **Non-blocking observations:** four unrelated frontend suites remain red exactly as on clean main; existing legacy terminal rows age out only after this code is deployed and the bounded backfill/TTL path runs.
- **Non-goals:** deployment/activation, automatic semantic deduplication by prompt text, conversion of every chat turn into a task, and automatic replay of ambiguous externally effectful attempts.
