### PR TITLE
[JVNAUTOSCI-2702] Add idempotent Retry for failed conversation work

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -2458,6 +2458,15 @@ def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
                 "handoff_source_queue_id": {"$exists": True, "$type": "string"}
             },
         )
+    if "retry_source_queue_id_unique" not in existing_indexes:
+        coll.create_index(
+            [("retry_source_queue_id", ASCENDING)],
+            name="retry_source_queue_id_unique",
+            unique=True,
+            partialFilterExpression={
+                "retry_source_queue_id": {"$exists": True, "$type": "string"}
+            },
+        )
     if "active_legacy_submission_key_unique" not in existing_indexes:
         coll.create_index(
             [("active_legacy_submission_key", ASCENDING)],

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -59,6 +59,11 @@ from ...services.chat_prompt_queue_dispatch_service import (
     reconcile_linked_task_execution_terminal,
     wake_chat_prompt_queue_dispatcher,
 )
+from ...services.task_execution_service import (
+    reconcile_task_execution_queue_record,
+    task_execution_concept_id_for_launch,
+    task_execution_enqueue_submission_id_for_launch,
+)
 from ...services import conversation_management_service
 from ...services import conversation_search_service
 from ...services.external_conversation_import_service import (
@@ -1126,12 +1131,18 @@ def _chat_prompt_queue_error_response(
     if isinstance(exc, chat_prompt_queue_service.InvalidChatPromptQueueInput):
         error_code = str(getattr(exc, "error_code", "invalid_input"))
         status_code = int(getattr(exc, "status_code", 400) or 400)
+        error_queue_id = getattr(exc, "queue_id", None)
         return (
             jsonify(
                 {
                     "success": False,
                     "error": str(exc),
                     "error_code": error_code,
+                    **(
+                        {"queue_id": error_queue_id}
+                        if error_queue_id
+                        else {}
+                    ),
                 }
             ),
             status_code,
@@ -1352,6 +1363,237 @@ def complete_chat_prompt_queue_handoff_route(queue_id: str):
         return _chat_prompt_queue_error_response(
             exc,
             action="complete_handoff",
+            queue_id=queue_id,
+            scope=scope,
+        )
+
+
+@von_bp.route(
+    "/api/chat_prompt_queue/<queue_id>/retry",
+    methods=["POST"],
+)
+def retry_failed_chat_prompt_queue_route(queue_id: str):
+    """Create one idempotent, linked successor for an actor-visible failure."""
+
+    scope = _get_current_chat_prompt_queue_scope()
+    if isinstance(scope, tuple):
+        return scope
+    payload = _chat_prompt_queue_payload()
+    retry_request_id = _normalise_non_empty_text(payload.get("retry_request_id"))
+    if not retry_request_id:
+        return _chat_prompt_queue_error_response(
+            chat_prompt_queue_service.InvalidChatPromptQueueInput(
+                "retry_request_id is required"
+            ),
+            action="retry",
+            queue_id=queue_id,
+            scope=scope,
+        )
+    if len(retry_request_id) > 200:
+        return _chat_prompt_queue_error_response(
+            chat_prompt_queue_service.InvalidChatPromptQueueInput(
+                "retry_request_id is too long"
+            ),
+            action="retry",
+            queue_id=queue_id,
+            scope=scope,
+        )
+
+    queue_record: dict[str, Any] | None = None
+    source: Mapping[str, Any] | None = None
+    task_execution: dict[str, Any] | None = None
+    try:
+        retry_state = chat_prompt_queue_service.get_failed_queue_record_for_retry(
+            scope=scope,
+            queue_id=queue_id,
+        )
+        existing_successor = retry_state.get("successor")
+        if isinstance(existing_successor, Mapping):
+            queue_record = chat_prompt_queue_service.serialise_queue_record(
+                existing_successor
+            )
+            if queue_record is None:  # pragma: no cover - defensive
+                raise chat_prompt_queue_service.ChatPromptQueueUnavailable(
+                    "retry successor could not be serialised"
+                )
+            try:
+                chat_prompt_queue_service.mark_failed_queue_record_retried(
+                    scope=scope,
+                    source_queue_id=queue_id,
+                    successor_queue_id=str(queue_record.get("queue_id") or ""),
+                )
+            except chat_prompt_queue_service.ChatPromptQueueRetryConflict as exc:
+                current_app.logger.warning(
+                    "Retry successor exists but source back-link could not be "
+                    "reconciled queue_id=%s successor_queue_id=%s: %s",
+                    queue_id,
+                    queue_record.get("queue_id"),
+                    exc,
+                )
+            queue_record["idempotent_replay"] = True
+            wake_chat_prompt_queue_dispatcher()
+            return jsonify(
+                {
+                    "success": True,
+                    "item": queue_record,
+                    "task_execution": None,
+                    "idempotent_replay": True,
+                    "reconciliation_pending": bool(
+                        queue_record.get("task_concept_id")
+                        and not queue_record.get("dispatch_ready")
+                    ),
+                }
+            ), 200
+
+        source_value = retry_state.get("source")
+        if not isinstance(source_value, Mapping):  # pragma: no cover - defensive
+            raise chat_prompt_queue_service.ChatPromptQueueUnavailable(
+                "retry source could not be read"
+            )
+        source = source_value
+        conversation_key = _normalise_non_empty_text(
+            source.get("conversation_key")
+        )
+        if not conversation_key:
+            raise chat_prompt_queue_service.InvalidChatPromptQueueInput(
+                "The failed work is not linked to a retryable conversation"
+            )
+
+        source_task_id = _normalise_non_empty_text(source.get("task_concept_id"))
+        source_execution_id = _normalise_non_empty_text(
+            source.get("task_execution_concept_id")
+        )
+        if bool(source_task_id) != bool(source_execution_id):
+            raise chat_prompt_queue_service.ChatPromptQueueRetryConflict(
+                "The failed work has incomplete task execution lineage"
+            )
+
+        retry_launch_id = f"queue-retry:{queue_id}"
+        execution_envelope = (
+            dict(source.get("execution_envelope"))
+            if isinstance(source.get("execution_envelope"), Mapping)
+            else {}
+        )
+        execution_envelope["initiation_id"] = retry_launch_id
+        execution_envelope.setdefault("turn_kind", "user_message")
+
+        task_execution_id = None
+        retry_enqueue_id = retry_launch_id
+        if source_task_id and source_execution_id:
+            actor_id = str(scope.get("user_concept_id") or "")
+            organisation_id = str(scope.get("organisation_concept_id") or "")
+            task_execution_id = task_execution_concept_id_for_launch(
+                task_concept_id=source_task_id,
+                creator_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+                launch_request_id=retry_launch_id,
+            )
+            retry_enqueue_id = task_execution_enqueue_submission_id_for_launch(
+                task_concept_id=source_task_id,
+                creator_concept_id=actor_id,
+                organisation_concept_id=organisation_id,
+                launch_request_id=retry_launch_id,
+            )
+            workflow_inputs = execution_envelope.get("workflow_inputs")
+            if not isinstance(workflow_inputs, Mapping):
+                raise chat_prompt_queue_service.ChatPromptQueueRetryConflict(
+                    "The failed task execution has no trusted workflow inputs"
+                )
+            execution_envelope["workflow_inputs"] = {
+                **dict(workflow_inputs),
+                "task_execution_concept_id": task_execution_id,
+                "retry_of_queue_id": queue_id,
+                "retry_of_task_execution_concept_id": source_execution_id,
+            }
+
+        queue_record = chat_prompt_queue_service.create_queue_record(
+            scope=scope,
+            prompt_raw=source.get("prompt_raw"),
+            session_id=source.get("session_id"),
+            session_name=source.get("session_name"),
+            status=chat_prompt_queue_service.STATUS_QUEUED,
+            source=("von_task" if source_task_id else "failed_retry"),
+            conversation_key=conversation_key,
+            enqueue_submission_id=retry_enqueue_id,
+            dispatch_mode=chat_prompt_queue_service.DISPATCH_MODE_SERVER,
+            execution_envelope_version=1,
+            execution_envelope=execution_envelope,
+            task_concept_id=source_task_id,
+            task_execution_concept_id=task_execution_id,
+            server_dispatch_ready=not bool(source_task_id),
+            retry_source_queue_id=queue_id,
+            retry_request_id=retry_request_id,
+            retry_source_task_execution_concept_id=source_execution_id,
+        )
+        idempotent_replay = bool(queue_record.get("idempotent_replay"))
+        chat_prompt_queue_service.mark_failed_queue_record_retried(
+            scope=scope,
+            source_queue_id=queue_id,
+            successor_queue_id=str(queue_record.get("queue_id") or ""),
+        )
+
+        if source_task_id and task_execution_id:
+            task_execution = reconcile_task_execution_queue_record(
+                {
+                    **queue_record,
+                    **scope,
+                    "execution_envelope": execution_envelope,
+                }
+            )
+            if (
+                queue_record.get("status")
+                == chat_prompt_queue_service.STATUS_QUEUED
+                and not queue_record.get("dispatch_ready")
+            ):
+                queue_record = (
+                    chat_prompt_queue_service.activate_server_dispatch_record(
+                        scope=scope,
+                        queue_id=str(queue_record.get("queue_id") or ""),
+                        enqueue_submission_id=retry_enqueue_id,
+                        task_execution_concept_id=task_execution_id,
+                    )
+                )
+                queue_record["idempotent_replay"] = idempotent_replay
+        wake_chat_prompt_queue_dispatcher()
+        return jsonify(
+            {
+                "success": True,
+                "item": queue_record,
+                "task_execution": task_execution,
+                "idempotent_replay": idempotent_replay,
+                "reconciliation_pending": False,
+            }
+        ), (200 if idempotent_replay else 201)
+    except Exception as exc:  # noqa: BLE001 - preserve route error boundary
+        if (
+            queue_record
+            and source
+            and source.get("task_concept_id")
+            and queue_record.get("status")
+            == chat_prompt_queue_service.STATUS_QUEUED
+            and not queue_record.get("dispatch_ready")
+        ):
+            current_app.logger.warning(
+                "Task retry accepted for durable reconciliation queue_id=%s: %s",
+                queue_record.get("queue_id"),
+                exc,
+            )
+            wake_chat_prompt_queue_dispatcher()
+            return jsonify(
+                {
+                    "success": True,
+                    "item": queue_record,
+                    "task_execution": task_execution,
+                    "idempotent_replay": bool(
+                        queue_record.get("idempotent_replay")
+                    ),
+                    "reconciliation_pending": True,
+                    "warning": "Task retry projection is being reconciled",
+                }
+            ), 202
+        return _chat_prompt_queue_error_response(
+            exc,
+            action="retry",
             queue_id=queue_id,
             scope=scope,
         )

--- a/src/backend/services/chat_prompt_queue_service.py
+++ b/src/backend/services/chat_prompt_queue_service.py
@@ -178,6 +178,17 @@ class ChatPromptQueueHandoffConflict(InvalidChatPromptQueueInput):
         self.queue_id = queue_id
 
 
+class ChatPromptQueueRetryConflict(InvalidChatPromptQueueInput):
+    """Raised when a failed row cannot accept a linked retry successor."""
+
+    error_code = "queue_retry_conflict"
+    status_code = 409
+
+    def __init__(self, message: str, *, queue_id: str | None = None) -> None:
+        super().__init__(message)
+        self.queue_id = queue_id
+
+
 _QUEUE_ADMISSION_LOCK = threading.RLock()
 _UNSET = object()
 
@@ -456,6 +467,7 @@ def _enqueue_fingerprint(
     task_execution_concept_id: str | None,
     dispatch_ready: bool,
     handoff_source_queue_id: str | None,
+    retry_source_queue_id: str | None,
 ) -> str:
     material = {
         "schema": "chat_prompt_queue_enqueue.v2",
@@ -470,6 +482,7 @@ def _enqueue_fingerprint(
         "task_execution_concept_id": task_execution_concept_id,
         "dispatch_ready_at_enqueue": dispatch_ready,
         "handoff_source_queue_id": handoff_source_queue_id,
+        "retry_source_queue_id": retry_source_queue_id,
     }
     encoded = json.dumps(
         material,
@@ -530,6 +543,25 @@ def _raise_if_handoff_source_already_bound(
         "The handoff source is already bound to another durable replacement",
         queue_id=str(existing.get("queue_id") or "") or None,
     )
+
+
+def _find_retry_successor(
+    *,
+    coll: Collection,
+    scope: Mapping[str, Any],
+    retry_source_queue_id: str | None,
+) -> dict[str, Any] | None:
+    if not retry_source_queue_id:
+        return None
+    existing = coll.find_one(
+        {
+            **_compatible_scope_query(scope),
+            "retry_source_queue_id": retry_source_queue_id,
+        }
+    )
+    if not isinstance(existing, Mapping):
+        return None
+    return _idempotent_enqueue_result(existing, replayed=True)
 
 
 def _normalise_user_concept_id(value: Any) -> str:
@@ -1026,6 +1058,13 @@ def serialise_queue_record(doc: Mapping[str, Any] | None) -> dict[str, Any] | No
         "handoff_reconciliation_last_error": doc.get(
             "handoff_reconciliation_last_error"
         ),
+        "retry_source_queue_id": doc.get("retry_source_queue_id"),
+        "retry_request_id": doc.get("retry_request_id"),
+        "retry_source_task_execution_concept_id": doc.get(
+            "retry_source_task_execution_concept_id"
+        ),
+        "retried_by_queue_id": doc.get("retried_by_queue_id"),
+        "retried_at": _serialise_datetime(doc.get("retried_at")),
         "execution_envelope_version": doc.get("execution_envelope_version"),
         "task_concept_id": doc.get("task_concept_id"),
         "task_execution_concept_id": doc.get("task_execution_concept_id"),
@@ -1096,16 +1135,164 @@ def list_recent_failed_queue_records(
         **_compatible_scope_query(scope),
         "status": STATUS_FAILED,
         "completed_at": {"$gte": cutoff},
+        "$or": [
+            {"retried_by_queue_id": {"$exists": False}},
+            {"retried_by_queue_id": None},
+            {"retried_by_queue_id": ""},
+        ],
     }
-    docs = (
+    docs = list(
         _collection()
         .find(query)
         .sort([("completed_at", -1), ("updated_at", -1)])
-        .limit(max_limit)
+        .limit(100)
     )
-    return [
-        record for record in (serialise_queue_record(doc) for doc in docs) if record
+    failed_ids = [
+        str(doc.get("queue_id") or "")
+        for doc in docs
+        if doc.get("queue_id")
     ]
+    retried_source_ids: set[str] = set()
+    if failed_ids:
+        successors = _collection().find(
+            {
+                **_compatible_scope_query(scope),
+                "retry_source_queue_id": {"$in": failed_ids},
+            },
+            {"retry_source_queue_id": 1},
+        )
+        retried_source_ids = {
+            str(doc.get("retry_source_queue_id") or "")
+            for doc in successors
+            if doc.get("retry_source_queue_id")
+        }
+    return [
+        record
+        for record in (
+            serialise_queue_record(doc)
+            for doc in docs
+            if str(doc.get("queue_id") or "") not in retried_source_ids
+        )
+        if record
+    ][:max_limit]
+
+
+def get_failed_queue_record_for_retry(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+) -> dict[str, Any]:
+    """Return one actor-visible failed row as canonical retry input.
+
+    The execution envelope is intentionally returned only to trusted server
+    code. It is not added to the general queue projection merely to support a
+    retry action.
+    """
+
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    coll = _collection()
+    existing_successor = coll.find_one(
+        {
+            **_compatible_scope_query(scope),
+            "retry_source_queue_id": queue_id_clean,
+        }
+    )
+    if isinstance(existing_successor, Mapping):
+        return {
+            "source": None,
+            "successor": dict(existing_successor),
+        }
+    source = coll.find_one(
+        {
+            **_compatible_scope_query(scope),
+            "queue_id": queue_id_clean,
+            "status": STATUS_FAILED,
+        }
+    )
+    if not isinstance(source, Mapping):
+        current = coll.find_one(
+            {
+                **_compatible_scope_query(scope),
+                "queue_id": queue_id_clean,
+            },
+            {"status": 1, "retried_by_queue_id": 1},
+        )
+        details = {
+            "current_status": current.get("status") if current else None,
+            "retried_by_queue_id": (
+                current.get("retried_by_queue_id") if current else None
+            ),
+        }
+        raise ChatPromptQueueRecordNotFound(
+            "The failed queue record is not available for retry",
+            error_code="queue_retry_source_not_found",
+            details=details,
+        )
+    return {"source": dict(source), "successor": None}
+
+
+def mark_failed_queue_record_retried(
+    *,
+    scope: Mapping[str, Any],
+    source_queue_id: str,
+    successor_queue_id: str,
+) -> dict[str, Any]:
+    """Back-link a failed source after its unique successor is durable.
+
+    A concurrent Dismiss may already have changed the source to cancelled.
+    Once the successor exists, Retry has been durably accepted, so preserve
+    that terminal status while recording the lineage instead of returning a
+    false failure for work that can now execute.
+    """
+
+    source_id = _coerce_scope_value(source_queue_id, field="source_queue_id")
+    successor_id = _coerce_scope_value(
+        successor_queue_id,
+        field="successor_queue_id",
+    )
+    coll = _collection()
+    successor = coll.find_one(
+        {
+            **_compatible_scope_query(scope),
+            "queue_id": successor_id,
+            "retry_source_queue_id": source_id,
+        },
+        {"queue_id": 1},
+    )
+    if not isinstance(successor, Mapping):
+        raise ChatPromptQueueRetryConflict(
+            "The retry successor does not match the failed source",
+            queue_id=successor_id,
+        )
+    now = _now()
+    source = coll.find_one_and_update(
+        {
+            **_compatible_scope_query(scope),
+            "queue_id": source_id,
+            "status": {"$in": [STATUS_FAILED, STATUS_CANCELLED]},
+            "$or": [
+                {"retried_by_queue_id": {"$exists": False}},
+                {"retried_by_queue_id": successor_id},
+            ],
+        },
+        {
+            "$set": {
+                "retried_by_queue_id": successor_id,
+                "retried_at": now,
+                "updated_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(source, Mapping):
+        raise ChatPromptQueueRetryConflict(
+            "The failed source changed while its retry was being accepted",
+            queue_id=successor_id,
+        )
+    record = serialise_queue_record(source)
+    if record is None:  # pragma: no cover - defensive
+        raise ChatPromptQueueUnavailable("retry source could not be serialised")
+    return record
 
 
 def list_queue_visibility_records(
@@ -1801,6 +1988,9 @@ def create_queue_record(
     task_execution_concept_id: Any = None,
     server_dispatch_ready: Any = None,
     handoff_source_queue_id: Any = None,
+    retry_source_queue_id: Any = None,
+    retry_request_id: Any = None,
+    retry_source_task_execution_concept_id: Any = None,
 ) -> dict[str, Any]:
     if status not in {STATUS_QUEUED, STATUS_IN_PROGRESS}:
         raise InvalidChatPromptQueueInput("status must be queued or in_progress")
@@ -1861,6 +2051,21 @@ def create_queue_record(
         field="handoff_source_queue_id",
         required=False,
     )
+    retry_source_queue_id_clean = _coerce_scope_value(
+        retry_source_queue_id,
+        field="retry_source_queue_id",
+        required=False,
+    )
+    retry_request_id_clean = _coerce_scope_value(
+        retry_request_id,
+        field="retry_request_id",
+        required=False,
+    )
+    retry_source_task_execution_concept_id_clean = _coerce_scope_value(
+        retry_source_task_execution_concept_id,
+        field="retry_source_task_execution_concept_id",
+        required=False,
+    )
     if bool(task_concept_id_clean) != bool(task_execution_concept_id_clean):
         raise InvalidChatPromptQueueInput(
             "task_concept_id and task_execution_concept_id must be supplied together"
@@ -1876,6 +2081,25 @@ def create_queue_record(
     if handoff_source_queue_id_clean and task_concept_id_clean:
         raise InvalidChatPromptQueueInput(
             "handoff_source_queue_id cannot be combined with task execution links"
+        )
+    if handoff_source_queue_id_clean and retry_source_queue_id_clean:
+        raise InvalidChatPromptQueueInput(
+            "handoff and retry source links cannot be combined"
+        )
+    if retry_source_queue_id_clean and dispatch_mode_clean != DISPATCH_MODE_SERVER:
+        raise InvalidChatPromptQueueInput(
+            "retry_source_queue_id requires server dispatch"
+        )
+    if bool(retry_source_queue_id_clean) != bool(retry_request_id_clean):
+        raise InvalidChatPromptQueueInput(
+            "retry_source_queue_id and retry_request_id must be supplied together"
+        )
+    if (
+        retry_source_task_execution_concept_id_clean
+        and not retry_source_queue_id_clean
+    ):
+        raise InvalidChatPromptQueueInput(
+            "retry task lineage requires retry_source_queue_id"
         )
     active_task_execution_key = (
         _active_task_execution_key(task_concept_id_clean)
@@ -1942,6 +2166,7 @@ def create_queue_record(
             task_execution_concept_id=task_execution_concept_id_clean,
             dispatch_ready=dispatch_ready,
             handoff_source_queue_id=handoff_source_queue_id_clean,
+            retry_source_queue_id=retry_source_queue_id_clean,
         )
     elif any(
         value is not None
@@ -1951,6 +2176,9 @@ def create_queue_record(
             execution_envelope_version,
             server_dispatch_ready,
             handoff_source_queue_id_clean,
+            retry_source_queue_id_clean,
+            retry_request_id_clean,
+            retry_source_task_execution_concept_id_clean,
         )
     ):
         raise InvalidChatPromptQueueInput(
@@ -2009,6 +2237,23 @@ def create_queue_record(
                     if handoff_source_queue_id_clean
                     else {}
                 ),
+                **(
+                    {
+                        "retry_source_queue_id": retry_source_queue_id_clean,
+                        "retry_request_id": retry_request_id_clean,
+                        **(
+                            {
+                                "retry_source_task_execution_concept_id": (
+                                    retry_source_task_execution_concept_id_clean
+                                )
+                            }
+                            if retry_source_task_execution_concept_id_clean
+                            else {}
+                        ),
+                    }
+                    if retry_source_queue_id_clean
+                    else {}
+                ),
             }
         )
     if task_concept_id_clean:
@@ -2029,6 +2274,13 @@ def create_queue_record(
             seconds=LEGACY_SUBMISSION_RENDEZVOUS_SECONDS
         )
     coll = _collection()
+    retry_successor = _find_retry_successor(
+        coll=coll,
+        scope=scope,
+        retry_source_queue_id=retry_source_queue_id_clean,
+    )
+    if retry_successor is not None:
+        return retry_successor
     if enqueue_submission_id_clean and enqueue_fingerprint:
         reusable = _find_idempotent_enqueue(
             coll=coll,
@@ -2112,6 +2364,13 @@ def create_queue_record(
                             coll=coll,
                             handoff_source_queue_id=handoff_source_queue_id_clean,
                         )
+                        retry_successor = _find_retry_successor(
+                            coll=coll,
+                            scope=scope,
+                            retry_source_queue_id=retry_source_queue_id_clean,
+                        )
+                        if retry_successor is not None:
+                            return retry_successor
                         _raise_if_task_execution_already_active(
                             coll=coll,
                             active_task_execution_key=active_task_execution_key,
@@ -2163,6 +2422,13 @@ def create_queue_record(
                 coll=coll,
                 handoff_source_queue_id=handoff_source_queue_id_clean,
             )
+            retry_successor = _find_retry_successor(
+                coll=coll,
+                scope=scope,
+                retry_source_queue_id=retry_source_queue_id_clean,
+            )
+            if retry_successor is not None:
+                return retry_successor
             _raise_if_task_execution_already_active(
                 coll=coll,
                 active_task_execution_key=active_task_execution_key,

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -34285,6 +34285,26 @@ function normaliseChatPromptQueueEntry(rawEntry, fallback = {}) {
         enqueueUnconfirmed: rawEntry.enqueueUnconfirmed === true
             || fallback.enqueueUnconfirmed === true,
         deleteInFlight: rawEntry.deleteInFlight === true || fallback.deleteInFlight === true,
+        retryInFlight: rawEntry.retryInFlight === true || fallback.retryInFlight === true,
+        retryRequestId: rawEntry.retryRequestId
+            || fallback.retryRequestId
+            || null,
+        acceptedRetryRequestId: rawEntry.retry_request_id
+            || rawEntry.acceptedRetryRequestId
+            || fallback.acceptedRetryRequestId
+            || null,
+        retrySourceQueueId: rawEntry.retry_source_queue_id
+            || rawEntry.retrySourceQueueId
+            || fallback.retrySourceQueueId
+            || null,
+        retrySourceTaskExecutionConceptId: rawEntry.retry_source_task_execution_concept_id
+            || rawEntry.retrySourceTaskExecutionConceptId
+            || fallback.retrySourceTaskExecutionConceptId
+            || null,
+        retriedByQueueId: rawEntry.retried_by_queue_id
+            || rawEntry.retriedByQueueId
+            || fallback.retriedByQueueId
+            || null,
         handoffSourceQueueId: rawEntry.handoff_source_queue_id
             || rawEntry.handoffSourceQueueId
             || fallback.handoffSourceQueueId
@@ -34470,6 +34490,7 @@ function getSelectedChatPromptQueueEntryForSend() {
         || !isDisplayedChatPromptQueueEntry(entry)
         || !isChatPromptQueueEntryForSession(entry)
         || isServerDispatchedChatPromptQueueEntry(entry)
+        || entry.status === CHAT_PROMPT_QUEUE_STATUS_FAILED
         || entry.enqueueFailed === true
         || entry.handoffEnqueueSubmissionId
         || entry.supersededByQueueId
@@ -34481,7 +34502,6 @@ function getSelectedChatPromptQueueEntryForSend() {
     }
     if (
         entry.status !== CHAT_PROMPT_QUEUE_STATUS_QUEUED
-        && entry.status !== CHAT_PROMPT_QUEUE_STATUS_FAILED
     ) {
         return null;
     }
@@ -34985,6 +35005,30 @@ async function deletePersistedChatPromptQueueEntry(entry) {
     return true;
 }
 
+async function retryFailedChatPromptQueueEntry(entry) {
+    if (!entry?.queueId) {
+        throw new Error('The canonical failed queue record is unavailable.');
+    }
+    const retryRequestId = (
+        typeof entry.retryRequestId === 'string'
+        && entry.retryRequestId.trim()
+    )
+        ? entry.retryRequestId.trim()
+        : createClientRequestId();
+    entry.retryRequestId = retryRequestId;
+    const data = await fetchChatPromptQueueJson(
+        `/${encodeURIComponent(entry.queueId)}/retry`,
+        {
+            method: 'POST',
+            body: JSON.stringify({ retry_request_id: retryRequestId })
+        }
+    );
+    if (!data.item) {
+        throw new Error('Retry returned no canonical successor.');
+    }
+    return normaliseChatPromptQueueEntry(data.item);
+}
+
 async function completePersistedChatPromptQueueHandoff(entry) {
     if (!entry?.queueId) {
         throw new Error('The canonical handoff queue record is unavailable.');
@@ -35226,10 +35270,10 @@ function ensureChatTaskQueuePanel() {
         panel.id = CHAT_TASK_QUEUE_PANEL_ID;
         panel.className = 'chat-task-queue-panel hidden';
         panel.setAttribute('aria-live', 'polite');
-        panel.setAttribute('aria-label', 'Queued prompts for this conversation');
+        panel.setAttribute('aria-label', 'Conversation activity and queued prompts');
         panel.innerHTML = `
             <div class="chat-task-queue-header">
-                <span class="chat-task-queue-title">Queued prompts</span>
+                <span class="chat-task-queue-title">Conversation activity</span>
                 <span id="${CHAT_TASK_QUEUE_COUNT_ID}" class="chat-task-queue-count">0 queued</span>
             </div>
             <div id="${CHAT_TASK_QUEUE_LIST_ID}" class="chat-task-queue-list"></div>
@@ -35442,10 +35486,17 @@ function ensureChatTaskQueuePanel() {
                     return;
                 }
                 const queued = queuedChatPrompts.find((entry) => entry.id === queueId);
-                if (!queued || queued.status !== CHAT_PROMPT_QUEUE_STATUS_FAILED) {
+                if (
+                    !queued
+                    || queued.status !== CHAT_PROMPT_QUEUE_STATUS_FAILED
+                    || queued.retryInFlight === true
+                ) {
                     return;
                 }
+                queued.deleteInFlight = true;
+                queued.syncError = null;
                 dismissButton.disabled = true;
+                renderChatTaskQueuePanel();
                 void (async () => {
                     try {
                         await deletePersistedChatPromptQueueEntry(queued);
@@ -35458,11 +35509,59 @@ function ensureChatTaskQueuePanel() {
                         updateSendButtonForCurrentChatState();
                         publishChatPromptQueueChange('failed_prompt_dismissed');
                     } catch (error) {
+                        queued.deleteInFlight = false;
                         queued.syncError = describeChatPromptQueueApiError(
                             error,
                             'Failed task could not be dismissed on the server.'
                         );
                         console.warn('[chatTab] Unable to dismiss failed prompt:', error);
+                        renderChatTaskQueuePanel();
+                    }
+                })();
+                return;
+            }
+            const failedRetryButton = target.closest('.chat-task-queue-failed-retry');
+            if (failedRetryButton) {
+                const queueId = String(
+                    failedRetryButton.getAttribute('data-queue-id') || ''
+                ).trim();
+                const failedEntry = queuedChatPrompts.find(
+                    (entry) => entry.id === queueId
+                );
+                if (
+                    !failedEntry
+                    || failedEntry.status !== CHAT_PROMPT_QUEUE_STATUS_FAILED
+                    || failedEntry.retryInFlight === true
+                    || failedEntry.deleteInFlight === true
+                ) {
+                    return;
+                }
+                failedEntry.retryInFlight = true;
+                failedEntry.syncError = null;
+                renderChatTaskQueuePanel();
+                void (async () => {
+                    try {
+                        const successor = await retryFailedChatPromptQueueEntry(
+                            failedEntry
+                        );
+                        queuedChatPrompts = queuedChatPrompts.filter((entry) => (
+                            entry.id !== failedEntry.id
+                            && entry.queueId !== failedEntry.queueId
+                        ));
+                        const merged = mergePersistedChatPromptQueueEntry(successor);
+                        selectedChatPromptQueueEntryId = merged?.id || null;
+                        publishChatPromptQueueChange('failed_prompt_retried');
+                        renderChatTaskQueuePanel();
+                        refreshChatSessionTabActivityIndicators();
+                        updateSendButtonForCurrentChatState();
+                        syncChatPromptQueuePolling();
+                    } catch (error) {
+                        failedEntry.retryInFlight = false;
+                        failedEntry.syncError = describeChatPromptQueueApiError(
+                            error,
+                            'Failed task could not be retried on the server.'
+                        );
+                        console.warn('[chatTab] Unable to retry failed prompt:', error);
                         renderChatTaskQueuePanel();
                     }
                 })();
@@ -35753,10 +35852,26 @@ function renderChatTaskQueuePanel() {
             actions.appendChild(deleteButton);
         }
         if (isFailed) {
+            const retryButton = document.createElement('button');
+            retryButton.type = 'button';
+            retryButton.className = 'btn-mini chat-task-queue-failed-retry';
+            retryButton.textContent = entry.retryInFlight === true
+                ? 'Retrying…'
+                : 'Retry';
+            retryButton.disabled = entry.retryInFlight === true
+                || entry.deleteInFlight === true;
+            retryButton.setAttribute('data-queue-id', entry.id);
+            retryButton.setAttribute('aria-label', `Retry failed task ${index + 1}`);
+            actions.appendChild(retryButton);
+
             const dismissButton = document.createElement('button');
             dismissButton.type = 'button';
             dismissButton.className = 'btn-mini chat-task-queue-dismiss';
-            dismissButton.textContent = 'Dismiss';
+            dismissButton.textContent = entry.deleteInFlight === true
+                ? 'Dismissing…'
+                : 'Dismiss';
+            dismissButton.disabled = entry.deleteInFlight === true
+                || entry.retryInFlight === true;
             dismissButton.setAttribute('data-queue-id', entry.id);
             dismissButton.setAttribute('aria-label', `Dismiss failed task ${index + 1}`);
             actions.appendChild(dismissButton);

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -221,9 +221,9 @@
       </div>
     </div>
 
-    <section id="chatTaskQueuePanel" class="chat-task-queue-panel hidden" aria-live="polite" aria-label="Queued prompts for this conversation">
+    <section id="chatTaskQueuePanel" class="chat-task-queue-panel hidden" aria-live="polite" aria-label="Conversation activity and queued prompts">
       <div class="chat-task-queue-header">
-        <span class="chat-task-queue-title">Queued prompts</span>
+        <span class="chat-task-queue-title">Conversation activity</span>
         <span id="chatTaskQueueCount" class="chat-task-queue-count">0 queued</span>
       </div>
       <div id="chatTaskQueueList" class="chat-task-queue-list"></div>

--- a/tests/backend/test_chat_prompt_queue_routes.py
+++ b/tests/backend/test_chat_prompt_queue_routes.py
@@ -345,6 +345,190 @@ def test_chat_prompt_queue_route_dismisses_failed_record_durably(client) -> None
     assert payload["turn_admission"]["pending_admission"] == 0
 
 
+def test_failed_queue_retry_creates_one_linked_successor_across_request_ids(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.wake_chat_prompt_queue_dispatcher",
+        lambda: None,
+    )
+    created = client.post(
+        "/von/api/chat_prompt_queue",
+        json={
+            "prompt_raw": "Try the research task again",
+            "session_id": "session-retry",
+            "session_name": "Research",
+        },
+    ).get_json()["item"]
+    failure_message = "model_error"
+    failed = client.post(
+        f"/von/api/chat_prompt_queue/{created['queue_id']}/finish",
+        json={"status": "failed", "error": failure_message},
+    ).get_json()["item"]
+    coll = mongo_client.get_chat_prompt_queue_collection()
+    assert coll is not None
+    completed_at_before_retry = coll.find_one(
+        {"queue_id": created["queue_id"]}
+    )["completed_at"]
+
+    first = client.post(
+        f"/von/api/chat_prompt_queue/{created['queue_id']}/retry",
+        json={"retry_request_id": "retry-tab-a"},
+    )
+    second = client.post(
+        f"/von/api/chat_prompt_queue/{created['queue_id']}/retry",
+        json={"retry_request_id": "retry-tab-b"},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    first_payload = first.get_json()
+    second_payload = second.get_json()
+    successor = first_payload["item"]
+    assert successor["queue_id"] != created["queue_id"]
+    assert successor["retry_source_queue_id"] == created["queue_id"]
+    assert successor["retry_request_id"] == "retry-tab-a"
+    assert successor["status"] == "queued"
+    assert successor["dispatch_mode"] == "server"
+    assert successor["dispatch_ready"] is True
+    assert second_payload["item"]["queue_id"] == successor["queue_id"]
+    assert second_payload["idempotent_replay"] is True
+
+    assert coll.count_documents({}) == 2
+    source = coll.find_one({"queue_id": created["queue_id"]})
+    assert source is not None
+    assert source["status"] == "failed"
+    assert source["last_error"] == failure_message
+    assert source["completed_at"] == completed_at_before_retry
+    assert failed["completed_at"] is not None
+    assert source["retried_by_queue_id"] == successor["queue_id"]
+    persisted_successor = coll.find_one({"queue_id": successor["queue_id"]})
+    assert persisted_successor is not None
+    assert persisted_successor["execution_envelope"] == {
+        "initiation_id": f"queue-retry:{created['queue_id']}",
+        "turn_kind": "user_message",
+    }
+
+    visible = client.get("/von/api/chat_prompt_queue").get_json()
+    assert [row["queue_id"] for row in visible["items"]] == [
+        successor["queue_id"]
+    ]
+    assert visible["recent_failed_items"] == []
+
+
+def test_failed_task_retry_preserves_task_and_conversation_lineage(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.services.task_execution_service import (
+        task_execution_concept_id_for_launch,
+        task_execution_enqueue_submission_id_for_launch,
+    )
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.wake_chat_prompt_queue_dispatcher",
+        lambda: None,
+    )
+    reconciled: dict = {}
+
+    def _reconcile(queue_record):
+        reconciled.update(queue_record)
+        return {
+            "task_execution_concept_id": queue_record[
+                "task_execution_concept_id"
+            ],
+            "queue_id": queue_record["queue_id"],
+            "enqueue_submission_id": queue_record["enqueue_submission_id"],
+        }
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.reconcile_task_execution_queue_record",
+        _reconcile,
+    )
+    scope = chat_prompt_queue_service.build_queue_scope(
+        user_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        namespace="#V#test_user@test_org",
+    )
+    task_id = "#V#task_retry_test"
+    initial_launch_id = "initial-task-launch"
+    initial_execution_id = task_execution_concept_id_for_launch(
+        task_concept_id=task_id,
+        creator_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        launch_request_id=initial_launch_id,
+    )
+    initial_enqueue_id = task_execution_enqueue_submission_id_for_launch(
+        task_concept_id=task_id,
+        creator_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        launch_request_id=initial_launch_id,
+    )
+    source = chat_prompt_queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Execute the assigned task",
+        session_id="session-task-retry",
+        session_name="Task conversation",
+        source="von_task",
+        conversation_key="conversation-task-retry",
+        enqueue_submission_id=initial_enqueue_id,
+        dispatch_mode="server",
+        execution_envelope_version=1,
+        execution_envelope={
+            "initiation_id": initial_launch_id,
+            "turn_kind": "user_message",
+            "workflow_inputs": {
+                "task_concept_id": task_id,
+                "task_execution_concept_id": initial_execution_id,
+                "originating_conversation_concept_id": "#V#conversation_retry",
+                "conversation_session_id": "session-task-retry",
+                "authority_actor_concept_id": "#V#test_user",
+                "authority_organisation_concept_id": "#V#test_org",
+                "authority_namespace": "#V#test_user@test_org",
+                "executor_concept_id": "#V#von",
+            },
+        },
+        task_concept_id=task_id,
+        task_execution_concept_id=initial_execution_id,
+    )
+    reservation = chat_prompt_queue_service.reserve_next_server_dispatch(
+        server_instance_id="test-server"
+    )
+    assert reservation is not None
+    assert chat_prompt_queue_service.fail_server_dispatch_reservation(
+        queue_id=source["queue_id"],
+        dispatch_reservation_token=reservation["dispatch_reservation_token"],
+        server_instance_id="test-server",
+        error="model_error",
+    )
+
+    response = client.post(
+        f"/von/api/chat_prompt_queue/{source['queue_id']}/retry",
+        json={"retry_request_id": "task-retry-click"},
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    successor = payload["item"]
+    assert successor["task_concept_id"] == task_id
+    assert successor["task_execution_concept_id"] != initial_execution_id
+    assert successor["retry_source_task_execution_concept_id"] == (
+        initial_execution_id
+    )
+    assert successor["dispatch_ready"] is True
+    assert reconciled["session_id"] == "session-task-retry"
+    assert reconciled["conversation_key"] == "conversation-task-retry"
+    workflow_inputs = reconciled["execution_envelope"]["workflow_inputs"]
+    assert workflow_inputs["task_execution_concept_id"] == successor[
+        "task_execution_concept_id"
+    ]
+    assert workflow_inputs["retry_of_queue_id"] == source["queue_id"]
+    assert workflow_inputs["retry_of_task_execution_concept_id"] == (
+        initial_execution_id
+    )
+
+
 def test_queue_routes_cannot_release_a_live_server_bound_turn(client) -> None:
     created = client.post(
         "/von/api/chat_prompt_queue",

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -552,6 +552,14 @@ def test_chat_prompt_queue_indexes_support_idempotent_dispatch_and_retention() -
     assert handoff_source["partialFilterExpression"] == {
         "handoff_source_queue_id": {"$exists": True, "$type": "string"}
     }
+    retry_source = indexes["retry_source_queue_id_unique"]
+    assert list(retry_source["key"].items()) == [
+        ("retry_source_queue_id", mc.ASCENDING)
+    ]
+    assert retry_source["unique"] is True
+    assert retry_source["partialFilterExpression"] == {
+        "retry_source_queue_id": {"$exists": True, "$type": "string"}
+    }
     assert list(indexes["scope_status_enqueue_sequence"]["key"].items()) == [
         ("user_concept_id", mc.ASCENDING),
         ("organisation_concept_id", mc.ASCENDING),

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -1476,6 +1476,7 @@ describe('chat task queue', () => {
             'The final response did not return from Von.'
         );
         expect(document.querySelector('.chat-task-queue-delete')).toBeNull();
+        expect(document.querySelector('.chat-task-queue-failed-retry')?.textContent).toBe('Retry');
         expect(document.querySelector('.chat-task-queue-dismiss')?.textContent).toBe('Dismiss');
         expect(document.querySelector('.chat-task-queue-restart')).toBeNull();
         expect(fetchCalls.some((call) => String(call.url).startsWith('/von/generate'))).toBe(false);
@@ -1610,57 +1611,16 @@ describe('chat task queue', () => {
         expect(document.querySelector('.chat-task-queue-dismiss')?.disabled).toBe(false);
     }, 15000);
 
-    test('resubmits the focused failed persisted prompt through the normal send path', async () => {
-        const { getUserContext } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+    test('retries a failed row once through the linked server endpoint', async () => {
         const {
             __testOnly_refreshChatPromptQueueFromServer,
-            sendMessage,
         } = require(chatTabModulePath);
 
-        getUserContext.mockReturnValue({
-            user_id: 'user',
-            org_id: 'org',
-            language: 'en-NZ',
-            gmail_profile: null
-        });
-
         const fetchCalls = [];
-        const generateBodies = [];
+        let resolveRetry = null;
         global.fetch = jest.fn((url, options = {}) => {
             fetchCalls.push({ url, options });
-
-            if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
-                const body = JSON.parse(options.body || '{}');
-                return Promise.resolve({
-                    ok: true,
-                    json: async () => ({ html: String(body.text || '') })
-                });
-            }
-
-            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
-                return Promise.resolve({
-                    ok: true,
-                    json: async () => ({ history_length: 0, authenticated: true })
-                });
-            }
-
             if (typeof url === 'string' && url === '/von/api/chat_prompt_queue') {
-                if ((options.method || 'GET') === 'POST') {
-                    const parsed = JSON.parse(options.body || '{}');
-                    return Promise.resolve({
-                        ok: true,
-                        json: async () => ({
-                            success: true,
-                            item: {
-                                queue_id: 'queue-active',
-                                prompt_raw: parsed.prompt_raw,
-                                status: parsed.status || 'in_progress',
-                                session_id: parsed.session_id,
-                                session_name: parsed.session_name
-                            }
-                        })
-                    });
-                }
                 return Promise.resolve({
                     ok: true,
                     json: async () => ({
@@ -1678,50 +1638,119 @@ describe('chat task queue', () => {
                     })
                 });
             }
-
-            if (typeof url === 'string' && url === '/von/api/chat_prompt_queue/queue-active/finish') {
-                return Promise.resolve({
-                    ok: true,
-                    json: async () => ({
-                        success: true,
-                        item: { queue_id: 'queue-active', status: 'completed' }
-                    })
+            if (
+                typeof url === 'string'
+                && url === '/von/api/chat_prompt_queue/queue-failed/retry'
+                && options.method === 'POST'
+            ) {
+                return new Promise((resolve) => {
+                    resolveRetry = () => resolve({
+                        ok: true,
+                        status: 201,
+                        json: async () => ({
+                            success: true,
+                            item: {
+                                queue_id: 'queue-retry',
+                                retry_source_queue_id: 'queue-failed',
+                                prompt_raw: 'List the most recent 10 gmail messages together with any labels',
+                                status: 'queued',
+                                dispatch_mode: 'server',
+                                dispatch_ready: true,
+                                session_id: 'session-1',
+                                session_name: 'Current'
+                            }
+                        })
+                    });
                 });
             }
-
-            if (typeof url === 'string' && url.startsWith('/von/generate')) {
-                const parsed = JSON.parse(options.body || '{}');
-                generateBodies.push(parsed);
-                return Promise.resolve({
-                    ok: true,
-                    json: async () => ({
-                        response: 'Selected failed prompt response',
-                        llm_debug: { model: 'gpt-5.2' }
-                    })
-                });
-            }
-
             return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
         });
 
         await __testOnly_refreshChatPromptQueueFromServer();
+        const retryButton = document.querySelector('.chat-task-queue-failed-retry');
+        expect(retryButton).toBeTruthy();
 
-        const failedEditor = document.querySelector('.chat-task-queue-edit');
-        expect(failedEditor).toBeTruthy();
-        failedEditor.focus();
-        failedEditor.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
-        expect(document.querySelector('.chat-task-queue-item-selected')).toBeTruthy();
+        retryButton.click();
+        retryButton.click();
+        await flushMicrotasks();
 
-        await sendMessage();
+        expect(resolveRetry).toBeTruthy();
+        expect(document.querySelector('.chat-task-queue-item-failed')).toBeTruthy();
+        expect(document.querySelector('.chat-task-queue-failed-retry')?.disabled).toBe(true);
+        expect(fetchCalls.filter((call) => (
+            call.url === '/von/api/chat_prompt_queue/queue-failed/retry'
+        ))).toHaveLength(1);
+
+        resolveRetry();
         await flushMicrotasks();
         await flushMicrotasks();
 
-        expect(generateBodies).toHaveLength(1);
-        expect(generateBodies[0].prompt).toBe('List the most recent 10 gmail messages together with any labels');
-        expect(generateBodies[0].conversation_session_id).toBe('session-1');
-        expect(fetchCalls.some((call) => String(call.url).includes('/queue-failed/claim'))).toBe(false);
-        expect(fetchCalls.some((call) => String(call.url).includes('/queue-failed/finish'))).toBe(false);
+        const retryCall = fetchCalls.find((call) => (
+            call.url === '/von/api/chat_prompt_queue/queue-failed/retry'
+        ));
+        expect(JSON.parse(retryCall.options.body)).toEqual({
+            retry_request_id: expect.any(String)
+        });
         expect(document.querySelector('.chat-task-queue-item-failed')).toBeNull();
+        expect(document.querySelector('.chat-task-queue-item-label')?.textContent)
+            .toBe('Next up • Current');
+        expect(fetchCalls.some((call) => String(call.url).startsWith('/von/generate'))).toBe(false);
+        expect(fetchCalls.some((call) => String(call.url).includes('/claim'))).toBe(false);
+        expect(fetchCalls.some((call) => String(call.url).includes('/finish'))).toBe(false);
+    }, 15000);
+
+    test('retains failure evidence when linked retry is not accepted', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue') {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        success: true,
+                        items: [],
+                        recent_failed_items: [{
+                            queue_id: 'queue-failed',
+                            prompt_raw: 'Retry me safely',
+                            status: 'failed',
+                            session_id: 'session-1',
+                            session_name: 'Current',
+                            last_error: 'model_error'
+                        }]
+                    })
+                });
+            }
+            if (
+                url === '/von/api/chat_prompt_queue/queue-failed/retry'
+                && options.method === 'POST'
+            ) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    json: async () => ({
+                        success: false,
+                        error: 'chat prompt queue storage is unavailable',
+                        error_code: 'backend_unavailable'
+                    })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({ success: true }) });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        document.querySelector('.chat-task-queue-failed-retry').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(document.querySelector('.chat-task-queue-item-failed')).toBeTruthy();
+        expect(document.querySelector('.chat-task-queue-failure-message')?.textContent)
+            .toBe('model_error');
+        expect(document.querySelector('.chat-task-queue-sync-warning')?.textContent)
+            .toBe('Queue storage is temporarily unavailable.');
+        expect(document.querySelector('.chat-task-queue-failed-retry')?.disabled)
+            .toBe(false);
     }, 15000);
 
     test('shows a precise persisted update failure for an editable legacy row', async () => {


### PR DESCRIPTION
## Outcome

Adds an explicit Retry action for failed conversation work. A retry creates one new linked queue item while preserving the failed source as evidence; repeated requests converge on the same successor.

## Scope

- server-owned retry reconstruction from the canonical failed row
- task and conversation lineage on the successor
- unique source-to-successor index and bounded reconciliation
- Retry beside Dismiss in Conversation activity
- no reuse of the generic Send path

## Validation

- 100 focused backend tests passed
- 29 frontend queue tests passed
- frontend static lint, JavaScript/Python syntax, and diff checks passed
- isolated candidate browser replay: one retry POST on double-click, one Dismiss DELETE, zero /von/generate calls

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2702