### PR TITLE
Recover evidence-rich Gemini turns after transient provider failures

### DIFF
--- a/src/backend/languagemodels/structured_tool_calling/providers/gemini_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/gemini_client.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
+import re
 from collections.abc import Mapping, Sequence
 from time import monotonic
 from typing import Any
 from uuid import uuid4
+
+import httpx
 
 from ....integrations.internal_mcp.tool_call_contracts import (
     strip_internal_schema_extensions,
@@ -44,6 +48,11 @@ from ..types import (
 
 GEMINI_INTERACTIONS_SURFACE = "interactions"
 GEMINI_GENERATE_CONTENT_SURFACE = "gemini_generate_content"
+_MAX_RETRY_AFTER_METADATA_SECONDS = 3_600.0
+_RETRY_AFTER_MESSAGE_RE = re.compile(
+    r"\bretry\s+in\s+([0-9]+(?:\.[0-9]+)?)\s*s(?:ec(?:ond)?s?)?\b",
+    flags=re.IGNORECASE,
+)
 
 
 def _value(value: Any, key: str, default: Any = None) -> Any:
@@ -108,6 +117,146 @@ def _is_gemini_37_flash(model: str) -> bool:
     if model_id.startswith("models/"):
         model_id = model_id.split("/", 1)[1]
     return model_id == "gemini-3.7-flash" or model_id.startswith("gemini-3.7-flash-")
+
+
+def _safe_provider_token(value: Any) -> str | None:
+    """Retain a bounded provider enum/code, never an arbitrary error message."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or len(candidate) > 96:
+        return None
+    if re.fullmatch(r"[A-Za-z0-9_.:-]+", candidate) is None:
+        return None
+    return candidate
+
+
+def _provider_status_code(exc: BaseException) -> int | None:
+    for value in (
+        getattr(exc, "code", None),
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    ):
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return None
+
+
+def _provider_error_code(exc: BaseException) -> str | None:
+    details = getattr(exc, "details", None)
+    if not isinstance(details, Mapping):
+        return None
+    error = details.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    direct_code = _safe_provider_token(error.get("code"))
+    if direct_code is not None:
+        return direct_code
+    nested_details = error.get("details")
+    if isinstance(nested_details, Sequence) and not isinstance(
+        nested_details,
+        (str, bytes, bytearray),
+    ):
+        for item in nested_details[:10]:
+            if not isinstance(item, Mapping):
+                continue
+            nested_code = _safe_provider_token(item.get("code"))
+            if nested_code is not None:
+                return nested_code
+    return None
+
+
+def _bounded_retry_after_seconds(value: Any) -> float | None:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if (
+        not math.isfinite(seconds)
+        or seconds < 0.0
+        or seconds > _MAX_RETRY_AFTER_METADATA_SECONDS
+    ):
+        return None
+    return seconds
+
+
+def _provider_retry_after(exc: BaseException) -> tuple[float | None, str | None]:
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        try:
+            raw_header = headers.get("Retry-After")
+        except (AttributeError, TypeError):
+            raw_header = None
+        retry_after = _bounded_retry_after_seconds(raw_header)
+        if retry_after is not None:
+            return retry_after, "response_header"
+
+    # google-genai 2.x has no dedicated retry-delay attribute. Its bounded
+    # provider message carries the observed decimal-second retry instruction.
+    provider_message = getattr(exc, "message", None)
+    if isinstance(provider_message, str):
+        match = _RETRY_AFTER_MESSAGE_RE.search(provider_message[:1_024])
+        if match is not None:
+            retry_after = _bounded_retry_after_seconds(match.group(1))
+            if retry_after is not None:
+                return retry_after, "provider_message"
+    return None, None
+
+
+def _transient_sdk_transport_error(
+    exc: BaseException,
+    *,
+    model: str,
+    surface: str,
+) -> StructuredToolTransportError | None:
+    """Classify only provider failures with safe, discriminating evidence."""
+
+    status_code = _provider_status_code(exc)
+    if status_code == 429:
+        decision: dict[str, Any] = {
+            "provider": "gemini",
+            "effective_api_surface": surface,
+            "model": model,
+            "provider_status_code": 429,
+            "failure_kind": "provider_rate_limited",
+            "provider_request_sent": True,
+        }
+        provider_status = _safe_provider_token(getattr(exc, "status", None))
+        if provider_status is not None:
+            decision["provider_status"] = provider_status
+        provider_error_code = _provider_error_code(exc)
+        if provider_error_code is not None:
+            decision["provider_error_code"] = provider_error_code
+        retry_after_seconds, retry_after_source = _provider_retry_after(exc)
+        if retry_after_seconds is not None:
+            decision["retry_after_seconds"] = retry_after_seconds
+            decision["retry_after_source"] = retry_after_source
+        return StructuredToolTransportError(
+            "Gemini temporarily rate-limited the structured-tool request.",
+            decision=decision,
+        )
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, (httpx.NetworkError, ConnectionError)):
+            decision = {
+                "provider": "gemini",
+                "effective_api_surface": surface,
+                "model": model,
+                "failure_kind": "provider_connection_failed",
+            }
+            if isinstance(current, httpx.ConnectError):
+                decision["provider_request_sent"] = False
+            return StructuredToolTransportError(
+                "Gemini could not be reached for the structured-tool request.",
+                decision=decision,
+            )
+        current = current.__cause__ or current.__context__
+    return None
 
 
 class GeminiClient(LLMClient):
@@ -221,6 +370,21 @@ class GeminiClient(LLMClient):
         except StructuredToolTransportError:
             raise
         except Exception as exc:
+            transient_error = _transient_sdk_transport_error(
+                exc,
+                model=request_model,
+                surface=surface,
+            )
+            if transient_error is not None:
+                decision = transient_error.decision
+                self.logger.error(
+                    "Gemini structured-tool transport failure: kind=%s "
+                    "status_code=%s retry_after_seconds=%s",
+                    decision.get("failure_kind"),
+                    decision.get("provider_status_code"),
+                    decision.get("retry_after_seconds"),
+                )
+                raise transient_error from exc
             safe_error = sanitise_transport_telemetry_text(str(exc))
             self.logger.error("Gemini structured-tool API error: %s", safe_error)
             raise ToolCallError(f"Gemini call failed: {safe_error}") from exc

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import threading
 import time
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import dataclass
@@ -89,6 +90,11 @@ _SUCCESSFUL_MODEL_DURATION_ADVISORY_MULTIPLIER = 1.25
 _MODEL_EVIDENCE_INDEX_MAX_BYTES = 24_000
 _MODEL_TOOL_RESULT_BATCH_MAX_BYTES = 24_000
 _MODEL_TRANSPORT_RECOVERY_CONTEXT_MAX_BYTES = 64_000
+# Twice the observed 43.424-second provider-directed wait, rounded up. Longer
+# delays return an honest retry-later outcome instead of holding a turn worker.
+_DEFAULT_PROVIDER_RETRY_WAIT_MAX_SECONDS = 90.0
+_PROVIDER_RETRY_WAIT_SLICE_SECONDS = 1.0
+_MAX_PROVIDER_RETRY_METADATA_SECONDS = 3_600.0
 _MODEL_EVIDENCE_PREVIEW_MAX_CHARS = 240
 _CAPABILITY_PURPOSE_MAX_CHARS = 160
 _CAPABILITY_CATALOGUE_SCHEMA_VERSION = "adaptive_turn_capabilities.v1"
@@ -1269,6 +1275,9 @@ def _structured_transport_failure_telemetry(
             "provider_status_code",
             "provider_error_code",
             "provider_errors",
+            "provider_request_sent",
+            "retry_after_seconds",
+            "retry_after_source",
             "failure_kind",
             "partial_response_available",
             "partial_response_char_count",
@@ -1277,6 +1286,23 @@ def _structured_transport_failure_telemetry(
         )
         if key in decision
     }
+    if not isinstance(retained_decision.get("provider_request_sent"), bool):
+        retained_decision.pop("provider_request_sent", None)
+    retry_after_seconds = retained_decision.get("retry_after_seconds")
+    if (
+        not isinstance(retry_after_seconds, (int, float))
+        or isinstance(retry_after_seconds, bool)
+        or not math.isfinite(float(retry_after_seconds))
+        or float(retry_after_seconds) < 0.0
+        or float(retry_after_seconds) > _MAX_PROVIDER_RETRY_METADATA_SECONDS
+    ):
+        retained_decision.pop("retry_after_seconds", None)
+        retained_decision.pop("retry_after_source", None)
+    elif retained_decision.get("retry_after_source") not in {
+        "provider_message",
+        "response_header",
+    }:
+        retained_decision.pop("retry_after_source", None)
     telemetry: dict[str, Any] = {
         "failure_kind": failure_kind or "structured_tool_transport_error",
     }
@@ -1284,6 +1310,9 @@ def _structured_transport_failure_telemetry(
         "provider_status",
         "provider_status_code",
         "provider_error_code",
+        "provider_request_sent",
+        "retry_after_seconds",
+        "retry_after_source",
         "partial_response_available",
         "partial_response_char_count",
         "partial_response_sha256",
@@ -6422,6 +6451,8 @@ def execute_adaptive_turn(
     final_synthesis_reserve_seconds: float | None = None,
     final_answer_reserve_seconds: float | None = None,
     clock: Any = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+    provider_retry_wait_max_seconds: float | None = None,
 ) -> AdaptiveTurnResult:
     """Run one ordinary turn without a selector, master workflow, critic, or gate."""
 
@@ -6450,6 +6481,11 @@ def execute_adaptive_turn(
             _DEFAULT_FINAL_ANSWER_RESERVE_SECONDS,
         )
     )
+    provider_retry_wait_max = float(
+        provider_retry_wait_max_seconds
+        if provider_retry_wait_max_seconds is not None
+        else _DEFAULT_PROVIDER_RETRY_WAIT_MAX_SECONDS
+    )
     if turn_budget <= 0.0:
         raise ValueError("turn_budget_seconds must be positive")
     if not 0.0 < final_reserve < turn_budget:
@@ -6459,6 +6495,10 @@ def execute_adaptive_turn(
         )
     if requested_final_answer_reserve < 0.0:
         raise ValueError("final_answer_reserve_seconds must be non-negative")
+    if not math.isfinite(provider_retry_wait_max) or provider_retry_wait_max <= 0.0:
+        raise ValueError(
+            "provider_retry_wait_max_seconds must be finite and positive"
+        )
     final_answer_reserve = min(
         requested_final_answer_reserve,
         final_reserve,
@@ -6566,6 +6606,7 @@ def execute_adaptive_turn(
             "enforcement": "advisory",
             "model_call_advisory_seconds": model_call_advisory,
             "model_call_hard_timeout_seconds": None,
+            "provider_retry_wait_max_seconds": provider_retry_wait_max,
         }
     ]
     usage_totals: dict[str, float] = {}
@@ -6615,6 +6656,8 @@ def execute_adaptive_turn(
                 "provider_status": call.get("provider_status"),
                 "provider_status_code": call.get("provider_status_code"),
                 "provider_error_code": call.get("provider_error_code"),
+                "retry_after_seconds": call.get("retry_after_seconds"),
+                "retry_after_source": call.get("retry_after_source"),
                 "transport_decision": call.get("transport_decision"),
                 "llm_usage_cost_summary": current_llm_usage_cost_summary(),
                 "result_summary": (
@@ -8504,6 +8547,71 @@ def execute_adaptive_turn(
             }
         )
 
+    def wait_for_provider_retry(
+        *,
+        retry_after_seconds: float,
+        call_id: str,
+        failure_telemetry: Mapping[str, Any],
+        evidence_count: int,
+    ) -> None:
+        """Wait once in cancellable slices before a materially smaller retry."""
+
+        wait_receipt = {
+            "type": "adaptive_turn_provider_retry_wait",
+            "schema_version": "adaptive_turn_provider_retry_wait.v1",
+            "call_id": call_id,
+            "reason": "provider_rate_limited_after_evidence",
+            "action": "wait_then_fresh_answer_without_tools",
+            "requested_wait_seconds": retry_after_seconds,
+            "wait_max_seconds": provider_retry_wait_max,
+            "wait_slice_seconds": _PROVIDER_RETRY_WAIT_SLICE_SECONDS,
+            "prior_model_call_count": model_call_sequence,
+            "tool_invocation_count": len(tool_invocations),
+            "evidence_count": evidence_count,
+            "observed_input_tokens": usage_totals.get("input_tokens"),
+            **dict(failure_telemetry),
+        }
+        aux_calls.append(wait_receipt)
+        _emit(
+            progress_tracker,
+            {
+                "status": "provider_retry_wait_start",
+                "event_kind": "provider_retry_wait_start",
+                "stage": "model_transport_recovery",
+                "phase": "model_transport_recovery",
+                "call_id": call_id,
+                "retry_after_seconds": retry_after_seconds,
+                "result_summary": (
+                    "The provider requested a bounded delay before one compact "
+                    "answer-only recovery call."
+                ),
+            },
+        )
+        remaining = retry_after_seconds
+        while remaining > 0.0:
+            _check_cancellation(progress_tracker)
+            wait_slice = min(_PROVIDER_RETRY_WAIT_SLICE_SECONDS, remaining)
+            sleeper(wait_slice)
+            remaining = max(0.0, remaining - wait_slice)
+        _check_cancellation(progress_tracker)
+        wait_receipt["wait_completed"] = True
+        _emit(
+            progress_tracker,
+            {
+                "status": "provider_retry_wait_end",
+                "event_kind": "provider_retry_wait_end",
+                "stage": "model_transport_recovery",
+                "phase": "model_transport_recovery",
+                "call_id": call_id,
+                "retry_after_seconds": retry_after_seconds,
+                "success": True,
+                "result_summary": (
+                    "The provider-directed wait completed; generating from "
+                    "retained evidence without tools."
+                ),
+            },
+        )
+
     while True:
         model_call_sequence += 1
         model_call_id = f"{turn_id or 'adaptive-turn'}:llm:{model_call_sequence}"
@@ -8691,6 +8799,10 @@ def execute_adaptive_turn(
                 if isinstance(exc, StructuredToolTransportError)
                 else {}
             )
+            if "provider_request_sent" in transport_failure_telemetry:
+                provider_request_sent = transport_failure_telemetry[
+                    "provider_request_sent"
+                ]
             partial_response = getattr(exc, "partial_response", None)
             partial_response_text = (
                 partial_response.text_response.strip()
@@ -8779,9 +8891,6 @@ def execute_adaptive_turn(
                     "be missing.\n\n" + partial_response_text,
                     status=terminal_status,
                 )
-            if final_synthesis and not answer_only:
-                enter_answer_only("evidence_call_failed")
-                continue
             available_evidence_count = len(evidence_store.index())
             # A provider may exhaust its own interaction budget only after a
             # long, otherwise successful tool continuation. Preserve that work
@@ -8789,17 +8898,63 @@ def execute_adaptive_turn(
             # exception and discarding every completed observation.
             if (
                 isinstance(exc, StructuredToolTransportError)
-                and not final_synthesis
+                and not answer_only
                 and (available_evidence_count > 0 or bool(evidence_views))
             ):
                 provider_status = transport_failure_telemetry.get(
                     "provider_status"
                 )
-                recovery_reason = (
-                    "provider_budget_exhausted_after_evidence"
-                    if provider_status == "budget_exceeded"
-                    else "structured_transport_failed_after_evidence"
-                )
+                failure_kind = transport_failure_telemetry.get("failure_kind")
+                if provider_status == "budget_exceeded":
+                    recovery_reason = "provider_budget_exhausted_after_evidence"
+                elif failure_kind == "provider_rate_limited":
+                    recovery_reason = "provider_rate_limited_after_evidence"
+                elif failure_kind == "provider_connection_failed":
+                    recovery_reason = "provider_connection_failed_after_evidence"
+                else:
+                    recovery_reason = "structured_transport_failed_after_evidence"
+                if recovery_reason == "provider_rate_limited_after_evidence":
+                    retry_after_seconds = transport_failure_telemetry.get(
+                        "retry_after_seconds"
+                    )
+                    if (
+                        not isinstance(retry_after_seconds, (int, float))
+                        or isinstance(retry_after_seconds, bool)
+                        or not math.isfinite(float(retry_after_seconds))
+                        or float(retry_after_seconds) < 0.0
+                        or float(retry_after_seconds) > provider_retry_wait_max
+                    ):
+                        aux_calls.append(
+                            {
+                                "type": "adaptive_turn_provider_retry_wait",
+                                "schema_version": (
+                                    "adaptive_turn_provider_retry_wait.v1"
+                                ),
+                                "call_id": model_call_id,
+                                "reason": (
+                                    "provider_retry_delay_missing_or_exceeds_bound"
+                                ),
+                                "action": "return_typed_retry_later_outcome",
+                                "requested_wait_seconds": retry_after_seconds,
+                                "wait_max_seconds": provider_retry_wait_max,
+                                "wait_completed": False,
+                                **transport_failure_telemetry,
+                            }
+                        )
+                        terminal_status = "model_error"
+                        return finish(
+                            "I gathered evidence for the request, but the model "
+                            "provider is temporarily rate-limited and did not "
+                            "supply a delay this turn could safely wait. Please "
+                            "try again later.",
+                            status=terminal_status,
+                        )
+                    wait_for_provider_retry(
+                        retry_after_seconds=float(retry_after_seconds),
+                        call_id=model_call_id,
+                        failure_telemetry=transport_failure_telemetry,
+                        evidence_count=available_evidence_count,
+                    )
                 recovery_context_before_bytes = len(_json_bytes(current_context))
                 enter_answer_only(recovery_reason)
                 compact_answer_context = _compact_context_after_limit(
@@ -8846,6 +9001,9 @@ def execute_adaptive_turn(
                         **transport_failure_telemetry,
                     }
                 )
+                continue
+            if final_synthesis and not answer_only:
+                enter_answer_only("evidence_call_failed")
                 continue
             if not final_synthesis and _is_transient_model_request_liveness_failure(
                 exc
@@ -8913,6 +9071,19 @@ def execute_adaptive_turn(
                         pending_results = []
                         continue
             terminal_status = "model_error"
+            failure_kind = transport_failure_telemetry.get("failure_kind")
+            if failure_kind == "provider_rate_limited":
+                text = last_partial_text.strip() or (
+                    "I could not complete the request because the model provider "
+                    "is temporarily rate-limited. Please try again later."
+                )
+                return finish(text, status=terminal_status)
+            if failure_kind == "provider_connection_failed":
+                text = last_partial_text.strip() or (
+                    "I could not complete the request because the model provider "
+                    "connection failed. Please try again."
+                )
+                return finish(text, status=terminal_status)
             text = last_partial_text.strip() or (
                 "I could not complete the request because the model call failed: "
                 f"{type(exc).__name__}."

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -2655,6 +2655,28 @@ def test_default_final_answer_reserve_is_nonzero_and_clamped() -> None:
     assert allocation["enforcement"] == "advisory"
     assert allocation["model_call_advisory_seconds"] == 120.0
     assert allocation["model_call_hard_timeout_seconds"] is None
+    assert allocation["provider_retry_wait_max_seconds"] == 90.0
+
+
+@pytest.mark.parametrize("invalid_wait_max", [0.0, -1.0, float("nan"), float("inf")])
+def test_provider_retry_wait_max_must_be_finite_and_positive(
+    invalid_wait_max: float,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="provider_retry_wait_max_seconds must be finite and positive",
+    ):
+        execute_adaptive_turn(
+            gateway=None,
+            prompt="A short request.",
+            context=[],
+            llm_client=_SequenceClient(LLMResponse(text_response="unused")),
+            model="test-model",
+            turn_id="invalid-provider-retry-wait-max",
+            turn_budget_seconds=10,
+            final_synthesis_reserve_seconds=2,
+            provider_retry_wait_max_seconds=invalid_wait_max,
+        )
 
 
 @pytest.mark.parametrize(
@@ -9182,6 +9204,333 @@ def test_structured_transport_failure_after_evidence_gets_one_tool_free_answer()
     assert recovery["context_max_bytes"] == 64_000
 
 
+def test_typed_connection_failure_after_evidence_gets_one_tool_free_answer() -> (
+    None
+):
+    connection_failure = StructuredToolTransportError(
+        "Gemini could not be reached for the structured-tool request.",
+        decision={
+            "provider": "gemini",
+            "effective_api_surface": "interactions",
+            "model": "gemini-3.7-flash",
+            "failure_kind": "provider_connection_failed",
+            "provider_request_sent": False,
+        },
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-connection-failure",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+            continuation=LLMContinuation(
+                provider="gemini",
+                api_surface="interactions",
+                model="gemini-3.7-flash",
+                state_mode="stateless",
+                input_items=[{"type": "user_input", "content": []}],
+                output_items=[
+                    {
+                        "type": "function_call",
+                        "id": "read-before-connection-failure",
+                        "name": "turn_invoke_capability",
+                        "arguments": {},
+                    }
+                ],
+            ),
+        ),
+        connection_failure,
+        LLMResponse(text_response="Recovered after the connection failure."),
+    )
+    sleeps: list[float] = []
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "success": True,
+                "students": [{"name": "Student A", "expected_end": "2027"}],
+            }
+        ),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-connection-failure-recovery",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        sleeper=lambda seconds: sleeps.append(seconds),
+    )
+
+    assert result.terminal_status == "completed"
+    assert result.response_text == "Recovered after the connection failure."
+    assert len(client.calls) == 3
+    assert sleeps == []
+    assert client.calls[2]["available_tools"] == []
+    assert "continuation" not in client.calls[2]
+    assert "tool_results" not in client.calls[2]
+    assert result.llm_calls[1]["failure_kind"] == "provider_connection_failed"
+    assert result.llm_calls[1]["provider_request_sent"] is False
+    recovery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_model_transport_recovery"
+    )
+    assert recovery["reason"] == "provider_connection_failed_after_evidence"
+
+
+def test_typed_rate_limit_after_evidence_waits_then_recovers_without_tools() -> (
+    None
+):
+    retry_after_seconds = 43.424416244
+    rate_limit = StructuredToolTransportError(
+        "Gemini temporarily rate-limited the structured-tool request.",
+        decision={
+            "provider": "gemini",
+            "effective_api_surface": "interactions",
+            "model": "gemini-3.7-flash",
+            "provider_status": "RESOURCE_EXHAUSTED",
+            "provider_status_code": 429,
+            "provider_error_code": "too_many_requests",
+            "failure_kind": "provider_rate_limited",
+            "provider_request_sent": True,
+            "retry_after_seconds": retry_after_seconds,
+            "retry_after_source": "provider_message",
+        },
+    )
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            usage={"input_tokens": 229_113, "output_tokens": 31},
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-rate-limit",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+            continuation=LLMContinuation(
+                provider="gemini",
+                api_surface="interactions",
+                model="gemini-3.7-flash",
+                state_mode="stateless",
+                input_items=[{"type": "user_input", "content": []}],
+                output_items=[
+                    {
+                        "type": "function_call",
+                        "id": "read-before-rate-limit",
+                        "name": "turn_invoke_capability",
+                        "arguments": {},
+                    }
+                ],
+            ),
+        ),
+        rate_limit,
+        LLMResponse(text_response="Recovered after the provider-directed wait."),
+    )
+    clock = _ManualClock()
+    sleep_slices: list[float] = []
+    progress_events: list[dict[str, Any]] = []
+
+    def sleep_and_advance(seconds: float) -> None:
+        sleep_slices.append(seconds)
+        clock.now += seconds
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "success": True,
+                "students": [{"name": "Student A", "expected_end": "2027"}],
+            }
+        ),
+        prompt="Make a table of my current students.",
+        context=[{"role": "assistant", "content": "old context " * 20_000}],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        progress_tracker=SimpleNamespace(
+            emit=lambda event: progress_events.append(dict(event))
+        ),
+        turn_id="turn-rate-limit-recovery",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        clock=clock,
+        sleeper=sleep_and_advance,
+        provider_retry_wait_max_seconds=90,
+    )
+
+    assert result.terminal_status == "completed"
+    assert result.response_text == "Recovered after the provider-directed wait."
+    assert len(client.calls) == 3
+    assert sum(sleep_slices) == pytest.approx(retry_after_seconds)
+    assert max(sleep_slices) <= 1.0
+    assert client.calls[2]["available_tools"] == []
+    assert "continuation" not in client.calls[2]
+    assert "tool_results" not in client.calls[2]
+    assert len(_json_bytes(client.calls[2]["context"])) <= 64_512
+    failed_call = result.llm_calls[1]
+    assert failed_call["failure_kind"] == "provider_rate_limited"
+    assert failed_call["provider_status_code"] == 429
+    assert failed_call["provider_error_code"] == "too_many_requests"
+    assert failed_call["provider_request_sent"] is True
+    assert failed_call["retry_after_seconds"] == retry_after_seconds
+    wait_receipt = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_provider_retry_wait"
+    )
+    assert wait_receipt["action"] == "wait_then_fresh_answer_without_tools"
+    assert wait_receipt["wait_completed"] is True
+    assert wait_receipt["observed_input_tokens"] == 229_113
+    assert wait_receipt["retry_after_source"] == "provider_message"
+    recovery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_model_transport_recovery"
+    )
+    assert recovery["reason"] == "provider_rate_limited_after_evidence"
+    assert [
+        event["event_kind"]
+        for event in progress_events
+        if event.get("event_kind", "").startswith("provider_retry_wait_")
+    ] == ["provider_retry_wait_start", "provider_retry_wait_end"]
+
+
+def test_rate_limit_recovery_is_not_repeated_for_answer_only_failure() -> None:
+    def rate_limit() -> StructuredToolTransportError:
+        return StructuredToolTransportError(
+            "Gemini temporarily rate-limited the structured-tool request.",
+            decision={
+                "provider": "gemini",
+                "provider_status_code": 429,
+                "provider_error_code": "too_many_requests",
+                "failure_kind": "provider_rate_limited",
+                "provider_request_sent": True,
+                "retry_after_seconds": 0.0,
+                "retry_after_source": "response_header",
+            },
+        )
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-two-rate-limits",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+        ),
+        rate_limit(),
+        rate_limit(),
+        LLMResponse(text_response="A fourth call must not happen."),
+    )
+    sleeps: list[float] = []
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True, "students": []}),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-rate-limit-single-recovery",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        sleeper=lambda seconds: sleeps.append(seconds),
+    )
+
+    assert result.terminal_status == "model_error"
+    assert len(client.calls) == 3
+    assert sleeps == []
+    assert "temporarily rate-limited" in result.response_text
+    assert len(
+        [
+            item
+            for item in result.aux_llm_calls
+            if item.get("type") == "adaptive_turn_provider_retry_wait"
+        ]
+    ) == 1
+    assert len(
+        [
+            item
+            for item in result.aux_llm_calls
+            if item.get("type") == "adaptive_turn_model_transport_recovery"
+        ]
+    ) == 1
+
+
+@pytest.mark.parametrize("retry_after_seconds", [None, 120.0])
+def test_rate_limit_after_evidence_without_safe_wait_returns_retry_later(
+    retry_after_seconds: float | None,
+) -> None:
+    decision: dict[str, Any] = {
+        "provider": "gemini",
+        "provider_status_code": 429,
+        "failure_kind": "provider_rate_limited",
+        "provider_request_sent": True,
+    }
+    if retry_after_seconds is not None:
+        decision["retry_after_seconds"] = retry_after_seconds
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read-before-unsafe-rate-limit-wait",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "current students"},
+                    },
+                )
+            ],
+        ),
+        StructuredToolTransportError(
+            "Gemini temporarily rate-limited the structured-tool request.",
+            decision=decision,
+        ),
+        LLMResponse(text_response="A third call must not happen."),
+    )
+    sleeps: list[float] = []
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True, "students": []}),
+        prompt="Make a table of my current students.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-rate-limit-no-safe-wait",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        sleeper=lambda seconds: sleeps.append(seconds),
+        provider_retry_wait_max_seconds=90,
+    )
+
+    assert result.terminal_status == "model_error"
+    assert len(client.calls) == 2
+    assert sleeps == []
+    assert "I gathered evidence" in result.response_text
+    wait_receipt = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_provider_retry_wait"
+    )
+    assert wait_receipt["action"] == "return_typed_retry_later_outcome"
+    assert wait_receipt["wait_completed"] is False
+
+
 def test_consecutive_incomplete_responses_deliver_visible_partial_answer() -> None:
     first_incomplete = StructuredToolTransportError(
         "Gemini Interactions returned an unsuccessful provider status.",
@@ -9398,6 +9747,49 @@ def test_structured_transport_failure_without_evidence_remains_terminal() -> Non
     assert result.llm_calls[0]["provider_status"] == "failed"
     assert not any(
         item.get("type") == "adaptive_turn_model_transport_recovery"
+        for item in result.aux_llm_calls
+    )
+
+
+def test_rate_limit_without_evidence_does_not_wait_or_retry() -> None:
+    client = _SequenceClient(
+        StructuredToolTransportError(
+            "Gemini temporarily rate-limited the structured-tool request.",
+            decision={
+                "provider": "gemini",
+                "provider_status_code": 429,
+                "failure_kind": "provider_rate_limited",
+                "provider_request_sent": True,
+                "retry_after_seconds": 43.424416244,
+                "retry_after_source": "provider_message",
+            },
+        ),
+        LLMResponse(text_response="This response must not be requested."),
+    )
+    sleeps: list[float] = []
+
+    result = execute_adaptive_turn(
+        gateway=None,
+        prompt="Answer without any prior evidence.",
+        context=[],
+        llm_client=client,
+        model="gemini-3.7-flash",
+        turn_id="turn-rate-limit-without-evidence",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+        sleeper=lambda seconds: sleeps.append(seconds),
+    )
+
+    assert len(client.calls) == 1
+    assert sleeps == []
+    assert result.terminal_status == "model_error"
+    assert "temporarily rate-limited" in result.response_text
+    assert not any(
+        item.get("type")
+        in {
+            "adaptive_turn_provider_retry_wait",
+            "adaptive_turn_model_transport_recovery",
+        }
         for item in result.aux_llm_calls
     )
 

--- a/tests/backend/test_gemini_structured_tool_transport.py
+++ b/tests/backend/test_gemini_structured_tool_transport.py
@@ -4,8 +4,10 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 from google import genai
+from google.genai import errors as genai_errors
 
 from src.backend.languagemodels.structured_tool_calling.client import (
     LLMClient,
@@ -17,6 +19,7 @@ from src.backend.languagemodels.structured_tool_calling.providers.gemini_client 
 from src.backend.languagemodels.structured_tool_calling.types import (
     StructuredToolProtocolError,
     StructuredToolTransportError,
+    ToolCallError,
     ToolDefinition,
     ToolResult,
 )
@@ -37,7 +40,10 @@ class _Interactions:
 
     async def create(self, **kwargs: Any) -> Any:
         self.requests.append(dict(kwargs))
-        return self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
 class _Models:
@@ -399,6 +405,106 @@ def test_gemini_37_fails_clearly_without_interactions_sdk_surface() -> None:
             SimpleNamespace(aio=SimpleNamespace()),
             "gemini-3.7-flash",
         )
+
+
+def test_interactions_connection_failure_is_typed_without_raw_sdk_text() -> None:
+    request = httpx.Request("POST", "https://generativelanguage.googleapis.com")
+    connection_error = httpx.ConnectError(
+        "Connection error. api_key=secret-provider-value",
+        request=request,
+    )
+    client = _client(_Interactions([connection_error]))
+
+    with pytest.raises(StructuredToolTransportError) as exc_info:
+        asyncio.run(client.generate_with_tools("Find evidence.", [_tool()]))
+
+    error = exc_info.value
+    assert str(error) == (
+        "Gemini could not be reached for the structured-tool request."
+    )
+    assert error.decision == {
+        "provider": "gemini",
+        "effective_api_surface": "interactions",
+        "model": "gemini-3.7-flash",
+        "failure_kind": "provider_connection_failed",
+        "provider_request_sent": False,
+    }
+    assert "secret-provider-value" not in str(error.decision)
+
+
+@pytest.mark.parametrize(
+    ("retry_header", "expected_source"),
+    [
+        ("43.424416244", "response_header"),
+        (None, "provider_message"),
+    ],
+)
+def test_interactions_rate_limit_retains_only_safe_retry_decision(
+    retry_header: str | None,
+    expected_source: str,
+) -> None:
+    request = httpx.Request("POST", "https://generativelanguage.googleapis.com")
+    headers = {"Retry-After": retry_header} if retry_header is not None else {}
+    response = httpx.Response(429, headers=headers, request=request)
+    rate_limit = genai_errors.ClientError(
+        429,
+        {
+            "error": {
+                "code": "too_many_requests",
+                "status": "RESOURCE_EXHAUSTED",
+                "message": (
+                    "api_key=secret-provider-value. Please retry in "
+                    "43.424416244s."
+                ),
+            }
+        },
+        response,
+    )
+    client = _client(_Interactions([rate_limit]))
+
+    with pytest.raises(StructuredToolTransportError) as exc_info:
+        asyncio.run(client.generate_with_tools("Find evidence.", [_tool()]))
+
+    error = exc_info.value
+    assert str(error) == (
+        "Gemini temporarily rate-limited the structured-tool request."
+    )
+    assert error.decision == {
+        "provider": "gemini",
+        "effective_api_surface": "interactions",
+        "model": "gemini-3.7-flash",
+        "provider_status_code": 429,
+        "provider_status": "RESOURCE_EXHAUSTED",
+        "provider_error_code": "too_many_requests",
+        "failure_kind": "provider_rate_limited",
+        "provider_request_sent": True,
+        "retry_after_seconds": 43.424416244,
+        "retry_after_source": expected_source,
+    }
+    assert "secret-provider-value" not in str(error.decision)
+
+
+def test_interactions_authentication_error_remains_non_retryable() -> None:
+    request = httpx.Request("POST", "https://generativelanguage.googleapis.com")
+    response = httpx.Response(401, request=request)
+    authentication_error = genai_errors.ClientError(
+        401,
+        {
+            "error": {
+                "code": "unauthenticated",
+                "status": "UNAUTHENTICATED",
+                "message": "api_key=secret-provider-value",
+            }
+        },
+        response,
+    )
+    client = _client(_Interactions([authentication_error]))
+
+    with pytest.raises(ToolCallError) as exc_info:
+        asyncio.run(client.generate_with_tools("Find evidence.", [_tool()]))
+
+    assert type(exc_info.value) is ToolCallError
+    assert "secret-provider-value" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Merge decision: ready — evidence-rich Gemini turns now recover once from classified connection and rate-limit failures instead of discarding retained evidence behind a generic ToolCallError.

## User outcome

A read-only adaptive turn that has already gathered useful evidence can complete after a transient Gemini connection failure or a bounded HTTP 429 retry instruction. It no longer immediately loses the answer behind the generic error seen in requests `194c5ddb-97a2-4d8d-b4d4-beaf4b80282e` and `564ca100-cacf-48b2-b327-286028c4baf6`.

Canonical issue and decision record: [JVNAUTOSCI-2696](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2696).

## Material changes

- Classify only Gemini `httpx` network failures and HTTP 429 responses as bounded structured-transport decisions.
- Retain safe status/error/retry/request-state facts without raw provider bodies, headers, request objects, or messages.
- After evidence, honour one finite provider-directed retry delay in cancellable one-second slices, compact retained evidence to at most 64 KB, clear continuation/results, disable tools, and make one fresh answer-only call.
- Return a specific retry-later non-success when the delay is missing, invalid, or above the incident-calibrated 90-second worker-liveness bound.
- Keep authentication, configuration, non-429 HTTP, unknown SDK, and no-evidence failures terminal; never switch model/provider and never permit a second recovery loop.
- Build on merged PR #499's idempotent queue retry. This PR neither duplicates nor changes that queue path.

## Evidence

- `16 passed`: complete Gemini structured-transport file, including installed `google-genai ClientError(429)`, numeric header and exact provider-message retry parsing, real `httpx.ConnectError`, sanitisation, 401 non-retry, incomplete response and correlation.
- `23 passed`: targeted neighbouring adaptive transport and provider-deadline regressions.
- `10 passed`: final focused rate-limit/connection/wait-bound slice.
- Python compile, `git diff --check`, and Ruff E/F/I/import checks passed on all four changed files.
- Independent read-only candidate review found no blocking correctness or security issue.
- The candidate is rebased onto `01e55333` / PR #499.

A whole adaptive test-file run was stopped after more than 90 passes when unrelated effect tests fell through to localhost Mongo in the clean worktree. The exact affected tests all pass. The environment-dependent effect test is unchanged by this PR and passes on exact `origin/main` in the primary configured checkout; it is not used as evidence for this transport claim.

## Ship boundary

- **Minimum ship criteria:** typed safe adapter decisions for both incident classes; exactly one compact no-tool recovery after evidence; bounded/cancellable 429 wait; no recovery for auth/unknown/no-evidence; affected and neighbouring tests green.
- **Stop-ship conditions:** raw provider data leakage, immediate unchanged quota repeat, tools/continuation retained for recovery, more than one retry, silent model/provider switch, or either exact failure class still collapsing immediately to generic ToolCallError.
- **Non-blocking observations:** the 90-second bound is calibrated from this incident rather than a universal provider guarantee; HTTP-date `Retry-After` is not parsed; this PR preserves work after quota pressure but does not claim to eliminate the broader 7.54M-input-token loop cost.
- **Non-goals:** prompt/domain-specific routing, fixed model-call/token ceilings, cross-provider fallback, provider eligibility changes, or broad adaptive-research redesign.

After merge, the authorised release step is to deploy exact merged `main` through `./run.sh deploy-main`, verify health/producer identity, and run a fresh non-Sol real-route turn with persisted telemetry.

[JVNAUTOSCI-2696]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ