### PR TITLE
Fix Gmail multi-send idempotency (JVNAUTOSCI-2685)

### DIFF
--- a/docs/engineering/gmail_mcp_plan.md
+++ b/docs/engineering/gmail_mcp_plan.md
@@ -25,8 +25,9 @@ the internal MCP gateway, and the stdio MCP manifest.
 - `gmail_list_labels(profile)` lists labels.
 - `gmail_modify_labels(profile, message_id, allow_mutation, add_labels?,
   remove_labels?)` performs guarded label mutation.
-- `gmail_send_message(profile, to, subject, body_text, allow_send, cc?, bcc?,
-  reply_to?, body_html?)` sends outbound email and returns Gmail send metadata.
+- `gmail_send_message(profile, to, subject, body_text, allow_send, request_id,
+  cc?, bcc?, reply_to?)` sends outbound email and returns Gmail send metadata.
+  Ordinary turns additionally bind a hidden turn idempotency scope.
 
 The default posture remains read-only. Durable import, mutations, and sends are
 available only through explicit guard fields and the applicable actor,
@@ -80,6 +81,13 @@ side effect; that authority remains in Vontology/workflow/prompt/tool metadata.
   inspection never imports, indexes, enriches, or represents the source. The
   tool descriptions and prompt authority instruct planners not to treat reads
   or label changes as evidence of sending.
+- **Per-intent outbound idempotency**: Direct trusted callers use `request_id`
+  as the identity of one exact delivery; reusing it with different content
+  fails closed. Ordinary turns bind a separate trusted turn scope, and the
+  Gmail boundary derives a private digest from that scope plus the normalised
+  recipients, subject, body, language, and authorship. Distinct messages in one
+  turn can therefore proceed independently, while exact retries converge even
+  if provider call IDs change. Only hashes and counts enter the delivery ledger.
 - **Compact untrusted evidence**: Message detail keeps stable message/thread and
   attachment identifiers, normalised headers, labels, and bounded text only.
   MIME traversal, decoded body bytes, archive expansion, document structures,
@@ -164,6 +172,9 @@ Optional default:
 - Turn-level validation must not claim an email was sent unless authenticated
   Gmail send execution returned success evidence for the resolved profile,
   recipient, subject, and body.
+- Turn-level validation should cover two distinct sends in one turn, exact
+  replay of each without another provider dispatch or quota reservation, and
+  legacy changed-content reuse of one direct request ID failing closed.
 
 ## Risks and mitigations
 

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -79,6 +79,7 @@ AI_AGENT_MACHINE_HEADER = "X-Von-AI-Agent"
 AI_AGENT_SENDER_DISPLAY_NAME = "Von AI Agent"
 DELIVERY_FINGERPRINT_HEADER = "X-Von-Delivery-Fingerprint"
 OUTBOUND_DELIVERY_FINGERPRINT_SCHEMA_VERSION = "gmail_outbound_delivery_key.v2"
+OUTBOUND_TURN_INTENT_SCHEMA_VERSION = "gmail_outbound_turn_intent.v1"
 _DEFAULT_OUTBOUND_COLLECTION = object()
 
 
@@ -1705,6 +1706,53 @@ def _outbound_delivery_identity(
     )
 
 
+def _outbound_turn_intent_request_id(
+    *,
+    idempotency_scope: str,
+    to: list[str],
+    cc: list[str],
+    bcc: list[str],
+    reply_to: list[str],
+    subject: str,
+    body_text: str,
+    body_html: str | None,
+    body_language: str | None,
+    body_authorship: str | None,
+) -> str:
+    """Derive one private, stable identity for a logical send in a turn.
+
+    Ordinary turns bind ``idempotency_scope`` to their trusted turn identity.
+    The remaining material is the normalised send intent, so exact retries
+    converge even when provider call IDs change while distinct messages in one
+    turn do not collide. Only the digest leaves this boundary.
+    """
+
+    scope = str(idempotency_scope or "").strip()
+    if not scope:
+        raise ValueError("idempotency_scope is required")
+    if len(scope) > 512:
+        raise ValueError("idempotency_scope is too long")
+    digest = _sha256_json(
+        {
+            "schema_version": OUTBOUND_TURN_INTENT_SCHEMA_VERSION,
+            "idempotency_scope": scope,
+            "to": _normalise_header_addresses(to),
+            "cc": _normalise_header_addresses(cc),
+            "bcc": _normalise_header_addresses(bcc),
+            "reply_to": _normalise_header_addresses(reply_to),
+            "subject": subject.strip(),
+            "body_text": body_text,
+            "body_html": body_html,
+            "body_language": str(body_language or "").strip().lower() or None,
+            "body_authorship": (
+                str(body_authorship or "unspecified").strip().lower()
+                or "unspecified"
+            ),
+        }
+    )
+    return f"gmail_turn_intent:{digest}"
+
+
 def _safe_canonical_readback(value: Any) -> dict[str, Any] | None:
     if isinstance(value, Mapping):
         return {
@@ -1833,6 +1881,7 @@ def send_message(
     audit_context: Mapping[str, object] | None = None,
     profile_resource_concept_id: str | None = None,
     request_id: str | None = None,
+    idempotency_scope: str | None = None,
     acting_user_concept_id: str | None = None,
     organisation_concept_id: str | None = None,
     body_language: str | None = None,
@@ -1847,8 +1896,11 @@ def send_message(
     authorised workflow gate. The helper also checks that the profile declares a
     Gmail scope accepted by ``users.messages.send`` before invoking the API.
     The trusted caller must also provide the represented profile resource and a
-    stable request id. Before provider dispatch this boundary durably claims the
-    idempotency key and atomically reserves mailbox-wide quota. A visible
+    stable request id. Ordinary actor turns also supply a trusted turn
+    idempotency scope, from which this boundary derives a stable identity for
+    each normalised logical message. Before provider dispatch this boundary
+    durably claims the idempotency key and atomically reserves mailbox-wide
+    quota. A visible
     AI-agent disclosure is absent by default and is added only when a trusted
     actor, organisation, or mailbox policy requires one. After Gmail accepts
     the message, the helper reads it back and returns a body-free verification
@@ -1894,6 +1946,21 @@ def send_message(
         raise ValueError("request_id is required")
     if len(trusted_request_id) > 512:
         raise ValueError("request_id is too long")
+
+    trusted_idempotency_scope = str(idempotency_scope or "").strip() or None
+    if trusted_idempotency_scope is not None:
+        trusted_request_id = _outbound_turn_intent_request_id(
+            idempotency_scope=trusted_idempotency_scope,
+            to=to_addresses,
+            cc=cc_addresses,
+            bcc=bcc_addresses,
+            reply_to=reply_to_addresses,
+            subject=subject,
+            body_text=body_text,
+            body_html=body_html,
+            body_language=body_language,
+            body_authorship=body_authorship,
+        )
 
     from ...services.gmail_visible_disclosure_policy_service import (
         GmailVisibleDisclosurePolicyError,

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -28954,6 +28954,7 @@ def _gmail_send_message(**kwargs):
             allow_send=allow_send,
             profile_resource_concept_id=profile_resource_id,
             request_id=request_id_value,
+            idempotency_scope=kwargs.get("idempotency_scope"),
             acting_user_concept_id=principal.user_concept_id,
             organisation_concept_id=principal.organisation_concept_id,
             audit_context={
@@ -39527,6 +39528,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             "reply_to": (str, list),
             "body_language": str,
             "body_authorship": str,
+            "idempotency_scope": str,
             "namespace": (str, type(None)),
             "acting_user_concept_id": (str, type(None)),
             "organisation_concept_id": (str, type(None)),
@@ -40239,6 +40241,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
                 "acting_user_concept_id": "actor_user_concept_id",
                 "organisation_concept_id": "actor_organisation_concept_id",
                 "request_id": "turn_id",
+                "idempotency_scope": "turn_id",
                 "namespace": "turn_namespace",
             },
             ordinary_turn_trusted_argument_choice_bindings={

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -3361,6 +3361,9 @@
                             "unspecified"
                         ]
                     },
+                    "idempotency_scope": {
+                        "type": "string"
+                    },
                     "namespace": {
                         "type": [
                             "string",

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -5587,7 +5587,14 @@ def _build_effect_outcome_report(
             "changed": state.get("changed") if isinstance(state.get("changed"), bool) else None,
             "initial_effect_status": state.get("initial_effect_status"),
             "current_outcome_status": state.get("current_outcome_status"),
-            "outcome_resolved": state.get("outcome_resolved") is True,
+            # A handler-level canonical read-back already resolves a successful
+            # effect. The reconciliation flag records whether a later repair
+            # pass ran; it must not make a verified success look uncertain in
+            # the portable outcome report or failure capsule.
+            "outcome_resolved": (
+                state.get("outcome_resolved") is True
+                or (effect_status == "succeeded" and canonical_readback_verified)
+            ),
             "reconciliation_status": state.get("reconciliation_status"),
             "canonical_readback_present": isinstance(
                 canonical_readback, Mapping

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -1058,6 +1058,7 @@ def _gmail_send_gateway(handler: Any) -> InternalMCPGateway:
                     "acting_user_concept_id": (str, type(None)),
                     "organisation_concept_id": (str, type(None)),
                     "request_id": (str, type(None)),
+                    "idempotency_scope": (str, type(None)),
                 },
                 aliases={
                     "profile_id": "profile",
@@ -1073,6 +1074,7 @@ def _gmail_send_gateway(handler: Any) -> InternalMCPGateway:
                 "acting_user_concept_id": "actor_user_concept_id",
                 "organisation_concept_id": "actor_organisation_concept_id",
                 "request_id": "turn_id",
+                "idempotency_scope": "turn_id",
                 "namespace": "turn_namespace",
             },
             ordinary_turn_trusted_argument_choice_bindings={
@@ -10510,6 +10512,7 @@ def test_explicit_request_guard_allows_actor_bound_gmail_send(
                             "acting_user_concept_id": "#V#spoof",
                             "organisation_concept_id": "#V#other",
                             "request_id": "spoofed-request",
+                            "idempotency_scope": "spoofed-idempotency-scope",
                         },
                     },
                 )
@@ -10550,6 +10553,7 @@ def test_explicit_request_guard_allows_actor_bound_gmail_send(
         "acting_user_concept_id": "#V#person",
         "organisation_concept_id": "#V#org",
         "request_id": "turn-send-gmail",
+        "idempotency_scope": "turn-send-gmail",
     }
     assert inferred["prompt"] == "Send this email now."
     assert inferred["recent_user_prompts"] == ["Draft a short note first."]
@@ -11826,6 +11830,7 @@ def test_domain_effect_report_preserves_readback_and_receipt_semantics() -> None
     assert fact["workflow_instance_readback_verified"] is False
     assert "workflow_instance_terminal_status" not in fact
     assert fact["canonical_readback_verified"] is True
+    assert fact["outcome_resolved"] is True
     assert fact["target_ids"] == [domain_target_id]
     assert fact["evidence_id"] == "evidence-domain-invocation"
     assert "### Verified, observed, recovered, or handler-reported" in screen_text

--- a/tests/backend/test_gmail_service.py
+++ b/tests/backend/test_gmail_service.py
@@ -7,6 +7,7 @@ from email.message import EmailMessage
 from email.parser import BytesParser
 from email.policy import default as default_email_policy
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import mongomock
@@ -683,6 +684,39 @@ def test_send_message_rejects_html_that_could_hide_agent_disclosure():
     assert delivery_collection.count_documents({}) == 0
 
 
+def test_turn_intent_identity_is_private_stable_and_normalises_recipient_headers():
+    common = {
+        "idempotency_scope": "turn-multiple-sends",
+        "cc": [],
+        "bcc": [],
+        "reply_to": [],
+        "subject": "Requested note",
+        "body_text": "Private message body.",
+        "body_html": None,
+        "body_language": "en-NZ",
+        "body_authorship": "von_drafted",
+    }
+
+    first = gs._outbound_turn_intent_request_id(
+        to=["Researcher <PERSON@EXAMPLE.TEST>"],
+        **common,
+    )
+    equivalent = gs._outbound_turn_intent_request_id(
+        to=["person@example.test"],
+        **{**common, "body_language": "en-nz"},
+    )
+    distinct = gs._outbound_turn_intent_request_id(
+        to=["other@example.test"],
+        **common,
+    )
+
+    assert first == equivalent
+    assert first != distinct
+    assert first.startswith("gmail_turn_intent:")
+    assert "person@example.test" not in first
+    assert "Private message body." not in first
+
+
 def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch):
     captured: dict = {}
     monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
@@ -855,6 +889,150 @@ def test_send_message_returns_verified_body_free_canonical_readback(monkeypatch)
     assert replay["idempotent_replay"] is True
     assert replay["changed"] is False
     assert replay["outcome_finality"] == "durable_idempotent_replay"
+
+
+def test_send_message_turn_scope_allows_distinct_messages_and_deduplicates_replays(
+    monkeypatch,
+):
+    monkeypatch.setattr(gs, "_resolve_vontology_profile_scopes", lambda _profile: None)
+    quota_collection, delivery_collection = _outbound_test_collections()
+    captured: dict[str, object] = {"send_count": 0, "raw_by_id": {}}
+
+    class _Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class _Messages:
+        def send(self, **kwargs):
+            captured["send_count"] = int(captured["send_count"]) + 1
+            message_id = f"sent-{captured['send_count']}"
+            raw_by_id = cast(dict[str, str], captured["raw_by_id"])
+            raw_by_id[message_id] = kwargs["body"]["raw"]
+            return _Request({"id": message_id, "threadId": f"thread-{message_id}"})
+
+        def get(self, **kwargs):
+            message_id = kwargs["id"]
+            raw_by_id = cast(dict[str, str], captured["raw_by_id"])
+            return _Request(
+                {
+                    "id": message_id,
+                    "threadId": f"thread-{message_id}",
+                    "labelIds": ["SENT"],
+                    "raw": raw_by_id[message_id],
+                }
+            )
+
+    class _Users:
+        def __init__(self):
+            self._messages = _Messages()
+
+        def messages(self):
+            return self._messages
+
+        def getProfile(self, **_kwargs):
+            return _Request({"emailAddress": "zhan@example.test"})
+
+    class _Service:
+        def __init__(self):
+            self._users = _Users()
+
+        def users(self):
+            return self._users
+
+    profiles = {
+        "zhan-gmail": gs.GmailProfile(
+            profile_id="zhan-gmail",
+            token_path="/tmp/fake-token.json",
+            scopes=[gs.MUTATION_SCOPE],
+        )
+    }
+    monkeypatch.setattr(gs, "get_service", lambda *_args, **_kwargs: _Service())
+    shared = {
+        "profile_id": "zhan-gmail",
+        "subject": "Google Scholar profile and ORCID iD",
+        "allow_send": True,
+        "profiles": profiles,
+        "idempotency_scope": "turn-multiple-gmail-sends",
+    }
+
+    def send(*, recipient: str, body: str):
+        return gs.send_message(
+            to=recipient,
+            body_text=body,
+            **shared,
+            **_outbound_send_kwargs(
+                quota_collection=quota_collection,
+                delivery_collection=delivery_collection,
+                request_id="turn-multiple-gmail-sends",
+            ),
+        )
+
+    first = send(
+        recipient="first@example.test",
+        body="Could you send your profile link?",
+    )
+    second = send(
+        recipient="second@example.test",
+        body="Could you send your profile link?",
+    )
+    first_replay = send(
+        recipient="first@example.test",
+        body="Could you send your profile link?",
+    )
+    second_replay = send(
+        recipient="second@example.test",
+        body="Could you send your profile link?",
+    )
+    legacy_first = gs.send_message(
+        profile_id="zhan-gmail",
+        to="legacy-first@example.test",
+        subject="Legacy direct request",
+        body_text="One exact direct delivery.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id="legacy-direct-request-id",
+        ),
+    )
+    legacy_conflict = gs.send_message(
+        profile_id="zhan-gmail",
+        to="legacy-second@example.test",
+        subject="Legacy direct request",
+        body_text="One exact direct delivery.",
+        allow_send=True,
+        profiles=profiles,
+        **_outbound_send_kwargs(
+            quota_collection=quota_collection,
+            delivery_collection=delivery_collection,
+            request_id="legacy-direct-request-id",
+        ),
+    )
+
+    assert first["effect_status"] == "succeeded"
+    assert second["effect_status"] == "succeeded"
+    assert first["delivery_fingerprint"] != second["delivery_fingerprint"]
+    assert first_replay["idempotent_replay"] is True
+    assert second_replay["idempotent_replay"] is True
+    assert first_replay["delivery_fingerprint"] == first["delivery_fingerprint"]
+    assert second_replay["delivery_fingerprint"] == second["delivery_fingerprint"]
+    assert legacy_first["effect_status"] == "succeeded"
+    assert legacy_conflict["error_code"] == "gmail_outbound_idempotency_conflict"
+    assert legacy_conflict["effect_status"] == "not_started"
+    assert captured["send_count"] == 3
+    assert delivery_collection.count_documents({}) == 3
+    quota_document = quota_collection.find_one({})
+    assert quota_document["messages_in_day"] == 3
+    persisted = json.dumps(list(delivery_collection.find({})), default=str)
+    assert "first@example.test" not in persisted
+    assert "second@example.test" not in persisted
+    assert "legacy-first@example.test" not in persisted
+    assert "legacy-second@example.test" not in persisted
+    assert "Could you send your profile link?" not in persisted
 
 
 def test_send_message_required_policy_is_localised_exact_once_and_read_back(

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -603,6 +603,7 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "acting_user_concept_id": "actor_user_concept_id",
         "organisation_concept_id": "actor_organisation_concept_id",
         "request_id": "turn_id",
+        "idempotency_scope": "turn_id",
         "namespace": "turn_namespace",
     }
     assert gmail_send_definition.ordinary_turn_trusted_argument_choice_bindings == {
@@ -1978,6 +1979,7 @@ def test_gmail_send_message_registered_and_gateway_invokes(
     assert captured["body_authorship"] == "von_drafted"
     assert captured["allow_send"] is True
     assert captured["request_id"] == "turn-send-1"
+    assert captured["idempotency_scope"] is None
     assert (
         captured["profile_resource_concept_id"]
         == "#V#gmail_profile_zhan_gmail"


### PR DESCRIPTION
> Merge impact: authorised Von turns can send multiple distinct Gmail messages without sharing one coarse delivery key, while exact retries remain at-most-once.
>
> Merge decision: ready — deterministic tests cover the structural collision, retry safety, legacy conflict behaviour, canonical outcome projection, and manifest parity.

## User outcome

A user can authorise several distinct Gmail messages in one turn and have each logical message execute at most once with its own durable receipt and canonical read-back. This fixes the live incidents tracked in JVNAUTOSCI-2685.

## Material changes

- Bind a hidden ordinary-turn idempotency scope to the trusted turn identity.
- Derive a private logical-send digest from that scope plus normalised delivery intent inside the Gmail boundary.
- Preserve the legacy explicit request identity contract for direct and stdio callers.
- Mark canonically read-back successful effects as resolved in outcome reports and portable failure capsules.
- Regenerate the MCP manifest and update the current Gmail engineering contract.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2685

## Evidence

- 86 Gmail, delivery-ledger, catalogue, and failure-capsule tests passed.
- 8 targeted adaptive Gmail and effect-outcome tests passed.
- 14 MCP manifest and code-authority tests passed.
- Python compile, diff check, and targeted Ruff fatal-error checks passed.
- Controlled fake Gmail dispatched two distinct same-turn messages once each; exact replay added no provider calls or quota reservations; raw recipients and body text were absent from the ledger.

## Ship boundary

- Minimum ship criteria: distinct same-turn messages use distinct trusted identities; exact retries reuse identity without dispatch; changed content under one legacy explicit request identity still conflicts; canonical read-back remains truthful.
- Stop-ship conditions: any duplicate-send route, model-controlled ordinary-turn identity, raw private content in the ledger, or regression in profile authority, quota, provider receipt, or canonical read-back.
- Non-blocking observations: live controlled-mailbox replay belongs to deployment acceptance; repository evidence uses deterministic provider fakes and no real email.
- Non-goals: resending incident emails, Gmail drafts/replies/attachments, broad effect-system redesign, or deployment.