### PR TITLE
Restore Thinking context for queued retries

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -14222,7 +14222,12 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
     const poll = {
         abortController,
         timeoutId: null,
-        nextDelayMs: FOREGROUND_TASK_RESULT_POLL_INITIAL_DELAY_MS,
+        // A server-dispatched retry is already running by the time the browser
+        // adopts it, so check promptly instead of imposing the foreground
+        // generate path's initial grace period.
+        nextDelayMs: request.observingServerDispatch === true
+            ? 250
+            : FOREGROUND_TASK_RESULT_POLL_INITIAL_DELAY_MS,
         delivering: false
     };
 
@@ -14359,7 +14364,11 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
     };
 
     request.foregroundTaskResultPoll = poll;
-    scheduleNextPoll(poll.nextDelayMs);
+    if (request.observingServerDispatch === true) {
+        void pollOnce();
+    } else {
+        scheduleNextPoll(poll.nextDelayMs);
+    }
 }
 
 // Cool-down for failed history talk-track backfills so we do not spam the server.
@@ -23743,6 +23752,7 @@ let chatPromptQueuePollAbortController = null;
 const queuedChatPromptClaimsInFlight = new Set();
 const queuedChatPromptSubmissionsInFlight = new Map();
 const queuedChatPromptSyncTimers = new Map();
+const serverDispatchedRetryObserversInFlight = new Set();
 let chatPromptQueueAdmissionServerInstanceId = null;
 let selectedChatPromptQueueEntryId = null;
 const locallyHiddenChatPromptQueueEntryKeys = new Set();
@@ -33561,7 +33571,9 @@ function setThinkingState(isThinking, request = activeChatRequest, options = {})
         abortButton.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
     }
     if (retryButton) {
-        const canRetryThinkingRequest = isThinking && request?.turnKind !== 'assistant_opening';
+        const canRetryThinkingRequest = isThinking
+            && request?.turnKind !== 'assistant_opening'
+            && request?.observingServerDispatch !== true;
         retryButton.setAttribute('aria-hidden', canRetryThinkingRequest ? 'false' : 'true');
     }
     if (copyDiagnosticsButton) {
@@ -33634,12 +33646,60 @@ function restorePromptEditingState(request, options = {}) {
     }
 }
 
+async function requestObservedServerDispatchCancellation(request) {
+    const requestId = (typeof request?.clientRequestId === 'string')
+        ? request.clientRequestId.trim()
+        : '';
+    if (
+        !requestId
+        || request?.observingServerDispatch !== true
+        || request?.backgroundCancellationRequested === true
+    ) {
+        return false;
+    }
+    request.backgroundCancellationRequested = true;
+    try {
+        const response = await fetch(
+            `/von/api/task/cancel/${encodeURIComponent(requestId)}`,
+            {
+                method: 'POST',
+                headers: buildChatFetchHeaders({
+                    'Content-Type': 'application/json'
+                }),
+                credentials: 'same-origin'
+            }
+        );
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok || payload?.success !== true) {
+            throw new Error(
+                payload?.detail
+                || payload?.error
+                || `HTTP ${response.status}`
+            );
+        }
+        publishChatPromptQueueChange('observed_retry_cancellation_requested');
+        return true;
+    } catch (error) {
+        request.backgroundCancellationRequested = false;
+        console.warn('[chatTab] Unable to cancel observed retry:', error);
+        showToast(
+            'The retry is still running on the server; cancellation was not acknowledged.',
+            'warning'
+        );
+        return false;
+    }
+}
+
 function abortActiveChatRequest(options = {}) {
     if (!activeChatRequest) {
         return;
     }
 
     const request = activeChatRequest;
+    const observingServerDispatch = request.observingServerDispatch === true;
+    if (observingServerDispatch) {
+        void requestObservedServerDispatchCancellation(request);
+    }
     request.aborted = true;
     releaseRequestFileCopyBinding(request);
 
@@ -33668,7 +33728,12 @@ function abortActiveChatRequest(options = {}) {
         });
     }
     syncActiveChatSessionThinkingState();
-    restorePromptEditingState(request, options);
+    restorePromptEditingState(request, {
+        ...options,
+        restorePrompt: observingServerDispatch
+            ? false
+            : options.restorePrompt
+    });
 }
 
 function abortActiveHistoryRequest() {
@@ -33981,6 +34046,9 @@ function retryActiveChatRequest() {
     }
 
     const request = activeChatRequest;
+    if (request.observingServerDispatch === true) {
+        return;
+    }
     const prompt = typeof request.promptRaw === 'string' ? request.promptRaw : '';
     const fileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
         request.pendingFileCopyConceptId
@@ -34729,6 +34797,48 @@ function activeConversationQueueStateChanged(previousEntries, nextEntries) {
     ));
 }
 
+function isObservableServerDispatchedRetry(entry) {
+    return Boolean(
+        entry?.queueId
+        && entry?.retrySourceQueueId
+        && entry?.clientRequestId
+        && entry?.attemptId
+        && entry.status === CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS
+        && isServerDispatchedChatPromptQueueEntry(entry)
+        && isChatPromptQueueEntryForSession(entry)
+    );
+}
+
+function syncServerDispatchedRetryObserver() {
+    const entry = queuedChatPrompts.find((candidate) => (
+        isObservableServerDispatchedRetry(candidate)
+        && !getLiveChatRequestForPromptQueueRecord(candidate.queueId)
+        && !liveChatRequestsBySession.has(candidate.sessionKey)
+        && !serverDispatchedRetryObserversInFlight.has(candidate.queueId)
+    ));
+    if (!entry) {
+        return false;
+    }
+
+    serverDispatchedRetryObserversInFlight.add(entry.queueId);
+    void handleSendPrompt({
+        promptOverride: entry.promptRaw,
+        fromQueue: true,
+        observeServerDispatch: true,
+        sessionId: entry.sessionId || null,
+        sessionName: entry.sessionName || null,
+        promptQueueRecordId: entry.queueId,
+        enqueueSubmissionId: entry.enqueueSubmissionId || null,
+        clientRequestId: entry.clientRequestId,
+        attemptId: entry.attemptId,
+        fileCopyConceptId: entry.fileCopyConceptId || null,
+        claimedAt: entry.claimedAt || null
+    }).finally(() => {
+        serverDispatchedRetryObserversInFlight.delete(entry.queueId);
+    });
+    return true;
+}
+
 function refreshActiveConversationHistoryAfterQueueChange() {
     const sessionId = normaliseHistorySessionId(activeChatSessionId);
     if (!sessionId) {
@@ -34833,6 +34943,7 @@ async function refreshChatPromptQueueFromServer(options = {}) {
         renderChatTaskQueuePanel();
         refreshChatSessionTabActivityIndicators();
         updateSendButtonForCurrentChatState();
+        syncServerDispatchedRetryObserver();
         syncChatPromptQueuePolling();
         if (shouldRefreshActiveHistory) {
             refreshActiveConversationHistoryAfterQueueChange();
@@ -36156,6 +36267,7 @@ async function handleSendPrompt(options = {}) {
     }
 
     const fromQueue = options && options.fromQueue === true;
+    const observeServerDispatch = options?.observeServerDispatch === true;
     const hasPromptOverride = options && typeof options.promptOverride === 'string';
     const selectedQueueEntry = (!fromQueue && !hasPromptOverride)
         ? getSelectedChatPromptQueueEntryForSend()
@@ -36222,7 +36334,7 @@ async function handleSendPrompt(options = {}) {
         return;
     }
 
-    if (getUnavailableLocalModelPreferenceForChat()) {
+    if (!observeServerDispatch && getUnavailableLocalModelPreferenceForChat()) {
         if (!fromQueue) {
             notifyUnavailableLocalModelForChat();
         }
@@ -36254,7 +36366,17 @@ async function handleSendPrompt(options = {}) {
         }
     }
 
-    if (isChatPromptSessionBusy(targetSessionId, { includeQueued: !fromQueue })) {
+    if (
+        observeServerDispatch
+        && liveChatRequestsBySession.has(getChatRequestSessionKey(targetSessionId))
+    ) {
+        return;
+    }
+
+    if (
+        !observeServerDispatch
+        && isChatPromptSessionBusy(targetSessionId, { includeQueued: !fromQueue })
+    ) {
         if (fromQueue) {
             return;
         }
@@ -36340,6 +36462,7 @@ async function handleSendPrompt(options = {}) {
         turnKind,
         initiationId
     });
+    const claimedAtMs = Date.parse(String(options?.claimedAt || ''));
     const request = {
         abortController: new AbortController(),
         organisationGeneration: chatOrganisationGeneration,
@@ -36358,12 +36481,13 @@ async function handleSendPrompt(options = {}) {
         attachmentBindingTransferred: false,
         attachmentBindingReleased: false,
         aborted: false,
+        observingServerDispatch: observeServerDispatch,
         enqueueSubmissionId,
         executionEnvelope,
         clientRequestId,
         attemptId,
         executionContextBinding,
-        thinkingStartedAtMs: Date.now(),
+        thinkingStartedAtMs: Number.isFinite(claimedAtMs) ? claimedAtMs : Date.now(),
         activityHistory: [],
         toolUseProgressHistory: [],
         workflowStagePath: null,
@@ -36420,6 +36544,11 @@ async function handleSendPrompt(options = {}) {
             });
     setFinishedThinkingCardForSession(targetSessionId, null);
     setLiveChatRequestForSession(targetSessionId, request);
+    if (observeServerDispatch) {
+        renderChatTaskQueuePanel();
+        refreshChatSessionTabActivityIndicators();
+        updateSendButtonForCurrentChatState();
+    }
     setConversationRuntimeCostLiveSummary(request, null, {
         active: true,
         reason: 'request_started'
@@ -36461,7 +36590,7 @@ async function handleSendPrompt(options = {}) {
     const assistantTurnId = `a-${Date.now()}`;
 
     // Add user message to chat with turnId
-    if (isRequestVisible() && !assistantOpening && promptText) {
+    if (isRequestVisible() && !assistantOpening && !observeServerDispatch && promptText) {
         appendMessage('User', promptText, userTurnId);
         // Fire-and-forget annotate user turn (do not await) - only if toggle is enabled
         const annotationToggle = document.getElementById('annotationToggle');
@@ -36690,6 +36819,39 @@ async function handleSendPrompt(options = {}) {
         return true;
     };
 
+    const foregroundTaskResultHandlers = {
+        onCompleted: async (generateBody) => {
+            request.serverQueueTerminalObserved = true;
+            request.attachmentBindingAccepted = true;
+            acknowledgeQueuedSource();
+            const delivered = deliverSuccessfulResponseData(generateBody, 'task_result');
+            if (delivered) {
+                try {
+                    request.abortController.abort();
+                } catch (_) {
+                    // Ignore; the original fetch or observer may already be resolving.
+                }
+            }
+        },
+        onFailed: async (statusPayload, status) => {
+            request.serverQueueTerminalObserved = true;
+            acknowledgeQueuedSource();
+            const delivered = status === 'cancelled'
+                ? deliverCancelledResponseData(statusPayload)
+                : deliverErrorResponseData(
+                    statusPayload,
+                    'Task failed before the response reached the chat UI.'
+                );
+            if (delivered) {
+                try {
+                    request.abortController.abort();
+                } catch (_) {
+                    // Ignore; the original fetch or observer may already be resolving.
+                }
+            }
+        }
+    };
+
     if (!fromQueue) {
         // Clear input only for direct sends; queued execution should preserve current draft text.
         if (promptText) {
@@ -36702,6 +36864,31 @@ async function handleSendPrompt(options = {}) {
         setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
 
         startThinkingTooltipTicker(request);
+
+        if (observeServerDispatch) {
+            if (
+                request.aborted
+                || !isLiveChatRequest(request)
+                || !isRequestCurrentOrganisation()
+            ) {
+                return;
+            }
+            startToolUseProgressPolling(request);
+            await new Promise((resolve) => {
+                let settled = false;
+                const settle = () => {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    request.abortController.signal.removeEventListener('abort', settle);
+                    resolve();
+                };
+                request.abortController.signal.addEventListener('abort', settle, { once: true });
+                startForegroundTaskResultPolling(request, foregroundTaskResultHandlers);
+            });
+            return;
+        }
 
         // Get user context from localStorage to send to backend
         const userContext = getUserContext();
@@ -36759,38 +36946,7 @@ async function handleSendPrompt(options = {}) {
             })
         });
         startToolUseProgressPolling(request);
-        startForegroundTaskResultPolling(request, {
-            onCompleted: async (generateBody) => {
-                request.serverQueueTerminalObserved = true;
-                request.attachmentBindingAccepted = true;
-                acknowledgeQueuedSource();
-                const delivered = deliverSuccessfulResponseData(generateBody, 'task_result');
-                if (delivered) {
-                    try {
-                        request.abortController.abort();
-                    } catch (_) {
-                        // Ignore; the original fetch may already be resolving.
-                    }
-                }
-            },
-            onFailed: async (statusPayload, status) => {
-                request.serverQueueTerminalObserved = true;
-                acknowledgeQueuedSource();
-                const delivered = status === 'cancelled'
-                    ? deliverCancelledResponseData(statusPayload)
-                    : deliverErrorResponseData(
-                        statusPayload,
-                        'Task failed before the response reached the chat UI.'
-                    );
-                if (delivered) {
-                    try {
-                        request.abortController.abort();
-                    } catch (_) {
-                        // Ignore; the original fetch may already be resolving.
-                    }
-                }
-            }
-        });
+        startForegroundTaskResultPolling(request, foregroundTaskResultHandlers);
         // Give an already-available first progress response a chance to land
         // before an immediate generate response tears down the active card.
         await Promise.resolve();
@@ -40656,6 +40812,9 @@ export async function __testOnly_openConversationSearchResult(row = {}) {
 export async function __testOnly_refreshChatPromptQueueFromServer() {
     return refreshChatPromptQueueFromServer({ silent: false });
 }
+export function __testOnly_getLiveChatRequestForSession(sessionId = null) {
+    return getLiveChatRequestForSession(sessionId);
+}
 export function __testOnly_handleChatPromptQueueStorageEvent(event) {
     handleChatPromptQueueStorageEvent(event);
 }
@@ -40680,6 +40839,17 @@ export function __testOnly_resetChatRequestState() {
     } catch (_) {
         // Ignore constrained test globals.
     }
+    for (const request of liveChatRequestsBySession.values()) {
+        request.aborted = true;
+        stopToolUseProgressPolling(request);
+        stopForegroundTaskResultPolling(request);
+        stopThinkingTooltipTicker(request);
+        try {
+            request.abortController?.abort();
+        } catch (_) {
+            // Ignore reset-time abort races.
+        }
+    }
     liveChatRequestsBySession.clear();
     finishedThinkingCardsBySession.clear();
     pendingFileCopyConceptIdsBySession.clear();
@@ -40697,6 +40867,7 @@ export function __testOnly_resetChatRequestState() {
     chatPromptQueuePollInFlight = false;
     queuedChatPromptClaimsInFlight.clear();
     queuedChatPromptSubmissionsInFlight.clear();
+    serverDispatchedRetryObserversInFlight.clear();
     chatPromptQueueAdmissionServerInstanceId = null;
     for (const timer of queuedChatPromptSyncTimers.values()) {
         clearTimeout(timer);

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -4,6 +4,7 @@ const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTa
 
 jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
     annotateTurn: jest.fn(),
+    fetchWithTimeout: jest.fn(),
     getUserContext: jest.fn(),
     getWindowSessionId: jest.fn(() => 'mock-window-session-id'),
     postJson: jest.fn(),
@@ -52,6 +53,8 @@ describe('chat task queue', () => {
             <textarea id="promptInput"></textarea>
             <input type="checkbox" id="annotationToggle" />
         `;
+        const { fetchWithTimeout } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        fetchWithTimeout.mockReset();
         const chatTab = require(chatTabModulePath);
         chatTab.__testOnly_resetChatRequestState();
         chatTab.__testOnly_setActiveChatSession('session-1', 'Current');
@@ -1697,6 +1700,209 @@ describe('chat task queue', () => {
         expect(fetchCalls.some((call) => String(call.url).startsWith('/von/generate'))).toBe(false);
         expect(fetchCalls.some((call) => String(call.url).includes('/claim'))).toBe(false);
         expect(fetchCalls.some((call) => String(call.url).includes('/finish'))).toBe(false);
+    }, 15000);
+
+    test('adopts an in-progress linked retry into the Thinking card and delivers its result', async () => {
+        const { fetchWithTimeout } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        const {
+            __testOnly_getLiveChatRequestForSession,
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+        const fetchCalls = [];
+
+        global.fetch = jest.fn((url, options = {}) => {
+                fetchCalls.push({ url, options });
+                if (url === '/von/api/chat_prompt_queue') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            success: true,
+                            items: [{
+                                queue_id: 'queue-retry',
+                                retry_source_queue_id: 'queue-failed',
+                                prompt_raw: 'Retry me with visible progress',
+                                status: 'in_progress',
+                                dispatch_mode: 'server',
+                                session_id: 'session-1',
+                                session_name: 'Current',
+                                enqueue_submission_id: 'enqueue-retry',
+                                client_request_id: 'request-retry',
+                                attempt_id: 'attempt-retry',
+                                claimed_at: '2026-09-01T19:42:00Z'
+                            }]
+                        })
+                    });
+                }
+                if (url === '/von/progress/request-retry') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            request_id: 'request-retry',
+                            status: 'working',
+                            phase: 'adaptive_research',
+                            phase_label: 'Researching',
+                            result_summary: 'Retry is running on the server.'
+                        })
+                    });
+                }
+                if (url === '/von/api/task/status/request-retry') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ status: 'completed' })
+                    });
+                }
+                if (url === '/von/api/task/result/request-retry') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            status: 'completed',
+                            result: {
+                                response: 'The retried task completed visibly.',
+                                llm_debug: { model: 'test-model' }
+                            }
+                        })
+                    });
+                }
+                if (typeof url === 'string' && url.startsWith('/von/api/render_markdown')) {
+                    const body = JSON.parse(options.body || '{}');
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ html: String(body.text || '') })
+                    });
+                }
+                if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ history_length: 2, authenticated: true })
+                    });
+                }
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true })
+                });
+        });
+        fetchWithTimeout.mockImplementation((url, options = {}) => global.fetch(url, options));
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const observedRequest = __testOnly_getLiveChatRequestForSession('session-1');
+        expect(observedRequest).toMatchObject({
+            aborted: false,
+            clientRequestId: 'request-retry',
+            observingServerDispatch: true,
+            sessionKey: 'session-1'
+        });
+        expect(observedRequest?.foregroundDeliveryCompleted).not.toBe(true);
+        expect(observedRequest?.foregroundTaskResultPoll).toBeTruthy();
+
+        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden'))
+            .toBe('false');
+        expect(document.getElementById('abortButton')?.getAttribute('aria-hidden'))
+            .toBe('false');
+        expect(document.querySelector('.chat-task-queue-item')).toBeNull();
+        expect(document.getElementById('scrollableField')?.textContent)
+            .not.toContain('Retry me with visible progress');
+        expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate')))
+            .toBe(false);
+
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(observedRequest?.aborted).toBe(false);
+        expect(fetchCalls.map(({ url }) => url))
+            .toContain('/von/api/task/status/request-retry');
+        expect(fetchCalls.filter(({ url }) => url === '/von/api/task/result/request-retry'))
+            .toHaveLength(1);
+        expect(document.querySelector('.chat-message-text')?.dataset.originalText)
+            .toBe('The retried task completed visibly.');
+        expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate')))
+            .toBe(false);
+    }, 15000);
+
+    test('Stop cancels the exact server-owned retry without submitting another generation', async () => {
+        const {
+            __testOnly_refreshChatPromptQueueFromServer,
+        } = require(chatTabModulePath);
+        const fetchCalls = [];
+
+        global.fetch = jest.fn((url, options = {}) => {
+            fetchCalls.push({ url, options });
+            if (url === '/von/api/chat_prompt_queue') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        success: true,
+                        items: [{
+                            queue_id: 'queue-retry-stop',
+                            retry_source_queue_id: 'queue-failed-stop',
+                            prompt_raw: 'Retry and then stop me',
+                            status: 'in_progress',
+                            dispatch_mode: 'server',
+                            session_id: 'session-1',
+                            session_name: 'Current',
+                            enqueue_submission_id: 'enqueue-retry-stop',
+                            client_request_id: 'request-retry-stop',
+                            attempt_id: 'attempt-retry-stop'
+                        }]
+                    })
+                });
+            }
+            if (url === '/von/progress/request-retry-stop') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 202,
+                    json: async () => ({
+                        request_id: 'request-retry-stop',
+                        status: 'working',
+                        result_summary: 'Still running.'
+                    })
+                });
+            }
+            if (
+                url === '/von/api/task/cancel/request-retry-stop'
+                && options.method === 'POST'
+            ) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true, status: 'cancelled' })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ success: true })
+            });
+        });
+
+        await __testOnly_refreshChatPromptQueueFromServer();
+        await Promise.resolve();
+        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden'))
+            .toBe('false');
+
+        document.getElementById('abortButton').click();
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        expect(fetchCalls.filter(({ url }) => (
+            url === '/von/api/task/cancel/request-retry-stop'
+        ))).toHaveLength(1);
+        expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate')))
+            .toBe(false);
+        expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden'))
+            .toBe('true');
+        expect(document.getElementById('promptInput')?.value).toBe('');
     }, 15000);
 
     test('retains failure evidence when linked retry is not accepted', async () => {


### PR DESCRIPTION
## Outcome

Adopt an in-progress server-owned failed-task retry into its originating conversation so it gets the normal Thinking card, progress/result delivery, and Stop control without a second generation request.

## Design

- Preserve server dispatcher ownership and queue idempotence.
- Correlate the foreground observer with the canonical queue ID, client request ID, and attempt ID.
- Suppress the duplicate local user turn and browser `/von/generate`.
- Route Stop to scoped task cancellation for the observed server request.

## Validation

- `npm test -- --runInBand --silent tests/frontend/chatTaskQueue.test.js tests/frontend/chatTabAbort.test.js tests/frontend/chatTabThinkingCardSelectorTelemetry.test.js tests/frontend/taskPanelQueueActivityPolling.test.js` — 46 passed.
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/chatTab.js tests/frontend/chatTaskQueue.test.js` — passed.
- JavaScript syntax checks and `git diff --check` — passed.

Jira: JVNAUTOSCI-2702