### PR TITLE
Make concept Q&A durable and constitutive-aware (JVNAUTOSCI-1035)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !sample_knowledge/*.json
 !src/backend/mcp_server/vontology_mcp.json
 !src/backend/workflows/repo_seed_bundles/*.json
+!src/backend/vontology/seed_bundles/constitutive_relation_requirements_seed_bundle.json
 
 # Python cache and virtual environments
 __pycache__/

--- a/scripts/reconcile_startup_seed_materialisations.py
+++ b/scripts/reconcile_startup_seed_materialisations.py
@@ -25,21 +25,31 @@ _summary_service = importlib.import_module(
 _publication_service = importlib.import_module(
     "src.backend.services.publication_scope_profile_vontology_service"
 )
+_constitutive_service = importlib.import_module(
+    "src.backend.services.constitutive_relation_requirement_service"
+)
 reconcile_canonical_concept_summary_fields = (
     _summary_service.reconcile_canonical_concept_summary_fields
 )
 reconcile_canonical_publication_scope_profiles = (
     _publication_service.reconcile_canonical_publication_scope_profiles
 )
+reconcile_canonical_constitutive_relation_requirement_profiles = (
+    _constitutive_service.reconcile_canonical_constitutive_relation_requirement_profiles
+)
 
 CONCEPT_SUMMARY_FIELDS = "concept-summary-fields"
 PUBLICATION_SCOPE_PROFILES = "publication-scope-profiles"
+CONSTITUTIVE_RELATION_REQUIREMENTS = "constitutive-relation-requirements"
 ALL_FAMILIES = "all"
 MACHINE_RECEIPT_PREFIX = "VON_STARTUP_SEED_RECONCILIATION_RECEIPT="
 
 _RECONCILERS: dict[str, Callable[[], dict[str, Any]]] = {
     CONCEPT_SUMMARY_FIELDS: reconcile_canonical_concept_summary_fields,
     PUBLICATION_SCOPE_PROFILES: reconcile_canonical_publication_scope_profiles,
+    CONSTITUTIVE_RELATION_REQUIREMENTS: (
+        reconcile_canonical_constitutive_relation_requirement_profiles
+    ),
 }
 
 

--- a/src/backend/server/routes/concept_routes.py
+++ b/src/backend/server/routes/concept_routes.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 import datetime as dt
 from typing import Any
-from ...services import concept_service  # Import concept_service
+from ...services import concept_qa_conversation_service, concept_service
 from ...services.window_session_context_service import get_effective_context
 from ...services.concept_service import (
     ConceptServiceError,
@@ -52,6 +52,20 @@ from ...vontology.utils_vontology import (
 from ...db.mongo_client import get_db
 
 concept_bp = Blueprint("concepts", __name__)  # Define blueprint
+
+
+def _concept_qa_error_response(error: Exception) -> ResponseReturnValue:
+    error_code = str(getattr(error, "error_code", "concept_q_and_a_failed"))
+    payload = {"success": False, "error": str(error), "error_code": error_code}
+    if isinstance(error, concept_qa_conversation_service.ConceptQAConversationNotFound):
+        return jsonify(payload), 404
+    if isinstance(error, concept_qa_conversation_service.ConceptQAConversationConflict):
+        return jsonify(payload), 409
+    if isinstance(
+        error, concept_qa_conversation_service.InvalidConceptQAConversationInput
+    ):
+        return jsonify(payload), 400
+    return jsonify(payload), 503
 
 
 def _get_trusted_interaction_user() -> str | None:
@@ -1152,6 +1166,164 @@ def get_legacy_import_metrics():
             jsonify({"success": False, "error": "Failed to fetch legacy metrics"}),
             500,
         )
+
+
+@concept_bp.route("/<string:concept_id>/q_and_a", methods=["GET"])
+def list_concept_q_and_a_route(concept_id: str):
+    user_id = _get_trusted_interaction_user()
+    if not user_id:
+        return jsonify(error="Concept Q&A requires authenticated user context"), 401
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        result = concept_qa_conversation_service.list_concept_qa_conversations(
+            concept_id=concept_id,
+            user_id=user_id,
+            namespace=_get_request_namespace(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+            session_id=request.args.get("session_id"),
+        )
+        return jsonify(result), 200
+    except concept_qa_conversation_service.ConceptQAConversationError as exc:
+        return _concept_qa_error_response(exc)
+
+
+@concept_bp.route("/<string:concept_id>/q_and_a/start", methods=["POST"])
+def start_concept_q_and_a_route(concept_id: str):
+    user_id = _get_trusted_interaction_user()
+    if not user_id:
+        return jsonify(error="Concept Q&A requires authenticated user context"), 401
+    data = request.get_json(silent=True) or {}
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        result = concept_qa_conversation_service.start_concept_qa_conversation(
+            concept_id=concept_id,
+            user_id=user_id,
+            namespace=_get_request_namespace(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+            initial_notes=data.get("initial_notes"),
+            initial_turn_id=data.get("turn_id") or data.get("initial_turn_id"),
+            model_provider=data.get("model_provider"),
+            model=data.get("model"),
+            model_parameters=data.get("model_parameters"),
+        )
+        return jsonify(result), 200
+    except concept_qa_conversation_service.ConceptQAConversationError as exc:
+        return _concept_qa_error_response(exc)
+
+
+@concept_bp.route(
+    "/<string:concept_id>/q_and_a/sessions/<string:session_id>/turns",
+    methods=["POST"],
+)
+def submit_concept_q_and_a_turn_route(concept_id: str, session_id: str):
+    user_id = _get_trusted_interaction_user()
+    if not user_id:
+        return jsonify(error="Concept Q&A requires authenticated user context"), 401
+    data = request.get_json(silent=True) or {}
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        result = concept_qa_conversation_service.submit_concept_qa_turn(
+            concept_id=concept_id,
+            session_id=session_id,
+            turn_id=data.get("turn_id"),
+            user_id=user_id,
+            answer=data.get("answer", ""),
+            notes_input=data.get("notes_input"),
+            namespace=_get_request_namespace(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+        )
+        return jsonify(result), 200
+    except concept_qa_conversation_service.ConceptQAConversationError as exc:
+        return _concept_qa_error_response(exc)
+
+
+def _transition_concept_q_and_a_route(
+    concept_id: str, session_id: str, target_status: str
+) -> ResponseReturnValue:
+    user_id = _get_trusted_interaction_user()
+    if not user_id:
+        return jsonify(error="Concept Q&A requires authenticated user context"), 401
+    data = request.get_json(silent=True) or {}
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        result = concept_qa_conversation_service.transition_concept_qa_conversation(
+            concept_id=concept_id,
+            session_id=session_id,
+            user_id=user_id,
+            target_status=target_status,
+            namespace=_get_request_namespace(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+            expected_revision=data.get("expected_revision"),
+        )
+        return jsonify(result), 200
+    except concept_qa_conversation_service.ConceptQAConversationError as exc:
+        return _concept_qa_error_response(exc)
+
+
+@concept_bp.route(
+    "/<string:concept_id>/q_and_a/sessions/<string:session_id>/finish",
+    methods=["POST"],
+)
+def finish_concept_q_and_a_route(concept_id: str, session_id: str):
+    return _transition_concept_q_and_a_route(concept_id, session_id, "finished")
+
+
+@concept_bp.route(
+    "/<string:concept_id>/q_and_a/sessions/<string:session_id>/cancel",
+    methods=["POST"],
+)
+def cancel_concept_q_and_a_route(concept_id: str, session_id: str):
+    return _transition_concept_q_and_a_route(concept_id, session_id, "cancelled")
+
+
+@concept_bp.route(
+    "/<string:concept_id>/q_and_a/sessions/<string:session_id>/formalisations/"
+    "<string:assertion_id>/confirm",
+    methods=["POST"],
+)
+def confirm_concept_q_and_a_formalisation_route(
+    concept_id: str, session_id: str, assertion_id: str
+):
+    user_id = _get_trusted_interaction_user()
+    if not user_id:
+        return jsonify(error="Concept Q&A requires authenticated user context"), 401
+    data = request.get_json(silent=True) or {}
+    try:
+        from ...security.access_control import get_effective_organisation_concept_id
+
+        result = concept_qa_conversation_service.confirm_concept_qa_formalisation(
+            concept_id=concept_id,
+            session_id=session_id,
+            assertion_id=assertion_id,
+            user_id=user_id,
+            namespace=_get_request_namespace(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+            request_id=data.get("request_id"),
+        )
+        if result.get("success") is True:
+            return jsonify(result), 200
+        confirmation = result.get("confirmation")
+        authority_decision = (
+            confirmation.get("authority_decision")
+            if isinstance(confirmation, dict)
+            else None
+        )
+        if (
+            isinstance(authority_decision, dict)
+            and authority_decision.get("allowed") is False
+        ):
+            return jsonify(result), 403
+        if isinstance(confirmation, dict) and confirmation.get(
+            "reconciliation_required"
+        ):
+            return jsonify(result), 409
+        return jsonify(result), 422
+    except concept_qa_conversation_service.ConceptQAConversationError as exc:
+        return _concept_qa_error_response(exc)
 
 
 @concept_bp.route("/<string:concept_id>/start_interaction", methods=["POST"])

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -10460,6 +10460,11 @@ def _load_conversation_session_state_fail_soft(
             if isinstance(session_state, Mapping)
             else None
         )
+        session_projection = (
+            chat_history_service.project_chat_session_mode_state(session_state)
+            if isinstance(session_state, Mapping)
+            else {"session_id": session_id}
+        )
         history_meta = {
             "history_offset": (
                 session_state.get("history_offset")
@@ -10498,6 +10503,7 @@ def _load_conversation_session_state_fail_soft(
                 if isinstance(session_state, Mapping)
                 else None
             ),
+            "session": session_projection,
         }
         return history, descriptor, text, revision, observations, history_meta
     except Exception as exc:
@@ -15787,6 +15793,22 @@ def history():
         meta = {"history_truncated": history_truncated}
         total_segments = len(segments)
 
+        session_projection = (
+            dict(owner_history_meta.get("session"))
+            if isinstance(owner_history_meta.get("session"), Mapping)
+            else {"session_id": session_id}
+        )
+        qa_session = (
+            session_projection
+            if isinstance(session_projection.get("concept_q_and_a"), Mapping)
+            else None
+        )
+        specialised_session_fields = (
+            {"session": session_projection, "qa_session": qa_session}
+            if qa_session is not None
+            else {}
+        )
+
         if total_segments == 0:
             return jsonify(
                 {
@@ -15799,6 +15821,7 @@ def history():
                     "conversation_observation_state": owner_history_meta.get(
                         "conversation_observation_state"
                     ),
+                    **specialised_session_fields,
                 }
             )
 
@@ -15831,6 +15854,7 @@ def history():
                 "conversation_observation_state": owner_history_meta.get(
                     "conversation_observation_state"
                 ),
+                **specialised_session_fields,
             }
         )
     except Exception as e:
@@ -18390,6 +18414,14 @@ def set_chat_session():
             "session_name": 1,
             chat_history_service.EXTERNAL_CONVERSATION_IMPORT_FIELD: 1,
             "conversation_lineage": 1,
+            "mode": 1,
+            "origin_kind": 1,
+            "focal_concept_ids": 1,
+            "focal_concept_ids_source": 1,
+            "focal_concept_ids_updated_at": 1,
+            "concept_q_and_a.schema_version": 1,
+            "concept_q_and_a.concept": 1,
+            "concept_q_and_a.lifecycle": 1,
         }
         if include_history:
             projection["history"] = 1
@@ -18429,6 +18461,19 @@ def set_chat_session():
             return jsonify({"error": "Session not found"}), 404
 
         session_name = doc.get("session_name")
+        session_mode_state = chat_history_service.project_chat_session_mode_state(
+            {**doc, "session_id": session_id}
+        )
+        qa_session = (
+            session_mode_state
+            if isinstance(session_mode_state.get("concept_q_and_a"), Mapping)
+            else None
+        )
+        specialised_session_fields = (
+            {**session_mode_state, "qa_session": qa_session}
+            if qa_session is not None
+            else {}
+        )
         external_conversation = (
             chat_history_service.project_external_conversation_metadata(doc)
         )
@@ -18508,6 +18553,7 @@ def set_chat_session():
                     "session_name": session_name,
                     "history": normalised_history,
                     "external_conversation": external_conversation,
+                    **specialised_session_fields,
                 }
             ),
             200,

--- a/src/backend/server/utils_flask.py
+++ b/src/backend/server/utils_flask.py
@@ -1557,6 +1557,7 @@ def create_flask_app(
     _maybe_start_relationship_extent_index_reconciliation(app)
     _bootstrap_concept_summary_fields_for_startup(app)
     _bootstrap_publication_scope_profiles_for_startup(app)
+    _bootstrap_constitutive_relation_requirements_for_startup(app)
     _configure_durable_workflow_startup(app)
     _maybe_start_external_conversation_import_worker(app)
     _maybe_start_chat_prompt_queue_dispatcher(app)
@@ -2851,6 +2852,51 @@ def _bootstrap_publication_scope_profiles_for_startup(app: Flask) -> None:
         )
 
 
+def _bootstrap_constitutive_relation_requirements_for_startup(app: Flask) -> None:
+    """Check freshness of represented constitutive relation requirements."""
+
+    if _is_running_under_pytest():
+        return
+    if _is_agent_test_instance():
+        app.config["CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"] = {
+            "success": True,
+            "skipped": True,
+            "reason": "agent_test_instance",
+        }
+        app.logger.info(
+            "[constitutive_relation_requirements] AgentTest mode: "
+            "skipping Vontology bootstrap."
+        )
+        return
+    if not _env_bool(
+        "VON_CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_ENABLE", True
+    ):
+        return
+    try:
+        from ..services.constitutive_relation_requirement_service import (
+            ensure_constitutive_relation_requirement_profiles_current_for_startup,
+        )
+
+        report = (
+            ensure_constitutive_relation_requirement_profiles_current_for_startup()
+        )
+        app.config["CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"] = report
+        if not bool(report.get("success", False)):
+            app.logger.warning(
+                "[constitutive_relation_requirements] bootstrap failed: %s",
+                report,
+            )
+    except Exception as exc:
+        app.config["CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"] = {
+            "success": False,
+            "error": str(exc),
+        }
+        app.logger.warning(
+            "[constitutive_relation_requirements] bootstrap error: %s",
+            exc,
+        )
+
+
 def _configure_durable_workflow_startup(app: Flask) -> None:
     """Initialise or defer durable workflow runtime startup."""
     running_under_pytest = _is_running_under_pytest()
@@ -3332,6 +3378,9 @@ def _build_startup_seed_materialisations_projection(
         "concept_summary_fields": "CONCEPT_SUMMARY_FIELD_BOOTSTRAP_REPORT",
         "publication_scope_profiles": (
             "PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"
+        ),
+        "constitutive_relation_requirements": (
+            "CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"
         ),
     }
     families: dict[str, dict[str, object]] = {}

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -68,11 +68,14 @@ _CHAT_HISTORY_LIGHT_SESSION_METADATA_INDEX_NAME = (
 )
 CONVERSATION_SEARCH_INDEX_VERSION = 1
 _CONVERSATION_SEARCH_TEXT_INDEX_NAME = "conversation_search_text_v1"
+_CONCEPT_QA_ACTIVE_KEY_INDEX_NAME = "concept_q_and_a_active_key_unique_v1"
 _CONVERSATION_SEARCH_MAX_SEGMENT_CHARS = 5_000
 _MAX_FOCAL_CONCEPT_IDS = 4
 CHAT_SESSION_ORIGIN_KIND_BROWSER_TEST_FIXTURE = "browser_test_fixture"
 CHAT_SESSION_ORIGIN_KIND_BENCHMARK_HARNESS = "benchmark_harness"
 CHAT_SESSION_ORIGIN_KIND_CODING_AGENT_TEST = "coding_agent_test"
+CHAT_SESSION_ORIGIN_KIND_CONCEPT_Q_AND_A = "concept_q_and_a"
+CHAT_SESSION_MODE_CONCEPT_Q_AND_A = "concept_q_and_a"
 CHAT_SESSION_AGENT_CREATED_ORIGIN_KINDS = frozenset(
     {
         CHAT_SESSION_ORIGIN_KIND_BROWSER_TEST_FIXTURE,
@@ -83,6 +86,7 @@ CHAT_SESSION_AGENT_CREATED_ORIGIN_KINDS = frozenset(
     }
 )
 CHAT_SESSION_PROVENANCE_FIELDS = (
+    "mode",
     "origin_kind",
     "created_by_actor_concept_id",
     "created_by_actor_type",
@@ -528,6 +532,18 @@ def _ensure_chat_history_indexes(collection) -> None:
                     ],
                     name="namespace_1_user_id_1_focal_concept_ids_1_updated_at_-1",
                 )
+            if _CONCEPT_QA_ACTIVE_KEY_INDEX_NAME not in existing_indexes:
+                collection.create_index(
+                    [("concept_q_and_a.active_key", ASCENDING)],
+                    name=_CONCEPT_QA_ACTIVE_KEY_INDEX_NAME,
+                    unique=True,
+                    partialFilterExpression={
+                        "mode": CHAT_SESSION_MODE_CONCEPT_Q_AND_A,
+                        "origin_kind": CHAT_SESSION_ORIGIN_KIND_CONCEPT_Q_AND_A,
+                        "concept_q_and_a.lifecycle.status": "active",
+                        "concept_q_and_a.active_key": {"$type": "string"},
+                    },
+                )
             if _CONVERSATION_SEARCH_TEXT_INDEX_NAME not in existing_indexes:
                 collection.create_index(
                     [
@@ -707,6 +723,11 @@ def _normalise_chat_session_provenance_fields(
 
 
 def _session_provenance_from_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
+    mode = _normalise_session_provenance_text(
+        doc.get("mode"),
+        max_len=80,
+        identifier=True,
+    )
     origin_kind = _normalise_session_provenance_text(
         doc.get("origin_kind"),
         max_len=80,
@@ -732,12 +753,96 @@ def _session_provenance_from_doc(doc: Dict[str, Any]) -> Dict[str, Any]:
         or test_kind
     )
     return {
+        "mode": mode,
         "origin_kind": origin_kind,
         "created_by_actor_concept_id": actor_id,
         "created_by_actor_type": actor_type,
         "is_agent_created": is_agent_created,
         "test_artifact_kind": test_kind,
     }
+
+
+def project_concept_q_and_a_session_metadata(
+    doc: Mapping[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return the bounded mode/lifecycle carrier needed by generic chat views."""
+
+    raw_state = doc.get("concept_q_and_a")
+    if not isinstance(raw_state, Mapping):
+        return None
+    raw_concept = raw_state.get("concept")
+    concept = (
+        {
+            key: raw_concept.get(key)
+            for key in ("concept_id", "name", "storage_id", "mongo_id")
+            if raw_concept.get(key) is not None
+        }
+        if isinstance(raw_concept, Mapping)
+        else None
+    )
+    raw_lifecycle = raw_state.get("lifecycle")
+    lifecycle: Dict[str, Any] = {}
+    if isinstance(raw_lifecycle, Mapping):
+        for key in ("status", "revision", "terminal_reason"):
+            if raw_lifecycle.get(key) is not None:
+                lifecycle[key] = raw_lifecycle.get(key)
+        for key in (
+            "started_at",
+            "updated_at",
+            "terminal_at",
+            "finished_at",
+            "cancelled_at",
+        ):
+            value = raw_lifecycle.get(key)
+            timestamp = _coerce_datetime(value)
+            if timestamp is not None:
+                lifecycle[key] = timestamp.isoformat()
+            elif isinstance(value, str) and value.strip():
+                lifecycle[key] = value.strip()
+    return {
+        "schema_version": raw_state.get("schema_version"),
+        "concept": concept,
+        "lifecycle": lifecycle or None,
+    }
+
+
+def _concept_q_and_a_metadata_field(doc: Mapping[str, Any]) -> Dict[str, Any]:
+    projected = project_concept_q_and_a_session_metadata(doc)
+    return {"concept_q_and_a": projected} if projected is not None else {}
+
+
+def _concept_q_and_a_completion(
+    doc: Mapping[str, Any],
+) -> tuple[bool, Optional[datetime]]:
+    projected = project_concept_q_and_a_session_metadata(doc)
+    lifecycle = projected.get("lifecycle") if isinstance(projected, Mapping) else None
+    if not isinstance(lifecycle, Mapping) or lifecycle.get("status") not in {
+        "finished",
+        "cancelled",
+    }:
+        return False, None
+    completed_at = _coerce_datetime(
+        lifecycle.get("terminal_at")
+        or lifecycle.get("finished_at")
+        or lifecycle.get("cancelled_at")
+    )
+    return True, completed_at
+
+
+def project_chat_session_mode_state(doc: Mapping[str, Any]) -> Dict[str, Any]:
+    """Project the generic session fields needed to reopen a specialised carrier."""
+
+    projection: Dict[str, Any] = {
+        "session_id": doc.get("session_id"),
+        **_session_provenance_from_doc(dict(doc)),
+        **_focus_projection_from_doc(dict(doc)),
+    }
+    concept_q_and_a = project_concept_q_and_a_session_metadata(doc)
+    if concept_q_and_a is not None:
+        projection["concept_q_and_a"] = concept_q_and_a
+        projection["concept"] = concept_q_and_a.get("concept")
+        projection["lifecycle"] = concept_q_and_a.get("lifecycle")
+    return projection
 
 
 def _external_conversation_summary_from_doc(
@@ -1004,6 +1109,9 @@ def _add_chat_session_provenance_projection(
         projection[field_name] = 1
     projection[EXTERNAL_CONVERSATION_IMPORT_FIELD] = 1
     projection["conversation_lineage"] = 1
+    projection["concept_q_and_a.schema_version"] = 1
+    projection["concept_q_and_a.concept"] = 1
+    projection["concept_q_and_a.lifecycle"] = 1
     return projection
 
 
@@ -1790,6 +1898,11 @@ def get_chat_history_session_state(
                             "focal_concept_ids": 1,
                             "focal_concept_ids_source": 1,
                             "focal_concept_ids_updated_at": 1,
+                            "mode": 1,
+                            "origin_kind": 1,
+                            "concept_q_and_a.schema_version": 1,
+                            "concept_q_and_a.concept": 1,
+                            "concept_q_and_a.lifecycle": 1,
                         }
                     },
                 ]
@@ -1818,6 +1931,11 @@ def get_chat_history_session_state(
                     "focal_concept_ids": 1,
                     "focal_concept_ids_source": 1,
                     "focal_concept_ids_updated_at": 1,
+                    "mode": 1,
+                    "origin_kind": 1,
+                    "concept_q_and_a.schema_version": 1,
+                    "concept_q_and_a.concept": 1,
+                    "concept_q_and_a.lifecycle": 1,
                 }
                 if include_history:
                     projection["history"] = 1
@@ -1851,6 +1969,7 @@ def get_chat_history_session_state(
         "session_id": session_id,
         "history": history,
         **_conversation_state_from_doc(doc),
+        **project_chat_session_mode_state(doc),
     }
     focus = _focus_projection_from_doc(doc)
     if focus["focal_concept_ids"]:
@@ -3713,6 +3832,111 @@ def add_message_to_history(
         raise ChatHistoryServiceError(f"Could not add message to history: {e}") from e
 
 
+def append_message_to_history_once(
+    *,
+    user_id: str,
+    session_id: str,
+    message: Dict[str, Any],
+    namespace: Optional[str] = None,
+    expected_session_fields: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Atomically append one identified turn to an existing chat carrier.
+
+    This is the exact-transcript primitive for retryable feature-specific
+    conversations.  It never creates a session and it never treats client
+    metadata as actor authority.  Reusing a ``turn_id`` returns the existing
+    stored turn instead of appending another copy.
+    """
+
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise ChatHistoryServiceError("user_id is required.")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ChatHistoryServiceError("session_id is required.")
+    if not isinstance(message, dict):
+        raise ChatHistoryServiceError("message must be an object.")
+    role = message.get("role")
+    content = message.get("content")
+    turn_id = message.get("turn_id")
+    if role not in {"user", "assistant", "system", "tool"}:
+        raise ChatHistoryServiceError("message.role is not supported.")
+    if not isinstance(content, str):
+        raise ChatHistoryServiceError("message.content must be a string.")
+    if not isinstance(turn_id, str) or not turn_id.strip():
+        raise ChatHistoryServiceError("message.turn_id is required.")
+
+    collection = get_chat_history_collection_service()
+    if collection is None:
+        raise ChatHistoryServiceError("Could not connect to chat history collection.")
+
+    base_query = build_chat_history_query(
+        user_id=user_id.strip(),
+        session_id=session_id.strip(),
+        namespace=namespace,
+        include_legacy=True,
+    )
+    if isinstance(expected_session_fields, Mapping):
+        for field_name, expected_value in expected_session_fields.items():
+            if not isinstance(field_name, str) or not field_name.strip():
+                raise ChatHistoryServiceError("expected session field names are required.")
+            base_query[field_name.strip()] = expected_value
+
+    stored_message = dict(message)
+    stored_message["turn_id"] = turn_id.strip()
+    if role == "user" and not isinstance(stored_message.get("author_user_id"), str):
+        stored_message["author_user_id"] = user_id.strip()
+    timestamp = stored_message.get("timestamp")
+    if not isinstance(timestamp, (datetime, str)):
+        stored_message["timestamp"] = datetime.now(timezone.utc)
+
+    set_fields: Dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+    push_fields: Dict[str, Any] = {"history": stored_message}
+    search_segment = _conversation_search_segment(stored_message)
+    if search_segment is not None:
+        push_fields["conversation_search_text"] = search_segment["text"]
+        push_fields["conversation_search_segments"] = search_segment
+        set_fields["conversation_search_indexed_at"] = datetime.now(timezone.utc)
+
+    append_query = dict(base_query)
+    append_query["history.turn_id"] = {"$ne": turn_id.strip()}
+    try:
+        result = collection.update_one(
+            append_query,
+            {"$push": push_fields, "$set": set_fields},
+        )
+        doc = collection.find_one(base_query, {"history": 1})
+    except PyMongoError as exc:
+        raise ChatHistoryServiceError(
+            f"Could not append identified chat history turn: {exc}"
+        ) from exc
+
+    if not isinstance(doc, dict):
+        return {
+            "matched": False,
+            "appended": False,
+            "duplicate": False,
+            "turn_id": turn_id.strip(),
+            "message": None,
+            "history_index": None,
+        }
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    existing_message = None
+    history_index = None
+    for index, entry in enumerate(history):
+        if isinstance(entry, dict) and entry.get("turn_id") == turn_id.strip():
+            existing_message = dict(entry)
+            history_index = index
+            break
+    appended = bool(getattr(result, "modified_count", 0) > 0)
+    return {
+        "matched": True,
+        "appended": appended,
+        "duplicate": not appended and existing_message is not None,
+        "turn_id": turn_id.strip(),
+        "message": existing_message,
+        "history_index": history_index,
+    }
+
+
 def set_chat_history_for_session(
     *,
     user_id: str,
@@ -4732,13 +4956,14 @@ def _build_session_summary_from_metadata(
         return None
 
     provenance = _session_provenance_from_doc(doc)
+    is_completed, completed_at_dt = _concept_q_and_a_completion(doc)
     return {
         "session_id": session_id,
         "session_name": session_name,
         "message_count": None,
         "last_message_at": last_ts.isoformat() if last_ts else None,
-        "is_completed": False,
-        "completed_at": None,
+        "is_completed": is_completed,
+        "completed_at": completed_at_dt.isoformat() if completed_at_dt else None,
         "created_at": created_ts.isoformat() if created_ts else None,
         "namespace": doc.get("namespace"),
         "organisation_concept_id": doc.get("organisation_concept_id"),
@@ -4754,6 +4979,7 @@ def _build_session_summary_from_metadata(
         "preview": None,
         **focus,
         **provenance,
+        **_concept_q_and_a_metadata_field(doc),
         **_session_external_projection_from_doc(doc),
     }
 
@@ -5013,6 +5239,10 @@ def _load_chat_history_session_summaries(
             completed_at_dt = None
             if is_completed and isinstance(last_entry, dict):
                 completed_at_dt = _coerce_datetime(last_entry.get("timestamp"))
+            qa_completed, qa_completed_at = _concept_q_and_a_completion(doc)
+            if qa_completed:
+                is_completed = True
+                completed_at_dt = qa_completed_at or completed_at_dt
 
             last_ts = _infer_last_message_timestamp(doc)
             created_ts = _infer_created_timestamp(doc)
@@ -5056,6 +5286,7 @@ def _load_chat_history_session_summaries(
                     "preview": preview,
                     **focus,
                     **provenance,
+                    **_concept_q_and_a_metadata_field(doc),
                     **_session_external_projection_from_doc(doc),
                 }
             )
@@ -5359,6 +5590,10 @@ def get_chat_history_session_summary(
     completed_at_dt = None
     if is_completed and isinstance(last_entry, dict):
         completed_at_dt = _coerce_datetime(last_entry.get("timestamp"))
+    qa_completed, qa_completed_at = _concept_q_and_a_completion(doc)
+    if qa_completed:
+        is_completed = True
+        completed_at_dt = qa_completed_at or completed_at_dt
 
     last_ts = _infer_last_message_timestamp(doc)
     created_ts = _infer_created_timestamp(doc)
@@ -5390,6 +5625,7 @@ def get_chat_history_session_summary(
         "preview": preview,
         **focus,
         **provenance,
+        **_concept_q_and_a_metadata_field(doc),
         **_session_external_projection_from_doc(doc),
     }
     _record_chat_history_read_success()
@@ -5404,12 +5640,14 @@ def create_chat_session(
     namespace: Optional[str] = None,
     organisation_concept_id: Optional[str] = None,
     role_in_org: Optional[str] = None,
+    mode: Optional[str] = None,
     origin_kind: Optional[str] = None,
     created_by_actor_concept_id: Optional[str] = None,
     created_by_actor_type: Optional[str] = None,
     is_agent_created: Optional[bool] = None,
     test_artifact_kind: Optional[str] = None,
     focal_concept_ids: Any = None,
+    concept_q_and_a_state: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Create a new chat session document if it does not already exist.
 
@@ -5420,11 +5658,15 @@ def create_chat_session(
         namespace: Optional explicit namespace (e.g., from window session context)
         organisation_concept_id: Optional explicit org ID (e.g., from window session context)
         role_in_org: Optional explicit role (e.g., from window session context)
+        mode: Optional durable conversation mode, such as concept_q_and_a
         origin_kind: Optional durable provenance kind for non-human/test sessions
         created_by_actor_concept_id: Optional Vontology actor concept attribution
         created_by_actor_type: Optional actor type concept, such as #V#coding_agent
         is_agent_created: Optional explicit test/agent-created flag
         test_artifact_kind: Optional test/benchmark fixture class
+        concept_q_and_a_state: Initial state for a concept_q_and_a mode carrier.
+            It is inserted atomically with the session so its active key can be
+            protected by the partial unique index.
 
     If namespace/org/role not provided, falls back to Flask session context.
     """
@@ -5455,12 +5697,19 @@ def create_chat_session(
         )
     name = _normalise_session_name(session_name)
     normalised_focus = normalise_focal_concept_ids(focal_concept_ids)
+    normalised_mode = _normalise_session_provenance_text(
+        mode,
+        max_len=80,
+        identifier=True,
+    )
 
     set_on_insert: Dict[str, Any] = {
         "created_at": now,
         "updated_at": now,
         "history": [],
     }
+    if normalised_mode:
+        set_on_insert["mode"] = normalised_mode
     if name:
         set_on_insert["session_name"] = name
         set_on_insert["conversation_search_title"] = name
@@ -5472,6 +5721,14 @@ def create_chat_session(
         set_on_insert["focal_concept_ids"] = normalised_focus
         set_on_insert["focal_concept_ids_source"] = "conversation_launch"
         set_on_insert["focal_concept_ids_updated_at"] = now
+    if concept_q_and_a_state is not None:
+        if normalised_mode != CHAT_SESSION_MODE_CONCEPT_Q_AND_A:
+            raise ChatHistoryServiceError(
+                "concept_q_and_a_state requires concept_q_and_a mode."
+            )
+        if not isinstance(concept_q_and_a_state, Mapping):
+            raise ChatHistoryServiceError("concept_q_and_a_state must be an object.")
+        set_on_insert["concept_q_and_a"] = dict(concept_q_and_a_state)
     if isinstance(ns, str) and ns.strip():
         set_on_insert["namespace"] = ns.strip()
     if isinstance(effective_org, str) and effective_org.strip():
@@ -5516,10 +5773,19 @@ def create_chat_session(
             "session_id": session_id,
             "session_name": _normalise_session_name((doc or {}).get("session_name")),
             "namespace": (doc or {}).get("namespace") or ns,
+            "mode": _normalise_session_provenance_text(
+                (doc or {}).get("mode") or normalised_mode,
+                max_len=80,
+                identifier=True,
+            ),
             **_focus_projection_from_doc(doc),
             **stored_provenance,
             **_session_external_projection_from_doc(doc or {}),
         }
+    except DuplicateKeyError:
+        # Feature-specific partial unique indexes use this as their atomic
+        # concurrency signal; callers must be able to read the winning row.
+        raise
     except PyMongoError as e:
         logger.error(f"Error creating chat session: {e}", exc_info=True)
         raise ChatHistoryServiceError(f"Could not create chat session: {e}") from e

--- a/src/backend/services/concept_effective_assertion_service.py
+++ b/src/backend/services/concept_effective_assertion_service.py
@@ -72,6 +72,10 @@ def _referenced_concept_ids(items: list[Mapping[str, Any]]) -> list[str]:
                 else None
             ),
         ]
+        for link in item.get("concept_links") or ():
+            if not isinstance(link, Mapping) or link.get("status") != "active":
+                continue
+            candidates.append(link.get("concept_id"))
         for candidate in candidates:
             if not isinstance(candidate, str) or not candidate.startswith("#V#"):
                 continue
@@ -79,6 +83,46 @@ def _referenced_concept_ids(items: list[Mapping[str, Any]]) -> list[str]:
                 seen.add(candidate)
                 ordered.append(candidate)
     return ordered
+
+
+def _concept_relevance(
+    item: Mapping[str, Any],
+    *,
+    focal_concept_id: str | None,
+) -> dict[str, Any] | None:
+    """Describe why an assertion appears on one concept page.
+
+    A standalone text assertion linked through ``concept_links`` is evidence
+    *about* the focal concept, not a subject-predicate-object assertion whose
+    subject can be silently inferred.  Keeping that distinction in the
+    projection lets the UI surface the exact claim without overstating its
+    formalisation.
+    """
+
+    focal_id = str(focal_concept_id or "").strip()
+    if not focal_id:
+        return None
+    subject_match = item.get("subject_concept_id") == focal_id
+    object_match = item.get("object_concept_id") == focal_id
+    if subject_match and object_match:
+        kind = "grounded_subject_and_object"
+    elif subject_match:
+        kind = "grounded_subject"
+    elif object_match:
+        kind = "grounded_object"
+    else:
+        linked = any(
+            isinstance(link, Mapping)
+            and link.get("status") == "active"
+            and link.get("concept_id") == focal_id
+            for link in item.get("concept_links") or ()
+        )
+        kind = "aboutness_only" if linked else "unrelated"
+    return {
+        "kind": kind,
+        "concept_id": focal_id,
+        "aboutness_only": kind == "aboutness_only",
+    }
 
 
 def _display_names_for_ids(concept_ids: list[str]) -> dict[str, str]:
@@ -107,6 +151,7 @@ def _project_item(
     item: Mapping[str, Any],
     *,
     display_names: Mapping[str, str],
+    focal_concept_id: str | None = None,
 ) -> dict[str, Any]:
     assertion_form = str(item.get("assertion_form") or "relation").strip()
     subject_id = str(item.get("subject_concept_id") or "").strip()
@@ -215,9 +260,14 @@ def _project_item(
         },
         "object": object_payload,
         "human_statement": human_statement,
+        "concept_relevance": _concept_relevance(
+            item,
+            focal_concept_id=focal_concept_id,
+        ),
         "presentation": presentation,
         "source_context": source_context,
         "status": item.get("status"),
+        "epistemic_status": item.get("epistemic_status") or "asserted",
         "canonical_publication": False,
         "assertion_context": item.get("assertion_context"),
         "provenance": item.get("provenance"),
@@ -272,14 +322,21 @@ def load_concept_effective_assertions(
     )
 
     page = list_visible_scoped_assertions_page(
-        subject_concept_ids=[subject_id],
+        argument_concept_id=subject_id,
+        epistemic_statuses=("asserted", "tentative"),
         limit=page_limit,
         offset=page_offset,
-        limit_per_subject=page_limit,
     )
     raw_items = [item for item in page.get("items") or [] if isinstance(item, Mapping)]
     display_names = _display_names_for_ids(_referenced_concept_ids(raw_items))
-    items = [_project_item(item, display_names=display_names) for item in raw_items]
+    items = [
+        _project_item(
+            item,
+            display_names=display_names,
+            focal_concept_id=subject_id,
+        )
+        for item in raw_items
+    ]
     return {
         "success": True,
         "concept_id": subject_id,

--- a/src/backend/services/concept_qa_conversation_service.py
+++ b/src/backend/services/concept_qa_conversation_service.py
@@ -1,0 +1,3094 @@
+"""Canonical actor-scoped conversation carrier for concept Q&A.
+
+The historical concept interaction store remains readable through its existing
+service and routes.  New Q&A sessions are ordinary ``chat_history`` sessions
+with a focal concept, typed mode/origin metadata, explicit lifecycle state and
+per-turn representation receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+from pymongo import DESCENDING
+from pymongo.errors import DuplicateKeyError, PyMongoError
+
+from ..vontology.utils_vontology import get_concept_display_name_with_names_fallback
+from . import (
+    chat_history_service,
+    concept_resolution_service,
+    concept_service,
+    scoped_assertion_service,
+)
+from .conversation_management_service import build_canonical_conversation_reference
+
+SESSION_SCHEMA_VERSION = "concept_q_and_a_session.v1"
+TURN_RECEIPT_SCHEMA_VERSION = "concept_q_and_a_turn_receipt.v1"
+EXACT_INPUT_RECEIPT_SCHEMA_VERSION = "concept_q_and_a_exact_input_receipt.v1"
+FORMALISATION_RECEIPT_SCHEMA_VERSION = "concept_q_and_a_formalisation_receipt.v1"
+NOTES_RECEIPT_SCHEMA_VERSION = "concept_q_and_a_notes_receipt.v1"
+MODE = chat_history_service.CHAT_SESSION_MODE_CONCEPT_Q_AND_A
+ORIGIN_KIND = chat_history_service.CHAT_SESSION_ORIGIN_KIND_CONCEPT_Q_AND_A
+ACTIVE = "active"
+FINISHED = "finished"
+CANCELLED = "cancelled"
+TERMINAL_STATUSES = frozenset({FINISHED, CANCELLED})
+_MAX_SESSIONS = 20
+
+
+class ConceptQAConversationError(RuntimeError):
+    """Base error carrying a stable HTTP-facing reason code."""
+
+    def __init__(self, message: str, *, error_code: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class ConceptQAConversationNotFound(ConceptQAConversationError):
+    """Raised when the actor-scoped session or concept does not exist."""
+
+
+class ConceptQAConversationConflict(ConceptQAConversationError):
+    """Raised for terminal or compare-and-set lifecycle conflicts."""
+
+
+class InvalidConceptQAConversationInput(ConceptQAConversationError):
+    """Raised when a request cannot be admitted to the carrier."""
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _iso(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_iso(item) for item in value]
+    return value
+
+
+def _normalise_turn_llm_debug_data(value: Any) -> dict[str, Any] | None:
+    """Retain rich identities while supporting the generic LLM-link affordance."""
+
+    if not isinstance(value, Mapping):
+        return None
+    debug = dict(value)
+    selected = debug.get("selected")
+    if isinstance(selected, Mapping):
+        if not debug.get("provider") and selected.get("provider"):
+            debug["provider"] = selected.get("provider")
+        if not debug.get("model") and selected.get("model"):
+            debug["model"] = selected.get("model")
+    return debug
+
+
+def _required_text(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise InvalidConceptQAConversationInput(
+            f"{field} is required", error_code=f"{field}_required"
+        )
+    return value.strip()
+
+
+def _normalise_actor_id(value: Any, *, field: str) -> str:
+    actor_id = _required_text(value, field=field)
+    if not actor_id.startswith("#V#"):
+        raise InvalidConceptQAConversationInput(
+            f"{field} must be a trusted Vontology concept ID",
+            error_code="authenticated_actor_context_required",
+        )
+    return actor_id
+
+
+def _normalise_org_id(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned.startswith("#V#") else f"#V#{cleaned.lstrip('#')}"
+
+
+def _resolve_namespace(
+    *, user_id: str, namespace: Any, organisation_concept_id: str | None
+) -> str:
+    if isinstance(namespace, str) and namespace.strip():
+        return namespace.strip()
+    from .namespace_service import derive_namespace_for_actor
+
+    derived = derive_namespace_for_actor(user_id, organisation_concept_id)
+    if not isinstance(derived, str) or not derived.strip():
+        raise ConceptQAConversationError(
+            "Could not derive the Q&A conversation namespace",
+            error_code="conversation_namespace_unavailable",
+        )
+    return derived.strip()
+
+
+def _load_focal_concept(
+    concept_id: str,
+    *,
+    user_id: str,
+    organisation_concept_id: str | None,
+) -> dict[str, Any]:
+    requested = _required_text(concept_id, field="concept_id")
+    try:
+        if requested.startswith("#V#"):
+            concept = concept_service.get_concept_by_concept_id(requested)
+        else:
+            concept = concept_service.get_concept_by_id(requested)
+            if concept is None:
+                concept = concept_service.get_concept_by_concept_id(f"#V#{requested}")
+    except Exception as exc:
+        raise ConceptQAConversationNotFound(
+            "Focal concept was not found", error_code="concept_not_found"
+        ) from exc
+    if not isinstance(concept, dict):
+        raise ConceptQAConversationNotFound(
+            "Focal concept was not found", error_code="concept_not_found"
+        )
+    canonical_id = str(concept.get("concept_id") or "").strip()
+    if not canonical_id.startswith("#V#"):
+        raise ConceptQAConversationError(
+            "Focal concept has no canonical concept ID",
+            error_code="canonical_concept_id_unavailable",
+        )
+    try:
+        from ..security.access_control import can_access_concept, override_current_actor
+
+        with override_current_actor(user_id, organisation_concept_id):
+            visible = can_access_concept(canonical_id)
+    except Exception:  # noqa: BLE001 - inaccessible and absent must be indistinguishable
+        visible = False
+    if not visible:
+        # Do not distinguish a private concept from an absent one.
+        raise ConceptQAConversationNotFound(
+            "Focal concept was not found", error_code="concept_not_found"
+        )
+    return concept
+
+
+def _active_key(*, user_id: str, namespace: str, concept_id: str) -> str:
+    digest = hashlib.sha256(
+        f"{user_id}\x00{namespace}\x00{concept_id}\x00{MODE}".encode()
+    ).hexdigest()
+    return f"concept_q_and_a:{digest}"
+
+
+def _collection(*, read_only: bool = False):
+    collection = chat_history_service.get_chat_history_collection_service(
+        read_only=read_only
+    )
+    if collection is None:
+        raise ConceptQAConversationError(
+            "Conversation store is unavailable",
+            error_code="conversation_store_unavailable",
+        )
+    return collection
+
+
+def _actor_query(
+    *, user_id: str, namespace: str, session_id: str | None = None
+) -> dict[str, Any]:
+    query = chat_history_service.build_chat_history_query(
+        user_id=user_id,
+        session_id=session_id,
+        namespace=namespace,
+        include_legacy=True,
+    )
+    query.update({"mode": MODE, "origin_kind": ORIGIN_KIND})
+    return query
+
+
+def _find_session(
+    *, user_id: str, namespace: str, session_id: str
+) -> dict[str, Any] | None:
+    try:
+        return _collection(read_only=True).find_one(
+            _actor_query(
+                user_id=user_id,
+                namespace=namespace,
+                session_id=session_id,
+            )
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not read the Q&A conversation",
+            error_code="conversation_read_failed",
+        ) from exc
+
+
+def _session_lifecycle(doc: Mapping[str, Any]) -> dict[str, Any]:
+    qa_state = doc.get("concept_q_and_a")
+    lifecycle = qa_state.get("lifecycle") if isinstance(qa_state, Mapping) else None
+    if not isinstance(lifecycle, Mapping):
+        return {"status": None, "revision": None}
+    return _iso(dict(lifecycle))
+
+
+def _session_concept(doc: Mapping[str, Any]) -> dict[str, Any]:
+    qa_state = doc.get("concept_q_and_a")
+    concept = qa_state.get("concept") if isinstance(qa_state, Mapping) else None
+    return _iso(dict(concept)) if isinstance(concept, Mapping) else {}
+
+
+def _structured_turns(doc: Mapping[str, Any]) -> list[dict[str, Any]]:
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    qa_state = doc.get("concept_q_and_a")
+    receipt_map = (
+        qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else None
+    )
+    receipts = receipt_map if isinstance(receipt_map, Mapping) else {}
+    turns: list[dict[str, Any]] = []
+    for history_index, raw_entry in enumerate(history):
+        if not isinstance(raw_entry, Mapping):
+            continue
+        entry = _iso(dict(raw_entry))
+        turn_id = entry.get("turn_id")
+        projected = {
+            **entry,
+            "history_location": {
+                "session_id": doc.get("session_id"),
+                "history_index": history_index,
+            },
+        }
+        if isinstance(turn_id, str) and isinstance(receipts.get(turn_id), Mapping):
+            projected["receipts"] = _iso(dict(receipts[turn_id]))
+        turns.append(projected)
+    return turns
+
+
+def _project_session(doc: Mapping[str, Any]) -> dict[str, Any]:
+    user_id = str(doc.get("user_id") or "")
+    session_id = str(doc.get("session_id") or "")
+    namespace = doc.get("namespace")
+    organisation_concept_id = doc.get("organisation_concept_id")
+    qa_state = doc.get("concept_q_and_a")
+    turn_receipts = (
+        qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else {}
+    )
+    canonical_reference = build_canonical_conversation_reference(
+        owner_user_id=user_id,
+        session_id=session_id,
+        namespace=namespace,
+        organisation_concept_id=organisation_concept_id,
+    )
+    return {
+        "schema_version": SESSION_SCHEMA_VERSION,
+        "session_id": session_id,
+        "interaction_id": session_id,
+        "session_name": doc.get("session_name"),
+        "mode": doc.get("mode"),
+        "origin_kind": doc.get("origin_kind"),
+        "namespace": namespace,
+        "organisation_concept_id": organisation_concept_id,
+        "focal_concept_ids": list(doc.get("focal_concept_ids") or []),
+        "concept": _session_concept(doc),
+        "lifecycle": _session_lifecycle(doc),
+        "llm_selection": _iso(qa_state.get("llm_selection"))
+        if isinstance(qa_state, Mapping)
+        else None,
+        "suppressed_predicate_ids": list(qa_state.get("suppressed_predicate_ids") or [])
+        if isinstance(qa_state, Mapping)
+        else [],
+        "suppressed_requirement_keys": list(
+            qa_state.get("suppressed_requirement_keys") or []
+        )
+        if isinstance(qa_state, Mapping)
+        else [],
+        "suppressed_requirements": _iso(
+            list(qa_state.get("suppressed_requirements") or [])
+        )
+        if isinstance(qa_state, Mapping)
+        else [],
+        "addressed_requirement_keys": list(
+            qa_state.get("addressed_requirement_keys") or []
+        )
+        if isinstance(qa_state, Mapping)
+        else [],
+        "requirement_dispositions": _iso(
+            list(qa_state.get("requirement_dispositions") or [])
+        )
+        if isinstance(qa_state, Mapping)
+        else [],
+        "created_at": _iso(doc.get("created_at")),
+        "updated_at": _iso(doc.get("updated_at")),
+        "conversation_reference": canonical_reference,
+        "conversation_ref": {
+            "kind": "von_conversation_ref",
+            "schema_version": "conversation_reference.v1",
+            "conversation_ref": canonical_reference,
+        },
+        "turns": _structured_turns(doc),
+        "turn_receipts": _iso(dict(turn_receipts))
+        if isinstance(turn_receipts, Mapping)
+        else {},
+    }
+
+
+_QUESTION_PREFIXES = (
+    "who ",
+    "what ",
+    "when ",
+    "where ",
+    "why ",
+    "how ",
+    "which ",
+    "is ",
+    "are ",
+    "was ",
+    "were ",
+    "do ",
+    "does ",
+    "did ",
+    "can ",
+    "could ",
+    "would ",
+    "should ",
+    "have ",
+    "has ",
+)
+_CONTROL_OR_META_PREFIXES = (
+    "please stop",
+    "stop ",
+    "finish ",
+    "cancel ",
+    "skip ",
+    "next question",
+    "go back",
+    "i don't know",
+    "i do not know",
+    "no idea",
+    "did you represent",
+    "have you represented",
+    "record that",
+    "save that",
+)
+
+
+def classify_user_input(text: Any) -> dict[str, Any]:
+    """Conservatively distinguish asserted knowledge from conversational control."""
+
+    source_text = _required_text(text, field="input_text")
+    normalised = " ".join(source_text.casefold().split())
+    if normalised.endswith("?") or normalised.startswith(_QUESTION_PREFIXES):
+        return {
+            "kind": "user_question",
+            "asserted_knowledge": False,
+            "reason_code": "user_question_is_not_asserted_knowledge",
+        }
+    if normalised.startswith(_CONTROL_OR_META_PREFIXES):
+        return {
+            "kind": "meta_or_control",
+            "asserted_knowledge": False,
+            "reason_code": "meta_or_control_is_not_asserted_knowledge",
+        }
+    return {
+        "kind": "asserted_knowledge",
+        "asserted_knowledge": True,
+        "reason_code": "user_presented_content_as_knowledge",
+    }
+
+
+def _is_representation_status_query(text: str) -> bool:
+    """Recognise narrow meta questions that must be answered from receipts."""
+
+    normalised = " ".join(str(text or "").casefold().split())
+    return normalised.startswith(
+        (
+            "did you represent",
+            "have you represented",
+            "did you record that",
+            "did you store that",
+            "did you save that",
+            "is that represented",
+            "is this represented",
+            "was that represented",
+            "was this represented",
+        )
+    )
+
+
+def _latest_knowledge_turn_receipt(
+    doc: Mapping[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Find the latest prior turn with a material knowledge-write receipt."""
+
+    qa_state = doc.get("concept_q_and_a")
+    raw_receipts = (
+        qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else None
+    )
+    if not isinstance(raw_receipts, Mapping):
+        return None, None
+
+    def _is_material(receipt: Mapping[str, Any]) -> bool:
+        exact = receipt.get("exact_input")
+        if isinstance(exact, Mapping) and exact.get("status") in {
+            "stored",
+            "partial_or_failed",
+        }:
+            return True
+        formalisation = receipt.get("formalisation")
+        return isinstance(formalisation, Mapping) and formalisation.get("status") in {
+            "tentative",
+            "asserted",
+            "deferred",
+            "rejected",
+        }
+
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    for entry in reversed(history):
+        if not isinstance(entry, Mapping) or entry.get("role") != "user":
+            continue
+        turn_id = str(entry.get("turn_id") or "").strip()
+        receipt = raw_receipts.get(turn_id) if turn_id else None
+        if isinstance(receipt, Mapping) and _is_material(receipt):
+            return turn_id, dict(receipt)
+    for turn_id, receipt in reversed(list(raw_receipts.items())):
+        if isinstance(receipt, Mapping) and _is_material(receipt):
+            return str(turn_id), dict(receipt)
+    return None, None
+
+
+def _representation_status_from_receipts(doc: Mapping[str, Any]) -> dict[str, Any]:
+    """Produce a deterministic, qualified answer about prior representation."""
+
+    source_turn_id, receipt = _latest_knowledge_turn_receipt(doc)
+    if receipt is None:
+        return {
+            "schema_version": "concept_q_and_a_representation_status.v1",
+            "status": "no_receipt",
+            "source_turn_id": None,
+            "message": (
+                "I do not have a durable representation receipt for an earlier "
+                "factual input in this Q&A, so I cannot claim that it was "
+                "represented as knowledge."
+            ),
+        }
+
+    exact = receipt.get("exact_input")
+    exact = dict(exact) if isinstance(exact, Mapping) else {}
+    formalisation = receipt.get("formalisation")
+    formalisation = dict(formalisation) if isinstance(formalisation, Mapping) else {}
+    notes = receipt.get("notes")
+    notes = dict(notes) if isinstance(notes, Mapping) else {}
+    assertion_ids = [
+        str(value)
+        for value in exact.get("assertion_ids") or []
+        if isinstance(value, str) and value
+    ]
+    exact_status = str(exact.get("status") or "unknown")
+    formalisation_status = str(formalisation.get("status") or "not_attempted")
+    predicate_id = str(formalisation.get("predicate_concept_id") or "").strip()
+    activation_effect = str(formalisation.get("activation_effect") or "").strip()
+
+    if exact_status == "stored":
+        parts = [
+            (
+                "Your exact wording was stored as an actor-scoped text claim with "
+                "provenance."
+            )
+        ]
+    else:
+        parts = [
+            (
+                "Your words remain in the conversation transcript, but the exact "
+                "scoped text-claim write did not succeed; I therefore cannot say "
+                "they were represented as knowledge."
+            )
+        ]
+
+    if formalisation_status == "tentative":
+        relation = f" {predicate_id}" if predicate_id else ""
+        parts.append(
+            f"A typed{relation} relation was also stored as tentative; it is "
+            "not confirmed or available to asserted-only consumers."
+        )
+        if activation_effect == "organisation_membership":
+            parts.append("It does not activate organisation membership.")
+    elif formalisation_status == "asserted":
+        relation = f" {predicate_id}" if predicate_id else ""
+        parts.append(
+            f"The actor-scoped typed{relation} relation was confirmed and read "
+            "back as asserted; it was not published as a canonical concept relation."
+        )
+    elif formalisation_status == "rejected":
+        parts.append("The tentative typed relation was rejected.")
+    else:
+        reason_code = str(formalisation.get("reason_code") or "").strip()
+        reason_suffix = f" ({reason_code})" if reason_code else ""
+        parts.append(
+            "It was not autoformalised as a typed relation" + reason_suffix + "."
+        )
+
+    if notes.get("notes_updated") is True:
+        parts.append("The receipt says the canonical concept notes were also updated.")
+    else:
+        parts.append("The canonical concept notes were not changed by that turn.")
+
+    return {
+        "schema_version": "concept_q_and_a_representation_status.v1",
+        "status": "receipt_found",
+        "source_turn_id": source_turn_id,
+        "exact_input_status": exact_status,
+        "exact_assertion_ids": assertion_ids,
+        "formalisation_status": formalisation_status,
+        "formalisation_assertion_id": formalisation.get("assertion_id"),
+        "predicate_concept_id": predicate_id or None,
+        "canonical_publication": formalisation.get("canonical_publication") is True,
+        "concept_notes_status": notes.get("status"),
+        "concept_notes_updated": notes.get("notes_updated") is True,
+        "message": " ".join(parts),
+    }
+
+
+def _previous_assistant_context(doc: Mapping[str, Any]) -> tuple[str, dict | None]:
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    for entry in reversed(history):
+        if not isinstance(entry, Mapping) or entry.get("role") != "assistant":
+            continue
+        content = str(entry.get("content") or "").strip()
+        metadata = entry.get("concept_q_and_a")
+        predicate = (
+            metadata.get("elicitation_predicate")
+            if isinstance(metadata, Mapping)
+            else None
+        )
+        return content or "What would you like to tell me?", (
+            dict(predicate) if isinstance(predicate, Mapping) else None
+        )
+    return "What would you like to tell me?", None
+
+
+def _exact_input_item(
+    *,
+    session_id: str,
+    turn_id: str,
+    input_kind: str,
+    text: str,
+    concept: Mapping[str, Any],
+    session_doc: Mapping[str, Any],
+    previous_prompt: str,
+    proposed_predicate: Mapping[str, Any] | None,
+    transcript_only_reason: str | None = None,
+) -> dict[str, Any]:
+    classification = classify_user_input(text)
+    if transcript_only_reason:
+        classification = {
+            "kind": "meta_or_control",
+            "asserted_knowledge": False,
+            "reason_code": transcript_only_reason,
+        }
+    base = {
+        "schema_version": EXACT_INPUT_RECEIPT_SCHEMA_VERSION,
+        "kind": "exact_input",
+        "input_kind": input_kind,
+        "source_turn_id": turn_id,
+        "classification": classification["kind"],
+        "asserted_knowledge": classification["asserted_knowledge"],
+        "exact_source_text_preserved": True,
+        "canonical_publication": False,
+        "target_concept_id": concept.get("concept_id"),
+    }
+    if not classification["asserted_knowledge"]:
+        return {
+            **base,
+            "status": "not_admitted",
+            "effect_status": "not_needed",
+            "reason_code": classification["reason_code"],
+        }
+    try:
+        stored = concept_service._store_concept_qa_input_assertion(
+            interaction_id=session_id,
+            input_kind=input_kind,
+            input_ordinal=1,
+            question_or_statement=previous_prompt,
+            input_text=text,
+            concept=concept,
+            session=session_doc,
+            proposed_predicate=proposed_predicate,
+            source_event_id=(
+                f"concept_q_and_a:{session_id}:turn:{turn_id}:{input_kind}"
+            ),
+        )
+        return {**base, **stored, "reason_code": classification["reason_code"]}
+    except Exception:  # noqa: BLE001 - exact-input receipt must report storage failure
+        return {
+            **base,
+            "status": "failed",
+            "effect_status": "failed",
+            "error_code": "exact_input_assertion_write_failed",
+            "reason_code": classification["reason_code"],
+        }
+
+
+def _aggregate_exact_input_receipt(
+    *,
+    session_id: str,
+    turn_id: str,
+    answer: str,
+    notes_input: str,
+    concept: Mapping[str, Any],
+    session_doc: Mapping[str, Any],
+    transcript_only_reason: str | None = None,
+) -> dict[str, Any]:
+    previous_prompt, proposed_predicate = _previous_assistant_context(session_doc)
+    items = []
+    if answer:
+        items.append(
+            _exact_input_item(
+                session_id=session_id,
+                turn_id=turn_id,
+                input_kind="answer",
+                text=answer,
+                concept=concept,
+                session_doc=session_doc,
+                previous_prompt=previous_prompt,
+                proposed_predicate=proposed_predicate,
+                transcript_only_reason=transcript_only_reason,
+            )
+        )
+    if notes_input:
+        items.append(
+            _exact_input_item(
+                session_id=session_id,
+                turn_id=turn_id,
+                input_kind="notes",
+                text=notes_input,
+                concept=concept,
+                session_doc=session_doc,
+                previous_prompt="User-provided concept notes during Q&A",
+                proposed_predicate=proposed_predicate if not answer else None,
+                transcript_only_reason=transcript_only_reason,
+            )
+        )
+    stored_ids = [
+        str(item.get("assertion_id"))
+        for item in items
+        if item.get("status") == "stored" and item.get("assertion_id")
+    ]
+    if any(item.get("status") == "failed" for item in items):
+        status, effect_status = "partial_or_failed", "failed"
+    elif stored_ids:
+        status, effect_status = "stored", "succeeded"
+    else:
+        status, effect_status = "not_admitted", "not_needed"
+    return {
+        "schema_version": EXACT_INPUT_RECEIPT_SCHEMA_VERSION,
+        "kind": "exact_input",
+        "status": status,
+        "effect_status": effect_status,
+        "assertion_ids": stored_ids,
+        "items": items,
+        "exact_source_text_preserved": True,
+        "canonical_publication": False,
+    }
+
+
+def _confirmation_action(*, concept_id: str, session_id: str, assertion_id: str) -> str:
+    return (
+        f"/api/concepts/{quote(concept_id, safe='')}/q_and_a/sessions/"
+        f"{quote(session_id, safe='')}/formalisations/"
+        f"{quote(assertion_id, safe='')}/confirm"
+    )
+
+
+def _deferred_formalisation_receipt(
+    *,
+    exact_input: Mapping[str, Any],
+    proposed_predicate: Any,
+    reason_code: str,
+    resolution: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    admitted_items = [
+        item
+        for item in exact_input.get("items", [])
+        if isinstance(item, Mapping) and item.get("status") == "stored"
+    ]
+    base = {
+        "schema_version": FORMALISATION_RECEIPT_SCHEMA_VERSION,
+        "kind": "formalisation",
+        "canonical_publication": False,
+    }
+    if not admitted_items:
+        return {
+            **base,
+            "status": "not_applicable",
+            "effect_status": "not_needed",
+            "reason_code": "no_asserted_knowledge_admitted",
+        }
+    receipt = {
+        **base,
+        "status": "deferred",
+        "effect_status": "not_started",
+        "reason_code": reason_code,
+        "candidate": (
+            dict(proposed_predicate)
+            if isinstance(proposed_predicate, Mapping)
+            else None
+        ),
+        "elicitation_requirement": (
+            concept_service._project_elicitation_metadata(proposed_predicate)
+            if isinstance(proposed_predicate, Mapping)
+            else None
+        ),
+        "automatic_formalisation_attempted": resolution is not None,
+    }
+    if isinstance(resolution, Mapping):
+        receipt["resolution"] = {
+            key: resolution.get(key)
+            for key in ("status", "resolved_concept_id", "candidates")
+        }
+    return receipt
+
+
+_UNSAFE_ENTITY_ANSWER_RE = re.compile(
+    r"(?:[;.!?]|\b(?:and|or|not|no|never|if|unless|maybe|perhaps|possibly|"
+    r"could|would|might|should|is|are|was|were|belongs?|members?|works?|"
+    r"said|says|according)\b)",
+    re.IGNORECASE,
+)
+
+
+def _safe_single_entity_answer(answer: str) -> bool:
+    cleaned = " ".join(str(answer or "").split())
+    return bool(
+        cleaned
+        and len(cleaned) <= 160
+        and len(cleaned.split()) <= 8
+        and not _UNSAFE_ENTITY_ANSWER_RE.search(cleaned)
+    )
+
+
+def _tentative_formalisation_receipt(
+    *,
+    exact_input: Mapping[str, Any],
+    answer: str,
+    proposed_predicate: Any,
+    concept_id: str,
+    concept_name: str,
+    session_id: str,
+    turn_id: str,
+    user_id: str,
+    organisation_concept_id: str | None,
+    namespace: str,
+) -> dict[str, Any]:
+    predicate = (
+        dict(proposed_predicate) if isinstance(proposed_predicate, Mapping) else None
+    )
+    predicate_id = str((predicate or {}).get("predicate_concept_id") or "").strip()
+    focal_argument = str((predicate or {}).get("focal_argument") or "").strip()
+    other_type = str(
+        (predicate or {}).get("other_argument_type_concept_id") or ""
+    ).strip()
+    if not any(
+        isinstance(item, Mapping) and item.get("status") == "stored"
+        for item in exact_input.get("items", [])
+    ):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="no_asserted_knowledge_admitted",
+        )
+    if (predicate or {}).get("auto_formalisation_allowed") is not True or str(
+        (predicate or {}).get("auto_formalisation_target_status") or ""
+    ) != "tentative":
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="auto_formalisation_permission_missing",
+        )
+    if not predicate_id.startswith("#V#"):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="no_unambiguous_known_predicate_candidate",
+        )
+    if focal_argument not in {"subject", "object"} or not other_type.startswith("#V#"):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="predicate_endpoint_contract_incomplete",
+        )
+    answer_item = next(
+        (
+            item
+            for item in exact_input.get("items", [])
+            if isinstance(item, Mapping)
+            and item.get("input_kind") == "answer"
+            and item.get("status") == "stored"
+        ),
+        None,
+    )
+    if answer_item is None:
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="no_asserted_answer_available_for_formalisation",
+        )
+    if not _safe_single_entity_answer(answer):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="answer_is_not_a_safe_single_entity_reference",
+        )
+    try:
+        from ..security.access_control import override_current_actor
+
+        with override_current_actor(user_id, organisation_concept_id):
+            resolution = concept_resolution_service.resolve_concept_by_name(
+                name=answer,
+                instance_of=other_type,
+                match_code_strings=False,
+                max_results=3,
+            )
+    except Exception:  # noqa: BLE001 - resolution adapters fail as a deferred candidate
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="entity_resolution_failed",
+        )
+    resolved_id = str(resolution.get("resolved_concept_id") or "").strip()
+    if resolution.get("status") != "resolved" or not resolved_id.startswith("#V#"):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code=(
+                "entity_reference_ambiguous"
+                if resolution.get("status") == "ambiguous"
+                else "entity_reference_not_found"
+            ),
+            resolution=resolution,
+        )
+    subject_id = concept_id if focal_argument == "subject" else resolved_id
+    object_id = resolved_id if focal_argument == "subject" else concept_id
+    source_assertion_ids = [
+        str(item.get("assertion_id"))
+        for item in exact_input.get("items", [])
+        if isinstance(item, Mapping)
+        and item.get("status") == "stored"
+        and item.get("assertion_id")
+    ]
+    try:
+        stored = scoped_assertion_service.upsert_scoped_assertion(
+            subject_concept_id=subject_id,
+            predicate=predicate_id,
+            target_concept_id=object_id,
+            scope_mode="user",
+            evidence={
+                "source_kind": "concept_q_and_a_exact_input",
+                "source_session_id": session_id,
+                "source_turn_id": turn_id,
+                "source_assertion_ids": source_assertion_ids,
+                "exact_source_text": answer,
+                "elicitation_predicate": predicate,
+            },
+            acting_user_concept_id=user_id,
+            organisation_concept_id=organisation_concept_id,
+            namespace=namespace,
+            turn_id=turn_id,
+            canonical_publication=False,
+            epistemic_status="tentative",
+        )
+    except PermissionError:
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="formalisation_endpoint_not_visible",
+            resolution=resolution,
+        )
+    except ValueError:
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="formalisation_predicate_or_types_incompatible",
+            resolution=resolution,
+        )
+    except Exception:  # noqa: BLE001 - formalisation adapters fail as a deferred candidate
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="tentative_formalisation_write_failed",
+            resolution=resolution,
+        )
+    assertion_id = str(stored.get("assertion_id") or "").strip()
+    read_back = stored.get("canonical_read_back")
+    if (
+        not assertion_id
+        or not isinstance(read_back, Mapping)
+        or read_back.get("epistemic_status") != "tentative"
+    ):
+        return _deferred_formalisation_receipt(
+            exact_input=exact_input,
+            proposed_predicate=predicate,
+            reason_code="tentative_formalisation_readback_failed",
+            resolution=resolution,
+        )
+    membership_predicate = bool(
+        predicate_id.casefold() == "#v#memberof"
+        and focal_argument == "object"
+        and other_type.casefold() == "#v#von_user"
+        and object_id == concept_id
+    )
+    return {
+        "schema_version": FORMALISATION_RECEIPT_SCHEMA_VERSION,
+        "kind": "formalisation",
+        "status": "tentative",
+        "effect_status": "succeeded",
+        "reason_code": "safe_tentative_formalisation_stored",
+        "assertion_id": assertion_id,
+        "subject_concept_id": subject_id,
+        "predicate_concept_id": predicate_id,
+        "object_concept_id": object_id,
+        "focal_argument": focal_argument,
+        "other_argument_type_concept_id": other_type,
+        "focal_concept_id": concept_id,
+        "requirement_id": (predicate or {}).get("requirement_id"),
+        "declared_on_type_concept_id": (predicate or {}).get(
+            "declared_on_type_concept_id"
+        ),
+        "inherited": (predicate or {}).get("inherited"),
+        "declaration_depth": (predicate or {}).get("declaration_depth"),
+        "declaration_source": (predicate or {}).get("declaration_source"),
+        "profile_predicate": (predicate or {}).get("profile_predicate"),
+        "elicitation_requirement": concept_service._project_elicitation_metadata(
+            predicate or {}
+        ),
+        "focal_concept_name": concept_name,
+        "confirmation_question_template": (predicate or {}).get(
+            "confirmation_question_template"
+        ),
+        "source_assertion_ids": source_assertion_ids,
+        "exact_source_text_preserved": True,
+        "epistemic_status": "tentative",
+        "canonical_publication": False,
+        "automatic_authority_grant": False,
+        "activation_effect": "organisation_membership"
+        if membership_predicate
+        else "scoped_assertion_epistemic_promotion",
+        "canonical_read_back": dict(read_back),
+        "confirmation": {
+            "available": True,
+            "method": "POST",
+            "action": _confirmation_action(
+                concept_id=concept_id,
+                session_id=session_id,
+                assertion_id=assertion_id,
+            ),
+            "requires_operational_authority": membership_predicate,
+            "actor_scope": "original_q_and_a_actor",
+            "available_after_finish": True,
+            "available_after_cancel": False,
+        },
+    }
+
+
+def _initial_notes_receipt() -> dict[str, Any]:
+    return {
+        "schema_version": NOTES_RECEIPT_SCHEMA_VERSION,
+        "kind": "notes",
+        "status": "not_attempted",
+        "effect_status": "not_needed",
+        "reason_code": "downstream_processing_not_started",
+    }
+
+
+def _record_turn_receipt(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    turn_id: str,
+    receipt: Mapping[str, Any],
+) -> None:
+    query = _actor_query(
+        user_id=user_id,
+        namespace=namespace,
+        session_id=session_id,
+    )
+    try:
+        result = _collection().update_one(
+            query,
+            {
+                "$set": {
+                    f"concept_q_and_a.turn_receipts.{turn_id}": dict(receipt),
+                    "updated_at": _now(),
+                }
+            },
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not persist the Q&A representation receipt",
+            error_code="turn_receipt_write_failed",
+        ) from exc
+    if getattr(result, "matched_count", 0) != 1:
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+
+
+def _legacy_history_from_chat(
+    doc: Mapping[str, Any], *, exclude_turn_id: str | None = None
+) -> list[dict[str, Any]]:
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    legacy: list[dict[str, Any]] = []
+    for entry in history:
+        if not isinstance(entry, Mapping) or entry.get("turn_id") == exclude_turn_id:
+            continue
+        role = entry.get("role")
+        content = str(entry.get("content") or "")
+        metadata = entry.get("concept_q_and_a")
+        timestamp = entry.get("timestamp") or _now()
+        if role == "assistant":
+            interaction_type = (
+                "llm_question" if content.rstrip().endswith("?") else "llm_statement"
+            )
+            detail_key = (
+                "question" if interaction_type == "llm_question" else "statement"
+            )
+            details: dict[str, Any] = {detail_key: content}
+            if isinstance(metadata, Mapping) and isinstance(
+                metadata.get("elicitation_predicate"), Mapping
+            ):
+                details["elicitation_predicate"] = dict(
+                    metadata["elicitation_predicate"]
+                )
+        elif role == "user":
+            kind = metadata.get("input_kind") if isinstance(metadata, Mapping) else None
+            interaction_type = (
+                "user_question" if kind == "user_question" else "user_answer"
+            )
+            details = {"answer": content, "input_kind": kind or "answer"}
+        else:
+            continue
+        legacy.append(
+            {
+                "interaction_type": interaction_type,
+                "details": details,
+                "timestamp": timestamp,
+            }
+        )
+    return legacy
+
+
+def _representation_item(
+    exact_input: Mapping[str, Any], input_kind: str
+) -> dict[str, Any]:
+    for item in exact_input.get("items", []):
+        if isinstance(item, Mapping) and item.get("input_kind") == input_kind:
+            return dict(item)
+    return {
+        "status": "not_provided",
+        "effect_status": "not_needed",
+        "canonical_publication": False,
+    }
+
+
+def _current_elicitation_predicate(concept_id: str) -> dict[str, Any] | None:
+    try:
+        plan = concept_service._get_concept_elicitation_plan(concept_id)
+    except Exception:  # noqa: BLE001 - elicitation is optional fail-soft guidance
+        return None
+    if not plan or not isinstance(plan[0], Mapping):
+        return None
+    return concept_service._project_elicitation_metadata(plan[0])
+
+
+def _suppressed_predicate_ids(doc: Mapping[str, Any]) -> set[str]:
+    qa_state = doc.get("concept_q_and_a")
+    raw = (
+        qa_state.get("suppressed_predicate_ids")
+        if isinstance(qa_state, Mapping)
+        else []
+    )
+    return {
+        str(item).strip()
+        for item in (raw if isinstance(raw, list) else [])
+        if isinstance(item, str) and item.strip()
+    }
+
+
+def _suppressed_requirement_keys(doc: Mapping[str, Any]) -> set[str]:
+    qa_state = doc.get("concept_q_and_a")
+    raw = (
+        qa_state.get("suppressed_requirement_keys")
+        if isinstance(qa_state, Mapping)
+        else []
+    )
+    return {
+        str(item).strip()
+        for item in (raw if isinstance(raw, list) else [])
+        if isinstance(item, str) and item.strip()
+    }
+
+
+def _addressed_requirement_keys(doc: Mapping[str, Any]) -> set[str]:
+    qa_state = doc.get("concept_q_and_a")
+    raw = (
+        qa_state.get("addressed_requirement_keys")
+        if isinstance(qa_state, Mapping)
+        else []
+    )
+    return {
+        str(item).strip()
+        for item in (raw if isinstance(raw, list) else [])
+        if isinstance(item, str) and item.strip()
+    }
+
+
+def _addressed_predicate_ids(doc: Mapping[str, Any]) -> set[str]:
+    qa_state = doc.get("concept_q_and_a")
+    raw = (
+        qa_state.get("addressed_predicate_ids") if isinstance(qa_state, Mapping) else []
+    )
+    return {
+        str(item).strip()
+        for item in (raw if isinstance(raw, list) else [])
+        if isinstance(item, str) and item.strip()
+    }
+
+
+def _next_unsuppressed_elicitation_predicate(
+    *,
+    concept_id: str,
+    session_doc: Mapping[str, Any],
+    exclude_requirement: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    legacy_suppressed_predicates = _suppressed_predicate_ids(
+        session_doc
+    ) | _addressed_predicate_ids(session_doc)
+    suppressed_requirement_keys = _suppressed_requirement_keys(
+        session_doc
+    ) | _addressed_requirement_keys(session_doc)
+    excluded_requirement_key = (
+        concept_service._elicitation_requirement_identity(exclude_requirement)
+        if isinstance(exclude_requirement, Mapping)
+        else None
+    )
+    excluded_legacy_predicate = (
+        str(exclude_requirement.get("predicate_concept_id") or "").strip()
+        if isinstance(exclude_requirement, Mapping) and excluded_requirement_key is None
+        else ""
+    )
+    try:
+        plan = concept_service._get_concept_elicitation_plan(concept_id)
+    except Exception:  # noqa: BLE001 - elicitation is optional fail-soft guidance
+        return None
+    for item in plan or []:
+        if not isinstance(item, Mapping):
+            continue
+        predicate_id = str(item.get("predicate_concept_id") or "").strip()
+        requirement_key = concept_service._elicitation_requirement_identity(item)
+        if requirement_key and requirement_key in suppressed_requirement_keys:
+            continue
+        if predicate_id and predicate_id in legacy_suppressed_predicates:
+            continue
+        if excluded_requirement_key and requirement_key == excluded_requirement_key:
+            continue
+        if excluded_legacy_predicate and predicate_id == excluded_legacy_predicate:
+            continue
+        return concept_service._project_elicitation_metadata(item)
+    return None
+
+
+def _suppress_confirmation_requirement(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    formalisation: Mapping[str, Any],
+    disposition: str,
+) -> None:
+    predicate_id = str(formalisation.get("predicate_concept_id") or "").strip()
+    if not predicate_id:
+        return
+    requirement_key = concept_service._elicitation_requirement_identity(formalisation)
+    suppression = {
+        "requirement_key": requirement_key,
+        "requirement_id": formalisation.get("requirement_id"),
+        "predicate_concept_id": predicate_id,
+        "focal_argument": formalisation.get("focal_argument"),
+        "other_argument_type_concept_id": formalisation.get(
+            "other_argument_type_concept_id"
+        ),
+        "declared_on_type_concept_id": formalisation.get("declared_on_type_concept_id"),
+        "declaration_source": formalisation.get("declaration_source"),
+        "profile_predicate": formalisation.get("profile_predicate"),
+        "assertion_id": formalisation.get("assertion_id"),
+        "disposition": disposition,
+    }
+    add_to_set: dict[str, Any] = {
+        "concept_q_and_a.suppressed_requirements": suppression,
+    }
+    if requirement_key:
+        add_to_set["concept_q_and_a.suppressed_requirement_keys"] = requirement_key
+    else:
+        # Legacy confirmation rows did not retain endpoint identity, so the
+        # predicate is the narrowest honest compatibility key available.
+        add_to_set["concept_q_and_a.suppressed_predicate_ids"] = predicate_id
+    try:
+        result = _collection().update_one(
+            _actor_query(
+                user_id=user_id,
+                namespace=namespace,
+                session_id=session_id,
+            ),
+            {
+                "$addToSet": add_to_set,
+                "$set": {"updated_at": _now()},
+            },
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not preserve the Q&A defer/reject disposition",
+            error_code="confirmation_disposition_write_failed",
+        ) from exc
+    if getattr(result, "matched_count", 0) != 1:
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+
+
+def _record_confirmed_requirement_disposition(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    formalisation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Prevent a confirmed actor-scoped relation from nagging in this conversation."""
+
+    predicate_id = str(formalisation.get("predicate_concept_id") or "").strip()
+    requirement_key = concept_service._elicitation_requirement_identity(formalisation)
+    disposition = {
+        "requirement_key": requirement_key,
+        "requirement_id": formalisation.get("requirement_id"),
+        "predicate_concept_id": predicate_id or None,
+        "focal_argument": formalisation.get("focal_argument"),
+        "other_argument_type_concept_id": formalisation.get(
+            "other_argument_type_concept_id"
+        ),
+        "declared_on_type_concept_id": formalisation.get("declared_on_type_concept_id"),
+        "disposition": "confirmed_for_conversation",
+        "canonical_requirement_satisfaction_claimed": False,
+    }
+    add_to_set: dict[str, Any] = {
+        "concept_q_and_a.requirement_dispositions": disposition,
+    }
+    if requirement_key:
+        add_to_set["concept_q_and_a.addressed_requirement_keys"] = requirement_key
+    elif predicate_id:
+        add_to_set["concept_q_and_a.addressed_predicate_ids"] = predicate_id
+    else:
+        return {
+            "status": "not_recorded",
+            "reason_code": "requirement_identity_unavailable",
+        }
+    try:
+        result = _collection().update_one(
+            _actor_query(
+                user_id=user_id,
+                namespace=namespace,
+                session_id=session_id,
+            ),
+            {
+                "$addToSet": add_to_set,
+                "$set": {"updated_at": _now()},
+            },
+        )
+    except PyMongoError:
+        return {
+            "status": "failed",
+            "reason_code": "conversation_requirement_disposition_write_failed",
+            "reconciliation_required": True,
+        }
+    if getattr(result, "matched_count", 0) != 1:
+        return {
+            "status": "failed",
+            "reason_code": "conversation_not_found",
+            "reconciliation_required": True,
+        }
+    return {
+        "status": "stored",
+        "requirement_key": requirement_key,
+        "canonical_requirement_satisfaction_claimed": False,
+    }
+
+
+def _pending_confirmation(doc: Mapping[str, Any]) -> dict[str, Any] | None:
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    for entry in reversed(history):
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get("role") == "user":
+            return None
+        if entry.get("role") != "assistant":
+            continue
+        metadata = entry.get("concept_q_and_a")
+        if not isinstance(metadata, Mapping):
+            return None
+        formalisation = metadata.get("formalisation")
+        if (
+            metadata.get("kind") == "formalisation_confirmation_request"
+            and isinstance(formalisation, Mapping)
+            and str(formalisation.get("assertion_id") or "").startswith("ska_")
+        ):
+            return dict(formalisation)
+        return None
+    return None
+
+
+def _confirmation_reply_kind(text: str) -> str | None:
+    normalised = re.sub(r"[^a-z0-9']+", " ", str(text or "").casefold()).strip()
+    if normalised in {
+        "yes",
+        "yes please",
+        "confirm",
+        "confirmed",
+        "correct",
+        "that's right",
+        "that is right",
+        "do it",
+    }:
+        return "affirm"
+    if normalised in {"no", "nope", "incorrect", "that's wrong", "that is wrong"}:
+        return "reject"
+    if normalised in {
+        "later",
+        "not now",
+        "defer",
+        "skip",
+        "leave it tentative",
+        "i don't know",
+        "i do not know",
+        "not sure",
+        "i'm not sure",
+        "i am not sure",
+        "unsure",
+        "no idea",
+    }:
+        return "defer"
+    return None
+
+
+def _locate_formalisation_receipt(
+    doc: Mapping[str, Any], assertion_id: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    qa_state = doc.get("concept_q_and_a")
+    receipts = qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else None
+    if not isinstance(receipts, Mapping):
+        return None, None
+    for source_turn_id, raw_receipt in receipts.items():
+        if not isinstance(raw_receipt, Mapping):
+            continue
+        formalisation = raw_receipt.get("formalisation")
+        if (
+            isinstance(formalisation, Mapping)
+            and formalisation.get("assertion_id") == assertion_id
+        ):
+            return str(source_turn_id), dict(formalisation)
+    return None, None
+
+
+def _record_formalisation_receipt(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    source_turn_id: str,
+    formalisation: Mapping[str, Any],
+) -> None:
+    try:
+        result = _collection().update_one(
+            _actor_query(
+                user_id=user_id,
+                namespace=namespace,
+                session_id=session_id,
+            ),
+            {
+                "$set": {
+                    f"concept_q_and_a.turn_receipts.{source_turn_id}.formalisation": dict(
+                        formalisation
+                    ),
+                    "updated_at": _now(),
+                }
+            },
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not persist the formalisation confirmation receipt",
+            error_code="formalisation_confirmation_receipt_write_failed",
+        ) from exc
+    if getattr(result, "matched_count", 0) != 1:
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+
+
+def _confirm_formalisation_effect(
+    *,
+    formalisation: Mapping[str, Any],
+    assertion_id: str,
+    user_id: str,
+    organisation_concept_id: str | None,
+    namespace: str,
+    request_id: str,
+    expected_focal_concept_id: str | None = None,
+) -> dict[str, Any]:
+    assertion = scoped_assertion_service.get_visible_scoped_assertion_by_id(
+        assertion_id,
+        user_concept_id=user_id,
+        organisation_concept_id=organisation_concept_id,
+    )
+    if not isinstance(assertion, Mapping):
+        return {
+            "success": False,
+            "status": "tentative",
+            "effect_status": "not_started",
+            "error_code": "tentative_formalisation_not_visible",
+            "actionable_denial": {
+                "mechanism": "ask the original asserting actor to confirm",
+            },
+        }
+    expected = {
+        "subject_concept_id": formalisation.get("subject_concept_id"),
+        "predicate": formalisation.get("predicate_concept_id"),
+        "object_concept_id": formalisation.get("object_concept_id"),
+    }
+    if any(assertion.get(key) != value for key, value in expected.items()):
+        return {
+            "success": False,
+            "status": "tentative",
+            "effect_status": "not_started",
+            "error_code": "formalisation_endpoint_readback_mismatch",
+        }
+    predicate_id = str(formalisation.get("predicate_concept_id") or "").strip()
+    focal_concept_id = str(
+        expected_focal_concept_id or formalisation.get("focal_concept_id") or ""
+    ).strip()
+    is_membership = bool(
+        predicate_id.casefold() == "#v#memberof"
+        and str(formalisation.get("focal_argument") or "").strip() == "object"
+        and str(formalisation.get("other_argument_type_concept_id") or "").casefold()
+        == "#v#von_user"
+        and focal_concept_id
+        and str(formalisation.get("object_concept_id") or "").strip()
+        == focal_concept_id
+    )
+    already_asserted = (assertion.get("epistemic_status") or "asserted") == "asserted"
+    if already_asserted and not is_membership:
+        return {
+            "success": True,
+            "status": "asserted",
+            "effect_status": "succeeded",
+            "changed": False,
+            "idempotent_replay": True,
+            "canonical_read_back": dict(assertion),
+        }
+
+    governance: dict[str, Any] | None = None
+    if is_membership:
+        from .organisation_membership_governance_service import (
+            manage_organisation_membership,
+        )
+        from .organisation_membership_service import (
+            resolve_user_organisation_membership,
+        )
+
+        member_id = str(formalisation.get("subject_concept_id") or "").strip()
+        organisation_id = str(formalisation.get("object_concept_id") or "").strip()
+
+        def _membership_read_back() -> dict[str, Any] | None:
+            try:
+                membership = resolve_user_organisation_membership(
+                    member_id,
+                    organisation_id,
+                )
+            except Exception:  # noqa: BLE001 - mutation path still supplies read-back
+                return None
+            if not isinstance(membership, Mapping):
+                return {
+                    "user_concept_id": member_id,
+                    "organisation_concept_id": organisation_id,
+                    "membership_present": False,
+                    "role": None,
+                }
+            return {
+                "user_concept_id": member_id,
+                "organisation_concept_id": organisation_id,
+                "membership_present": True,
+                # Confirmation needs only the exact membership postcondition;
+                # do not widen an actor-scoped Q&A receipt with another user's
+                # organisation role.
+                "role_projected": False,
+            }
+
+        membership_read_back = _membership_read_back()
+        if (
+            isinstance(membership_read_back, Mapping)
+            and membership_read_back.get("membership_present") is True
+        ):
+            governance = {
+                "success": True,
+                "effect_status": "succeeded",
+                "changed": False,
+                "idempotent_replay": True,
+                "postcondition_preexisting": True,
+                "canonical_read_back": dict(membership_read_back),
+                "authority_check_required": False,
+                "reason_code": "membership_already_present",
+            }
+        else:
+            governance = manage_organisation_membership(
+                action="add",
+                user_concept_id=member_id,
+                organisation_concept_id=organisation_id,
+                role="member",
+                request_id=request_id,
+                reason=(
+                    "Confirm actor-scoped tentative concept Q&A membership "
+                    f"formalisation {assertion_id}"
+                ),
+                acting_actor_concept_id=user_id,
+            )
+        if governance.get("success") is not True:
+            # An authorised administrator may have completed the canonical
+            # membership through its own actor-scoped management path after
+            # this actor's first attempt. Reconcile that postcondition before
+            # returning another authority denial.
+            reconciled_membership = _membership_read_back()
+            if (
+                isinstance(reconciled_membership, Mapping)
+                and reconciled_membership.get("membership_present") is True
+            ):
+                governance = {
+                    "success": True,
+                    "effect_status": "succeeded",
+                    "changed": False,
+                    "idempotent_replay": True,
+                    "postcondition_preexisting": True,
+                    "canonical_read_back": dict(reconciled_membership),
+                    "authority_check_required": False,
+                    "reason_code": "membership_present_after_reconciliation",
+                }
+            else:
+                authority = governance.get("authority_decision")
+                required_permissions = (
+                    authority.get("required_permissions")
+                    if isinstance(authority, Mapping)
+                    else ["MANAGE_MEMBERS"]
+                )
+                return {
+                    "success": False,
+                    "status": "tentative",
+                    "effect_status": governance.get("effect_status") or "not_started",
+                    "error_code": governance.get("error_code")
+                    or "organisation_membership_confirmation_denied",
+                    "authority_decision": authority,
+                    "governance_receipt": governance.get("governance_receipt"),
+                    "canonical_read_back": governance.get("canonical_read_back"),
+                    "actionable_denial": {
+                        "who_can_add_membership": (
+                            "an organisation admin or owner with the represented "
+                            "MANAGE_MEMBERS permission"
+                        ),
+                        "required_permissions": required_permissions,
+                        "mechanism": "canonical_organisation_membership_handoff",
+                        "membership_management_path": (
+                            "canonical organisation membership management"
+                        ),
+                        "same_q_and_a_action_available_to_other_actor": False,
+                        "original_actor_next_step": (
+                            "After an authorised actor adds the membership, the "
+                            "original Q&A actor can retry this Confirm action; it "
+                            "will reconcile the membership and promote the "
+                            "source-linked tentative assertion."
+                        ),
+                        "tentative_assertion_preserved": True,
+                    },
+                }
+        if already_asserted:
+            return {
+                "success": True,
+                "status": "asserted",
+                "effect_status": "succeeded",
+                "changed": bool(governance.get("changed")),
+                "idempotent_replay": not bool(governance.get("changed")),
+                "canonical_read_back": dict(assertion),
+                "governed_activation": governance,
+            }
+    try:
+        promoted = scoped_assertion_service.promote_scoped_assertion_epistemic_status(
+            assertion_id=assertion_id,
+            acting_user_concept_id=user_id,
+            organisation_concept_id=organisation_concept_id,
+            namespace=namespace,
+            request_id=request_id,
+        )
+    except PermissionError:
+        response = {
+            "success": False,
+            "status": "tentative",
+            "effect_status": "not_started",
+            "error_code": "formalisation_confirmation_actor_required",
+            "actionable_denial": {
+                "who_can_confirm": "the original asserting actor",
+                "tentative_assertion_preserved": True,
+            },
+        }
+        if governance is not None and governance.get("success") is True:
+            response.update(
+                {
+                    "effect_status": "partial_success",
+                    "error_code": "governed_activation_succeeded_assertion_promotion_pending",
+                    "governed_activation": governance,
+                    "canonical_read_back": governance.get("canonical_read_back"),
+                    "reconciliation_required": True,
+                }
+            )
+        return response
+    except Exception:  # noqa: BLE001 - preserve partial governed-effect receipt
+        response = {
+            "success": False,
+            "status": "tentative",
+            "effect_status": "failed",
+            "error_code": "formalisation_confirmation_failed",
+            "actionable_denial": {"tentative_assertion_preserved": True},
+        }
+        if governance is not None and governance.get("success") is True:
+            response.update(
+                {
+                    "effect_status": "partial_success",
+                    "error_code": "governed_activation_succeeded_assertion_promotion_pending",
+                    "governed_activation": governance,
+                    "canonical_read_back": governance.get("canonical_read_back"),
+                    "reconciliation_required": True,
+                }
+            )
+        return response
+    return {
+        "success": True,
+        "status": "asserted",
+        "effect_status": "succeeded",
+        "changed": promoted.get("changed"),
+        "assertion_id": assertion_id,
+        "canonical_read_back": promoted.get("canonical_read_back"),
+        "governed_activation": governance,
+    }
+
+
+def _confirmation_failure_message(confirmation: Mapping[str, Any]) -> str:
+    denial = confirmation.get("actionable_denial")
+    if isinstance(denial, Mapping) and denial.get("mechanism") == (
+        "canonical_organisation_membership_handoff"
+    ):
+        return (
+            "I could not add this membership with your current authority. The "
+            "tentative assertion is preserved. An authorised organisation admin "
+            "or owner can add the membership through canonical organisation "
+            "membership management; afterwards, return as the original Q&A actor "
+            "and retry Confirm."
+        )
+    return (
+        "I could not confirm that formalisation with the current actor's "
+        "authority. The tentative assertion is preserved in this actor-scoped "
+        "Q&A receipt."
+    )
+
+
+def _confirmation_question(
+    *, formalisation: Mapping[str, Any], answer_text: str
+) -> str:
+    template = str(formalisation.get("confirmation_question_template") or "").strip()
+    if template:
+        try:
+            rendered = template.format(
+                counterpart_name=answer_text,
+                instance_name=str(
+                    formalisation.get("focal_concept_name") or "this concept"
+                ),
+            ).strip()
+        except (KeyError, ValueError):
+            rendered = ""
+        if rendered:
+            return rendered
+    return f"I recorded a tentative relation for {answer_text}. Should I confirm it?"
+
+
+def _notes_receipt_from_downstream(result: Mapping[str, Any]) -> dict[str, Any]:
+    representation = result.get("representation")
+    notes = (
+        representation.get("concept_notes")
+        if isinstance(representation, Mapping)
+        else None
+    )
+    source = dict(notes) if isinstance(notes, Mapping) else {}
+    raw_status = str(source.get("status") or "not_attempted")
+    if source.get("effect_status") == "failed" or raw_status in {
+        "error",
+        "persistence_failed",
+    }:
+        status = "failed"
+    elif source.get("notes_updated") is True or raw_status == "updated":
+        status = "updated"
+    else:
+        status = "not_updated"
+    return {
+        "schema_version": NOTES_RECEIPT_SCHEMA_VERSION,
+        "kind": "notes",
+        "status": status,
+        "effect_status": source.get("effect_status") or "not_needed",
+        "notes_updated": source.get("notes_updated") is True,
+        "source_assertion_id": source.get("source_assertion_id"),
+        "reason_code": source.get("reason_code") or source.get("reason"),
+        "error_code": source.get("error_code"),
+    }
+
+
+def _append_turn_once(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    message: dict[str, Any],
+    require_active: bool,
+) -> dict[str, Any]:
+    expected = {"concept_q_and_a.lifecycle.status": ACTIVE} if require_active else None
+    result = chat_history_service.append_message_to_history_once(
+        user_id=user_id,
+        session_id=session_id,
+        namespace=namespace,
+        message=message,
+        expected_session_fields=expected,
+    )
+    if result.get("matched"):
+        return result
+    doc = _find_session(user_id=user_id, namespace=namespace, session_id=session_id)
+    if doc is None:
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+    status = _session_lifecycle(doc).get("status")
+    if require_active and status in TERMINAL_STATUSES:
+        raise ConceptQAConversationConflict(
+            f"Q&A conversation is {status}", error_code="conversation_terminal"
+        )
+    raise ConceptQAConversationConflict(
+        "Q&A turn could not be appended",
+        error_code="conversation_turn_compare_and_set_failed",
+    )
+
+
+def _ensure_initial_assistant_turn(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    concept: Mapping[str, Any],
+    session_doc: Mapping[str, Any],
+) -> None:
+    history = (
+        session_doc.get("history")
+        if isinstance(session_doc.get("history"), list)
+        else []
+    )
+    if any(
+        isinstance(item, Mapping) and item.get("role") == "assistant"
+        for item in history
+    ):
+        return
+    qa_state = session_doc.get("concept_q_and_a")
+    initial_notes = (
+        qa_state.get("initial_notes") if isinstance(qa_state, Mapping) else None
+    )
+    runtime_session = {
+        "user_id": user_id,
+        "organisation_concept_id": session_doc.get("organisation_concept_id"),
+        "namespace": namespace,
+        "llm_selection": qa_state.get("llm_selection")
+        if isinstance(qa_state, Mapping)
+        else None,
+    }
+    result = concept_service.generate_initial_question(
+        str(concept.get("concept_id")),
+        initial_notes=str(initial_notes or ""),
+        interaction_session=runtime_session,
+        persist_interaction_question=False,
+    )
+    if not isinstance(result, Mapping) or result.get("status") != "success":
+        raise ConceptQAConversationError(
+            "Could not generate the initial Q&A turn",
+            error_code=str(
+                (result or {}).get("status")
+                if isinstance(result, Mapping)
+                else "initial_question_failed"
+            ),
+        )
+    question = str(result.get("question") or "").strip()
+    if not question:
+        raise ConceptQAConversationError(
+            "Initial Q&A turn was empty", error_code="initial_question_empty"
+        )
+    emitted_predicate = result.get("elicitation_predicate")
+    elicitation_predicate = (
+        concept_service._project_elicitation_metadata(emitted_predicate)
+        if isinstance(emitted_predicate, Mapping)
+        else None
+    )
+    assistant_turn_id = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"von:concept-qa:{session_id}:initial-assistant")
+    )
+    metadata: dict[str, Any] = {"kind": "initial_question"}
+    if elicitation_predicate:
+        metadata["elicitation_predicate"] = elicitation_predicate
+    assistant_message: dict[str, Any] = {
+        "role": "assistant",
+        "content": question,
+        "turn_id": assistant_turn_id,
+        "concept_q_and_a": metadata,
+    }
+    llm_debug_data = _normalise_turn_llm_debug_data(result.get("llm_debug_data"))
+    if llm_debug_data is not None:
+        assistant_message["llm_debug_data"] = llm_debug_data
+    _append_turn_once(
+        user_id=user_id,
+        namespace=namespace,
+        session_id=session_id,
+        message=assistant_message,
+        require_active=True,
+    )
+
+
+def start_concept_qa_conversation(
+    *,
+    concept_id: str,
+    user_id: str,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    initial_notes: str | None = None,
+    initial_turn_id: str | None = None,
+    model_provider: str | None = None,
+    model: str | None = None,
+    model_parameters: Any = None,
+) -> dict[str, Any]:
+    """Start or resume the one active actor/concept Q&A conversation."""
+
+    actor_id = _normalise_actor_id(user_id, field="user_id")
+    org_id = _normalise_org_id(organisation_concept_id)
+    resolved_namespace = _resolve_namespace(
+        user_id=actor_id,
+        namespace=namespace,
+        organisation_concept_id=org_id,
+    )
+    concept = _load_focal_concept(
+        concept_id,
+        user_id=actor_id,
+        organisation_concept_id=org_id,
+    )
+    canonical_concept_id = str(concept["concept_id"])
+    collection = _collection()
+    active_query = _actor_query(user_id=actor_id, namespace=resolved_namespace)
+    active_query.update(
+        {
+            "focal_concept_ids": canonical_concept_id,
+            "concept_q_and_a.lifecycle.status": ACTIVE,
+        }
+    )
+    existing = collection.find_one(active_query, sort=[("updated_at", DESCENDING)])
+    created = False
+    initial_receipt_turn_id: str | None = None
+    if existing is None:
+        session_id = str(uuid.uuid4())
+        display_name = get_concept_display_name_with_names_fallback(concept)
+        llm_selection = concept_service._normalise_interaction_llm_selection(
+            provider=model_provider,
+            model=model,
+            model_parameters=model_parameters,
+        )
+        now = _now()
+        qa_state: dict[str, Any] = {
+            "schema_version": SESSION_SCHEMA_VERSION,
+            "concept": {
+                "concept_id": canonical_concept_id,
+                "storage_id": str(concept.get("_id") or ""),
+                "name": display_name,
+            },
+            "active_key": _active_key(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                concept_id=canonical_concept_id,
+            ),
+            "lifecycle": {
+                "status": ACTIVE,
+                "revision": 0,
+                "started_at": now,
+                "terminal_at": None,
+            },
+            "turn_receipts": {},
+            "initial_notes": str(initial_notes or "").strip() or None,
+        }
+        if llm_selection:
+            qa_state["llm_selection"] = llm_selection
+        try:
+            chat_history_service.create_chat_session(
+                user_id=actor_id,
+                session_id=session_id,
+                session_name=f"Concept Q&A: {display_name or canonical_concept_id}",
+                namespace=resolved_namespace,
+                organisation_concept_id=org_id,
+                mode=MODE,
+                origin_kind=ORIGIN_KIND,
+                created_by_actor_concept_id=actor_id,
+                focal_concept_ids=[canonical_concept_id],
+                concept_q_and_a_state=qa_state,
+            )
+            created = True
+            existing = _find_session(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=session_id,
+            )
+        except DuplicateKeyError:
+            # The partial unique active-key index is the concurrency boundary.
+            # Return the winner instead of creating a second active carrier.
+            created = False
+            existing = collection.find_one(
+                active_query, sort=[("updated_at", DESCENDING)]
+            )
+        if existing is None:
+            raise ConceptQAConversationError(
+                "Could not read back the Q&A carrier",
+                error_code="conversation_readback_failed",
+            )
+        notes_text = str(initial_notes or "").strip()
+        if created and notes_text:
+            start_turn_id = (
+                _required_text(initial_turn_id, field="initial_turn_id")
+                if initial_turn_id
+                else str(
+                    uuid.uuid5(
+                        uuid.NAMESPACE_URL,
+                        f"von:concept-qa:{session_id}:initial-notes",
+                    )
+                )
+            )
+            _append_turn_once(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=session_id,
+                message={
+                    "role": "user",
+                    "content": notes_text,
+                    "turn_id": start_turn_id,
+                    "concept_q_and_a": {
+                        "kind": "initial_notes",
+                        "input_kind": "asserted_knowledge",
+                    },
+                },
+                require_active=True,
+            )
+            existing = (
+                _find_session(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=session_id,
+                )
+                or existing
+            )
+            exact_input = _aggregate_exact_input_receipt(
+                session_id=session_id,
+                turn_id=start_turn_id,
+                answer="",
+                notes_input=notes_text,
+                concept=concept,
+                session_doc=existing,
+            )
+            _, predicate = _previous_assistant_context(existing)
+            receipt = {
+                "schema_version": TURN_RECEIPT_SCHEMA_VERSION,
+                "turn_id": start_turn_id,
+                "exact_input": exact_input,
+                "formalisation": _deferred_formalisation_receipt(
+                    exact_input=exact_input,
+                    proposed_predicate=predicate,
+                    reason_code="initial_notes_are_not_a_short_elicited_entity_answer",
+                ),
+                "notes": {
+                    **_initial_notes_receipt(),
+                    "reason_code": "initial_notes_are_prompt_context_only",
+                },
+            }
+            _record_turn_receipt(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=session_id,
+                turn_id=start_turn_id,
+                receipt=receipt,
+            )
+            initial_receipt_turn_id = start_turn_id
+    session_id = str(existing.get("session_id"))
+    refreshed = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=session_id,
+    )
+    if refreshed is None:
+        raise ConceptQAConversationError(
+            "Could not read back the Q&A carrier",
+            error_code="conversation_readback_failed",
+        )
+    _ensure_initial_assistant_turn(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=session_id,
+        concept=concept,
+        session_doc=refreshed,
+    )
+    readback = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=session_id,
+    )
+    if readback is None:
+        raise ConceptQAConversationError(
+            "Could not read back the initial Q&A turn",
+            error_code="conversation_readback_failed",
+        )
+    if initial_receipt_turn_id:
+        qa_state = readback.get("concept_q_and_a")
+        receipts = (
+            qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else None
+        )
+        initial_receipt = (
+            receipts.get(initial_receipt_turn_id)
+            if isinstance(receipts, Mapping)
+            else None
+        )
+        if isinstance(initial_receipt, Mapping) and not initial_receipt.get(
+            "completed_at"
+        ):
+            completed_initial_receipt = dict(initial_receipt)
+            completed_initial_receipt["completed_at"] = _now()
+            completed_initial_receipt["assistant_turn_id"] = str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"von:concept-qa:{session_id}:initial-assistant",
+                )
+            )
+            _record_turn_receipt(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=session_id,
+                turn_id=initial_receipt_turn_id,
+                receipt=completed_initial_receipt,
+            )
+            readback = (
+                _find_session(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=session_id,
+                )
+                or readback
+            )
+    return {**_project_session(readback), "created": created, "resumed": not created}
+
+
+def list_concept_qa_conversations(
+    *,
+    concept_id: str,
+    user_id: str,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    actor_id = _normalise_actor_id(user_id, field="user_id")
+    org_id = _normalise_org_id(organisation_concept_id)
+    resolved_namespace = _resolve_namespace(
+        user_id=actor_id,
+        namespace=namespace,
+        organisation_concept_id=org_id,
+    )
+    concept = _load_focal_concept(
+        concept_id,
+        user_id=actor_id,
+        organisation_concept_id=org_id,
+    )
+    canonical_concept_id = str(concept["concept_id"])
+    query = _actor_query(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=session_id,
+    )
+    query["focal_concept_ids"] = canonical_concept_id
+    try:
+        docs = list(
+            _collection(read_only=True)
+            .find(query)
+            .sort([("updated_at", DESCENDING), ("created_at", DESCENDING)])
+            .limit(_MAX_SESSIONS)
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not list Q&A conversations",
+            error_code="conversation_list_failed",
+        ) from exc
+    sessions = [_project_session(doc) for doc in docs]
+    active_session = next(
+        (
+            item
+            for item in sessions
+            if item.get("lifecycle", {}).get("status") == ACTIVE
+        ),
+        None,
+    )
+    legacy_active_interactions: list[dict[str, Any]] = []
+    try:
+        storage_id = str(concept.get("_id") or "")
+        if storage_id:
+            legacy_active_interactions = (
+                concept_service.get_active_interactions_for_concept(
+                    storage_id,
+                    actor_id,
+                    organisation_concept_id=org_id,
+                )[:_MAX_SESSIONS]
+            )
+    except Exception:  # noqa: BLE001 - legacy compatibility cannot block canonical listing
+        legacy_active_interactions = []
+    return {
+        "schema_version": "concept_q_and_a_collection.v1",
+        "concept_id": canonical_concept_id,
+        "sessions": sessions,
+        "active_session": active_session,
+        "legacy_active_interactions": _iso(legacy_active_interactions),
+        # Compatibility alias. The adjacent scope field makes it explicit that
+        # this legacy store projection contains active rows only.
+        "legacy_interactions": _iso(legacy_active_interactions),
+        "legacy_interaction_scope": "active_only",
+        "count": len(sessions),
+    }
+
+
+def submit_concept_qa_turn(
+    *,
+    concept_id: str,
+    session_id: str,
+    turn_id: str,
+    user_id: str,
+    answer: str,
+    notes_input: str | None = None,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+) -> dict[str, Any]:
+    actor_id = _normalise_actor_id(user_id, field="user_id")
+    resolved_session_id = _required_text(session_id, field="session_id")
+    resolved_turn_id = _required_text(turn_id, field="turn_id")
+    answer_text = answer.strip() if isinstance(answer, str) else ""
+    notes_text = notes_input.strip() if isinstance(notes_input, str) else ""
+    if not answer_text and not notes_text:
+        raise InvalidConceptQAConversationInput(
+            "answer or notes_input must contain text",
+            error_code="concept_q_and_a_input_required",
+        )
+    org_id = _normalise_org_id(organisation_concept_id)
+    resolved_namespace = _resolve_namespace(
+        user_id=actor_id,
+        namespace=namespace,
+        organisation_concept_id=org_id,
+    )
+    concept = _load_focal_concept(
+        concept_id,
+        user_id=actor_id,
+        organisation_concept_id=org_id,
+    )
+    canonical_concept_id = str(concept["concept_id"])
+    doc = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if doc is None or canonical_concept_id not in list(
+        doc.get("focal_concept_ids") or []
+    ):
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found for this concept",
+            error_code="conversation_not_found",
+        )
+    lifecycle = _session_lifecycle(doc)
+    if lifecycle.get("status") != ACTIVE:
+        raise ConceptQAConversationConflict(
+            f"Q&A conversation is {lifecycle.get('status') or 'not active'}",
+            error_code="conversation_terminal",
+        )
+    effective_org_id = _normalise_org_id(doc.get("organisation_concept_id")) or org_id
+    prior_doc = doc
+    pending_confirmation = _pending_confirmation(prior_doc)
+    representation_status_query = bool(
+        answer_text and not notes_text and _is_representation_status_query(answer_text)
+    )
+    confirmation_reply = (
+        _confirmation_reply_kind(answer_text)
+        if pending_confirmation is not None and answer_text and not notes_text
+        else None
+    )
+    transcript_only_reason = (
+        "confirmation_reply_is_control_evidence"
+        if confirmation_reply is not None
+        else "representation_status_query_is_control_evidence"
+        if representation_status_query
+        else None
+    )
+
+    transcript_entries: list[dict[str, Any]] = []
+    if answer_text:
+        classification = (
+            {"kind": "meta_or_control"}
+            if transcript_only_reason
+            else classify_user_input(answer_text)
+        )
+        transcript_entries.append(
+            {
+                "role": "user",
+                "content": answer_text,
+                "turn_id": resolved_turn_id,
+                "concept_q_and_a": {
+                    "kind": "user_input",
+                    "input_kind": classification["kind"],
+                    "confirmation_reply": confirmation_reply,
+                },
+            }
+        )
+    if notes_text:
+        notes_turn_id = (
+            resolved_turn_id
+            if not answer_text
+            else str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"von:concept-qa:{resolved_session_id}:{resolved_turn_id}:notes",
+                )
+            )
+        )
+        transcript_entries.append(
+            {
+                "role": "user",
+                "content": notes_text,
+                "turn_id": notes_turn_id,
+                "in_reply_to_turn_id": resolved_turn_id if answer_text else None,
+                "concept_q_and_a": {
+                    "kind": "user_input",
+                    "input_kind": "notes",
+                    "source_request_turn_id": resolved_turn_id,
+                },
+            }
+        )
+
+    primary_duplicate = False
+    for entry in transcript_entries:
+        append_result = _append_turn_once(
+            user_id=actor_id,
+            namespace=resolved_namespace,
+            session_id=resolved_session_id,
+            message=entry,
+            require_active=True,
+        )
+        existing_message = append_result.get("message")
+        if append_result.get("duplicate") and isinstance(existing_message, Mapping):
+            if existing_message.get("content") != entry["content"]:
+                raise ConceptQAConversationConflict(
+                    "turn_id was already used for different content",
+                    error_code="turn_id_content_conflict",
+                )
+            if entry["turn_id"] == resolved_turn_id:
+                primary_duplicate = True
+    if primary_duplicate:
+        replay_doc = _find_session(
+            user_id=actor_id,
+            namespace=resolved_namespace,
+            session_id=resolved_session_id,
+        )
+        qa_state = (
+            replay_doc.get("concept_q_and_a")
+            if isinstance(replay_doc, Mapping)
+            else None
+        )
+        receipts = (
+            qa_state.get("turn_receipts") if isinstance(qa_state, Mapping) else None
+        )
+        existing_receipt = (
+            receipts.get(resolved_turn_id) if isinstance(receipts, Mapping) else None
+        )
+        if isinstance(existing_receipt, Mapping) and existing_receipt.get(
+            "completed_at"
+        ):
+            return {
+                **_project_session(replay_doc),
+                "receipts": _iso(dict(existing_receipt)),
+                "turn_id": resolved_turn_id,
+                "replayed": True,
+            }
+
+    doc = (
+        _find_session(
+            user_id=actor_id,
+            namespace=resolved_namespace,
+            session_id=resolved_session_id,
+        )
+        or prior_doc
+    )
+    exact_input = _aggregate_exact_input_receipt(
+        session_id=resolved_session_id,
+        turn_id=resolved_turn_id,
+        answer=answer_text,
+        notes_input=notes_text,
+        concept=concept,
+        session_doc=prior_doc,
+        transcript_only_reason=transcript_only_reason,
+    )
+    _, proposed_predicate = _previous_assistant_context(prior_doc)
+    if pending_confirmation is not None and confirmation_reply is not None:
+        formalisation: dict[str, Any] = {
+            "schema_version": FORMALISATION_RECEIPT_SCHEMA_VERSION,
+            "kind": "formalisation_confirmation_reply",
+            "status": "processing",
+            "effect_status": "not_started",
+            "assertion_id": pending_confirmation.get("assertion_id"),
+            "reply_kind": confirmation_reply,
+        }
+    else:
+        formalisation = _tentative_formalisation_receipt(
+            exact_input=exact_input,
+            answer=answer_text,
+            proposed_predicate=proposed_predicate,
+            concept_id=canonical_concept_id,
+            concept_name=(
+                get_concept_display_name_with_names_fallback(concept)
+                or canonical_concept_id
+            ),
+            session_id=resolved_session_id,
+            turn_id=resolved_turn_id,
+            user_id=actor_id,
+            organisation_concept_id=effective_org_id,
+            namespace=resolved_namespace,
+        )
+    receipt: dict[str, Any] = {
+        "schema_version": TURN_RECEIPT_SCHEMA_VERSION,
+        "turn_id": resolved_turn_id,
+        "accepted_at": _now(),
+        "transcript_turn_ids": [entry["turn_id"] for entry in transcript_entries],
+        "exact_input": exact_input,
+        "formalisation": formalisation,
+        "notes": _initial_notes_receipt(),
+    }
+    _record_turn_receipt(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+        turn_id=resolved_turn_id,
+        receipt=receipt,
+    )
+
+    assistant_metadata: dict[str, Any]
+    downstream: Mapping[str, Any] | None = None
+    status = "success"
+    if representation_status_query:
+        representation_status = _representation_status_from_receipts(prior_doc)
+        receipt["formalisation"] = {
+            "schema_version": FORMALISATION_RECEIPT_SCHEMA_VERSION,
+            "kind": "formalisation",
+            "status": "not_applicable",
+            "effect_status": "not_needed",
+            "canonical_publication": False,
+            "reason_code": "representation_status_query_is_control_evidence",
+        }
+        receipt["notes"] = {
+            **_initial_notes_receipt(),
+            "reason_code": "representation_status_query_does_not_update_notes",
+        }
+        receipt["representation_status"] = representation_status
+        assistant_content = str(representation_status["message"])
+        assistant_metadata = {
+            "kind": "representation_status_response",
+            "representation_status": representation_status,
+        }
+    elif pending_confirmation is not None and confirmation_reply is not None:
+        assertion_id = str(pending_confirmation.get("assertion_id") or "")
+        source_turn_id, original_formalisation = _locate_formalisation_receipt(
+            doc, assertion_id
+        )
+        if not source_turn_id or not isinstance(original_formalisation, Mapping):
+            confirmation = {
+                "success": False,
+                "status": "tentative",
+                "effect_status": "not_started",
+                "error_code": "formalisation_confirmation_source_not_found",
+            }
+        elif confirmation_reply == "affirm":
+            confirmation = _confirm_formalisation_effect(
+                formalisation=original_formalisation,
+                assertion_id=assertion_id,
+                user_id=actor_id,
+                organisation_concept_id=effective_org_id,
+                namespace=resolved_namespace,
+                request_id=(
+                    f"concept_q_and_a:{resolved_session_id}:{assertion_id}:confirm"
+                ),
+                expected_focal_concept_id=canonical_concept_id,
+            )
+            if confirmation.get("success") is True:
+                confirmation = {
+                    **confirmation,
+                    "conversation_progress": _record_confirmed_requirement_disposition(
+                        user_id=actor_id,
+                        namespace=resolved_namespace,
+                        session_id=resolved_session_id,
+                        formalisation=original_formalisation,
+                    ),
+                }
+            updated_original = dict(original_formalisation)
+            updated_original["status"] = confirmation.get("status", "tentative")
+            updated_original["epistemic_status"] = confirmation.get(
+                "status", "tentative"
+            )
+            updated_original["effect_status"] = confirmation.get("effect_status")
+            if "canonical_read_back" in confirmation:
+                updated_original["canonical_read_back"] = confirmation.get(
+                    "canonical_read_back"
+                )
+            updated_original["confirmation"] = {
+                **dict(updated_original.get("confirmation") or {}),
+                "available": confirmation.get("success") is not True,
+                "last_attempt": confirmation,
+            }
+            _record_formalisation_receipt(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=resolved_session_id,
+                source_turn_id=source_turn_id,
+                formalisation=updated_original,
+            )
+        elif confirmation_reply == "reject":
+            try:
+                rejected = scoped_assertion_service.retract_scoped_assertion(
+                    assertion_id=assertion_id,
+                    acting_user_concept_id=actor_id,
+                    organisation_concept_id=effective_org_id,
+                    namespace=resolved_namespace,
+                )
+                confirmation = {
+                    "success": True,
+                    "status": "rejected",
+                    "effect_status": "succeeded",
+                    "changed": rejected.get("changed"),
+                    "canonical_read_back": rejected.get("canonical_read_back"),
+                }
+                updated_original = {
+                    **dict(original_formalisation),
+                    "status": "rejected",
+                    "epistemic_status": "rejected",
+                    "effect_status": confirmation.get("effect_status"),
+                    "canonical_read_back": confirmation.get("canonical_read_back"),
+                    "confirmation": {
+                        **dict(original_formalisation.get("confirmation") or {}),
+                        "available": False,
+                        "last_attempt": confirmation,
+                    },
+                }
+                _record_formalisation_receipt(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=resolved_session_id,
+                    source_turn_id=source_turn_id,
+                    formalisation=updated_original,
+                )
+            except Exception:  # noqa: BLE001 - rejection failure is a typed receipt
+                confirmation = {
+                    "success": False,
+                    "status": "tentative",
+                    "effect_status": "failed",
+                    "error_code": "tentative_formalisation_rejection_failed",
+                }
+        else:
+            confirmation = {
+                "success": True,
+                "status": "tentative",
+                "effect_status": "not_needed",
+                "changed": False,
+                "deferred": True,
+            }
+            if source_turn_id and isinstance(original_formalisation, Mapping):
+                updated_original = {
+                    **dict(original_formalisation),
+                    "confirmation": {
+                        **dict(original_formalisation.get("confirmation") or {}),
+                        "available": True,
+                        "last_attempt": confirmation,
+                    },
+                }
+                _record_formalisation_receipt(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=resolved_session_id,
+                    source_turn_id=source_turn_id,
+                    formalisation=updated_original,
+                )
+        next_predicate = None
+        if (
+            source_turn_id
+            and isinstance(original_formalisation, Mapping)
+            and confirmation_reply in {"affirm", "defer", "reject"}
+            and confirmation.get("success") is True
+        ):
+            if confirmation_reply in {"defer", "reject"}:
+                _suppress_confirmation_requirement(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=resolved_session_id,
+                    formalisation=original_formalisation,
+                    disposition=confirmation_reply,
+                )
+            progress_doc = (
+                _find_session(
+                    user_id=actor_id,
+                    namespace=resolved_namespace,
+                    session_id=resolved_session_id,
+                )
+                or doc
+            )
+            next_predicate = _next_unsuppressed_elicitation_predicate(
+                concept_id=canonical_concept_id,
+                session_doc=progress_doc,
+                exclude_requirement=(
+                    original_formalisation if confirmation_reply == "affirm" else None
+                ),
+            )
+        receipt["formalisation"] = {
+            **formalisation,
+            "status": confirmation.get("status"),
+            "effect_status": confirmation.get("effect_status"),
+            "confirmation": confirmation,
+        }
+        receipt["notes"] = {
+            **_initial_notes_receipt(),
+            "reason_code": "confirmation_control_turn_does_not_update_notes",
+        }
+        if confirmation.get("success") is True and confirmation_reply == "affirm":
+            assistant_content = (
+                "Confirmed. The formalisation has been read back as asserted."
+            )
+        elif confirmation_reply == "reject" and confirmation.get("success") is True:
+            assistant_content = "Understood. I rejected the tentative formalisation."
+        elif confirmation_reply == "defer":
+            assistant_content = "Understood. I left the formalisation tentative."
+        else:
+            assistant_content = _confirmation_failure_message(confirmation)
+            status = "partial_success"
+        if (
+            confirmation_reply in {"affirm", "defer", "reject"}
+            and confirmation.get("success") is True
+        ):
+            next_question = str((next_predicate or {}).get("question") or "").strip()
+            assistant_content = (
+                f"{assistant_content} {next_question}"
+                if next_question
+                else (
+                    f"{assistant_content} What other useful information should be "
+                    "recorded about this concept?"
+                )
+            )
+        assistant_metadata = {
+            "kind": "formalisation_confirmation_result",
+            "formalisation": receipt["formalisation"],
+        }
+        if next_predicate:
+            assistant_metadata["elicitation_predicate"] = next_predicate
+    else:
+        qa_state = prior_doc.get("concept_q_and_a")
+        transient_session = {
+            "concept_id": str(concept.get("_id") or ""),
+            "user_id": actor_id,
+            "organisation_concept_id": effective_org_id,
+            "namespace": resolved_namespace,
+            "history": _legacy_history_from_chat(prior_doc),
+            "llm_selection": qa_state.get("llm_selection")
+            if isinstance(qa_state, Mapping)
+            else None,
+            "suppressed_requirement_keys": list(
+                qa_state.get("suppressed_requirement_keys") or []
+            )
+            if isinstance(qa_state, Mapping)
+            else [],
+            "suppressed_predicate_ids": list(
+                qa_state.get("suppressed_predicate_ids") or []
+            )
+            if isinstance(qa_state, Mapping)
+            else [],
+            "addressed_requirement_keys": list(
+                qa_state.get("addressed_requirement_keys") or []
+            )
+            if isinstance(qa_state, Mapping)
+            else [],
+            "addressed_predicate_ids": list(
+                qa_state.get("addressed_predicate_ids") or []
+            )
+            if isinstance(qa_state, Mapping)
+            else [],
+        }
+        downstream = concept_service.submit_concept_answer(
+            interaction_id=resolved_session_id,
+            user_answer=answer_text,
+            user_notes_input=notes_text,
+            session=transient_session,
+            representation_overrides={
+                "exact_answer": _representation_item(exact_input, "answer"),
+                "notes_input": _representation_item(exact_input, "notes"),
+            },
+            persist_interaction_session=False,
+            allow_canonical_notes_update=False,
+        )
+        if not isinstance(downstream, Mapping) or downstream.get("status") != "success":
+            receipt["notes"] = {
+                "schema_version": NOTES_RECEIPT_SCHEMA_VERSION,
+                "kind": "notes",
+                "status": "failed",
+                "effect_status": "failed",
+                "error_code": str(
+                    downstream.get("status")
+                    if isinstance(downstream, Mapping)
+                    else "downstream_processing_failed"
+                ),
+            }
+            assistant_content = (
+                "I preserved your exact input and its representation receipt, but I "
+                "could not complete the notes update or next question. You can retry this turn."
+            )
+            assistant_metadata = {"kind": "downstream_processing_failed"}
+            status = "partial_success"
+        else:
+            receipt["notes"] = _notes_receipt_from_downstream(downstream)
+            assistant_content = str(downstream.get("next_step_content") or "").strip()
+            assistant_metadata = {
+                "kind": downstream.get("next_step_type") or "assistant_response",
+            }
+            if formalisation.get("status") == "tentative":
+                assistant_content = _confirmation_question(
+                    formalisation=formalisation,
+                    answer_text=answer_text,
+                )
+                assistant_metadata = {
+                    "kind": "formalisation_confirmation_request",
+                    "formalisation": {
+                        key: formalisation.get(key)
+                        for key in (
+                            "assertion_id",
+                            "subject_concept_id",
+                            "predicate_concept_id",
+                            "object_concept_id",
+                            "requirement_id",
+                            "focal_argument",
+                            "other_argument_type_concept_id",
+                            "declared_on_type_concept_id",
+                            "inherited",
+                            "declaration_depth",
+                            "declaration_source",
+                            "profile_predicate",
+                            "confirmation_question_template",
+                            "elicitation_requirement",
+                            "confirmation",
+                        )
+                    },
+                }
+            else:
+                emitted_predicate = downstream.get("elicitation_predicate")
+                next_predicate = (
+                    concept_service._project_elicitation_metadata(emitted_predicate)
+                    if isinstance(emitted_predicate, Mapping)
+                    else None
+                )
+                if next_predicate:
+                    assistant_metadata["elicitation_predicate"] = next_predicate
+        if not assistant_content:
+            assistant_content = "Your input was preserved. What else should I know?"
+
+    assistant_turn_id = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"von:concept-qa:{resolved_session_id}:{resolved_turn_id}:assistant",
+        )
+    )
+    assistant_message: dict[str, Any] = {
+        "role": "assistant",
+        "content": assistant_content,
+        "turn_id": assistant_turn_id,
+        "in_reply_to_turn_id": resolved_turn_id,
+        "concept_q_and_a": assistant_metadata,
+    }
+    llm_debug_data = _normalise_turn_llm_debug_data(
+        downstream.get("llm_debug_data") if isinstance(downstream, Mapping) else None
+    )
+    if llm_debug_data is not None:
+        assistant_message["llm_debug_data"] = llm_debug_data
+    _append_turn_once(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+        message=assistant_message,
+        require_active=False,
+    )
+    assistant_readback = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if not isinstance(assistant_readback, Mapping) or not any(
+        isinstance(entry, Mapping) and entry.get("turn_id") == assistant_turn_id
+        for entry in assistant_readback.get("history") or []
+    ):
+        raise ConceptQAConversationError(
+            "Could not read back the assistant Q&A turn",
+            error_code="assistant_turn_readback_failed",
+        )
+    receipt["assistant_turn_id"] = assistant_turn_id
+    receipt["completed_at"] = _now()
+    _record_turn_receipt(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+        turn_id=resolved_turn_id,
+        receipt=receipt,
+    )
+    readback = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if readback is None:
+        raise ConceptQAConversationError(
+            "Could not read back the completed Q&A turn",
+            error_code="conversation_readback_failed",
+        )
+    return {
+        **_project_session(readback),
+        "status": status,
+        "turn_id": resolved_turn_id,
+        "receipts": _iso(receipt),
+        "downstream_error": (
+            _iso(dict(downstream))
+            if status == "partial_success" and isinstance(downstream, Mapping)
+            else None
+        ),
+        "replayed": False,
+    }
+
+
+def confirm_concept_qa_formalisation(
+    *,
+    concept_id: str,
+    session_id: str,
+    assertion_id: str,
+    user_id: str,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    """Confirm one source-linked tentative relation and return canonical read-back."""
+
+    actor_id = _normalise_actor_id(user_id, field="user_id")
+    resolved_session_id = _required_text(session_id, field="session_id")
+    resolved_assertion_id = _required_text(assertion_id, field="assertion_id")
+    if not resolved_assertion_id.startswith("ska_"):
+        raise InvalidConceptQAConversationInput(
+            "assertion_id must identify a scoped assertion",
+            error_code="invalid_formalisation_assertion_id",
+        )
+    org_id = _normalise_org_id(organisation_concept_id)
+    resolved_namespace = _resolve_namespace(
+        user_id=actor_id,
+        namespace=namespace,
+        organisation_concept_id=org_id,
+    )
+    concept = _load_focal_concept(
+        concept_id,
+        user_id=actor_id,
+        organisation_concept_id=org_id,
+    )
+    canonical_concept_id = str(concept["concept_id"])
+    doc = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if doc is None or canonical_concept_id not in list(
+        doc.get("focal_concept_ids") or []
+    ):
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found for this concept",
+            error_code="conversation_not_found",
+        )
+    lifecycle_status = _session_lifecycle(doc).get("status")
+    if lifecycle_status == CANCELLED:
+        raise ConceptQAConversationConflict(
+            "A cancelled Q&A conversation cannot confirm formalisations",
+            error_code="conversation_cancelled",
+        )
+    if lifecycle_status not in {ACTIVE, FINISHED}:
+        raise ConceptQAConversationConflict(
+            "Q&A conversation is not confirmable",
+            error_code="conversation_not_confirmable",
+        )
+    source_turn_id, formalisation = _locate_formalisation_receipt(
+        doc, resolved_assertion_id
+    )
+    if not source_turn_id or not isinstance(formalisation, Mapping):
+        raise ConceptQAConversationNotFound(
+            "Tentative formalisation was not found in this Q&A conversation",
+            error_code="formalisation_not_found",
+        )
+    effective_org_id = _normalise_org_id(doc.get("organisation_concept_id")) or org_id
+    resolved_request_id = (
+        _required_text(request_id, field="request_id")
+        if request_id
+        else f"concept_q_and_a:{resolved_session_id}:{resolved_assertion_id}:confirm"
+    )
+    confirmation = _confirm_formalisation_effect(
+        formalisation=formalisation,
+        assertion_id=resolved_assertion_id,
+        user_id=actor_id,
+        organisation_concept_id=effective_org_id,
+        namespace=resolved_namespace,
+        request_id=resolved_request_id,
+        expected_focal_concept_id=canonical_concept_id,
+    )
+    if confirmation.get("success") is True:
+        confirmation = {
+            **confirmation,
+            "conversation_progress": _record_confirmed_requirement_disposition(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=resolved_session_id,
+                formalisation=formalisation,
+            ),
+        }
+    updated_formalisation = dict(formalisation)
+    updated_formalisation["status"] = confirmation.get("status", "tentative")
+    updated_formalisation["epistemic_status"] = confirmation.get("status", "tentative")
+    updated_formalisation["effect_status"] = confirmation.get("effect_status")
+    if "canonical_read_back" in confirmation:
+        updated_formalisation["canonical_read_back"] = confirmation.get(
+            "canonical_read_back"
+        )
+    updated_formalisation["confirmation"] = {
+        **dict(updated_formalisation.get("confirmation") or {}),
+        "available": confirmation.get("success") is not True,
+        "available_after_finish": True,
+        "available_after_cancel": False,
+        "last_attempt": confirmation,
+    }
+    _record_formalisation_receipt(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+        source_turn_id=source_turn_id,
+        formalisation=updated_formalisation,
+    )
+    next_predicate = None
+    if confirmation.get("success") is True and lifecycle_status == ACTIVE:
+        progress_doc = (
+            _find_session(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=resolved_session_id,
+            )
+            or doc
+        )
+        next_predicate = _next_unsuppressed_elicitation_predicate(
+            concept_id=canonical_concept_id,
+            session_doc=progress_doc,
+            exclude_requirement=updated_formalisation,
+        )
+        next_question = str((next_predicate or {}).get("question") or "").strip()
+        assistant_content = (
+            "Confirmed. The formalisation has been read back as asserted. "
+            + (
+                next_question
+                or "What other useful information should be recorded about this concept?"
+            )
+        )
+    elif confirmation.get("effect_status") == "partial_success":
+        assistant_content = (
+            "The governed activation succeeded, but the tentative assertion still "
+            "needs reconciliation. Its canonical read-back is preserved in the receipt."
+        )
+    else:
+        assistant_content = _confirmation_failure_message(confirmation)
+    result_turn_id: str | None = None
+    if lifecycle_status == ACTIVE:
+        result_turn_id = str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                (
+                    f"von:concept-qa:{resolved_session_id}:{resolved_assertion_id}:"
+                    f"direct-confirm:{confirmation.get('status')}:"
+                    f"{confirmation.get('effect_status')}"
+                ),
+            )
+        )
+        result_metadata: dict[str, Any] = {
+            "kind": "formalisation_confirmation_result",
+            "formalisation": updated_formalisation,
+            "confirmation_source": "explicit_action",
+        }
+        if next_predicate:
+            result_metadata["elicitation_predicate"] = next_predicate
+        try:
+            _append_turn_once(
+                user_id=actor_id,
+                namespace=resolved_namespace,
+                session_id=resolved_session_id,
+                message={
+                    "role": "assistant",
+                    "content": assistant_content,
+                    "turn_id": result_turn_id,
+                    "concept_q_and_a": result_metadata,
+                },
+                require_active=True,
+            )
+        except ConceptQAConversationConflict as exc:
+            if exc.error_code != "conversation_terminal":
+                raise
+            # The effect receipt is durable. If Finish won the race, keep the
+            # transcript terminal and let the response project the updated
+            # source receipt without appending a post-terminal turn.
+            result_turn_id = None
+    readback = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if readback is None:
+        raise ConceptQAConversationError(
+            "Could not read back formalisation confirmation",
+            error_code="formalisation_confirmation_readback_failed",
+        )
+    return {
+        **_project_session(readback),
+        "success": confirmation.get("success") is True,
+        "status": confirmation.get("status", "tentative"),
+        "effect_status": confirmation.get("effect_status"),
+        "assertion_id": resolved_assertion_id,
+        "source_turn_id": source_turn_id,
+        "assistant_turn_id": result_turn_id,
+        "confirmed_after_finish": (
+            _session_lifecycle(readback).get("status") == FINISHED
+        ),
+        "confirmation": _iso(confirmation),
+        "receipts": {"formalisation": _iso(updated_formalisation)},
+    }
+
+
+def transition_concept_qa_conversation(
+    *,
+    concept_id: str,
+    session_id: str,
+    user_id: str,
+    target_status: str,
+    namespace: str | None = None,
+    organisation_concept_id: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    if target_status not in TERMINAL_STATUSES:
+        raise InvalidConceptQAConversationInput(
+            "target_status must be finished or cancelled",
+            error_code="invalid_lifecycle_target",
+        )
+    actor_id = _normalise_actor_id(user_id, field="user_id")
+    resolved_session_id = _required_text(session_id, field="session_id")
+    org_id = _normalise_org_id(organisation_concept_id)
+    resolved_namespace = _resolve_namespace(
+        user_id=actor_id,
+        namespace=namespace,
+        organisation_concept_id=org_id,
+    )
+    concept = _load_focal_concept(
+        concept_id,
+        user_id=actor_id,
+        organisation_concept_id=org_id,
+    )
+    canonical_concept_id = str(concept["concept_id"])
+    query = _actor_query(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    query.update(
+        {
+            "focal_concept_ids": canonical_concept_id,
+            "concept_q_and_a.lifecycle.status": ACTIVE,
+        }
+    )
+    if expected_revision is not None:
+        if isinstance(expected_revision, bool) or not isinstance(
+            expected_revision, int
+        ):
+            raise InvalidConceptQAConversationInput(
+                "expected_revision must be an integer",
+                error_code="invalid_expected_revision",
+            )
+        query["concept_q_and_a.lifecycle.revision"] = expected_revision
+    now = _now()
+    try:
+        result = _collection().update_one(
+            query,
+            {
+                "$set": {
+                    "concept_q_and_a.lifecycle.status": target_status,
+                    "concept_q_and_a.lifecycle.terminal_at": now,
+                    "concept_q_and_a.lifecycle.terminal_reason": (
+                        "user_finished"
+                        if target_status == FINISHED
+                        else "user_cancelled"
+                    ),
+                    "updated_at": now,
+                },
+                "$inc": {"concept_q_and_a.lifecycle.revision": 1},
+                "$unset": {"concept_q_and_a.active_key": ""},
+            },
+        )
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not transition the Q&A lifecycle",
+            error_code="lifecycle_write_failed",
+        ) from exc
+    readback = _find_session(
+        user_id=actor_id,
+        namespace=resolved_namespace,
+        session_id=resolved_session_id,
+    )
+    if readback is None or canonical_concept_id not in list(
+        readback.get("focal_concept_ids") or []
+    ):
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+    lifecycle = _session_lifecycle(readback)
+    if getattr(result, "modified_count", 0) == 0:
+        if lifecycle.get("status") == target_status:
+            return {**_project_session(readback), "changed": False}
+        raise ConceptQAConversationConflict(
+            "Q&A lifecycle compare-and-set failed",
+            error_code="lifecycle_compare_and_set_failed",
+        )
+    if lifecycle.get("status") != target_status:
+        raise ConceptQAConversationError(
+            "Q&A lifecycle read-back did not match the requested state",
+            error_code="lifecycle_readback_failed",
+        )
+    return {**_project_session(readback), "changed": True}

--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -31,7 +31,16 @@ import os
 import uuid  # Added for GUID generation
 from datetime import datetime, timedelta, timezone  # Ensure timezone is imported
 import requests  # Added for requests.exceptions.ConnectionError
-from typing import Dict, Any, Optional, List, Tuple, Iterable, Mapping  # Added Tuple
+from typing import (  # Added Tuple
+    Dict,
+    Any,
+    Optional,
+    List,
+    Tuple,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from pymongo.errors import PyMongoError  # Added for DB operations
 
 try:
@@ -2706,7 +2715,7 @@ def _normalise_interaction_llm_selection(
 
 def _resolve_interaction_llm_runtime(
     interaction_session: Optional[Mapping[str, Any]] = None,
-) -> tuple[Any, Optional[str], Dict[str, Any]]:
+) -> tuple[Any, Optional[str], Dict[str, Any], Dict[str, Optional[str]]]:
     """Resolve one coherent actor-scoped client, model, and parameter bundle."""
 
     from ..languagemodels.llm_interface import (
@@ -2732,7 +2741,15 @@ def _resolve_interaction_llm_runtime(
                 user_concept_id=user_concept_id,
                 org_concept_id=org_concept_id,
             )
-            return client, model, dict(params) if isinstance(params, Mapping) else {}
+            return (
+                client,
+                model,
+                dict(params) if isinstance(params, Mapping) else {},
+                {
+                    "configured_provider": provider,
+                    "selected_provider": _llm_client_provider(client),
+                },
+            )
 
     active_setting = resolve_llm_setting(
         user_concept_id=user_concept_id,
@@ -2756,7 +2773,37 @@ def _resolve_interaction_llm_runtime(
         user_concept_id=user_concept_id,
         org_concept_id=org_concept_id,
     )
-    return client, model, dict(params or {})
+    return (
+        client,
+        model,
+        dict(params or {}),
+        {
+            "configured_provider": provider,
+            "selected_provider": _llm_client_provider(client),
+        },
+    )
+
+
+def _llm_client_provider(client: Any) -> Optional[str]:
+    """Identify the client actually returned, including cross-provider fallback."""
+
+    for attribute in ("provider_name", "provider", "client_type"):
+        value = getattr(client, attribute, None)
+        if (
+            isinstance(value, str)
+            and value.strip().lower() in _INTERACTION_LLM_PROVIDERS
+        ):
+            return value.strip().lower()
+    class_name = type(client).__name__.casefold()
+    for marker, provider in (
+        ("openrouter", "openrouter"),
+        ("gemini", "gemini"),
+        ("ollama", "ollama"),
+        ("openai", "openai"),
+    ):
+        if marker in class_name:
+            return provider
+    return None
 
 
 def _store_concept_qa_input_assertion(
@@ -2769,6 +2816,7 @@ def _store_concept_qa_input_assertion(
     concept: Mapping[str, Any],
     session: Mapping[str, Any],
     proposed_predicate: Optional[Mapping[str, Any]] = None,
+    source_event_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Preserve one exact Q&A input before semantic enrichment.
 
@@ -2798,8 +2846,10 @@ def _store_concept_qa_input_assertion(
     if resolved_input_kind not in {"answer", "question", "notes", "initial_notes"}:
         raise InvalidConceptDataError("Unsupported concept Q&A input kind")
     resolved_ordinal = max(1, input_ordinal)
-    source_event_id = (
-        f"concept_q_and_a:{interaction_id}:{resolved_input_kind}:{resolved_ordinal}"
+    resolved_source_event_id = (
+        str(source_event_id).strip()
+        if isinstance(source_event_id, str) and source_event_id.strip()
+        else f"concept_q_and_a:{interaction_id}:{resolved_input_kind}:{resolved_ordinal}"
     )
     organisation_concept_id = _canonical_organisation_concept_id(
         session.get("organisation_concept_id")
@@ -2827,12 +2877,12 @@ def _store_concept_qa_input_assertion(
         language="en-NZ",
         scope_mode="user",
         context_id=f"concept_q_and_a:{interaction_id}",
-        source_event_id=source_event_id,
+        source_event_id=resolved_source_event_id,
         evidence=evidence,
         acting_user_concept_id=user_id,
         organisation_concept_id=organisation_concept_id,
         namespace=namespace,
-        turn_id=source_event_id,
+        turn_id=resolved_source_event_id,
         canonical_publication=False,
     )
     assertion_id = str(receipt.get("assertion_id") or "").strip()
@@ -2860,7 +2910,7 @@ def _store_concept_qa_input_assertion(
         acting_user_concept_id=user_id,
         organisation_concept_id=organisation_concept_id,
         namespace=namespace,
-        turn_id=source_event_id,
+        turn_id=resolved_source_event_id,
     )
     return {
         "status": "stored",
@@ -2907,11 +2957,9 @@ def _record_initial_interaction_question(
     detail_key = "question" if interaction_type == "llm_question" else "statement"
     details: Dict[str, Any] = {detail_key: question_text}
     if interaction_type == "llm_question" and elicitation_predicate:
-        details["elicitation_predicate"] = {
-            "predicate_concept_id": elicitation_predicate.get("predicate_concept_id"),
-            "predicate_label": elicitation_predicate.get("predicate_label"),
-            "priority": elicitation_predicate.get("priority"),
-        }
+        details["elicitation_predicate"] = _project_elicitation_metadata(
+            elicitation_predicate
+        )
     entry = InteractionEntry(
         interaction_type=interaction_type,
         details=details,
@@ -3226,6 +3274,7 @@ def get_active_interactions_for_concept(
         query: dict[str, Any] = {
             "concept_id": ObjectId(concept_id),
             "user_id": user_id,
+            "status": "active",
         }
 
         org_scope_values = _organisation_scope_values(organisation_concept_id)
@@ -3353,11 +3402,171 @@ MINIMAL_IMPOSITION_QUESTION_TASK_INSTRUCTION = (
     "Only ask the human if their input is genuinely needed, likely known without extra work, "
     "and materially improves the concept. "
     "When asking, ask one concise, low-effort, high-value question. "
-    "Prefer the highest-priority missing salient predicate when it fits the "
-    "conversation; its represented predicate ID is a proposed formalisation "
-    "target, not proof that the user's answer fills it. "
+    "Prioritise an active unmet constitutive relation requirement before ordinary "
+    "salient-predicate opportunities. Respect its declaration_source: only a "
+    "requirement whose source is 'represented' may be described as represented; "
+    "'builtin_compatibility' is compatibility metadata, not represented knowledge. "
+    "Otherwise prefer the highest-priority useful salient predicate that fits the "
+    "conversation. Treat represented predicate, endpoint, and suggested-question "
+    "metadata as an elicitation target, never as proof that the user's answer fills it. "
+    "A safe, explicitly permitted autoformalisation is tentative until confirmed; "
+    "do not describe it as asserted, confirmed, or authority-activating. Let the user "
+    "defer or say they do not know without repeating or nagging about the same gap. "
     "Avoid broad or unrewarding requests. Ask at most one question in the response."
 )
+
+
+_ELICITATION_REQUIREMENT_IDENTITY_FIELDS = (
+    "requirement_id",
+    "predicate_concept_id",
+    "focal_argument",
+    "other_argument_type_concept_id",
+    "declared_on_type_concept_id",
+)
+
+ELICITATION_METADATA_FIELDS = (
+    "requirement_id",
+    "predicate_concept_id",
+    "predicate_label",
+    "priority",
+    "priority_class",
+    "requirement_kind",
+    "status",
+    "gap_status",
+    "reason",
+    "declared_on_type_concept_id",
+    "inherited",
+    "declaration_depth",
+    "declaration_source",
+    "profile_predicate",
+    "activation_relevance",
+    "authority_relevance",
+    "focal_argument",
+    "other_argument_type_concept_id",
+    "auto_formalisation_allowed",
+    "auto_formalisation_target_status",
+    "confirmation_required_for_activation",
+    "confirmation_question_template",
+    "question",
+)
+
+
+def _project_elicitation_metadata(item: Mapping[str, Any]) -> Dict[str, Any]:
+    """Project the bounded Q&A contract without losing declaration provenance."""
+
+    return {key: item.get(key) for key in ELICITATION_METADATA_FIELDS}
+
+
+def _normalise_emitted_question(value: Any) -> str:
+    """Normalise only presentation-level variation in an emitted question."""
+
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.strip().casefold().split())
+
+
+def _match_emitted_elicitation_requirement(
+    response_text: Any,
+    elicitation_plan: Sequence[Mapping[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Bind metadata only to the exact planned question actually emitted.
+
+    The plan is advisory input to the model. It is not safe to attach the first
+    plan item to an arbitrary question: doing so can invert endpoints or
+    autoformalise an answer under a predicate the user was never asked about.
+    A planned question is therefore bound only when it is the response's exact
+    final question. Duplicate wording with distinct requirement identities is
+    deliberately treated as ambiguous and left unbound.
+    """
+
+    emitted = _normalise_emitted_question(response_text)
+    if not emitted.endswith("?"):
+        return None
+    matches: List[Mapping[str, Any]] = []
+    for item in elicitation_plan:
+        if not isinstance(item, Mapping):
+            continue
+        planned_question = _normalise_emitted_question(item.get("question"))
+        if not planned_question or not planned_question.endswith("?"):
+            continue
+        if emitted == planned_question or emitted.endswith(f" {planned_question}"):
+            matches.append(item)
+    if not matches:
+        return None
+    identities = {
+        _elicitation_requirement_identity(item)
+        or json.dumps(
+            _project_elicitation_metadata(item),
+            ensure_ascii=True,
+            sort_keys=True,
+            default=str,
+        )
+        for item in matches
+    }
+    if len(identities) != 1:
+        return None
+    return _project_elicitation_metadata(matches[0])
+
+
+def _elicitation_requirement_identity(item: Mapping[str, Any]) -> Optional[str]:
+    """Return a stable identity only when requirement metadata is specific enough."""
+
+    values = {
+        key: str(item.get(key) or "").strip()
+        for key in _ELICITATION_REQUIREMENT_IDENTITY_FIELDS
+    }
+    if not (
+        values["predicate_concept_id"]
+        and values["focal_argument"]
+        and values["other_argument_type_concept_id"]
+        and (values["requirement_id"] or values["declared_on_type_concept_id"])
+    ):
+        return None
+    return "concept_q_and_a_requirement.v1:" + json.dumps(
+        values,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _filter_suppressed_elicitation_plan(
+    plan: Sequence[Mapping[str, Any]],
+    session: Optional[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Apply exact Q&A requirement dispositions, with predicate fallback for legacy rows."""
+
+    if not isinstance(session, Mapping):
+        return [dict(item) for item in plan if isinstance(item, Mapping)]
+    exact_keys = {
+        str(value).strip()
+        for value in (
+            list(session.get("suppressed_requirement_keys") or [])
+            + list(session.get("addressed_requirement_keys") or [])
+        )
+        if isinstance(value, str) and value.strip()
+    }
+    legacy_predicate_ids = {
+        str(value).strip()
+        for value in (
+            list(session.get("suppressed_predicate_ids") or [])
+            + list(session.get("addressed_predicate_ids") or [])
+        )
+        if isinstance(value, str) and value.strip()
+    }
+    filtered: List[Dict[str, Any]] = []
+    for raw_item in plan:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item = dict(raw_item)
+        identity = _elicitation_requirement_identity(item)
+        predicate_id = str(item.get("predicate_concept_id") or "").strip()
+        if identity is not None and identity in exact_keys:
+            continue
+        if predicate_id and predicate_id in legacy_predicate_ids:
+            continue
+        filtered.append(item)
+    return filtered
 
 
 def _get_concept_elicitation_plan(
@@ -3600,9 +3809,7 @@ def generate_concept_question(
 
     salient_projection = [
         {
-            "predicate_concept_id": item.get("predicate_concept_id"),
-            "predicate_label": item.get("predicate_label"),
-            "priority": item.get("priority"),
+            **_project_elicitation_metadata(item),
             "suggested_question": item.get("question"),
         }
         for item in (elicitation_plan or [])[:6]
@@ -3612,8 +3819,14 @@ def generate_concept_question(
         f"{filled.rstrip()}\n\n"
         "CURRENT MIXED-INITIATIVE AND REPRESENTATION RULE:\n"
         f"{MINIMAL_IMPOSITION_QUESTION_TASK_INSTRUCTION}\n"
-        "Missing salient-predicate opportunities, ordered by represented "
-        f"priority: {json.dumps(salient_projection, ensure_ascii=False)}\n"
+        "Missing constitutive-and-salient opportunities, ordered by declared "
+        "priority with declaration sources shown explicitly: "
+        f"{json.dumps(salient_projection, ensure_ascii=False)}\n"
+        "Use the suggested question only when it is useful in context; metadata is "
+        "an elicitation plan and not evidence that the relation holds.\n"
+        "If you use a suggested question, reproduce it exactly as the final "
+        "question in your response. A paraphrase or a different question will "
+        "remain unbound text and will not drive typed autoformalisation.\n"
         "If the latest input is a user question, do not ignore it in order to "
         "ask an elicitation question. If a follow-up is useful, answer first and "
         "then ask at most one concise question."
@@ -3639,6 +3852,10 @@ def submit_concept_answer(
     user_answer: str,
     session: dict,
     user_notes_input: Optional[str] = None,
+    *,
+    representation_overrides: Optional[Mapping[str, Any]] = None,
+    persist_interaction_session: bool = True,
+    allow_canonical_notes_update: bool = True,
 ) -> dict:
     """
     Submits a user's answer during an concept interaction, gets the LLM's next question or conclusion,
@@ -3799,46 +4016,58 @@ def submit_concept_answer(
         "canonical_publication": False,
     }
     if answer_text and answer_history_entry is not None:
-        answer_ordinal = sum(
-            1
-            for entry in current_history
-            if entry.get("interaction_type") in {"user_answer", "user_question"}
+        supplied_answer_representation = (
+            representation_overrides.get("exact_answer")
+            if isinstance(representation_overrides, Mapping)
+            else None
         )
-        try:
-            answer_representation = _store_concept_qa_input_assertion(
-                interaction_id=interaction_id,
-                input_kind=("question" if answer_text.endswith("?") else "answer"),
-                input_ordinal=answer_ordinal,
-                question_or_statement=previous_question,
-                input_text=answer_text,
-                concept=concept,
-                session=session,
-                proposed_predicate=(
-                    previous_elicitation_predicate
-                    if not answer_text.endswith("?")
-                    else None
-                ),
-            )
-            logger.info(
-                "Represented concept Q&A input as assertion %s about %s",
-                answer_representation.get("assertion_id"),
-                answer_representation.get("target_concept_id"),
-            )
-        except Exception as e:
-            logger.error(
-                "Could not preserve concept Q&A input %s for session %s: %s",
-                answer_ordinal,
-                interaction_id,
-                e,
-                exc_info=True,
-            )
+        if isinstance(supplied_answer_representation, Mapping):
+            answer_representation = dict(supplied_answer_representation)
+        elif answer_text.endswith("?"):
             answer_representation = {
-                "status": "failed",
-                "effect_status": "failed",
-                "error_code": "answer_assertion_write_failed",
+                "status": "not_admitted",
+                "effect_status": "not_needed",
+                "reason_code": "user_question_is_not_asserted_knowledge",
                 "target_concept_id": concept.get("concept_id"),
                 "canonical_publication": False,
             }
+        else:
+            answer_ordinal = sum(
+                1
+                for entry in current_history
+                if entry.get("interaction_type") in {"user_answer", "user_question"}
+            )
+            try:
+                answer_representation = _store_concept_qa_input_assertion(
+                    interaction_id=interaction_id,
+                    input_kind="answer",
+                    input_ordinal=answer_ordinal,
+                    question_or_statement=previous_question,
+                    input_text=answer_text,
+                    concept=concept,
+                    session=session,
+                    proposed_predicate=previous_elicitation_predicate,
+                )
+                logger.info(
+                    "Represented concept Q&A input as assertion %s about %s",
+                    answer_representation.get("assertion_id"),
+                    answer_representation.get("target_concept_id"),
+                )
+            except Exception as e:
+                logger.error(
+                    "Could not preserve concept Q&A input %s for session %s: %s",
+                    answer_ordinal,
+                    interaction_id,
+                    e,
+                    exc_info=True,
+                )
+                answer_representation = {
+                    "status": "failed",
+                    "effect_status": "failed",
+                    "error_code": "answer_assertion_write_failed",
+                    "target_concept_id": concept.get("concept_id"),
+                    "canonical_publication": False,
+                }
         answer_history_entry["details"]["representation"] = answer_representation
 
     notes_representation: Dict[str, Any] = {
@@ -3847,48 +4076,59 @@ def submit_concept_answer(
         "canonical_publication": False,
     }
     if notes_text and notes_history_entry is not None:
-        notes_ordinal = sum(
-            1
-            for entry in current_history
-            if entry.get("interaction_type")
-            in {"user_provided_notes", "user_provided_initial_notes"}
+        supplied_notes_representation = (
+            representation_overrides.get("notes_input")
+            if isinstance(representation_overrides, Mapping)
+            else None
         )
-        try:
-            notes_representation = _store_concept_qa_input_assertion(
-                interaction_id=interaction_id,
-                input_kind="notes",
-                input_ordinal=notes_ordinal,
-                question_or_statement="User-provided concept notes during Q&A",
-                input_text=notes_text,
-                concept=concept,
-                session=session,
-                proposed_predicate=(
-                    previous_elicitation_predicate if not answer_text else None
-                ),
+        if isinstance(supplied_notes_representation, Mapping):
+            notes_representation = dict(supplied_notes_representation)
+        else:
+            notes_ordinal = sum(
+                1
+                for entry in current_history
+                if entry.get("interaction_type")
+                in {"user_provided_notes", "user_provided_initial_notes"}
             )
-        except Exception as e:
-            logger.error(
-                "Could not preserve concept Q&A notes %s for session %s: %s",
-                notes_ordinal,
-                interaction_id,
-                e,
-                exc_info=True,
-            )
-            notes_representation = {
-                "status": "failed",
-                "effect_status": "failed",
-                "error_code": "notes_assertion_write_failed",
-                "target_concept_id": concept.get("concept_id"),
-                "canonical_publication": False,
-            }
+            try:
+                notes_representation = _store_concept_qa_input_assertion(
+                    interaction_id=interaction_id,
+                    input_kind="notes",
+                    input_ordinal=notes_ordinal,
+                    question_or_statement="User-provided concept notes during Q&A",
+                    input_text=notes_text,
+                    concept=concept,
+                    session=session,
+                    proposed_predicate=(
+                        previous_elicitation_predicate if not answer_text else None
+                    ),
+                )
+            except Exception as e:
+                logger.error(
+                    "Could not preserve concept Q&A notes %s for session %s: %s",
+                    notes_ordinal,
+                    interaction_id,
+                    e,
+                    exc_info=True,
+                )
+                notes_representation = {
+                    "status": "failed",
+                    "effect_status": "failed",
+                    "error_code": "notes_assertion_write_failed",
+                    "target_concept_id": concept.get("concept_id"),
+                    "canonical_publication": False,
+                }
         notes_history_entry["details"]["representation"] = notes_representation
 
     # IMPORTANT: Do synthesis FIRST before generating the next question
     # This ensures the next question is based on updated notes that include the current synthesis
     try:
-        llm_client, selected_model, llm_params = _resolve_interaction_llm_runtime(
-            session
-        )
+        (
+            llm_client,
+            selected_model,
+            llm_params,
+            llm_runtime,
+        ) = _resolve_interaction_llm_runtime(session)
         safe_model = selected_model or "default"
     except Exception as e:
         logger.error(
@@ -3915,7 +4155,11 @@ def submit_concept_answer(
             else None
         ),
     }
-    if answer_text and not answer_text.endswith("?"):
+    if (
+        allow_canonical_notes_update
+        and answer_text
+        and answer_representation.get("status") == "stored"
+    ):
         try:
             synthesis_outcome = synthesize_and_update_concept_notes(
                 concept_id=concept_id_str,
@@ -3975,6 +4219,15 @@ def submit_concept_answer(
                 "error_code": "synthesis_processing_failed",
             }
             # Continue because the exact answer may already be durably represented.
+    elif answer_text and answer_representation.get("status") == "stored":
+        synthesis_outcome = {
+            "status": "not_attempted",
+            "effect_status": "not_needed",
+            "synthesis": None,
+            "notes_updated": False,
+            "reason": "canonical_concept_edit_authority_not_delegated",
+            "source_assertion_id": answer_representation.get("assertion_id"),
+        }
     if answer_history_entry is not None:
         answer_history_entry["details"]["concept_notes_synthesis"] = synthesis_outcome
 
@@ -4007,6 +4260,10 @@ def submit_concept_answer(
     # concept_type_name_for_prompt was already calculated above, no need to recalculate
     elicitation_plan = _get_concept_elicitation_plan(
         str(concept.get("concept_id") or concept_id_str)
+    )
+    elicitation_plan = _filter_suppressed_elicitation_plan(
+        elicitation_plan,
+        session,
     )
 
     try:
@@ -4079,13 +4336,13 @@ def submit_concept_answer(
         llm_interaction_type = "llm_statement"
         llm_details_key = "statement"
 
+    emitted_elicitation_predicate = _match_emitted_elicitation_requirement(
+        llm_response_text,
+        elicitation_plan or [],
+    )
     llm_response_details: Dict[str, Any] = {llm_details_key: llm_response_text}
-    if llm_interaction_type == "llm_question" and elicitation_plan:
-        llm_response_details["elicitation_predicate"] = {
-            "predicate_concept_id": elicitation_plan[0].get("predicate_concept_id"),
-            "predicate_label": elicitation_plan[0].get("predicate_label"),
-            "priority": elicitation_plan[0].get("priority"),
-        }
+    if emitted_elicitation_predicate is not None:
+        llm_response_details["elicitation_predicate"] = emitted_elicitation_predicate
     llm_response_interaction_entry = InteractionEntry(
         interaction_type=llm_interaction_type,
         details=llm_response_details,
@@ -4095,23 +4352,26 @@ def submit_concept_answer(
 
     try:
         # Ensure interaction_id is ObjectId for MongoDB query
-        interaction_oid = (
-            ObjectId(interaction_id)
-            if not isinstance(interaction_id, ObjectId)
-            else interaction_id
-        )
+        if not persist_interaction_session:
+            update_result = None
+        else:
+            interaction_oid = (
+                ObjectId(interaction_id)
+                if not isinstance(interaction_id, ObjectId)
+                else interaction_id
+            )
 
-        update_result = interactions_collection.update_one(
-            {"_id": interaction_oid},
-            {
-                "$set": {
-                    "history": current_history,  # current_history has already been updated
-                    "last_updated_time": datetime.now(timezone.utc),
-                    "indexing_status": "pending",
-                }
-            },
-        )
-        if update_result.matched_count == 0:
+            update_result = interactions_collection.update_one(
+                {"_id": interaction_oid},
+                {
+                    "$set": {
+                        "history": current_history,
+                        "last_updated_time": datetime.now(timezone.utc),
+                        "indexing_status": "pending",
+                    }
+                },
+            )
+        if update_result is not None and update_result.matched_count == 0:
             logger.error(
                 f"Interaction session {interaction_id} (OID: {interaction_oid}) not found for update."
             )
@@ -4119,7 +4379,8 @@ def submit_concept_answer(
                 "error": "Interaction session not found for update",
                 "status": "error_db_update_notfound",
             }
-        logger.info(f"Successfully updated interaction session {interaction_id}")
+        if update_result is not None:
+            logger.info(f"Successfully updated interaction session {interaction_id}")
     except PyMongoError as e:
         logger.error(
             f"MongoDB error updating interaction session {interaction_id}: {e}"
@@ -4141,8 +4402,28 @@ def submit_concept_answer(
     return {
         "next_step_type": llm_interaction_type,
         "next_step_content": llm_response_text,
+        "elicitation_predicate": emitted_elicitation_predicate,
         "status": "success",
         "interaction_id": interaction_id,  # Return the original string ID
+        "llm_debug_data": {
+            "schema_version": "concept_q_and_a_llm_debug.v1",
+            "purpose": "concept_q_and_a_next_turn",
+            "requested": (
+                dict(session.get("llm_selection"))
+                if isinstance(session.get("llm_selection"), Mapping)
+                else None
+            ),
+            "configured": {
+                "provider": llm_runtime.get("configured_provider"),
+            },
+            "provider": llm_runtime.get("selected_provider"),
+            "model": safe_model,
+            "selected": {
+                "provider": llm_runtime.get("selected_provider"),
+                "model": safe_model,
+                "model_parameters": dict(llm_params or {}),
+            },
+        },
         "synthesis": synthesis_outcome.get("synthesis"),
         "synthesis_status": synthesis_outcome.get("status"),
         "representation": {
@@ -5182,6 +5463,8 @@ def generate_initial_question(
     concept_id: str,
     initial_notes: Optional[str] = None,
     interaction_session: Optional[Mapping[str, Any]] = None,
+    *,
+    persist_interaction_question: bool = True,
 ) -> dict:
     """
     Ask the LLM for the *first* question to pose about an concept.
@@ -5235,6 +5518,10 @@ def generate_initial_question(
     elicitation_plan = _get_concept_elicitation_plan(
         str(concept.get("concept_id") or concept_id)
     )
+    elicitation_plan = _filter_suppressed_elicitation_plan(
+        elicitation_plan,
+        interaction_session,
+    )
 
     # ------------------------------------------------------------------ 2. prompt
     try:
@@ -5258,9 +5545,12 @@ def generate_initial_question(
 
     # ------------------------------------------------------------------ 3. call LLM
     try:
-        llm_client, model_name, llm_params = _resolve_interaction_llm_runtime(
-            interaction_session
-        )
+        (
+            llm_client,
+            model_name,
+            llm_params,
+            llm_runtime,
+        ) = _resolve_interaction_llm_runtime(interaction_session)
         raw = llm_client.generate(
             prompt=final_prompt,
             model=model_name or "default",
@@ -5283,20 +5573,48 @@ def generate_initial_question(
     if not initial_question:
         initial_question = _build_minimal_imposition_fallback_question(display_name)
 
-    if interaction_session is not None:
+    emitted_elicitation_predicate = _match_emitted_elicitation_requirement(
+        initial_question,
+        elicitation_plan,
+    )
+
+    requested_selection = (
+        interaction_session.get("llm_selection")
+        if isinstance(interaction_session, Mapping)
+        else None
+    )
+    llm_debug_data = {
+        "schema_version": "concept_q_and_a_llm_debug.v1",
+        "purpose": "concept_q_and_a_initial_turn",
+        "requested": (
+            dict(requested_selection)
+            if isinstance(requested_selection, Mapping)
+            else None
+        ),
+        "configured": {
+            "provider": llm_runtime.get("configured_provider"),
+        },
+        "provider": llm_runtime.get("selected_provider"),
+        "model": model_name or "default",
+        "selected": {
+            "provider": llm_runtime.get("selected_provider"),
+            "model": model_name or "default",
+            "model_parameters": dict(llm_params or {}),
+        },
+    }
+
+    if interaction_session is not None and persist_interaction_question:
         _record_initial_interaction_question(
             interaction_session=interaction_session,
             question_or_statement=initial_question,
-            elicitation_predicate=(
-                elicitation_plan[0]
-                if initial_question.endswith("?") and elicitation_plan
-                else None
-            ),
+            elicitation_predicate=emitted_elicitation_predicate,
         )
 
     return {
         "question": initial_question,
         "status": "success",
+        "elicitation_predicate": emitted_elicitation_predicate,
+        "llm_debug_data": llm_debug_data,
         "concept": {
             "_id": str(concept.get("_id", concept_id)),
             "name": display_name,

--- a/src/backend/services/constitutive_relation_requirement_service.py
+++ b/src/backend/services/constitutive_relation_requirement_service.py
@@ -1,0 +1,996 @@
+"""Load and evaluate inheritable constitutive relation requirements.
+
+Constitutive requirements are represented on type concepts as JSON text values.
+They are deliberately separate from salient predicates: salience says that a
+relation is useful to ask about, while a constitutive requirement says that an
+instance remains incomplete until a qualifying relation is represented.
+
+Runtime evaluation is read-only.  It reports missing requirements for
+elicitation but does not reject concept creation or write a relation from free
+text. The versioned seed bundle is the single repository source for the
+temporary compatibility fallback and explicit release materialisation; a valid
+live Vontology profile remains authoritative and is never overwritten.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..vontology.utils_vontology import get_vontology_node_and_descendant_ids
+from . import concept_service
+from . import startup_seed_freshness_service as seed_freshness
+from .text_value_service import (
+    get_texts_for_concepts,
+    upsert_singleton_text_relation,
+)
+
+CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION = "constitutive_relation_requirements.v1"
+CONSTITUTIVE_REQUIREMENT_SEED_SCHEMA_VERSION = (
+    "constitutive_relation_requirement_seed_bundle.v1"
+)
+CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID = "constitutive_relation_requirements"
+CONSTITUTIVE_REQUIREMENT_STARTUP_PRODUCER_SCHEMA_VERSION = (
+    "constitutive_relation_requirement_startup_materialisation.v1"
+)
+CONSTITUTIVE_REQUIREMENTS_PREDICATE = "#V#has_constitutive_relation_requirements_json"
+CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES: tuple[str, ...] = (
+    CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+    "has_constitutive_relation_requirements_json",
+    "hasConstitutiveRelationRequirementsJson",
+)
+
+VON_USER_ORGANISATION_TYPE_ID = "#V#von_user_organisation"
+VON_USER_TYPE_ID = "#V#von_user"
+MEMBER_OF_PREDICATE_ID = "#V#memberOf"
+
+_SEED_ASSET_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "vontology"
+    / "seed_bundles"
+    / "constitutive_relation_requirements_seed_bundle.json"
+)
+
+
+def _load_seed_bundle(asset_path: str | Path | None = None) -> dict[str, Any]:
+    path = Path(asset_path or _SEED_ASSET_PATH).resolve()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise TypeError("constitutive_requirement_seed_bundle_not_mapping")
+    if _text(payload.get("schema_version")) != (
+        CONSTITUTIVE_REQUIREMENT_SEED_SCHEMA_VERSION
+    ):
+        raise ValueError("constitutive_requirement_seed_bundle_schema_unsupported")
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, Sequence) or isinstance(profiles, (str, bytes)):
+        raise TypeError("constitutive_requirement_seed_profiles_invalid")
+    seen_type_ids: set[str] = set()
+    for spec in profiles:
+        if not isinstance(spec, Mapping):
+            raise TypeError("constitutive_requirement_seed_profile_not_mapping")
+        type_id = _text(spec.get("declaring_type_concept_id"))
+        if not type_id:
+            raise ValueError("constitutive_requirement_seed_type_missing")
+        if type_id in seen_type_ids:
+            raise ValueError("constitutive_requirement_seed_type_duplicate")
+        seen_type_ids.add(type_id)
+        _normalise_profile(spec.get("payload"))
+    return {**dict(payload), "asset_path": str(path)}
+
+
+def _profile_blueprints_from_bundle(
+    bundle: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    return {
+        str(spec["declaring_type_concept_id"]): json.loads(json.dumps(spec["payload"]))
+        for spec in bundle["profiles"]
+    }
+
+
+def canonical_constitutive_requirement_profile_blueprints(
+    *, asset_path: str | Path | None = None
+) -> dict[str, dict[str, Any]]:
+    """Load copy-on-read starter profiles from the versioned release input."""
+
+    return _profile_blueprints_from_bundle(_load_seed_bundle(asset_path))
+
+
+def _startup_freshness_scope(bundle: Mapping[str, Any]) -> dict[str, list[str]]:
+    type_ids = [
+        str(spec.get("declaring_type_concept_id") or "").strip()
+        for spec in bundle.get("profiles") or ()
+        if isinstance(spec, Mapping)
+        and str(spec.get("declaring_type_concept_id") or "").strip()
+    ]
+    return {
+        "concept_ids": sorted(set(type_ids)),
+        "text_relation_subject_ids": sorted(set(type_ids)),
+        "text_relation_predicates": sorted(
+            set(CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES)
+        ),
+    }
+
+
+def _startup_source_digest(bundle: Mapping[str, Any]) -> str:
+    return seed_freshness.build_startup_seed_source_digest(
+        asset_path=str(bundle.get("asset_path") or ""),
+        producer_paths=[Path(__file__), Path(seed_freshness.__file__)],
+        material_configuration={
+            "seed_schema_version": CONSTITUTIVE_REQUIREMENT_SEED_SCHEMA_VERSION,
+            "profile_schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+            "producer_schema_version": (
+                CONSTITUTIVE_REQUIREMENT_STARTUP_PRODUCER_SCHEMA_VERSION
+            ),
+        },
+    )
+
+
+def ensure_canonical_constitutive_relation_requirement_profiles(
+    *,
+    type_concept_ids: Sequence[str] | None = None,
+    predicate: str = CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+    language: str = "en-NZ",
+    provenance: Mapping[str, Any] | None = None,
+    asset_path: str | Path | None = None,
+    freshness_context: Mapping[str, Any] | None = None,
+    concept_getter: Callable[[str], Any] | None = None,
+    text_writer: Callable[..., Mapping[str, Any]] | None = None,
+    text_reader: Callable[..., Mapping[str, list[Mapping[str, Any]]]] | None = None,
+) -> dict[str, Any]:
+    """Materialise starter profiles and verify their exact represented read-back.
+
+    This is an explicit seed/maintenance operation, not an import-time write.
+    Missing declaring types are reported rather than implicitly created.
+    """
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    source_tag = _text(bundle.get("source_tag")) or "JVNAUTOSCI-1035"
+    managed_by = (
+        _text(bundle.get("managed_by")) or "constitutive_relation_requirement_service"
+    )
+    getter = concept_getter or concept_service.get_concept_by_concept_id
+    writer = text_writer or upsert_singleton_text_relation
+    reader = text_reader or get_texts_for_concepts
+    blueprints = _profile_blueprints_from_bundle(bundle)
+    requested = list(
+        dict.fromkeys(
+            type_id
+            for type_id in (type_concept_ids or tuple(blueprints))
+            if isinstance(type_id, str) and type_id
+        )
+    )
+    persisted: list[str] = []
+    read_back: list[str] = []
+    represented_overrides: list[str] = []
+    changed_type_ids: list[str] = []
+    missing: list[str] = []
+    unknown: list[str] = []
+    errors_by_type: dict[str, str] = {}
+    concepts_by_type: dict[str, Mapping[str, Any]] = {}
+    tracked_rows_by_type: dict[str, list[Mapping[str, Any]]] = {}
+    read_predicates = list(
+        dict.fromkeys([predicate, *CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES])
+    )
+    text_query_metadata: dict[str, Any] = {}
+
+    def read_rows(type_ids: Sequence[str]) -> Mapping[str, list[Mapping[str, Any]]]:
+        return reader(
+            list(type_ids),
+            predicates=read_predicates,
+            limit_per_concept=10,
+            recent_first=True,
+            query_metadata=text_query_metadata,
+        )
+
+    def select_profile(
+        rows: Sequence[Mapping[str, Any]],
+    ) -> tuple[list[dict[str, Any]] | None, Mapping[str, Any] | None, bool]:
+        found = False
+        for selected_predicate in read_predicates:
+            for row in rows:
+                if not isinstance(row, Mapping):
+                    continue
+                if _text(row.get("predicate")) != selected_predicate:
+                    continue
+                found = True
+                try:
+                    represented = json.loads(str(row.get("text") or ""))
+                    return _normalise_profile(represented), row, found
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+        return None, None, found
+
+    for type_id in requested:
+        profile = blueprints.get(type_id)
+        if profile is None:
+            unknown.append(type_id)
+            continue
+        try:
+            concept = getter(type_id)
+        except Exception:  # noqa: BLE001 - maintenance reports dependency failure
+            concept = None
+        if not isinstance(concept, Mapping):
+            missing.append(type_id)
+            continue
+        concepts_by_type[type_id] = concept
+
+    readable_type_ids = [
+        type_id
+        for type_id in requested
+        if type_id in concepts_by_type and type_id not in unknown
+    ]
+    try:
+        initial_rows_by_type = read_rows(readable_type_ids)
+        if not isinstance(initial_rows_by_type, Mapping):
+            raise TypeError("profile_read_result_not_mapping")
+    except Exception as exc:  # noqa: BLE001 - maintenance returns typed receipt
+        initial_rows_by_type = {}
+        for type_id in readable_type_ids:
+            errors_by_type[type_id] = f"profile_read_failed:{exc}"
+
+    for type_id in readable_type_ids:
+        if type_id in errors_by_type:
+            continue
+        profile = blueprints[type_id]
+        rows = [
+            row
+            for row in initial_rows_by_type.get(type_id, [])
+            if isinstance(row, Mapping)
+        ]
+        normalised_existing, _selected_row, represented_found = select_profile(rows)
+        if represented_found and normalised_existing is None:
+            # Never overwrite a malformed represented policy with a repo
+            # fallback.  It needs an explicit Vontology repair.
+            errors_by_type[type_id] = "represented_profile_malformed"
+            tracked_rows_by_type[type_id] = rows
+            continue
+        if normalised_existing is not None:
+            if normalised_existing != _normalise_profile(profile):
+                represented_overrides.append(type_id)
+            tracked_rows_by_type[type_id] = rows
+            read_back.append(type_id)
+            continue
+
+        try:
+            _normalise_profile(profile)
+            result = writer(
+                subject_concept_id=type_id,
+                predicate=predicate,
+                text=json.dumps(profile, ensure_ascii=True, sort_keys=True),
+                lang=language,
+                policy="replace_others",
+                provenance={
+                    "source": managed_by,
+                    "source_tag": source_tag,
+                    **dict(provenance or {}),
+                },
+                context={},
+                garbage_collect=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - maintenance returns typed receipt
+            errors_by_type[type_id] = f"profile_write_failed:{exc}"
+            continue
+        if not bool(result.get("success")):
+            errors_by_type[type_id] = "profile_write_unsuccessful"
+            continue
+        persisted.append(type_id)
+        changed_type_ids.append(type_id)
+
+        try:
+            rows_by_type = read_rows([type_id])
+            rows = rows_by_type.get(type_id, [])
+            normalised_represented, _selected_row, _found = select_profile(rows)
+            if normalised_represented != _normalise_profile(profile):
+                raise ValueError("profile_read_back_mismatch")
+        except Exception as exc:  # noqa: BLE001 - read-back failure is reported
+            errors_by_type[type_id] = f"profile_read_back_failed:{exc}"
+            continue
+        tracked_rows_by_type[type_id] = [
+            row for row in rows if isinstance(row, Mapping)
+        ]
+        read_back.append(type_id)
+
+    success = not (missing or unknown or errors_by_type) and len(read_back) == len(
+        requested
+    )
+    report: dict[str, Any] = {
+        "success": success,
+        "profile_source": "vontology_type_text_relations",
+        "asset_path": bundle.get("asset_path"),
+        "seed_schema_version": bundle.get("schema_version"),
+        "seed_version": bundle.get("seed_version"),
+        "source_tag": source_tag,
+        "managed_by": managed_by,
+        "predicate": predicate,
+        "requested_type_concept_ids": requested,
+        "persisted_type_concept_ids": persisted,
+        "read_back_type_concept_ids": read_back,
+        "represented_override_type_concept_ids": represented_overrides,
+        "changed_type_concept_ids": changed_type_ids,
+        "changed": bool(changed_type_ids),
+        "missing_type_concept_ids": missing,
+        "unknown_type_concept_ids": unknown,
+        "errors_by_type_concept_id": errors_by_type,
+        "read_strategy": "bounded_canonical_state",
+        "read_phases": 2 if changed_type_ids else 1,
+        "canonical_read_batches": {
+            "concepts": len(requested),
+            "text_assertions": 1 + len(changed_type_ids),
+        },
+        "text_query_metadata": text_query_metadata,
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "counts": {
+            "profiles_requested": len(requested),
+            "profiles_written": len(persisted),
+            "profiles_changed": len(changed_type_ids),
+            "represented_overrides_preserved": len(represented_overrides),
+            "profiles_read_back": len(read_back),
+            "errors": len(errors_by_type),
+        },
+    }
+
+    if freshness_context is not None:
+        canonical_read_complete = not bool(
+            text_query_metadata.get("relation_query_truncated")
+        )
+        if success and not changed_type_ids and canonical_read_complete:
+            scope = _startup_freshness_scope(bundle)
+            receipt_result = seed_freshness.record_startup_seed_freshness(
+                family_id=CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID,
+                source_digest=_text(freshness_context.get("source_digest")) or "",
+                producer_schema_version=(
+                    CONSTITUTIVE_REQUIREMENT_STARTUP_PRODUCER_SCHEMA_VERSION
+                ),
+                concept_ids=scope["concept_ids"],
+                text_relation_subject_ids=scope["text_relation_subject_ids"],
+                text_relation_predicates=scope["text_relation_predicates"],
+                tracked_concept_document_ids=[
+                    concept.get("_id") or concept.get("id")
+                    for concept in concepts_by_type.values()
+                    if concept.get("_id") is not None or concept.get("id") is not None
+                ],
+                tracked_text_relation_document_ids=[
+                    row.get("relation_id") or row.get("_id")
+                    for rows in tracked_rows_by_type.values()
+                    for row in rows
+                    if row.get("relation_id") is not None or row.get("_id") is not None
+                ],
+                tracked_text_value_document_ids=[
+                    row.get("text_value_id") or row.get("object_text_id")
+                    for rows in tracked_rows_by_type.values()
+                    for row in rows
+                    if row.get("text_value_id") is not None
+                    or row.get("object_text_id") is not None
+                ],
+                observation=freshness_context.get("observation") or {},
+                metadata={
+                    "seed_schema_version": report.get("seed_schema_version"),
+                    "seed_version": report.get("seed_version"),
+                    "source_tag": source_tag,
+                    "managed_by": managed_by,
+                    "counts": report.get("counts"),
+                },
+            )
+        else:
+            receipt_result = {
+                "persisted": False,
+                "reason": (
+                    "canonical_verification_failed"
+                    if not success
+                    else (
+                        "canonical_read_truncated"
+                        if not canonical_read_complete
+                        else "canonical_state_changed"
+                    )
+                ),
+            }
+        report["freshness_receipt"] = (
+            seed_freshness.public_startup_seed_freshness_result(receipt_result)
+        )
+    return report
+
+
+def reconcile_canonical_constitutive_relation_requirement_profiles(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Apply and verify the release seed, then publish a freshness receipt.
+
+    This is an explicit release/maintenance write. Ordinary process startup
+    must call the read-only freshness check below instead.
+    """
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    source_digest = _startup_source_digest(bundle)
+    passes: list[dict[str, Any]] = []
+
+    def run_canonical_pass() -> dict[str, Any]:
+        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        report = ensure_canonical_constitutive_relation_requirement_profiles(
+            asset_path=asset_path,
+            freshness_context={
+                "source_digest": source_digest,
+                "observation": observation,
+            },
+        )
+        passes.append(report)
+        return report
+
+    final_report = run_canonical_pass()
+    final_receipt = final_report.get("freshness_receipt")
+    receipt_persisted = bool(
+        isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+    )
+    if final_report.get("success") and (
+        final_report.get("changed") or not receipt_persisted
+    ):
+        # A mutating pass cannot establish its own quiet verification window.
+        final_report = run_canonical_pass()
+        final_receipt = final_report.get("freshness_receipt")
+        receipt_persisted = bool(
+            isinstance(final_receipt, Mapping) and final_receipt.get("persisted")
+        )
+
+    ready = bool(
+        final_report.get("success")
+        and not final_report.get("changed")
+        and receipt_persisted
+    )
+    receipt_reason = (
+        _text(final_receipt.get("reason"))
+        if isinstance(final_receipt, Mapping)
+        else None
+    )
+    return {
+        "schema_version": "startup_seed_reconciliation.v1",
+        "family_id": CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID,
+        "success": ready,
+        "ready": ready,
+        "state": "ready" if ready else "unavailable",
+        "reason": (
+            "canonical_reconciliation_verified"
+            if ready
+            else receipt_reason or "canonical_reconciliation_unverified"
+        ),
+        "changed": any(bool(report.get("changed")) for report in passes),
+        "reconciliation_pass_count": len(passes),
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": (
+            dict(final_receipt) if isinstance(final_receipt, Mapping) else {}
+        ),
+        "passes": passes,
+    }
+
+
+def ensure_constitutive_relation_requirement_profiles_current_for_startup(
+    *,
+    asset_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Check the release receipt without reading or writing canonical profiles."""
+
+    started_at = time.perf_counter()
+    bundle = _load_seed_bundle(asset_path)
+    scope = _startup_freshness_scope(bundle)
+    freshness_check = seed_freshness.check_startup_seed_freshness(
+        family_id=CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID,
+        source_digest=_startup_source_digest(bundle),
+        producer_schema_version=(
+            CONSTITUTIVE_REQUIREMENT_STARTUP_PRODUCER_SCHEMA_VERSION
+        ),
+        concept_ids=scope["concept_ids"],
+        text_relation_subject_ids=scope["text_relation_subject_ids"],
+        text_relation_predicates=scope["text_relation_predicates"],
+    )
+    public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    common = {
+        "skipped": True,
+        "changed": False,
+        "asset_path": bundle.get("asset_path"),
+        "schema_version": bundle.get("schema_version"),
+        "seed_version": bundle.get("seed_version"),
+        "read_strategy": "dependency_receipt",
+        "read_phases": 1,
+        "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "freshness_receipt": public_check,
+        "errors": [],
+    }
+    if freshness_check.get("fresh"):
+        metadata = freshness_check.get("metadata")
+        metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+        return {
+            "success": True,
+            "ready": True,
+            "state": "ready",
+            "reason": "dependency_receipt_current",
+            "reconciliation_required": False,
+            "source_tag": metadata.get("source_tag") or bundle.get("source_tag"),
+            "managed_by": metadata.get("managed_by") or bundle.get("managed_by"),
+            "counts": dict(metadata.get("counts") or {}),
+            **common,
+        }
+    return {
+        "success": False,
+        "ready": False,
+        "state": "unavailable",
+        "reason": "startup_seed_reconciliation_required",
+        "reconciliation_required": True,
+        **common,
+    }
+
+
+def _text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_values(value: Any) -> list[str]:
+    values = value if isinstance(value, list) else [value]
+    output: list[str] = []
+    for item in values:
+        normalised = _text(item)
+        if normalised and normalised not in output:
+            output.append(normalised)
+    return output
+
+
+def _identifier_variants(concept_id: str) -> list[str]:
+    variants = [concept_id]
+    if concept_id.startswith("#V#"):
+        variants.append(concept_id[3:])
+    return list(dict.fromkeys(item for item in variants if item))
+
+
+def _predicate_storage_keys(predicate_concept_id: str) -> list[str]:
+    keys = [predicate_concept_id]
+    if predicate_concept_id.startswith("#V#"):
+        keys.append(predicate_concept_id[3:])
+    if predicate_concept_id in {
+        MEMBER_OF_PREDICATE_ID,
+        "memberOf",
+        "#V#member_of_organisation",
+    }:
+        # Reads remain compatible with both the current membership edge key and
+        # the historical ontology predicate.  This does not equate membership
+        # with visibility predicates such as #V#specific_to_user.
+        keys.extend(
+            [
+                "memberOf",
+                "#V#memberOf",
+                "#V#member_of_organisation",
+                "member_of_organisation",
+            ]
+        )
+    return list(dict.fromkeys(key for key in keys if key))
+
+
+def _human_label(concept_id: str) -> str:
+    value = concept_id.replace("#V#", "").replace("_", " ")
+    value = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", value)
+    return value.strip().lower()
+
+
+def _normalise_requirement(raw: Mapping[str, Any]) -> dict[str, Any]:
+    requirement_id = _text(raw.get("requirement_id"))
+    predicate_id = _text(raw.get("predicate_concept_id"))
+    focal_argument = _text(raw.get("focal_argument"))
+    other_type_id = _text(raw.get("other_argument_type_concept_id"))
+    if not requirement_id:
+        raise ValueError("requirement_id_missing")
+    if not predicate_id:
+        raise ValueError("predicate_concept_id_missing")
+    if focal_argument not in {"subject", "object"}:
+        raise ValueError("focal_argument_invalid")
+    if not other_type_id:
+        raise ValueError("other_argument_type_concept_id_missing")
+
+    raw_minimum = raw.get("minimum_cardinality", 1)
+    if isinstance(raw_minimum, bool):
+        raise TypeError("minimum_cardinality_invalid")
+    try:
+        minimum_cardinality = int(raw_minimum)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("minimum_cardinality_invalid") from exc
+    if minimum_cardinality < 1:
+        raise ValueError("minimum_cardinality_invalid")
+
+    auto_formalisation_allowed = raw.get("auto_formalisation_allowed", False)
+    if not isinstance(auto_formalisation_allowed, bool):
+        raise TypeError("auto_formalisation_allowed_invalid")
+    confirmation_required = raw.get(
+        "confirmation_required_for_activation",
+        bool(auto_formalisation_allowed and raw.get("activation_relevance")),
+    )
+    if not isinstance(confirmation_required, bool):
+        raise TypeError("confirmation_required_for_activation_invalid")
+    confirmation_creates_new_claim = raw.get("confirmation_creates_new_claim", False)
+    if not isinstance(confirmation_creates_new_claim, bool):
+        raise TypeError("confirmation_creates_new_claim_invalid")
+    activation_minimum_status = (
+        _text(raw.get("activation_minimum_status")) or "asserted"
+    )
+    activation_satisfying_statuses = _normalise_values(
+        raw.get("activation_satisfying_statuses") or activation_minimum_status
+    )
+
+    return {
+        "requirement_id": requirement_id,
+        "predicate_concept_id": predicate_id,
+        "predicate_label": _text(raw.get("predicate_label"))
+        or _human_label(predicate_id),
+        "focal_argument": focal_argument,
+        "other_argument_type_concept_id": other_type_id,
+        "other_argument_type_label": _text(raw.get("other_argument_type_label"))
+        or _human_label(other_type_id),
+        "minimum_cardinality": minimum_cardinality,
+        "reason": _text(raw.get("reason")),
+        "activation_relevance": _text(raw.get("activation_relevance")),
+        "authority_relevance": _text(raw.get("authority_relevance")),
+        "auto_formalisation_allowed": auto_formalisation_allowed,
+        "auto_formalisation_target_status": _text(
+            raw.get("auto_formalisation_target_status")
+        )
+        or ("tentative" if auto_formalisation_allowed else None),
+        "activation_minimum_status": activation_minimum_status,
+        "activation_satisfying_statuses": activation_satisfying_statuses,
+        "confirmation_required_for_activation": confirmation_required,
+        "confirmation_elicitation_priority": _text(
+            raw.get("confirmation_elicitation_priority")
+        ),
+        "confirmation_effect": _text(raw.get("confirmation_effect")),
+        "confirmation_creates_new_claim": confirmation_creates_new_claim,
+        "question_template": _text(raw.get("question_template")),
+        "confirmation_question_template": _text(
+            raw.get("confirmation_question_template")
+        ),
+    }
+
+
+def _normalise_profile(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, Mapping):
+        raise TypeError("profile_not_object")
+    if raw.get("schema_version") != CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION:
+        raise ValueError("profile_schema_version_invalid")
+    raw_requirements = raw.get("requirements")
+    if not isinstance(raw_requirements, Sequence) or isinstance(
+        raw_requirements, (str, bytes)
+    ):
+        raise TypeError("profile_requirements_invalid")
+
+    requirements: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for raw_requirement in raw_requirements:
+        if not isinstance(raw_requirement, Mapping):
+            raise TypeError("profile_requirement_not_object")
+        requirement = _normalise_requirement(raw_requirement)
+        requirement_id = requirement["requirement_id"]
+        if requirement_id in seen_ids:
+            raise ValueError("profile_requirement_id_duplicate")
+        seen_ids.add(requirement_id)
+        requirements.append(requirement)
+    return requirements
+
+
+class ConstitutiveRelationRequirementService:
+    """Resolve represented requirements and report their missing witnesses."""
+
+    def __init__(
+        self,
+        *,
+        text_reader: Callable[..., Mapping[str, list[Mapping[str, Any]]]] | None = None,
+        concept_finder: Callable[..., Any] | None = None,
+        descendant_resolver: Callable[..., Any] | None = None,
+    ) -> None:
+        self._text_reader = text_reader or get_texts_for_concepts
+        self._concept_finder = concept_finder or ConceptsRepository.find
+        self._descendant_resolver = (
+            descendant_resolver or get_vontology_node_and_descendant_ids
+        )
+
+    def load_requirements(
+        self,
+        *,
+        type_depth_by_id: Mapping[str, int],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Load nearest-first inherited requirements for an instance's types."""
+
+        ordered_type_ids = sorted(
+            (
+                type_id
+                for type_id in type_depth_by_id
+                if isinstance(type_id, str) and type_id
+            ),
+            key=lambda type_id: (int(type_depth_by_id[type_id]), type_id),
+        )
+        diagnostics: dict[str, Any] = {
+            "represented_profile_type_ids": [],
+            "builtin_profile_type_ids": [],
+            "fallback_suppressed_type_ids": [],
+            "malformed_profile_type_ids": [],
+            "profile_read_failed": False,
+            "compatibility_profile_load_failed": False,
+            "compatibility_profile_load_error_type": None,
+        }
+        try:
+            rows_by_type = self._text_reader(
+                ordered_type_ids,
+                predicates=list(CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES),
+                limit_per_concept=10,
+                recent_first=True,
+            )
+            if not isinstance(rows_by_type, Mapping):
+                rows_by_type = {}
+        except Exception:  # noqa: BLE001 - represented policy failure is fail-soft
+            rows_by_type = {}
+            diagnostics["profile_read_failed"] = True
+
+        requirements: list[dict[str, Any]] = []
+        seen_requirement_ids: set[str] = set()
+        compatibility_profiles: dict[str, dict[str, Any]] | None = None
+        for type_id in ordered_type_ids:
+            represented_requirements: list[dict[str, Any]] | None = None
+            selected_predicate: str | None = None
+            represented_profile_found = False
+            profile_rows = rows_by_type.get(type_id) or []
+            for predicate in CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES:
+                predicate_rows = [
+                    row
+                    for row in profile_rows
+                    if isinstance(row, Mapping)
+                    and _text(row.get("predicate")) == predicate
+                ]
+                represented_profile_found = (
+                    bool(predicate_rows) or represented_profile_found
+                )
+                for row in predicate_rows:
+                    try:
+                        parsed = json.loads(str(row.get("text") or ""))
+                        represented_requirements = _normalise_profile(parsed)
+                        selected_predicate = predicate
+                        break
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        if type_id not in diagnostics["malformed_profile_type_ids"]:
+                            diagnostics["malformed_profile_type_ids"].append(type_id)
+                if represented_requirements is not None:
+                    break
+
+            declaration_source = "represented"
+            profile_requirements = represented_requirements
+            if profile_requirements is None:
+                if represented_profile_found or diagnostics["profile_read_failed"]:
+                    # A malformed or unreadable live declaration is not evidence
+                    # that the represented policy is absent.  Continue without
+                    # the requirement rather than laundering code fallback as
+                    # the active represented meaning.
+                    diagnostics["fallback_suppressed_type_ids"].append(type_id)
+                    continue
+                if compatibility_profiles is None:
+                    try:
+                        compatibility_profiles = (
+                            canonical_constitutive_requirement_profile_blueprints()
+                        )
+                    except Exception as exc:  # noqa: BLE001 - fail-soft fallback
+                        compatibility_profiles = {}
+                        diagnostics["compatibility_profile_load_failed"] = True
+                        diagnostics["compatibility_profile_load_error_type"] = type(
+                            exc
+                        ).__name__
+                builtin_profile = compatibility_profiles.get(type_id)
+                if builtin_profile is None:
+                    continue
+                profile_requirements = _normalise_profile(builtin_profile)
+                declaration_source = "builtin_compatibility"
+                diagnostics["builtin_profile_type_ids"].append(type_id)
+            else:
+                diagnostics["represented_profile_type_ids"].append(type_id)
+
+            depth = max(0, int(type_depth_by_id.get(type_id, 0)))
+            for requirement in profile_requirements:
+                requirement_id = str(requirement["requirement_id"])
+                if requirement_id in seen_requirement_ids:
+                    continue
+                seen_requirement_ids.add(requirement_id)
+                requirements.append(
+                    {
+                        **requirement,
+                        "declared_on_type_concept_id": type_id,
+                        "declaration_depth": depth,
+                        "inherited": depth > 0,
+                        "declaration_source": declaration_source,
+                        "profile_predicate": selected_predicate,
+                        "profile_schema_version": (
+                            CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION
+                        ),
+                    }
+                )
+
+        return requirements, diagnostics
+
+    def get_missing_requirements(
+        self,
+        *,
+        instance: Mapping[str, Any],
+        type_depth_by_id: Mapping[str, int],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Return missing requirement plan entries without mutating the instance."""
+
+        requirements, diagnostics = self.load_requirements(
+            type_depth_by_id=type_depth_by_id
+        )
+        instance_id = _text(instance.get("concept_id")) or _text(instance.get("id"))
+        if not instance_id:
+            return [], diagnostics
+        instance_name = _text(instance.get("name")) or "this concept"
+
+        type_extent_cache: dict[str, set[str]] = {}
+        missing: list[dict[str, Any]] = []
+        for requirement in requirements:
+            counterpart_ids = self._matching_counterpart_ids(
+                instance=instance,
+                instance_id=instance_id,
+                requirement=requirement,
+                type_extent_cache=type_extent_cache,
+            )
+            current_cardinality = len(counterpart_ids)
+            minimum_cardinality = int(requirement["minimum_cardinality"])
+            if current_cardinality >= minimum_cardinality:
+                continue
+            question = self._question_for_requirement(
+                requirement=requirement,
+                instance_name=instance_name,
+            )
+            auto_formalisation_allowed = bool(
+                requirement.get("auto_formalisation_allowed")
+            )
+            missing.append(
+                {
+                    **requirement,
+                    "requirement_kind": "constitutive_relation",
+                    "priority_class": "constitutive",
+                    "current_cardinality": current_cardinality,
+                    "matching_counterpart_concept_ids": counterpart_ids,
+                    "status": "missing",
+                    "gap_status": "asserted_relation_missing",
+                    "question": question,
+                    "creation_blocking": False,
+                    "tentative_counts_as_satisfied": False,
+                    "formalisation_mode": (
+                        "tentative_candidate"
+                        if auto_formalisation_allowed
+                        else "candidate_only"
+                    ),
+                }
+            )
+        return missing, diagnostics
+
+    def _matching_counterpart_ids(
+        self,
+        *,
+        instance: Mapping[str, Any],
+        instance_id: str,
+        requirement: Mapping[str, Any],
+        type_extent_cache: dict[str, set[str]],
+    ) -> list[str]:
+        predicate_id = str(requirement["predicate_concept_id"])
+        storage_keys = _predicate_storage_keys(predicate_id)
+        other_type_id = str(requirement["other_argument_type_concept_id"])
+        qualifying_types = type_extent_cache.get(other_type_id)
+        if qualifying_types is None:
+            try:
+                raw_types = self._descendant_resolver(other_type_id) or []
+            except Exception:  # noqa: BLE001 - fall back to exact type only
+                raw_types = []
+            qualifying_types = {
+                type_id for type_id in raw_types if isinstance(type_id, str) and type_id
+            }
+            qualifying_types.add(other_type_id)
+            type_extent_cache[other_type_id] = qualifying_types
+
+        if requirement["focal_argument"] == "subject":
+            relationships = instance.get("relationships")
+            relationships = relationships if isinstance(relationships, Mapping) else {}
+            target_ids: list[str] = []
+            for storage_key in storage_keys:
+                target_ids.extend(_normalise_values(relationships.get(storage_key)))
+            target_ids = list(dict.fromkeys(target_ids))
+            if not target_ids:
+                return []
+            query_ids: list[str] = []
+            for target_id in target_ids:
+                query_ids.extend(_identifier_variants(target_id))
+            docs = self._find_docs(
+                {"concept_id": {"$in": list(dict.fromkeys(query_ids))}}
+            )
+        else:
+            focal_variants = _identifier_variants(instance_id)
+            docs = self._find_docs(
+                {
+                    "$or": [
+                        {f"relationships.{storage_key}": {"$in": focal_variants}}
+                        for storage_key in storage_keys
+                    ]
+                }
+            )
+
+        counterpart_ids: list[str] = []
+        for doc in docs:
+            if not self._has_qualifying_type(doc, qualifying_types):
+                continue
+            counterpart_id = _text(doc.get("concept_id"))
+            if counterpart_id and counterpart_id not in counterpart_ids:
+                counterpart_ids.append(counterpart_id)
+        return sorted(counterpart_ids)
+
+    def _find_docs(self, query: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        projection = {
+            "concept_id": 1,
+            "relationships.is_an_instance_of": 1,
+            "relationships.#V#is_an_instance_of": 1,
+        }
+        try:
+            rows = self._concept_finder(dict(query), projection)
+            return [row for row in rows if isinstance(row, Mapping)]
+        except Exception:  # noqa: BLE001 - an unreadable witness remains missing
+            return []
+
+    @staticmethod
+    def _has_qualifying_type(
+        concept: Mapping[str, Any], qualifying_types: set[str]
+    ) -> bool:
+        relationships = concept.get("relationships")
+        if not isinstance(relationships, Mapping):
+            return False
+        direct_types: list[str] = []
+        for predicate in ("is_an_instance_of", "#V#is_an_instance_of"):
+            direct_types.extend(_normalise_values(relationships.get(predicate)))
+        return bool(set(direct_types).intersection(qualifying_types))
+
+    @staticmethod
+    def _question_for_requirement(
+        *, requirement: Mapping[str, Any], instance_name: str
+    ) -> str:
+        template = _text(requirement.get("question_template"))
+        format_values = {
+            "instance_name": instance_name,
+            "predicate_label": requirement.get("predicate_label") or "relation",
+            "other_argument_type_label": requirement.get("other_argument_type_label")
+            or "concept",
+        }
+        if template:
+            try:
+                return template.format(**format_values)
+            except (KeyError, ValueError):
+                pass
+        if requirement.get("focal_argument") == "object":
+            return (
+                f"Which {format_values['other_argument_type_label']} has "
+                f"{format_values['predicate_label']} {instance_name}?"
+            )
+        return f"What is {format_values['predicate_label']} for {instance_name}?"
+
+
+__all__ = [
+    "CONSTITUTIVE_REQUIREMENTS_PREDICATE",
+    "CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION",
+    "CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES",
+    "CONSTITUTIVE_REQUIREMENT_SEED_SCHEMA_VERSION",
+    "CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID",
+    "CONSTITUTIVE_REQUIREMENT_STARTUP_PRODUCER_SCHEMA_VERSION",
+    "MEMBER_OF_PREDICATE_ID",
+    "VON_USER_ORGANISATION_TYPE_ID",
+    "VON_USER_TYPE_ID",
+    "ConstitutiveRelationRequirementService",
+    "canonical_constitutive_requirement_profile_blueprints",
+    "ensure_canonical_constitutive_relation_requirement_profiles",
+    "ensure_constitutive_relation_requirement_profiles_current_for_startup",
+    "reconcile_canonical_constitutive_relation_requirement_profiles",
+]

--- a/src/backend/services/conversation_management_service.py
+++ b/src/backend/services/conversation_management_service.py
@@ -360,6 +360,28 @@ def apply_conversation_preferences(
     return projected
 
 
+def build_canonical_conversation_reference(
+    *,
+    owner_user_id: str,
+    session_id: str,
+    namespace: Any = None,
+    organisation_concept_id: Any = None,
+) -> dict[str, Any]:
+    """Build the one canonical reference shape for an explicit conversation."""
+
+    owner = _required_text(owner_user_id, field="owner_user_id")
+    session = _required_text(session_id, field="session_id")
+    return {
+        "schema_version": "conversation_reference.v1",
+        "binding_kind": "explicit_session_id",
+        "session_id": session,
+        "user_concept_id": owner,
+        "namespace": namespace,
+        "organisation_concept_id": _normalise_concept_id(organisation_concept_id),
+        "include_legacy": True,
+    }
+
+
 def _project_actor_conversation_contract(
     *, actor_user_id: str, row: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -381,17 +403,12 @@ def _project_actor_conversation_contract(
     ]
     if not shared:
         available_actions.append("restore" if trashed else "trash")
-    canonical_reference = {
-        "schema_version": "conversation_reference.v1",
-        "binding_kind": "explicit_session_id",
-        "session_id": session_id,
-        "user_concept_id": owner_user_id,
-        "namespace": projected.get("namespace"),
-        "organisation_concept_id": _normalise_concept_id(
-            projected.get("organisation_concept_id")
-        ),
-        "include_legacy": True,
-    }
+    canonical_reference = build_canonical_conversation_reference(
+        owner_user_id=owner_user_id,
+        session_id=session_id,
+        namespace=projected.get("namespace"),
+        organisation_concept_id=projected.get("organisation_concept_id"),
+    )
     projected.update(
         {
             "display_name": projected.get("session_name"),

--- a/src/backend/services/relation_elicitation_service.py
+++ b/src/backend/services/relation_elicitation_service.py
@@ -1,8 +1,11 @@
 # src/backend/services/relation_elicitation_service.py
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
-from ..services import concept_service
 from ..db.repositories.concepts_repository import ConceptsRepository
+from ..services import concept_service
+from .constitutive_relation_requirement_service import (
+    ConstitutiveRelationRequirementService,
+)
 from .uncertain_relationship_service import (
     collect_uncertain_predicates,
     upsert_uncertain_relationship_assertion,
@@ -12,8 +15,16 @@ from .uncertain_relationship_service import (
 class RelationElicitationService:
     """Service for proactively enriching the knowledge graph."""
 
-    def __init__(self, llm_client: Optional[Any] = None):
+    def __init__(
+        self,
+        llm_client: Optional[Any] = None,
+        *,
+        constitutive_requirement_service: Optional[Any] = None,
+    ):
         """Initialise the service with an optional preconfigured LLM client."""
+        self.constitutive_requirement_service = (
+            constitutive_requirement_service or ConstitutiveRelationRequirementService()
+        )
         self._llm_initialisation_error: Optional[Exception] = None
         if llm_client is not None:
             self.llm_client = llm_client
@@ -38,8 +49,8 @@ class RelationElicitationService:
     ) -> List[str]:
         """Return unfilled suggested or salient predicates for an individual.
 
-        Traverses direct and ancestor types (forward is_a_type_of + reverse has_subtype) and
-        unions values of both "suggested_relations_for_type" and "#V#salient_binary_predicate_for_type".
+        Traverses direct and ancestor types (forward ``is_a_type_of`` plus
+        reverse ``has_subtype``) and combines suggested and salient predicates.
         Filters out predicates already present as relationship keys.
         By default, predicates already present in hypothesized_relations are also
         excluded; set include_hypothesized=True when downstream workflows need to
@@ -150,12 +161,14 @@ class RelationElicitationService:
             return []
         instance_name = str(instance.get("name") or "this concept").strip()
         relationships = instance.get("relationships") or {}
-        direct_types = relationships.get("is_an_instance_of") or []
-        if isinstance(direct_types, str):
-            direct_types = [direct_types]
-        direct_types = [
-            item for item in direct_types if isinstance(item, str) and item
-        ]
+        direct_types: List[str] = []
+        for instance_predicate in ("is_an_instance_of", "#V#is_an_instance_of"):
+            values = relationships.get(instance_predicate) or []
+            if isinstance(values, str):
+                values = [values]
+            for value in values:
+                if isinstance(value, str) and value and value not in direct_types:
+                    direct_types.append(value)
 
         # Prefer the recomputed inherited field used by the salient-predicate
         # API. If an empty cache is stale, recover through a small number of
@@ -166,6 +179,7 @@ class RelationElicitationService:
             "relationships.suggested_relations_for_type": 1,
             "relationships.#V#salient_binary_predicate_for_type": 1,
             "relationships.is_a_type_of": 1,
+            "relationships.#V#is_a_type_of": 1,
         }
         type_docs = list(
             ConceptsRepository.find(
@@ -176,6 +190,7 @@ class RelationElicitationService:
         opportunities: List[str] = []
         seen_predicates: set[str] = set()
         visited_types: set[str] = set()
+        type_depth_by_id: Dict[str, int] = {type_id: 0 for type_id in direct_types}
 
         def consume_type_docs(docs: List[Dict[str, Any]]) -> List[str]:
             next_parents: List[str] = []
@@ -187,9 +202,7 @@ class RelationElicitationService:
                 candidates = [
                     *(type_relationships.get("suggested_relations_for_type") or []),
                     *(
-                        type_relationships.get(
-                            "#V#salient_binary_predicate_for_type"
-                        )
+                        type_relationships.get("#V#salient_binary_predicate_for_type")
                         or []
                     ),
                     *(doc.get("inherited_salient_binary_predicates") or []),
@@ -202,28 +215,57 @@ class RelationElicitationService:
                     ):
                         seen_predicates.add(candidate)
                         opportunities.append(candidate)
-                for parent in type_relationships.get("is_a_type_of") or []:
-                    if (
-                        isinstance(parent, str)
-                        and parent
-                        and parent not in visited_types
-                        and parent not in next_parents
-                    ):
-                        next_parents.append(parent)
+                for type_predicate in ("is_a_type_of", "#V#is_a_type_of"):
+                    for parent in type_relationships.get(type_predicate) or []:
+                        if (
+                            isinstance(parent, str)
+                            and parent
+                            and parent not in visited_types
+                            and parent not in next_parents
+                        ):
+                            next_parents.append(parent)
+                            parent_depth = int(type_depth_by_id.get(concept_id, 0)) + 1
+                            current_depth = type_depth_by_id.get(parent)
+                            if current_depth is None or parent_depth < current_depth:
+                                type_depth_by_id[parent] = parent_depth
             return next_parents
 
         pending_parents = consume_type_docs(type_docs)
         ancestor_batches = 0
-        while not opportunities and pending_parents and ancestor_batches < 4:
-            current_batch = pending_parents[:32]
+        while pending_parents and ancestor_batches < 16 and len(visited_types) < 250:
+            remaining_capacity = max(1, 250 - len(visited_types))
+            current_batch = pending_parents[: min(32, remaining_capacity)]
+            remaining_parents = pending_parents[len(current_batch) :]
             ancestor_docs = list(
                 ConceptsRepository.find(
                     {"concept_id": {"$in": current_batch}},
                     type_projection,
                 )
             )
-            pending_parents = consume_type_docs(ancestor_docs)
+            discovered_parents = consume_type_docs(ancestor_docs)
+            pending_parents = list(
+                dict.fromkeys(
+                    parent
+                    for parent in [*remaining_parents, *discovered_parents]
+                    if parent not in visited_types
+                )
+            )
             ancestor_batches += 1
+
+        # A constitutive relation is not merely salient.  Evaluate it against
+        # canonical relation incidence (including incoming relations) and put
+        # missing witnesses before optional salience prompts.  Any profile/read
+        # failure remains advisory and must not block concept creation or the
+        # rest of elicitation.
+        try:
+            constitutive_plan, _constitutive_diagnostics = (
+                self.constitutive_requirement_service.get_missing_requirements(
+                    instance=instance,
+                    type_depth_by_id=type_depth_by_id,
+                )
+            )
+        except Exception:
+            constitutive_plan = []
 
         existing_relations = set(relationships.keys())
         existing_hypothesized = set(
@@ -240,22 +282,34 @@ class RelationElicitationService:
             if predicate not in existing_relations
             and predicate not in existing_hypothesized
             and predicate not in existing_uncertain
+            and predicate
+            not in {
+                item.get("predicate_concept_id")
+                for item in constitutive_plan
+                if isinstance(item, dict)
+            }
         ]
 
-        selected_predicates = opportunities[:bounded_limit]
-        predicate_docs = list(
-            ConceptsRepository.find(
-                {"concept_id": {"$in": selected_predicates}},
-                {"concept_id": 1, "name": 1, "names": 1},
+        plan: List[Dict[str, Any]] = [
+            dict(item) for item in constitutive_plan[:bounded_limit]
+        ]
+        selected_predicates = opportunities[: max(0, bounded_limit - len(plan))]
+        predicate_docs = (
+            list(
+                ConceptsRepository.find(
+                    {"concept_id": {"$in": selected_predicates}},
+                    {"concept_id": 1, "name": 1, "names": 1},
+                )
             )
+            if selected_predicates
+            else []
         )
         predicate_docs_by_id = {
             str(doc.get("concept_id")): doc
             for doc in predicate_docs
             if doc.get("concept_id")
         }
-        plan: List[Dict[str, Any]] = []
-        for priority, predicate in enumerate(selected_predicates, start=1):
+        for predicate in selected_predicates:
             predicate_doc = predicate_docs_by_id.get(predicate) or {}
             predicate_label = str(
                 predicate_doc.get("name")
@@ -266,11 +320,14 @@ class RelationElicitationService:
                 {
                     "predicate_concept_id": predicate,
                     "predicate_label": predicate_label,
-                    "priority": priority,
+                    "requirement_kind": "salient_relation",
+                    "priority_class": "salient",
                     "question": question,
                     "status": "missing",
                 }
             )
+        for priority, item in enumerate(plan, start=1):
+            item["priority"] = priority
         return plan
 
     def generate_question_for_elicit(

--- a/src/backend/services/scoped_assertion_service.py
+++ b/src/backend/services/scoped_assertion_service.py
@@ -39,6 +39,7 @@ STORAGE_SURFACE = "scoped_knowledge_assertions"
 STANDALONE_TEXT_ASSERTION_FORM = "standalone_text"
 SCOPE_MODES = frozenset({"user", "organisation"})
 OBJECT_KINDS = frozenset({"text", "concept"})
+EPISTEMIC_STATUSES = frozenset({"tentative", "asserted"})
 MAX_PAGE_LIMIT = 1000
 MAX_PAGE_SUBJECTS = 100
 MAX_PAGE_CANDIDATES = 10_000
@@ -833,11 +834,15 @@ def upsert_scoped_assertion(
     namespace: Any = None,
     turn_id: Any = None,
     canonical_publication: bool = False,
+    epistemic_status: str = "asserted",
 ) -> dict[str, Any]:
     """Upsert one idempotent scoped assertion and return canonical read-back."""
 
     if canonical_publication is not False:
         raise ValueError("scoped assertions cannot request canonical publication")
+    requested_epistemic_status = str(epistemic_status or "").strip().lower()
+    if requested_epistemic_status not in EPISTEMIC_STATUSES:
+        raise ValueError("epistemic_status must be tentative or asserted")
     scope, actor_context = _scope_for_actor(
         scope_mode=scope_mode,
         acting_user_concept_id=acting_user_concept_id,
@@ -954,6 +959,7 @@ def upsert_scoped_assertion(
         "scope": scope,
         "canonical_publication": False,
         "status": "asserted",
+        "epistemic_status": requested_epistemic_status,
         "created_at": now,
         "updated_at": now,
         "provenance": provenance,
@@ -989,6 +995,40 @@ def upsert_scoped_assertion(
         if previous is None:
             raise
     created = previous is None
+    promoted = None
+    if (
+        isinstance(previous, Mapping)
+        and previous.get("status") == "asserted"
+        and previous.get("epistemic_status") == "tentative"
+        and requested_epistemic_status == "asserted"
+    ):
+        # Epistemic status is monotonic on an active assertion. A normal
+        # asserted upsert must not silently replay an older tentative candidate;
+        # exactly one concurrent caller promotes it and emits the asserted event.
+        promoted = collection.find_one_and_update(
+            {
+                "assertion_id": assertion_id,
+                "status": "asserted",
+                "epistemic_status": "tentative",
+            },
+            {
+                "$set": {
+                    "epistemic_status": "asserted",
+                    "updated_at": now,
+                    "epistemic_promotion": {
+                        "promoted_at": now,
+                        "promoted_by_user_concept_id": actor_context[
+                            "user_concept_id"
+                        ],
+                        "turn_id": str(turn_id or "").strip() or None,
+                        "capability_name": "upsert_scoped_assertion",
+                        "reason": "asserted_upsert",
+                    },
+                },
+                "$inc": {"assertion_revision": 1},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
     reactivated = None
     if isinstance(previous, Mapping) and previous.get("status") == "retracted":
         retraction_history_item = {
@@ -1010,6 +1050,7 @@ def upsert_scoped_assertion(
         # immutable; a bounded history preserves the retraction being undone.
         reactivation_set: dict[str, Any] = {
             "status": "asserted",
+            "epistemic_status": requested_epistemic_status,
             "updated_at": now,
             "reasserted_at": now,
             "reassertion_provenance": reassertion_provenance,
@@ -1035,13 +1076,13 @@ def upsert_scoped_assertion(
             },
             return_document=ReturnDocument.AFTER,
         )
-    persisted = reactivated or collection.find_one(
+    persisted = promoted or reactivated or collection.find_one(
         {"assertion_id": assertion_id}
     )
     read_back = _serialise(persisted)
     if read_back is None:
         raise RuntimeError("scoped assertion write did not produce read-back")
-    changed = bool(created or reactivated is not None)
+    changed = bool(created or promoted is not None or reactivated is not None)
     result = {
         "success": True,
         "effect_status": "succeeded",
@@ -1051,8 +1092,9 @@ def upsert_scoped_assertion(
         "canonical_read_back": read_back,
         "canonical_publication": False,
         "storage_surface": STORAGE_SURFACE,
+        "epistemic_status": read_back.get("epistemic_status") or "asserted",
     }
-    if changed:
+    if changed and (read_back.get("epistemic_status") or "asserted") == "asserted":
         # Scoped knowledge is a first-class mutation surface. Emit the same
         # actor-bound, best-effort event shape used by canonical Vontology
         # writes so represented workflows can react without task-specific
@@ -1070,8 +1112,11 @@ def upsert_scoped_assertion(
                 "predicate": storage_predicate,
                 "object_kind": object_kind,
                 "scope_mode": scope["mode"],
+                "epistemic_status": "asserted",
                 "canonical_publication": False,
             }
+            if promoted is not None:
+                event_payload["promoted_from_epistemic_status"] = "tentative"
             maybe_launch_vontology_mutation_workflow(
                 mutation_event_type=EVENT_TYPE_SCOPED_ASSERTION_UPSERTED,
                 mutation_id=assertion_id,
@@ -1087,6 +1132,116 @@ def upsert_scoped_assertion(
             # ambiguous failure.
             pass
     return result
+
+
+def promote_scoped_assertion_epistemic_status(
+    *,
+    assertion_id: Any,
+    acting_user_concept_id: Any,
+    organisation_concept_id: Any = None,
+    namespace: Any = None,
+    request_id: Any = None,
+) -> dict[str, Any]:
+    """Idempotently promote an actor-owned tentative assertion to asserted."""
+
+    assertion_token = str(assertion_id or "").strip()
+    if not assertion_token.startswith("ska_"):
+        raise ValueError("assertion_id must be an exact scoped assertion ID")
+    actor_context = _resolve_actor_context(
+        acting_user_concept_id=acting_user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        namespace=namespace,
+    )
+    user_id = actor_context["user_concept_id"]
+    org_id = actor_context["organisation_concept_id"]
+    scope_clauses: list[dict[str, Any]] = [{"scope.mode": "user"}]
+    if org_id:
+        scope_clauses.append(
+            {
+                "scope.mode": "organisation",
+                "scope.organisation_concept_id": org_id,
+            }
+        )
+    authority_filter: dict[str, Any] = {
+        "assertion_id": assertion_token,
+        "provenance.asserted_by_user_concept_id": user_id,
+        "status": "asserted",
+        "$or": scope_clauses,
+    }
+    collection = get_scoped_knowledge_assertions_collection()
+    if collection is None:
+        raise RuntimeError("scoped assertion storage is unavailable")
+    now = datetime.now(timezone.utc)
+    promoted = collection.find_one_and_update(
+        {
+            **authority_filter,
+            "epistemic_status": "tentative",
+        },
+        {
+            "$set": {
+                "epistemic_status": "asserted",
+                "updated_at": now,
+                "epistemic_confirmation": {
+                    "confirmed_at": now,
+                    "confirmed_by_user_concept_id": user_id,
+                    "request_id": str(request_id or "").strip() or None,
+                    "capability_name": "promote_scoped_assertion_epistemic_status",
+                },
+            },
+            "$inc": {"assertion_revision": 1},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    changed = promoted is not None
+    persisted = promoted or collection.find_one(authority_filter)
+    if not isinstance(persisted, Mapping):
+        raise PermissionError("scoped assertion is unavailable to the current actor")
+    # Assertions created before epistemic status existed are asserted by default.
+    stored_epistemic_status = persisted.get("epistemic_status") or "asserted"
+    if stored_epistemic_status != "asserted":
+        raise RuntimeError("scoped assertion epistemic promotion did not read back")
+    read_back = _serialise(persisted)
+    if read_back is None:
+        raise RuntimeError("scoped assertion promotion did not produce read-back")
+    if changed:
+        try:
+            from .workflow_event_integration_service import (
+                EVENT_TYPE_SCOPED_ASSERTION_UPSERTED,
+                maybe_launch_vontology_mutation_workflow,
+            )
+
+            event_payload = {
+                "assertion_id": assertion_token,
+                "subject_concept_id": read_back.get("subject_concept_id"),
+                "predicate": read_back.get("predicate"),
+                "object_kind": read_back.get("object_kind"),
+                "scope_mode": (read_back.get("scope") or {}).get("mode"),
+                "epistemic_status": "asserted",
+                "canonical_publication": False,
+                "promoted_from_epistemic_status": "tentative",
+            }
+            maybe_launch_vontology_mutation_workflow(
+                mutation_event_type=EVENT_TYPE_SCOPED_ASSERTION_UPSERTED,
+                mutation_id=assertion_token,
+                user_id=user_id,
+                org_id=org_id,
+                namespace=actor_context["namespace"],
+                event_payload=event_payload,
+                inputs=dict(event_payload),
+            )
+        except Exception:
+            pass
+    return {
+        "success": True,
+        "effect_status": "succeeded",
+        "changed": changed,
+        "assertion_id": assertion_token,
+        "epistemic_status": "asserted",
+        "assertion": read_back,
+        "canonical_read_back": read_back,
+        "canonical_publication": False,
+        "storage_surface": STORAGE_SURFACE,
+    }
 
 
 def retract_scoped_assertion(
@@ -1146,6 +1301,7 @@ def retract_scoped_assertion(
         {
             "_id": 0,
             "assertion_form": 1,
+            "epistemic_status": 1,
         },
     )
     update: dict[str, Any] = {
@@ -1214,7 +1370,16 @@ def retract_scoped_assertion(
             "durable": True,
             "rag_index": read_back.get("rag_index"),
         }
-    if changed and read_back.get("assertion_form") != STANDALONE_TEXT_ASSERTION_FORM:
+    current_epistemic_status = (
+        current.get("epistemic_status") or "asserted"
+        if isinstance(current, Mapping)
+        else None
+    )
+    if (
+        changed
+        and current_epistemic_status == "asserted"
+        and read_back.get("assertion_form") != STANDALONE_TEXT_ASSERTION_FORM
+    ):
         try:
             from .workflow_event_integration_service import (
                 EVENT_TYPE_SCOPED_ASSERTION_RETRACTED,
@@ -1227,6 +1392,7 @@ def retract_scoped_assertion(
                 "predicate": read_back.get("predicate"),
                 "object_kind": read_back.get("object_kind"),
                 "scope_mode": (read_back.get("scope") or {}).get("mode"),
+                "epistemic_status": "asserted",
                 "canonical_publication": False,
             }
             maybe_launch_vontology_mutation_workflow(
@@ -1433,7 +1599,26 @@ def _build_assertion_query(
     languages: Sequence[str] | None,
     assertion_form: str | None,
     context_id: str | None,
+    epistemic_statuses: Sequence[str] | None,
 ) -> dict[str, Any]:
+    requested_epistemic_statuses = {
+        str(item or "").strip().lower() for item in (epistemic_statuses or ())
+    }
+    if not requested_epistemic_statuses:
+        requested_epistemic_statuses = {"asserted"}
+    invalid_epistemic_statuses = requested_epistemic_statuses - EPISTEMIC_STATUSES
+    if invalid_epistemic_statuses:
+        raise ValueError("epistemic_statuses may contain tentative or asserted")
+    epistemic_clauses: list[dict[str, Any]] = []
+    if "asserted" in requested_epistemic_statuses:
+        epistemic_clauses.extend(
+            [
+                {"epistemic_status": "asserted"},
+                {"epistemic_status": {"$exists": False}},
+            ]
+        )
+    if "tentative" in requested_epistemic_statuses:
+        epistemic_clauses.append({"epistemic_status": "tentative"})
     query: dict[str, Any] = {
         (
             "scope.audience_key"
@@ -1441,6 +1626,7 @@ def _build_assertion_query(
             else "scope.audience_keys"
         ): {"$in": list(audience_keys)},
         "status": "asserted",
+        "$and": [{"$or": epistemic_clauses}],
     }
     if subject_concept_ids:
         query["subject_concept_id"] = {"$in": list(subject_concept_ids)}
@@ -1553,6 +1739,7 @@ def list_visible_scoped_assertions_page(
     languages: Sequence[str] | None = None,
     assertion_form: str | None = None,
     context_id: str | None = None,
+    epistemic_statuses: Sequence[str] | None = None,
     limit: int = 200,
     offset: int = 0,
     limit_per_subject: int | None = None,
@@ -1674,6 +1861,7 @@ def list_visible_scoped_assertions_page(
             languages=languages,
             assertion_form=assertion_form,
             context_id=context_id,
+            epistemic_statuses=epistemic_statuses,
         )
         collection = get_scoped_knowledge_assertions_collection()
         if collection is None:
@@ -1923,6 +2111,7 @@ def list_visible_scoped_assertions(
     languages: Sequence[str] | None = None,
     assertion_form: str | None = None,
     context_id: str | None = None,
+    epistemic_statuses: Sequence[str] | None = None,
     limit: int = 200,
     user_concept_id: str | None = None,
     organisation_concept_id: str | None = None,
@@ -1937,6 +2126,7 @@ def list_visible_scoped_assertions(
         languages=languages,
         assertion_form=assertion_form,
         context_id=context_id,
+        epistemic_statuses=epistemic_statuses,
         limit=limit,
         user_concept_id=user_concept_id,
         organisation_concept_id=organisation_concept_id,

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -56,6 +56,7 @@ _TEXT_PREDICATE_IDS = [
     f"#V#{RelationPredicate.HAS_INTERACTION}",
     "#V#hasDefinition",
     "#V#has_renderer_profile_json",
+    "#V#has_constitutive_relation_requirements_json",
 ]
 
 _FILE_METADATA_PREDICATE_IDS = [

--- a/src/backend/vontology/seed_bundles/constitutive_relation_requirements_seed_bundle.json
+++ b/src/backend/vontology/seed_bundles/constitutive_relation_requirements_seed_bundle.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "constitutive_relation_requirement_seed_bundle.v1",
+  "seed_version": "1",
+  "source_tag": "JVNAUTOSCI-1035",
+  "managed_by": "constitutive_relation_requirement_service",
+  "profiles": [
+    {
+      "declaring_type_concept_id": "#V#von_user_organisation",
+      "payload": {
+        "schema_version": "constitutive_relation_requirements.v1",
+        "requirements": [
+          {
+            "requirement_id": "von_user_organisation_has_von_user_member",
+            "predicate_concept_id": "#V#memberOf",
+            "predicate_label": "member of",
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "other_argument_type_label": "Von user",
+            "minimum_cardinality": 1,
+            "reason": "A Von user organisation is incomplete until at least one Von user membership is represented as an asserted relation.",
+            "activation_relevance": "identity_namespace_activation",
+            "authority_relevance": "organisation_membership_authority",
+            "auto_formalisation_allowed": true,
+            "auto_formalisation_target_status": "tentative",
+            "activation_minimum_status": "asserted",
+            "activation_satisfying_statuses": [
+              "asserted",
+              "confirmed"
+            ],
+            "confirmation_required_for_activation": true,
+            "confirmation_elicitation_priority": "before_fresh_gap",
+            "confirmation_effect": "promote_existing_candidate",
+            "confirmation_creates_new_claim": false,
+            "question_template": "Which Von user is a member of {instance_name}?",
+            "confirmation_question_template": "Should {counterpart_name} be confirmed as a member of {instance_name}?"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -14,6 +14,10 @@ import {
     decorateInspectableReferences,
     initializeReferenceInspector
 } from './components/referenceInspector.js';
+import {
+    renderConceptQaReceipt,
+    updateConceptQaReceiptConfirmationState,
+} from './components/conceptQaReceipt.js';
 import { elements, getCurrentUserConceptId, renderSpanSuggestions } from './domUtils.js';
 import { activateTab } from './tabNavigation.js';
 import { isAnnotationEnabled } from './featureFlags.js';
@@ -46,6 +50,17 @@ import {
     parseIsoTimestampMs,
     selectConversationHistorySessions
 } from './utils/conversationHistoryPreferences.js';
+import { buildConversationReferencePayload as buildSharedConversationReferencePayload } from './utils/conversationReference.js';
+import {
+    confirmConceptQaFormalisation,
+    conceptQaActionAllowed,
+    describeConceptQaElicitationGap,
+    isConceptQaSession,
+    normaliseConceptQaReceipts,
+    normaliseConceptQaSession,
+    submitConceptQaTurn,
+    transitionConceptQaSession,
+} from './utils/conceptQaSession.js';
 import {
     normaliseConversationSessionViewModel,
     normaliseConversationSessionViewModels
@@ -155,6 +170,10 @@ let totalHistorySegments = 1;
 let activeChatSessionId = null;
 let activeChatSessionName = null;
 let activeChatSessionOwnerId = null;
+const conceptQaSessionsByChatSession = new Map();
+const conceptQaSubmitInFlight = new Set();
+const conceptQaTransitionInFlight = new Set();
+const conceptQaErrorBySession = new Map();
 let activeExternalConversationMetadata = null;
 let chatSessionSelectionGeneration = 0;
 let newChatCreationInFlight = null;
@@ -1750,52 +1769,16 @@ function toggleConversationPinned(sessionId) {
 }
 
 function buildConversationReferencePayload(session) {
-    const sid = (typeof session?.session_id === 'string') ? session.session_id.trim() : '';
-    if (!sid) {
-        return null;
-    }
     const orgContext = getSessionScopedOrgContext();
-    const orgId = (
-        typeof session?.organisation_concept_id === 'string' && session.organisation_concept_id.trim()
-            ? session.organisation_concept_id.trim()
-            : (
-                typeof orgContext?.concept_id === 'string' && orgContext.concept_id.trim()
-                    ? orgContext.concept_id.trim()
-                    : (typeof orgContext?.id === 'string' && orgContext.id.trim() ? orgContext.id.trim() : null)
-            )
-    );
-    const currentUserId = getCurrentUserConceptId() || null;
-    const ownerUserId = (
-        typeof session?.shared_owner_user_id === 'string' && session.shared_owner_user_id.trim()
-            ? session.shared_owner_user_id.trim()
-            : currentUserId
-    );
-    const namespace = (
-        typeof session?.namespace === 'string' && session.namespace.trim()
-            ? session.namespace.trim()
-            : (getSessionScopedNamespace() || null)
-    );
-    return {
-        kind: 'von_conversation_ref',
-        conversation_ref: {
-            session_id: sid,
-            user_concept_id: ownerUserId,
-            namespace,
-            organisation_concept_id: orgId,
-            include_legacy: false,
-        },
-        chat_history_lookup: {
-            user_id: ownerUserId,
-            session_id: sid,
-            namespace,
-            include_legacy: false,
-        },
-        display: {
-            session_name: typeof session?.session_name === 'string' ? session.session_name : null,
-            last_message_at: typeof session?.last_message_at === 'string' ? session.last_message_at : null,
-            current_user_concept_id: currentUserId,
-        },
-    };
+    return buildSharedConversationReferencePayload(session, {
+        currentUserConceptId: getCurrentUserConceptId() || null,
+        namespace: getSessionScopedNamespace() || null,
+        organisationConceptId: (
+            typeof orgContext?.concept_id === 'string' && orgContext.concept_id.trim()
+                ? orgContext.concept_id.trim()
+                : (typeof orgContext?.id === 'string' && orgContext.id.trim() ? orgContext.id.trim() : null)
+        ),
+    });
 }
 
 async function copyConversationReferenceToClipboard(session) {
@@ -1818,6 +1801,535 @@ async function copyConversationReferenceToClipboard(session) {
         copied ? 'success' : 'error'
     );
     return copied;
+}
+
+function rememberConceptQaSession(value, defaults = {}) {
+    const projection = normaliseConceptQaSession(value, defaults);
+    if (!projection) return null;
+    conceptQaSessionsByChatSession.set(projection.chat_session_id, projection);
+    if (projection.session_id !== projection.chat_session_id) {
+        conceptQaSessionsByChatSession.set(projection.session_id, projection);
+    }
+    return projection;
+}
+
+function getConceptQaSessionForChat(sessionId = activeChatSessionId) {
+    const sid = normaliseHistorySessionId(sessionId);
+    if (!sid) return null;
+    const remembered = conceptQaSessionsByChatSession.get(sid);
+    if (remembered) return remembered;
+    const session = sessionTabsCache.find((row) => normaliseHistorySessionId(row?.session_id) === sid);
+    if (!isConceptQaSession(session)) return null;
+    const focalConceptId = Array.isArray(session?.focal_concept_ids)
+        ? session.focal_concept_ids.find((value) => typeof value === 'string' && value.trim())
+        : null;
+    return rememberConceptQaSession(session, { conceptId: focalConceptId, sessionId: sid });
+}
+
+function conceptQaReceiptsChangedKnowledge(value) {
+    const receipts = normaliseConceptQaReceipts(value);
+    const exactStatus = String(receipts.exact_input?.status || '').toLowerCase();
+    const formalisationStatus = String(receipts.formalisation?.status || '').toLowerCase();
+    const notesStatus = String(receipts.notes?.status || '').toLowerCase();
+    return ['stored', 'asserted', 'succeeded', 'success'].includes(exactStatus)
+        || ['candidate', 'proposed', 'tentative', 'uncertain', 'stored', 'asserted', 'succeeded', 'success'].includes(formalisationStatus)
+        || ['updated', 'stored', 'succeeded', 'success'].includes(notesStatus);
+}
+
+function dispatchConceptQaKnowledgeChange(session, receipts, reason = 'concept_q_and_a_turn') {
+    if (!session?.concept_id || !conceptQaReceiptsChangedKnowledge(receipts)) return;
+    document.dispatchEvent(new CustomEvent('von:conceptKnowledgeChanged', {
+        detail: {
+            conceptId: session.concept_id,
+            sessionId: session.session_id,
+            reason,
+            receipts: normaliseConceptQaReceipts(receipts),
+        },
+    }));
+    document.dispatchEvent(new CustomEvent('concept-updated', {
+        detail: {
+            conceptId: session.concept_id,
+            reason,
+            source: 'concept_q_and_a',
+        },
+    }));
+}
+
+function getConceptQaConfirmationUiState(
+    receipt = null,
+    session = getConceptQaSessionForChat(),
+) {
+    if (!session) {
+        return {
+            available: false,
+            label: 'Confirmation unavailable',
+            reason: 'Open the concept Q&A conversation that recorded this tentative relation.',
+        };
+    }
+    if (session.lifecycle === 'cancelled') {
+        return {
+            available: false,
+            label: 'Unavailable — Q&A cancelled',
+            reason: 'This concept Q&A was cancelled, so this receipt can no longer confirm the tentative relation.',
+        };
+    }
+    if (
+        session.lifecycle === 'finished'
+        && receipt?.confirmation?.available_after_finish !== true
+    ) {
+        return {
+            available: false,
+            label: 'Unavailable — Q&A finished',
+            reason: 'This finished Q&A receipt does not permit post-finish confirmation.',
+        };
+    }
+    if (!['active', 'finished'].includes(session.lifecycle)) {
+        return {
+            available: false,
+            label: `Unavailable — Q&A ${session.lifecycle}`,
+            reason: `This concept Q&A is ${session.lifecycle}; confirmation is not available in this lifecycle state.`,
+        };
+    }
+    if (conceptQaTransitionInFlight.has(session.session_id)) {
+        return {
+            available: false,
+            label: 'Confirmation unavailable',
+            reason: 'Wait for the current Q&A confirmation or lifecycle change to finish.',
+        };
+    }
+    return { available: true };
+}
+
+function updateVisibleConceptQaConfirmationUi(session = getConceptQaSessionForChat()) {
+    const scrollableField = document.getElementById('scrollableField');
+    if (!scrollableField) return;
+    updateConceptQaReceiptConfirmationState(
+        scrollableField,
+        (receipt) => getConceptQaConfirmationUiState(receipt, session),
+    );
+}
+
+function updateConceptQaComposerUi() {
+    const session = getConceptQaSessionForChat();
+    const promptInput = getPromptInputElement();
+    if (!promptInput) return;
+    if (!promptInput.dataset.nativePlaceholder) {
+        promptInput.dataset.nativePlaceholder = promptInput.getAttribute('placeholder') || 'Talk with Von here...';
+    }
+    if (!session) {
+        if (!isExternalConversationReadOnly()) {
+            promptInput.disabled = false;
+            promptInput.setAttribute('placeholder', promptInput.dataset.nativePlaceholder);
+        }
+        return;
+    }
+    const busy = conceptQaSubmitInFlight.has(session.session_id)
+        || conceptQaTransitionInFlight.has(session.session_id);
+    const terminal = session.lifecycle !== 'active';
+    const readOnly = isExternalConversationReadOnly();
+    promptInput.disabled = readOnly || terminal || busy;
+    promptInput.setAttribute(
+        'placeholder',
+        readOnly
+            ? 'Imported snapshot — choose Continue to add new turns.'
+            : terminal
+            ? `Concept Q&A ${session.lifecycle}; the transcript remains available.`
+            : (busy ? 'Saving this Q&A turn…' : 'Answer the current concept question…'),
+    );
+}
+
+function renderConceptQaConversationControls() {
+    const mount = document.getElementById('conceptQaConversationControls');
+    if (!mount) return;
+    const session = getConceptQaSessionForChat();
+    if (!session) {
+        mount.replaceChildren();
+        mount.classList.add('hidden');
+        updateVisibleConceptQaConfirmationUi(null);
+        updateConceptQaComposerUi();
+        return;
+    }
+
+    mount.classList.remove('hidden');
+    mount.replaceChildren();
+    const header = document.createElement('div');
+    header.className = 'concept-qa-conversation-header';
+    const title = document.createElement('strong');
+    title.textContent = 'Concept Q&A';
+    const status = document.createElement('span');
+    status.className = 'concept-qa-conversation-status';
+    status.textContent = session.lifecycle === 'active'
+        ? 'Active · answers and representation outcomes are saved in this conversation.'
+        : `${session.lifecycle === 'finished' ? 'Finished' : 'Cancelled'} · transcript and prior knowledge are retained.`;
+    header.append(title, status);
+    mount.appendChild(header);
+
+    const gapText = describeConceptQaElicitationGap(session);
+    if (gapText) {
+        const gap = document.createElement('p');
+        gap.className = 'concept-qa-conversation-gap';
+        gap.textContent = gapText;
+        mount.appendChild(gap);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'concept-qa-conversation-actions';
+    const busy = conceptQaTransitionInFlight.has(session.session_id);
+
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.className = 'btn-mini';
+    copy.textContent = 'Copy reference';
+    copy.disabled = busy;
+    copy.addEventListener('click', () => void copyConversationReferenceToClipboard(session));
+    actions.appendChild(copy);
+
+    if (session.lifecycle === 'active') {
+        const finish = document.createElement('button');
+        finish.type = 'button';
+        finish.className = 'btn-mini concept-qa-finish';
+        finish.textContent = busy ? 'Saving…' : 'Finish Q&A';
+        finish.disabled = busy || !conceptQaActionAllowed(session, 'finish');
+        finish.addEventListener('click', () => void transitionActiveConceptQa('finish'));
+
+        const cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.className = 'btn-mini concept-qa-cancel';
+        cancel.textContent = 'Cancel Q&A';
+        cancel.title = 'Stop future Q&A turns. The transcript and already recorded knowledge are retained.';
+        cancel.disabled = busy || !conceptQaActionAllowed(session, 'cancel');
+        cancel.addEventListener('click', () => void transitionActiveConceptQa('cancel'));
+        actions.append(finish, cancel);
+    }
+    mount.appendChild(actions);
+    const errorText = conceptQaErrorBySession.get(session.session_id);
+    if (errorText) {
+        const message = document.createElement('p');
+        message.className = 'concept-qa-conversation-error';
+        message.textContent = errorText;
+        mount.appendChild(message);
+    }
+    updateVisibleConceptQaConfirmationUi(session);
+    updateConceptQaComposerUi();
+    updateSendButtonForCurrentChatState();
+}
+
+async function transitionActiveConceptQa(action) {
+    const current = getConceptQaSessionForChat();
+    if (!current?.concept_id || !current?.session_id) return false;
+    const key = current.session_id;
+    if (conceptQaTransitionInFlight.has(key)) return false;
+    conceptQaTransitionInFlight.add(key);
+    conceptQaErrorBySession.delete(key);
+    renderConceptQaConversationControls();
+    try {
+        const updated = await transitionConceptQaSession({
+            conceptId: current.concept_id,
+            sessionId: current.session_id,
+            action,
+        });
+        rememberConceptQaSession(updated);
+        const cacheIndex = sessionTabsCache.findIndex((row) => row?.session_id === current.chat_session_id);
+        if (cacheIndex >= 0) {
+            sessionTabsCache[cacheIndex] = normaliseConversationSessionViewModel({
+                ...sessionTabsCache[cacheIndex],
+                ...updated,
+                is_completed: updated.lifecycle !== 'active',
+            });
+        }
+        showToast(
+            action === 'finish'
+                ? 'Concept Q&A finished. Its transcript is retained.'
+                : 'Concept Q&A cancelled. Its transcript and prior knowledge are retained.',
+            'success',
+        );
+        document.dispatchEvent(new CustomEvent('von:conceptQaLifecycleChanged', {
+            detail: { conceptId: updated.concept_id, session: updated },
+        }));
+        scheduleChatSessionTabsRefresh(true);
+        return true;
+    } catch (error) {
+        conceptQaErrorBySession.set(
+            key,
+            error?.status === 409
+                ? 'This Q&A changed elsewhere. Reload the conversation status and try again.'
+                : (error?.message || 'The Q&A state could not be changed. Try again.'),
+        );
+        return false;
+    } finally {
+        conceptQaTransitionInFlight.delete(key);
+        renderConceptQaConversationControls();
+    }
+}
+
+function renderConceptQaTurns(session) {
+    const turns = Array.isArray(session?.turns) ? session.turns : [];
+    const scrollableField = document.getElementById('scrollableField');
+    if (!turns.length || !scrollableField) return false;
+    historySegmentsShown = 1;
+    totalHistorySegments = 1;
+    rehydrateHistory(scrollableField, turns, {
+        scrollToBottom: true,
+        preserveScroll: false,
+        showResetNotice: false,
+        forceScrollToBottom: true,
+    });
+    displayedHistorySessionId = session.chat_session_id;
+    return true;
+}
+
+export async function openConceptQaConversation(value) {
+    const session = rememberConceptQaSession(value);
+    if (!session) return { ok: false, error: 'Concept Q&A session is missing.' };
+    const existing = sessionTabsCache.find((row) => row?.session_id === session.chat_session_id);
+    const viewModel = normaliseConversationSessionViewModel({
+        ...existing,
+        ...session,
+        session_id: session.chat_session_id,
+        session_name: session.session_name || existing?.session_name || 'Concept Q&A',
+        focal_concept_ids: session.concept_id ? [session.concept_id] : existing?.focal_concept_ids,
+        is_completed: session.lifecycle !== 'active',
+    });
+    sessionTabsCache = normaliseConversationSessionViewModels([
+        viewModel,
+        ...sessionTabsCache.filter((row) => row?.session_id !== session.chat_session_id),
+    ]);
+    activateTab('chatTab');
+    const switched = await switchToChatSession(session.chat_session_id);
+    if (!switched?.ok && !renderConceptQaTurns(session)) return switched;
+    setActiveChatSession(session.chat_session_id, viewModel?.session_name || 'Concept Q&A');
+    if (session.turns.length) renderConceptQaTurns(session);
+    renderChatSessionTabs(sessionTabsCache, session.chat_session_id);
+    renderConceptQaConversationControls();
+    return { ok: true, session };
+}
+
+async function submitActiveConceptQaPrompt({ session, promptInput, promptRaw }) {
+    if (!session?.concept_id || !session?.session_id) return false;
+    if (session.lifecycle !== 'active') {
+        showToast(`This concept Q&A is ${session.lifecycle}; its transcript remains available.`, 'info');
+        renderConceptQaConversationControls();
+        return false;
+    }
+    const key = session.session_id;
+    if (conceptQaSubmitInFlight.has(key)) return false;
+    conceptQaSubmitInFlight.add(key);
+    conceptQaErrorBySession.delete(key);
+    renderConceptQaConversationControls();
+    try {
+        const result = await submitConceptQaTurn({
+            conceptId: session.concept_id,
+            sessionId: session.session_id,
+            answer: promptRaw,
+        });
+        const updated = rememberConceptQaSession(result.session);
+        if (!updated) throw new Error('The Q&A response did not include session read-back.');
+        rememberLastSubmittedUserPrompt(promptRaw);
+        setPromptComposerValue('', { promptInput });
+        invalidateSessionHistoryCache(updated.chat_session_id);
+        if (!renderConceptQaTurns(updated)) {
+            await loadChatHistory({
+                segments: Math.max(historySegmentsShown, 1),
+                scrollToBottom: true,
+                preserveScroll: false,
+                showResetNotice: false,
+                forceScrollToBottom: true,
+            });
+        }
+        dispatchConceptQaKnowledgeChange(updated, result.receipts);
+        if (updated.lifecycle !== 'active') scheduleChatSessionTabsRefresh(true);
+        return true;
+    } catch (error) {
+        const readBack = normaliseConceptQaSession(error?.payload, {
+            conceptId: session.concept_id,
+            sessionId: session.session_id,
+        });
+        if (error?.status === 409 && readBack) rememberConceptQaSession(readBack);
+        conceptQaErrorBySession.set(
+            key,
+            error?.status === 409
+                ? 'This Q&A is no longer active. Its current state and transcript have been retained.'
+                : (error?.message || 'This Q&A turn could not be saved. Your draft remains in the composer.'),
+        );
+        return false;
+    } finally {
+        conceptQaSubmitInFlight.delete(key);
+        renderConceptQaConversationControls();
+    }
+}
+
+function conceptQaConfirmationDenialText({
+    denial = {},
+    requiredConfirmer = '',
+    reason = '',
+    reconciliationRequired = false,
+} = {}) {
+    const sentence = (value) => {
+        const text = String(value || '').trim();
+        if (!text) return '';
+        return /[.!?]$/.test(text) ? text : `${text}.`;
+    };
+    const whoCanAddMembership = String(denial?.who_can_add_membership || '').trim();
+    const membershipManagementPath = String(denial?.membership_management_path || '').trim();
+    const originalActorNextStep = String(denial?.original_actor_next_step || '').trim();
+    const genericConfirmer = String(
+        denial?.who_can_confirm
+        || denial?.required_confirmer
+        || requiredConfirmer
+        || '',
+    ).trim();
+    const permissions = Array.isArray(denial?.required_permissions)
+        ? denial.required_permissions.filter(Boolean).join(', ')
+        : '';
+    const membershipHandoff = whoCanAddMembership
+        ? sentence([
+            'Membership handoff:',
+            whoCanAddMembership,
+            membershipManagementPath ? `must add the membership through ${membershipManagementPath}` : '',
+        ].filter(Boolean).join(' '))
+        : (membershipManagementPath
+            ? sentence(`Use ${membershipManagementPath} to add the membership`)
+            : '');
+
+    return [
+        'The tentative relation was retained.',
+        reconciliationRequired
+            ? 'A governed activation may have completed and needs reconciliation.'
+            : '',
+        membershipHandoff,
+        denial?.same_q_and_a_action_available_to_other_actor === false
+            ? 'The authorised membership manager cannot use this actor-scoped Q&A Confirm action on behalf of the original actor.'
+            : '',
+        originalActorNextStep
+            ? `Next step for the original Q&A actor: ${sentence(originalActorNextStep)}`
+            : '',
+        !whoCanAddMembership && genericConfirmer
+            ? sentence(`Confirmation requires ${genericConfirmer}`)
+            : '',
+        permissions ? sentence(`Required permission: ${permissions}`) : '',
+        reason
+            ? sentence(`Reason: ${reason}`)
+            : 'Confirmation did not complete; try again.',
+    ].filter(Boolean).join(' ');
+}
+
+async function confirmActiveConceptQaFormalisation(receipt) {
+    const session = getConceptQaSessionForChat();
+    const assertionId = typeof receipt?.assertion_id === 'string' ? receipt.assertion_id.trim() : '';
+    if (!session?.concept_id || !session?.session_id || !assertionId) return false;
+    const key = session.session_id;
+    if (receipt?.confirmation?.available !== true) {
+        conceptQaErrorBySession.set(
+            key,
+            'This receipt no longer offers confirmation; reload the conversation for current status.',
+        );
+        renderConceptQaConversationControls();
+        return false;
+    }
+    const confirmationState = getConceptQaConfirmationUiState(receipt, session);
+    if (!confirmationState.available) {
+        conceptQaErrorBySession.set(
+            key,
+            `${confirmationState.reason} The tentative relation was not changed.`,
+        );
+        renderConceptQaConversationControls();
+        return false;
+    }
+    if (conceptQaTransitionInFlight.has(key)) return false;
+    conceptQaTransitionInFlight.add(key);
+    conceptQaErrorBySession.delete(key);
+    renderConceptQaConversationControls();
+    try {
+        const result = await confirmConceptQaFormalisation({
+            conceptId: session.concept_id,
+            sessionId: session.session_id,
+            assertionId,
+            confirmation: receipt.confirmation,
+        });
+        const updated = rememberConceptQaSession(result.session);
+        if (updated?.turns?.length) {
+            renderConceptQaTurns(updated);
+        } else {
+            invalidateSessionHistoryCache(session.chat_session_id);
+            await loadChatHistory({
+                segments: Math.max(historySegmentsShown, 1),
+                scrollToBottom: false,
+                preserveScroll: true,
+                showResetNotice: false,
+            });
+        }
+        const formalisation = result.receipts?.formalisation;
+        const formalisationStatus = String(formalisation?.status || '').toLowerCase();
+        const confirmationOutcome = result.payload?.confirmation;
+        const canonicalReadBack = confirmationOutcome?.canonical_read_back
+            ?? formalisation?.confirmation?.last_attempt?.canonical_read_back
+            ?? formalisation?.canonical_read_back
+            ?? formalisation?.read_back;
+        const readBackStatus = String(
+            canonicalReadBack?.epistemic_status || canonicalReadBack?.status || '',
+        ).toLowerCase();
+        const confirmed = result.payload?.success !== false
+            && ['asserted', 'succeeded', 'success'].includes(formalisationStatus)
+            && (canonicalReadBack === true
+                || canonicalReadBack?.verified === true
+                || ['asserted', 'verified', 'succeeded'].includes(readBackStatus));
+        if (!confirmed) {
+            const denial = formalisation?.actionable_denial
+                || result.payload?.actionable_denial
+                || result.payload?.confirmation?.actionable_denial
+                || {};
+            const reason = formalisation?.error_code
+                || result.payload?.error_code
+                || result.payload?.reason;
+            conceptQaErrorBySession.set(
+                key,
+                conceptQaConfirmationDenialText({ denial, reason }),
+            );
+            return false;
+        }
+        dispatchConceptQaKnowledgeChange(
+            updated || session,
+            result.receipts,
+            'concept_q_and_a_formalisation_confirmed',
+        );
+        showToast('Tentative relation confirmed and read back.', 'success');
+        return true;
+    } catch (error) {
+        const readBack = normaliseConceptQaSession(error?.payload, {
+            conceptId: session.concept_id,
+            sessionId: session.session_id,
+        });
+        if (readBack) {
+            rememberConceptQaSession(readBack);
+            if (readBack.turns?.length) renderConceptQaTurns(readBack);
+        }
+        const confirmation = error?.payload?.confirmation;
+        const denial = confirmation?.actionable_denial
+            || error?.payload?.actionable_denial
+            || {};
+        const requiredConfirmer = denial.who_can_confirm
+            || denial.required_confirmer
+            || error?.payload?.required_confirmer
+            || confirmation?.required_confirmer;
+        const detail = confirmation?.error_code
+            || error?.payload?.error_code
+            || error?.payload?.reason
+            || error?.payload?.detail
+            || error?.message;
+        conceptQaErrorBySession.set(
+            key,
+            conceptQaConfirmationDenialText({
+                denial,
+                requiredConfirmer,
+                reason: detail,
+                reconciliationRequired: confirmation?.reconciliation_required === true,
+            }),
+        );
+        return false;
+    } finally {
+        conceptQaTransitionInFlight.delete(key);
+        renderConceptQaConversationControls();
+    }
 }
 
 function toggleShowHiddenSessions() {
@@ -6016,6 +6528,10 @@ function updateExternalConversationUi() {
             button.disabled = readOnly;
         }
     });
+    // Session-list refreshes also pass through this function. Reapply the
+    // stronger concept-Q&A lifecycle state so a finished or cancelled Q&A is
+    // not made editable just because it is an ordinary (non-imported) chat.
+    updateConceptQaComposerUi();
     updateSendButtonForCurrentChatState();
 }
 
@@ -6034,11 +6550,33 @@ function updateSendButtonForCurrentChatState() {
         || queueCounts.queued > 0
         || queueCounts.restartable > 0;
     const readOnly = isExternalConversationReadOnly();
-    sendButton.disabled = uploadInFlight || queueSubmissionInFlight || readOnly;
-    sendButton.setAttribute('aria-busy', queueSubmissionInFlight ? 'true' : 'false');
+    const conceptQaSession = getConceptQaSessionForChat();
+    const conceptQaBusy = Boolean(
+        conceptQaSession
+        && (
+            conceptQaSubmitInFlight.has(conceptQaSession.session_id)
+            || conceptQaTransitionInFlight.has(conceptQaSession.session_id)
+        )
+    );
+    const conceptQaTerminal = Boolean(conceptQaSession && conceptQaSession.lifecycle !== 'active');
+    sendButton.disabled = uploadInFlight
+        || queueSubmissionInFlight
+        || readOnly
+        || conceptQaBusy
+        || conceptQaTerminal;
+    sendButton.setAttribute('aria-busy', queueSubmissionInFlight || conceptQaBusy ? 'true' : 'false');
     if (readOnly) {
         sendButton.textContent = 'Read-only import';
         sendButton.title = 'Continue this imported snapshot before sending a new message.';
+        return;
+    }
+    if (conceptQaSession) {
+        sendButton.textContent = conceptQaTerminal
+            ? `Q&A ${conceptQaSession.lifecycle}`
+            : (conceptQaBusy ? 'Saving Q&A…' : 'Submit answer');
+        sendButton.title = conceptQaTerminal
+            ? 'The transcript remains available, but this concept Q&A no longer accepts turns.'
+            : (conceptQaBusy ? 'Saving this turn and its representation receipts.' : 'Submit this answer to concept Q&A.');
         return;
     }
     sendButton.textContent = queueSubmissionInFlight
@@ -24440,6 +24978,7 @@ function setActiveChatSession(sessionId, sessionName, externalConversation = und
     renderActiveUploadUi();
     renderChatTaskQueuePanel();
     updateExternalConversationUi();
+    renderConceptQaConversationControls();
 }
 
 function getChatSessionTabsContainer() {
@@ -28065,6 +28604,10 @@ async function switchToChatSession(sessionId, options = {}) {
             throw new Error('Conversation switch response did not match the selected session.');
         }
 
+        if (isConceptQaSession(data) || isConceptQaSession(data?.qa_session)) {
+            rememberConceptQaSession(data?.qa_session || data, { sessionId: sid });
+        }
+
         setActiveChatSession(
             data?.session_id,
             data?.session_name,
@@ -28623,6 +29166,13 @@ async function loadChatHistory(options = {}) {
         });
         const data = await response.json().catch(() => ({}));
 
+        if (isConceptQaSession(data) || isConceptQaSession(data?.qa_session)) {
+            rememberConceptQaSession(data?.qa_session || data, {
+                sessionId: requestedSessionId,
+            });
+            renderConceptQaConversationControls();
+        }
+
         if (!isChatOrganisationRequestCurrent(organisationGenerationAtStart)) {
             return false;
         }
@@ -28876,7 +29426,8 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
 
     historyMessages.forEach((msg, index) => {
         if (msg.role === 'user' || msg.role === 'assistant') {
-            const turnId = `history-${msg.role}-${index}`;
+            const persistedTurnId = typeof msg.turn_id === 'string' ? msg.turn_id.trim() : '';
+            const turnId = persistedTurnId || `history-${msg.role}-${index}`;
             let label = msg.role === 'user' ? 'User' : 'Von';
             const externalActor = (
                 msg.external_actor && typeof msg.external_actor === 'object'
@@ -28903,6 +29454,11 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
                 const merged = {
                     ...(msg.llm_debug_data && typeof msg.llm_debug_data === 'object' ? msg.llm_debug_data : {}),
                     history_location: msg.history_location || null,
+                    reference_manifest: msg.reference_manifest
+                        || msg.llm_debug_data?.reference_manifest
+                        || null,
+                    receipts: msg.receipts || msg.representation_receipts || null,
+                    representation: msg.representation || null,
                     timestamp: (
                         msg.llm_debug_data
                         && typeof msg.llm_debug_data === 'object'
@@ -28915,6 +29471,20 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
                 setLlmDebugDataEntry(turnId, merged);
             }
 
+            const historyMessageOptions = {
+                ...(externalActor ? {
+                    assistantMessage: msg.role === 'assistant',
+                    externalActor,
+                    readOnly: true
+                } : {}),
+                conceptQaReceipt: {
+                    receipts: msg.receipts || msg.representation_receipts || null,
+                    representation: msg.representation || null,
+                    reference_manifest: msg.reference_manifest
+                        || msg.llm_debug_data?.reference_manifest
+                        || null,
+                },
+            };
             appendMessage(
                 label,
                 msg.content,
@@ -28924,11 +29494,7 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
                 msg.timestamp,
                 null,
                 null,
-                externalActor ? {
-                    assistantMessage: msg.role === 'assistant',
-                    externalActor,
-                    readOnly: true
-                } : null
+                historyMessageOptions
             );
             if (msg.role === 'assistant') {
                 const debugData = llmDebugData.get(turnId);
@@ -36334,6 +36900,16 @@ async function handleSendPrompt(options = {}) {
         return;
     }
 
+    const conceptQaSession = getConceptQaSessionForChat(targetSessionId);
+    if (conceptQaSession && directComposerSubmission && !assistantOpening) {
+        await submitActiveConceptQaPrompt({
+            session: conceptQaSession,
+            promptInput,
+            promptRaw,
+        });
+        return;
+    }
+
     if (!observeServerDispatch && getUnavailableLocalModelPreferenceForChat()) {
         if (!fromQueue) {
             notifyUnavailableLocalModelForChat();
@@ -37669,8 +38245,18 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
                     buttonifyOptions: debugData?.buttonify?.options
                 });
                 appendQuickReplyButtons(messageContent, debugData?.buttonify);
+                renderConceptQaReceipt(
+                    messageContent,
+                    options.conceptQaReceipt || debugData,
+                    {
+                        onConfirm: confirmActiveConceptQaFormalisation,
+                        getConfirmationState: (receipt) => (
+                            getConceptQaConfirmationUiState(receipt)
+                        ),
+                    },
+                );
             } catch (err) {
-                console.warn('[chatTab] Quick reply rendering failed:', err);
+                console.warn('[chatTab] Assistant turn enrichment rendering failed:', err);
             }
             if (thinkingCardSlot) {
                 messageContent.appendChild(thinkingCardSlot);
@@ -37791,6 +38377,20 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
 
             messageContainer.appendChild(messageHeader);
             messageContainer.appendChild(messageText);
+            try {
+                renderConceptQaReceipt(
+                    messageContainer,
+                    options.conceptQaReceipt,
+                    {
+                        onConfirm: confirmActiveConceptQaFormalisation,
+                        getConfirmationState: (receipt) => (
+                            getConceptQaConfirmationUiState(receipt)
+                        ),
+                    },
+                );
+            } catch (err) {
+                console.warn('[chatTab] User turn representation receipt rendering failed:', err);
+            }
             if (turnId && sender === 'Error') {
                 const thinkingCardSlot = document.createElement('div');
                 thinkingCardSlot.className = 'thinking-card-inline-slot';
@@ -40749,6 +41349,48 @@ export function __testOnly_setActiveChatSession(
 ) {
     setActiveChatSession(sessionId, sessionName, externalConversation);
     syncActiveChatRequestPointers();
+}
+export function __testOnly_setConceptQaSession(session, { active = true } = {}) {
+    const projection = rememberConceptQaSession(session);
+    if (!projection) return null;
+    sessionTabsCache = normaliseConversationSessionViewModels([
+        {
+            ...projection,
+            session_id: projection.chat_session_id,
+            session_name: projection.session_name || 'Concept Q&A',
+            is_completed: projection.lifecycle !== 'active',
+        },
+        ...sessionTabsCache.filter((row) => row?.session_id !== projection.chat_session_id),
+    ]);
+    if (active) {
+        activeChatSessionId = projection.chat_session_id;
+        activeChatSessionName = projection.session_name || 'Concept Q&A';
+    }
+    renderConceptQaConversationControls();
+    return projection;
+}
+export function __testOnly_getConceptQaSession(sessionId = null) {
+    return getConceptQaSessionForChat(sessionId || activeChatSessionId);
+}
+export function __testOnly_renderConceptQaConversationControls() {
+    renderConceptQaConversationControls();
+}
+export async function __testOnly_transitionActiveConceptQa(action) {
+    return transitionActiveConceptQa(action);
+}
+export async function __testOnly_submitActiveConceptQaPrompt(promptRaw) {
+    const session = getConceptQaSessionForChat();
+    const promptInput = getPromptInputElement();
+    return submitActiveConceptQaPrompt({ session, promptInput, promptRaw });
+}
+export async function __testOnly_confirmActiveConceptQaFormalisation(receipt) {
+    return confirmActiveConceptQaFormalisation(receipt);
+}
+export function __testOnly_resetConceptQaState() {
+    conceptQaSessionsByChatSession.clear();
+    conceptQaSubmitInFlight.clear();
+    conceptQaTransitionInFlight.clear();
+    conceptQaErrorBySession.clear();
 }
 export function __testOnly_updateExternalConversationUi() {
     updateExternalConversationUi();

--- a/src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js
@@ -6,6 +6,7 @@ const actorContextState = globalThis[ACTOR_CONTEXT_STATE_KEY] || {
   registrations: new Map(),
   listenersBound: false,
   reload: null,
+  refreshKnowledge: null,
 };
 globalThis[ACTOR_CONTEXT_STATE_KEY] = actorContextState;
 const panelRegistrations = actorContextState.registrations;
@@ -122,26 +123,112 @@ function createAssertionDetails(item) {
   return details;
 }
 
-function createAssertionRow(item) {
+function assertionRelevanceKind(item) {
+  return cleanText(item?.concept_relevance?.kind).toLowerCase();
+}
+
+function assertionDirection(item) {
+  const relevanceKind = assertionRelevanceKind(item);
+  if (relevanceKind === 'grounded_object') return 'incoming';
+  if (relevanceKind === 'grounded_subject') return 'outgoing';
+  if (relevanceKind === 'grounded_subject_and_object') return 'reflexive';
+  if (relevanceKind === 'aboutness_only') return 'aboutness';
+  return 'unspecified';
+}
+
+function assertionArgumentLabel(argument) {
+  if (!argument || typeof argument !== 'object') return '';
+  if (argument.kind === 'text') return cleanText(argument.text);
+  return cleanText(argument.display_name) || cleanText(argument.concept_id);
+}
+
+function assertionStatementPresentation(item) {
   const predicate = cleanText(item?.predicate?.display_name) || 'Assertion';
-  const object = item?.object || {};
-  const value = object.kind === 'concept'
-    ? cleanText(object.display_name) || cleanText(object.concept_id)
-    : cleanText(object.text);
+  const value = assertionArgumentLabel(item?.object);
   if (!value) return null;
+
+  const humanStatement = cleanText(item?.human_statement);
+  if (humanStatement) {
+    return { complete: true, predicate, text: humanStatement, value };
+  }
+
+  const relevanceKind = assertionRelevanceKind(item);
+  if (relevanceKind === 'aboutness_only') {
+    return { complete: true, predicate, text: value, value };
+  }
+
+  const subject = assertionArgumentLabel(item?.subject);
+  if (subject) {
+    return {
+      complete: true,
+      predicate,
+      text: [subject, predicate, value].join(' '),
+      value,
+    };
+  }
+  return { complete: false, predicate, text: '', value };
+}
+
+function createAssertionRow(item) {
+  const presentation = assertionStatementPresentation(item);
+  if (!presentation) return null;
 
   const row = document.createElement('article');
   row.className = 'concept-effective-assertion-row';
   row.dataset.assertionId = cleanText(item?.assertion_id);
+  row.dataset.relationDirection = assertionDirection(item);
 
   const statement = document.createElement('div');
   statement.className = 'concept-effective-assertion-statement';
-  appendText(statement, 'span', 'concept-effective-assertion-predicate', predicate);
-  appendText(statement, 'span', 'concept-effective-assertion-value', value);
+  if (presentation.complete) {
+    statement.classList.add('is-complete-statement');
+    appendText(
+      statement,
+      'span',
+      'concept-effective-assertion-human-statement',
+      presentation.text,
+    );
+  } else {
+    appendText(
+      statement,
+      'span',
+      'concept-effective-assertion-predicate',
+      presentation.predicate,
+    );
+    appendText(
+      statement,
+      'span',
+      'concept-effective-assertion-value',
+      presentation.value,
+    );
+  }
   row.appendChild(statement);
+
+  if (item?.concept_relevance?.aboutness_only === true
+      || item?.concept_relevance?.kind === 'aboutness_only') {
+    const relevance = appendText(
+      row,
+      'p',
+      'concept-effective-assertion-relevance aboutness-only',
+      'Exact text linked to this concept; no typed relation asserted.',
+    );
+    if (relevance) relevance.setAttribute('role', 'note');
+  }
 
   const context = item?.source_context || {};
   const contextKind = context.kind === 'organisation' ? 'organisation' : 'personal';
+  const epistemicStatus = cleanText(item?.epistemic_status).toLowerCase();
+  const aboutnessOnly = item?.concept_relevance?.aboutness_only === true
+    || item?.concept_relevance?.kind === 'aboutness_only';
+  if (epistemicStatus === 'tentative' && !aboutnessOnly) {
+    const tentative = appendText(
+      row,
+      'span',
+      'concept-effective-assertion-epistemic concept-effective-assertion-epistemic-tentative',
+      'Tentative typed relation; not confirmed/authority-active',
+    );
+    if (tentative) tentative.setAttribute('aria-label', tentative.textContent);
+  }
   const badge = appendText(
     row,
     'span',
@@ -214,7 +301,7 @@ async function loadPage({ conceptId, suffix, offset, append }) {
 
   try {
     const { data } = await getJsonDetailed(
-      `/api/concepts/${encodeURIComponent(conceptId)}/effective_assertions?limit=${DEFAULT_PAGE_LIMIT}&offset=${offset}`,
+      `/api/concepts/${encodeURIComponent(conceptId)}/effective_assertions?limit=${DEFAULT_PAGE_LIMIT}&offset=${offset}&argument_concept_id=${encodeURIComponent(conceptId)}`,
       { cache: 'no-store' },
     );
     if (panel.dataset.loadToken !== token || panel.dataset.conceptId !== conceptId) {
@@ -223,7 +310,10 @@ async function loadPage({ conceptId, suffix, offset, append }) {
 
     const contextView = cleanText(data?.context_view);
     const items = Array.isArray(data?.items)
-      ? data.items.filter((item) => item?.status === 'asserted')
+      ? data.items.filter((item) => (
+        item?.status === 'asserted'
+        || cleanText(item?.epistemic_status).toLowerCase() === 'tentative'
+      ))
       : [];
     if (contextView !== 'actor_effective' || (items.length === 0 && !append)) {
       panel.classList.add('hidden');
@@ -297,14 +387,45 @@ function clearAndReloadRegisteredPanels() {
   }
 }
 
+export function refreshConceptEffectiveAssertionsPanel({ conceptId, suffix = null } = {}) {
+  const targetConceptId = cleanText(conceptId);
+  const matching = [];
+  for (const [registeredSuffix, registration] of panelRegistrations.entries()) {
+    const registeredMount = document.getElementById(
+      registeredSuffix
+        ? `conceptEffectiveAssertionsMount_${registeredSuffix}`
+        : 'conceptEffectiveAssertionsMount',
+    );
+    if (!registeredMount?.isConnected) {
+      panelRegistrations.delete(registeredSuffix);
+      continue;
+    }
+    if (suffix !== null && registeredSuffix !== suffix) continue;
+    if (targetConceptId && registration.conceptId !== targetConceptId) continue;
+    matching.push(loadPage({
+      conceptId: registration.conceptId,
+      suffix: registeredSuffix,
+      offset: 0,
+      append: false,
+    }));
+  }
+  return Promise.allSettled(matching);
+}
+
 function registerActorContextInvalidation(conceptId, suffix) {
   panelRegistrations.set(suffix, { conceptId });
   actorContextState.reload = clearAndReloadRegisteredPanels;
+  actorContextState.refreshKnowledge = refreshConceptEffectiveAssertionsPanel;
   if (actorContextState.listenersBound) return;
   actorContextState.listenersBound = true;
   const reloadLatestProjection = () => actorContextState.reload?.();
   document.addEventListener('orgSwitched', reloadLatestProjection);
   document.addEventListener('authStatusChanged', reloadLatestProjection);
+  document.addEventListener('von:conceptKnowledgeChanged', (event) => {
+    const conceptId = cleanText(event?.detail?.conceptId);
+    if (!conceptId) return;
+    void actorContextState.refreshKnowledge?.({ conceptId });
+  });
 }
 
 export async function ensureConceptEffectiveAssertionsPanel({ conceptId, suffix }) {
@@ -315,5 +436,7 @@ export async function ensureConceptEffectiveAssertionsPanel({ conceptId, suffix 
 export const _test = {
   createAssertionRow,
   appendAssertionToPredicateGroup,
+  assertionDirection,
+  assertionStatementPresentation,
   formatDate,
 };

--- a/src/frontend/web/von_interface/static/js/components/conceptQaReceipt.js
+++ b/src/frontend/web/von_interface/static/js/components/conceptQaReceipt.js
@@ -1,0 +1,374 @@
+import { normaliseConceptQaReceipts } from '../utils/conceptQaSession.js';
+import {
+  normaliseReferenceManifest,
+  openReferenceInspector,
+} from './referenceInspector.js';
+
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normaliseStatus(value) {
+  return cleanText(value).toLowerCase().replace(/[\s-]+/g, '_');
+}
+
+function hasReceiptSignal(receipts) {
+  return Boolean(receipts?.exact_input || receipts?.formalisation || receipts?.notes);
+}
+
+function exactInputPresentation(receipt) {
+  if (!receipt) return null;
+  const status = normaliseStatus(receipt.status);
+  if (['not_admitted', 'transcript_only', 'question', 'meta', 'control'].includes(status)) {
+    return {
+      tone: 'neutral',
+      label: 'Transcript only',
+      text: 'This question, meta-comment or control turn was not stored as a knowledge claim.',
+    };
+  }
+  if (['stored', 'asserted', 'succeeded', 'success'].includes(status)) {
+    return {
+      tone: 'success',
+      label: 'Exact text claim stored',
+      text: 'Stored with provenance. The source wording remains visible independently of any formalisation.',
+    };
+  }
+  if (status === 'partial_or_failed') {
+    return {
+      tone: 'error',
+      label: 'Exact text claim partially stored',
+      text: cleanText(receipt.message)
+        || 'At least one exact input storage attempt failed. The transcript remains visible; inspect the item receipts for durable claim IDs.',
+    };
+  }
+  if (['failed', 'error', 'persistence_failed'].includes(status)) {
+    return {
+      tone: 'error',
+      label: 'Exact text claim not stored',
+      text: cleanText(receipt.message) || 'The transcript turn remains visible, but durable claim storage failed.',
+    };
+  }
+  return status ? {
+    tone: 'warning',
+    label: 'Exact text claim status',
+    text: cleanText(receipt.message) || status.replace(/_/g, ' '),
+  } : null;
+}
+
+function isMembershipCandidate(receipt) {
+  if (!receipt || typeof receipt !== 'object') return false;
+  const token = [
+    receipt.predicate_id,
+    receipt.predicate_concept_id,
+    receipt.predicate,
+    receipt.relation,
+    receipt.relation_kind,
+  ].map(cleanText).join(' ').toLowerCase();
+  return token.includes('memberof') || token.includes('member_of') || token.includes('member of');
+}
+
+function formalisationPresentation(receipt) {
+  if (!receipt) return null;
+  const status = normaliseStatus(receipt.status);
+  if (['not_attempted', 'not_applicable', 'none', 'skipped'].includes(status)) {
+    return {
+      tone: 'neutral',
+      label: 'Formalisation not attempted',
+      text: 'No typed relation was asserted.',
+    };
+  }
+  if (['tentative', 'uncertain'].includes(status)) {
+    const membershipCandidate = isMembershipCandidate(receipt);
+    return {
+      tone: 'warning',
+      label: 'Tentative typed relation recorded',
+      text: membershipCandidate
+        ? 'Recorded with clear provenance. It is not an asserted relation and does not activate identity or namespace.'
+        : 'Recorded with clear provenance. It is not confirmed or authority-active.',
+    };
+  }
+  if (['candidate', 'proposed', 'pending'].includes(status)) {
+    return {
+      tone: 'warning',
+      label: 'Formalisation candidate',
+      text: 'A candidate was recorded for review; no typed relation was asserted.',
+    };
+  }
+  if (['deferred', 'needs_review', 'review_required'].includes(status)) {
+    return {
+      tone: 'warning',
+      label: 'Formalisation deferred',
+      text: isMembershipCandidate(receipt)
+        ? 'No asserted relation was created, and identity or namespace was not activated.'
+        : 'No typed relation was asserted.',
+    };
+  }
+  if (['succeeded', 'stored', 'asserted', 'success'].includes(status)) {
+    const readBack = receipt.confirmation?.last_attempt?.canonical_read_back
+      ?? receipt.canonical_read_back
+      ?? receipt.read_back;
+    const readBackVerified = readBack === true
+      || readBack?.verified === true
+      || ['verified', 'succeeded', 'asserted'].includes(normaliseStatus(readBack?.status))
+      || normaliseStatus(readBack?.epistemic_status) === 'asserted';
+    return {
+      tone: readBackVerified ? 'success' : 'warning',
+      label: readBackVerified ? 'Typed assertion succeeded' : 'Typed assertion reported',
+      text: readBackVerified
+        ? 'The typed assertion was read back. The exact source claim remains visible above.'
+        : 'The server reported a typed assertion, but canonical read-back was not included. The exact source claim remains visible.',
+    };
+  }
+  if (['failed', 'error'].includes(status)) {
+    return {
+      tone: 'error',
+      label: 'Formalisation failed',
+      text: cleanText(receipt.message) || 'No typed relation was confirmed. The exact source claim remains available.',
+    };
+  }
+  return status ? {
+    tone: 'warning',
+    label: 'Formalisation status',
+    text: cleanText(receipt.message) || `${status.replace(/_/g, ' ')}; no typed relation is implied.`,
+  } : null;
+}
+
+function notesPresentation(receipt) {
+  if (!receipt) return null;
+  const status = normaliseStatus(receipt.status);
+  if (['updated', 'stored', 'succeeded', 'success'].includes(status)) {
+    return { tone: 'success', label: 'Concept notes updated', text: 'The notes update completed.' };
+  }
+  if (['no_update', 'not_updated', 'not_attempted', 'unchanged', 'skipped'].includes(status)) {
+    return { tone: 'neutral', label: 'Concept notes unchanged', text: 'No notes update was applied.' };
+  }
+  if (['failed', 'error', 'persistence_failed'].includes(status)) {
+    return {
+      tone: 'error',
+      label: 'Concept notes update failed',
+      text: cleanText(receipt.message) || 'This does not change the separate exact-claim status.',
+    };
+  }
+  return status ? {
+    tone: 'warning',
+    label: 'Concept notes status',
+    text: cleanText(receipt.message) || status.replace(/_/g, ' '),
+  } : null;
+}
+
+function referenceForReceipt(receipt, manifest, preferredTypes) {
+  const ids = [
+    receipt?.assertion_id,
+    ...(Array.isArray(receipt?.assertion_ids) ? receipt.assertion_ids : []),
+    receipt?.receipt_id,
+    receipt?.mutation_receipt_id,
+    receipt?.reference_id,
+  ].map(cleanText).filter(Boolean);
+  if (!ids.length || !manifest?.references?.length) return null;
+  return manifest.references.find((reference) => (
+    ids.includes(cleanText(reference.reference_id))
+    && (!preferredTypes.length || preferredTypes.includes(reference.reference_type))
+  )) || null;
+}
+
+function normaliseConfirmationUiState(value) {
+  if (!value || value.available !== false) {
+    return {
+      available: true,
+      label: 'Confirm relation',
+      reason: 'Promote this tentative relation and verify canonical read-back',
+    };
+  }
+  return {
+    available: false,
+    label: cleanText(value.label) || 'Confirmation unavailable',
+    reason: cleanText(value.reason)
+      || 'This tentative relation cannot be confirmed from the current Q&A state.',
+  };
+}
+
+function applyConfirmationUiState(button, value) {
+  if (!(button instanceof HTMLButtonElement)) return;
+  const state = normaliseConfirmationUiState(value);
+  button.disabled = !state.available;
+  button.textContent = state.label;
+  button.title = state.reason;
+  button.setAttribute('aria-label', state.reason);
+  button.dataset.confirmationUiAvailable = state.available ? 'true' : 'false';
+}
+
+function resolveConfirmationUiState(options, receipt) {
+  if (typeof options?.getConfirmationState === 'function') {
+    return normaliseConfirmationUiState(options.getConfirmationState(receipt));
+  }
+  return normaliseConfirmationUiState(options?.confirmationState);
+}
+
+function confirmationReceiptFromButton(button) {
+  return {
+    confirmation: {
+      available: button?.dataset?.receiptConfirmationAvailable === 'true',
+      available_after_finish: button?.dataset?.availableAfterFinish === 'true',
+      available_after_cancel: button?.dataset?.availableAfterCancel === 'true',
+    },
+  };
+}
+
+export function updateConceptQaReceiptConfirmationState(container, value) {
+  if (!(container instanceof Element)) return;
+  const buttons = container.matches('.concept-qa-receipt-confirm')
+    ? [container]
+    : Array.from(container.querySelectorAll('.concept-qa-receipt-confirm'));
+  for (const button of buttons) {
+    const state = typeof value === 'function'
+      ? value(confirmationReceiptFromButton(button))
+      : value;
+    applyConfirmationUiState(button, state);
+  }
+}
+
+function appendReceiptRow(
+  container,
+  key,
+  receipt,
+  presentation,
+  manifest,
+  onInspect,
+  onConfirm,
+  confirmationOptions,
+) {
+  if (!presentation) return;
+  const row = document.createElement('div');
+  row.className = `concept-qa-receipt-row tone-${presentation.tone}`;
+  row.dataset.receiptKind = key;
+
+  const copy = document.createElement('div');
+  copy.className = 'concept-qa-receipt-copy';
+  const label = document.createElement('strong');
+  label.textContent = presentation.label;
+  const detail = document.createElement('span');
+  detail.textContent = presentation.text;
+  copy.append(label, detail);
+  row.appendChild(copy);
+
+  const preferredTypes = key === 'exact_input'
+    ? ['scoped_assertion']
+    : (key === 'formalisation' ? ['ontology_mutation_receipt', 'scoped_assertion'] : []);
+  const reference = referenceForReceipt(receipt, manifest, preferredTypes);
+  if (reference) {
+    const inspect = document.createElement('button');
+    inspect.type = 'button';
+    inspect.className = 'btn-mini concept-qa-receipt-inspect';
+    inspect.textContent = 'Inspect';
+    inspect.title = `Inspect ${presentation.label.toLowerCase()}`;
+    inspect.addEventListener('click', () => {
+      void onInspect(reference, { trigger: inspect });
+    });
+    row.appendChild(inspect);
+  }
+  const confirmation = receipt?.confirmation;
+  const assertionId = cleanText(receipt?.assertion_id);
+  if (
+    key === 'formalisation'
+    && confirmation?.available === true
+    && assertionId
+    && typeof onConfirm === 'function'
+  ) {
+    const confirm = document.createElement('button');
+    confirm.type = 'button';
+    confirm.className = 'btn-mini concept-qa-receipt-confirm';
+    confirm.dataset.assertionId = assertionId;
+    confirm.dataset.receiptConfirmationAvailable = 'true';
+    confirm.dataset.availableAfterFinish = confirmation.available_after_finish === true
+      ? 'true'
+      : 'false';
+    confirm.dataset.availableAfterCancel = confirmation.available_after_cancel === true
+      ? 'true'
+      : 'false';
+    applyConfirmationUiState(
+      confirm,
+      resolveConfirmationUiState(confirmationOptions, receipt),
+    );
+    confirm.addEventListener('click', async () => {
+      if (confirm.disabled) return;
+      confirm.disabled = true;
+      confirm.textContent = 'Confirming…';
+      try {
+        await onConfirm(receipt, { button: confirm });
+      } finally {
+        if (confirm.isConnected) {
+          applyConfirmationUiState(
+            confirm,
+            resolveConfirmationUiState(confirmationOptions, receipt),
+          );
+        }
+      }
+    });
+    row.appendChild(confirm);
+  }
+  container.appendChild(row);
+}
+
+export function renderConceptQaReceipt(container, value, options = {}) {
+  if (!(container instanceof Element)) return null;
+  const receipts = normaliseConceptQaReceipts(value);
+  if (!hasReceiptSignal(receipts)) return null;
+  const manifest = normaliseReferenceManifest(
+    value?.reference_manifest
+      || value?.llm_debug_data?.reference_manifest
+      || value?.llm_debug?.reference_manifest,
+  );
+  const onInspect = typeof options.onInspect === 'function'
+    ? options.onInspect
+    : openReferenceInspector;
+  const onConfirm = typeof options.onConfirm === 'function' ? options.onConfirm : null;
+
+  const panel = document.createElement('section');
+  panel.className = 'concept-qa-receipt';
+  panel.setAttribute('aria-label', 'Concept Q&A representation receipt');
+  const heading = document.createElement('h4');
+  heading.className = 'concept-qa-receipt-title';
+  heading.textContent = 'What was recorded';
+  panel.appendChild(heading);
+
+  appendReceiptRow(
+    panel,
+    'exact_input',
+    receipts.exact_input,
+    exactInputPresentation(receipts.exact_input),
+    manifest,
+    onInspect,
+    onConfirm,
+    options,
+  );
+  appendReceiptRow(
+    panel,
+    'formalisation',
+    receipts.formalisation,
+    formalisationPresentation(receipts.formalisation),
+    manifest,
+    onInspect,
+    onConfirm,
+    options,
+  );
+  appendReceiptRow(
+    panel,
+    'notes',
+    receipts.notes,
+    notesPresentation(receipts.notes),
+    manifest,
+    onInspect,
+    onConfirm,
+    options,
+  );
+  container.appendChild(panel);
+  return panel;
+}
+
+export const _test = {
+  exactInputPresentation,
+  formalisationPresentation,
+  notesPresentation,
+  isMembershipCandidate,
+  normaliseConfirmationUiState,
+};

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -21,9 +21,21 @@ import {
   setCurrentlySelectedConceptId,
   setSelectedConceptOriginalName
 } from './state.js';
-import { getSessionScopedOrgId } from './utils/sessionScopedStorage.js';
+import {
+  getSessionScopedNamespace,
+  getSessionScopedOrgContext,
+  getSessionScopedOrgId,
+} from './utils/sessionScopedStorage.js';
 import { buildLocalModelRequestFields } from './utils/localModelPreferences.js';
 import { annotateElementText, linkifyVontologyTokensInElement } from './utils/textDecorator.js';
+import {
+  describeConceptQaElicitationGap,
+  fetchConceptQaProjection,
+  startConceptQaSession,
+} from './utils/conceptQaSession.js';
+import { buildConversationReferencePayload } from './utils/conversationReference.js';
+import { copyTextWithClipboardFallback } from './utils/copyJsonButtonState.js';
+import { showToast } from './utils/toast.js';
 import { chooseBestTypeForIndividual, insertNodeIntoVontologyTree, selectVontologyNodeByIdentifier } from './vontology.js';
 
 async function renderConceptMarkdownInto(container, markdownText) {
@@ -53,6 +65,8 @@ export function initializeConceptTabState() {
 
 // Global interaction state
 let currentInteractionId = null;
+const conceptQaSessionByConcept = new Map();
+const conceptQaCardLoadTokenBySuffix = new Map();
 
 async function buildConceptInteractionHeaders() {
   const windowSessionId = await ensureUniqueWindowSessionId();
@@ -1158,6 +1172,7 @@ export function selectConceptWithSuffix(concept, suffix = '', radioId = null) {
   const conceptId = concept.concept_id || concept._id;
   if (conceptId) {
     loadConceptNames(conceptId, suffix);
+    void refreshConceptQaSessionCard(conceptId, suffix);
   }
   updateConceptIdRenamePanel(concept, suffix);
 }
@@ -1547,6 +1562,204 @@ function getElementForSuffix(baseId, suffix) {
   return document.getElementById(baseId);
 }
 
+function getConceptQaCardElements(suffix = '') {
+  return {
+    card: getElementForSuffix('conceptQaSessionCard', suffix),
+    badge: getElementForSuffix('conceptQaSessionBadge', suffix),
+    summary: getElementForSuffix('conceptQaSessionSummary', suffix),
+    gap: getElementForSuffix('conceptQaGapStatus', suffix),
+    start: getElementForSuffix('startInteractionButton', suffix),
+    resume: getElementForSuffix('resumeConceptQaButton', suffix),
+    open: getElementForSuffix('openConceptQaTranscriptButton', suffix),
+    copy: getElementForSuffix('copyConceptQaReferenceButton', suffix),
+  };
+}
+
+function setConceptQaCardBusy(suffix, busy) {
+  const controls = getConceptQaCardElements(suffix);
+  [controls.start, controls.resume, controls.open, controls.copy].forEach((button) => {
+    if (button) button.disabled = Boolean(busy);
+  });
+  controls.card?.setAttribute('aria-busy', busy ? 'true' : 'false');
+}
+
+async function openConceptQaSessionInChat(session) {
+  const chat = await import('./chatTab.js');
+  if (typeof chat.openConceptQaConversation !== 'function') {
+    throw new Error('The conversation workspace is not ready for concept Q&A.');
+  }
+  return chat.openConceptQaConversation(session);
+}
+
+async function copyConceptQaReference(session) {
+  const orgContext = getSessionScopedOrgContext();
+  const payload = buildConversationReferencePayload(session, {
+    currentUserConceptId: getCurrentUserConceptId() || null,
+    namespace: getSessionScopedNamespace() || null,
+    organisationConceptId: orgContext?.concept_id || orgContext?.id || null,
+  });
+  if (!payload) {
+    showToast('This Q&A does not yet have a stable conversation reference.', 'info');
+    return false;
+  }
+  const copied = await copyTextWithClipboardFallback(JSON.stringify(payload, null, 2));
+  showToast(
+    copied ? 'Copied conversation reference.' : 'Could not copy conversation reference.',
+    copied ? 'success' : 'error',
+  );
+  return copied;
+}
+
+function renderConceptQaSessionCard({ suffix = '', session = null, error = null, legacyCount = 0 } = {}) {
+  const controls = getConceptQaCardElements(suffix);
+  if (!controls.card) return false;
+
+  const state = error ? 'error' : (session?.lifecycle || 'ready');
+  controls.card.dataset.state = state;
+  if (controls.badge) {
+    controls.badge.textContent = error
+      ? 'Unavailable'
+      : (session?.lifecycle === 'active'
+        ? 'Active'
+        : (session?.lifecycle === 'finished'
+          ? 'Finished'
+          : (session?.lifecycle === 'cancelled' ? 'Cancelled' : 'Ready')));
+  }
+  if (controls.summary) {
+    if (error) {
+      controls.summary.textContent = 'Q&A status could not be checked. You can retry without losing an existing transcript.';
+    } else if (session?.lifecycle === 'active') {
+      controls.summary.textContent = 'A recoverable Q&A conversation is active for this concept.';
+    } else if (session?.lifecycle === 'finished') {
+      controls.summary.textContent = 'This Q&A is finished. Its transcript and representation receipts remain available.';
+    } else if (session?.lifecycle === 'cancelled') {
+      controls.summary.textContent = 'This Q&A was cancelled. Its transcript and already recorded knowledge remain available.';
+    } else if (legacyCount > 0) {
+      controls.summary.textContent = 'Older Q&A activity exists, but it has not yet been mapped to a copyable conversation.';
+    } else {
+      controls.summary.textContent = 'Start a guided, recoverable conversation about missing information for this concept.';
+    }
+  }
+  if (controls.gap) {
+    const gapText = session ? describeConceptQaElicitationGap(session) : '';
+    controls.gap.textContent = gapText;
+    controls.gap.classList.toggle('hidden', !gapText);
+  }
+
+  const hasSession = Boolean(session?.session_id);
+  const isActive = session?.lifecycle === 'active';
+  if (controls.start) {
+    controls.start.classList.toggle('hidden', isActive);
+    controls.start.textContent = hasSession ? 'Start new Q&A' : 'Improve concept by Q&A';
+    controls.start.title = 'Answer guided questions in a recoverable conversation; admitted exact claims retain provenance.';
+  }
+  if (controls.resume) {
+    controls.resume.classList.toggle('hidden', !isActive);
+    controls.resume.onclick = isActive ? () => void openConceptQaSessionInChat(session) : null;
+  }
+  if (controls.open) {
+    controls.open.classList.toggle('hidden', !hasSession);
+    controls.open.onclick = hasSession ? () => void openConceptQaSessionInChat(session) : null;
+  }
+  if (controls.copy) {
+    const hasReference = Boolean(session?.conversation_reference?.session_id);
+    controls.copy.classList.toggle('hidden', !hasReference);
+    controls.copy.onclick = hasReference ? () => void copyConceptQaReference(session) : null;
+  }
+  setConceptQaCardBusy(suffix, false);
+  return true;
+}
+
+export async function refreshConceptQaSessionCard(conceptId, suffix = '') {
+  const targetConceptId = String(conceptId || getSelectedConceptIdForSuffix(suffix) || '').trim();
+  if (!targetConceptId || !getConceptQaCardElements(suffix).card) return null;
+  const token = `${targetConceptId}:${Date.now()}:${Math.random()}`;
+  conceptQaCardLoadTokenBySuffix.set(suffix, token);
+  setConceptQaCardBusy(suffix, true);
+  const controls = getConceptQaCardElements(suffix);
+  if (controls.badge) controls.badge.textContent = 'Checking…';
+  try {
+    const projection = await fetchConceptQaProjection(targetConceptId);
+    if (conceptQaCardLoadTokenBySuffix.get(suffix) !== token) return null;
+    const session = projection.active_session || projection.sessions[0] || null;
+    if (session) conceptQaSessionByConcept.set(targetConceptId, session);
+    else conceptQaSessionByConcept.delete(targetConceptId);
+    renderConceptQaSessionCard({
+      suffix,
+      session,
+      legacyCount: projection.legacy_interactions.length,
+    });
+    return session;
+  } catch (error) {
+    if (conceptQaCardLoadTokenBySuffix.get(suffix) !== token) return null;
+    renderConceptQaSessionCard({ suffix, error });
+    return null;
+  }
+}
+
+export function isUnmistakableMissingConceptQaRoute(error) {
+  if (Number(error?.status) !== 404) return false;
+  const payload = error?.payload;
+  // The request helper parses an HTML route miss as an empty object. Any
+  // structured JSON response belongs to the canonical API (including
+  // actor-scoped concept/session absence) and must be shown, not re-routed.
+  return Boolean(
+    payload
+    && typeof payload === 'object'
+    && !Array.isArray(payload)
+    && Object.keys(payload).length === 0
+  );
+}
+
+export async function handleStartInteraction() {
+  const suffix = getActiveConceptTabSuffix();
+  const conceptId = getSelectedConceptIdForSuffix(suffix, { fallbackToGlobal: !suffix });
+  if (!conceptId) {
+    alert('Select a concept before starting concept Q&A.');
+    return false;
+  }
+  setConceptQaCardBusy(suffix, true);
+  const controls = getConceptQaCardElements(suffix);
+  if (controls.summary) controls.summary.textContent = 'Starting a recoverable Q&A conversation…';
+  try {
+    const session = await startConceptQaSession(conceptId, buildLocalModelRequestFields());
+    conceptQaSessionByConcept.set(conceptId, session);
+    renderConceptQaSessionCard({ suffix, session });
+    await openConceptQaSessionInChat(session);
+    return true;
+  } catch (error) {
+    // Keep the old interaction path available while installations migrate to
+    // the canonical carrier endpoints. Never fall back on an authority or
+    // server failure: only an absent route denotes an older installation.
+    if (isUnmistakableMissingConceptQaRoute(error)) {
+      renderConceptQaSessionCard({ suffix, error });
+      await handleLegacyStartInteraction();
+      return true;
+    }
+    renderConceptQaSessionCard({ suffix, error });
+    if (controls.summary) controls.summary.textContent = error?.message || 'Concept Q&A could not be started.';
+    return false;
+  } finally {
+    setConceptQaCardBusy(suffix, false);
+  }
+}
+
+try {
+  document.addEventListener('von:conceptQaLifecycleChanged', (event) => {
+    const session = event?.detail?.session;
+    const conceptId = String(event?.detail?.conceptId || session?.concept_id || '').trim();
+    if (!conceptId || !session) return;
+    conceptQaSessionByConcept.set(conceptId, session);
+    for (const suffix of listOpenConceptTabSuffixes()) {
+      if (getSelectedConceptIdForSuffix(suffix, { fallbackToGlobal: !suffix }) === conceptId) {
+        renderConceptQaSessionCard({ suffix, session });
+      }
+    }
+  });
+} catch (_) {
+  // The module can also be imported in non-browser test environments.
+}
+
 function isMissingInteractionSessionMessage(message) {
   const msg = String(message || '').toLowerCase();
   return msg.includes('interaction session not found') ||
@@ -1588,7 +1801,7 @@ export function describeConceptQaRepresentation(data = {}) {
   if (exactAnswerStored && synthesisStatus === 'updated') {
     return {
       synthesisText,
-      statusText: 'Answer represented with provenance and concept notes updated. Please respond to the next question.',
+      statusText: 'Exact text claim stored with provenance; concept notes updated. Please respond to the next question.',
       statusColor: 'green',
     };
   }
@@ -1596,8 +1809,8 @@ export function describeConceptQaRepresentation(data = {}) {
     return {
       synthesisText,
       statusText: exactAnswerStored
-        ? 'Response and supplied notes represented with provenance and used to guide the next exchange.'
-        : 'Supplied notes represented with provenance and used to guide the next question.',
+        ? 'Exact text claim and supplied notes stored separately with provenance and used to guide the next exchange.'
+        : 'Supplied notes stored with provenance and used to guide the next question.',
       statusColor: 'green',
     };
   }
@@ -1605,21 +1818,21 @@ export function describeConceptQaRepresentation(data = {}) {
     return {
       synthesisText,
       statusText: synthesisStatus === 'no_update'
-        ? 'Answer preserved as scoped knowledge; no concept-notes change was proposed. Please respond to the next question.'
-        : 'Answer preserved as scoped knowledge, but the concept-notes update did not complete. Please respond to the next question.',
+        ? 'Exact text claim stored as scoped knowledge; no concept-notes change was proposed. No typed relation is implied.'
+        : 'Exact text claim stored as scoped knowledge, but the concept-notes update did not complete. No typed relation is implied.',
       statusColor: '#a65f00',
     };
   }
   if (synthesisStatus === 'updated') {
     return {
       synthesisText,
-      statusText: 'Concept notes updated, but exact-answer provenance storage failed. Please respond to the next question.',
+      statusText: 'Concept notes updated, but exact-text-claim storage failed. No typed relation is implied.',
       statusColor: '#a65f00',
     };
   }
   return {
     synthesisText,
-    statusText: 'The answer was received, but durable knowledge representation failed. Please retry or finish the Q&A.',
+    statusText: 'The transcript turn was received, but exact-claim storage and notes update failed. No typed relation was asserted.',
     statusColor: 'red',
   };
 }
@@ -1772,7 +1985,7 @@ function ensureInteractionSaveButtonState() {
 }
 
 // Handle specialised concept-improvement Q&A button click.
-export async function handleStartInteraction() {
+async function handleLegacyStartInteraction() {
   const currentlySelectedconceptId = getCurrentlySelectedConceptId();
   console.log("handleStartInteraction called. Currently selected concept ID:", currentlySelectedconceptId);
   const displayNames = getConceptTypeDisplayNames(getCurrentConceptType());

--- a/src/frontend/web/von_interface/static/js/utils/conceptQaSession.js
+++ b/src/frontend/web/von_interface/static/js/utils/conceptQaSession.js
@@ -1,0 +1,324 @@
+import {
+  ensureUniqueWindowSessionId,
+  WINDOW_SESSION_HEADER,
+} from '../apiService.js';
+import { getCurrentUserConceptId } from '../domUtils.js';
+
+export const CONCEPT_QA_ORIGIN_KIND = 'concept_q_and_a';
+export const CONCEPT_QA_MODE = 'concept_q_and_a';
+
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function firstObject(...values) {
+  return values.find((value) => value && typeof value === 'object' && !Array.isArray(value)) || null;
+}
+
+function normaliseLifecycle(value) {
+  const token = cleanText(value).toLowerCase().replace(/[\s-]+/g, '_');
+  if (['finished', 'completed', 'complete', 'ended'].includes(token)) return 'finished';
+  if (['cancelled', 'canceled', 'abandoned'].includes(token)) return 'cancelled';
+  return token === 'active' || token === 'open' || token === 'in_progress'
+    ? 'active'
+    : (token || 'active');
+}
+
+function normaliseActionList(value, lifecycle) {
+  const supplied = Array.isArray(value)
+    ? value.map(cleanText).filter(Boolean)
+    : [];
+  if (supplied.length) return [...new Set(supplied)];
+  if (lifecycle === 'active') return ['submit_turn', 'finish', 'cancel', 'open_transcript', 'copy_reference'];
+  return ['open_transcript', 'copy_reference'];
+}
+
+export function normaliseConceptQaReceipts(value) {
+  const source = firstObject(value?.receipts, value?.representation, value) || {};
+  return {
+    exact_input: firstObject(source.exact_input, source.exact_answer) || null,
+    formalisation: firstObject(source.formalisation, source.formalization) || null,
+    notes: firstObject(source.notes, source.concept_notes) || null,
+  };
+}
+
+export function normaliseConceptQaSession(value, defaults = {}) {
+  const root = firstObject(value) || {};
+  const source = firstObject(
+    root.qa_session,
+    root.q_and_a_session,
+    root.session,
+    root.active_session,
+    root.concept_q_and_a,
+    root,
+  ) || {};
+  const canonicalRef = firstObject(
+    source.conversation_reference,
+    source.conversation_ref?.conversation_ref,
+    root.conversation_reference,
+  );
+  const sessionId = cleanText(source.session_id)
+    || cleanText(source.chat_session_id)
+    || cleanText(canonicalRef?.session_id)
+    || cleanText(defaults.sessionId);
+  if (!sessionId) return null;
+  const lifecycle = normaliseLifecycle(
+    source.lifecycle?.status
+      || source.lifecycle?.state
+      || source.lifecycle
+      || source.status
+      || defaults.lifecycle,
+  );
+  const conceptId = cleanText(source.focal_concept_id)
+    || cleanText(source.concept_id)
+    || cleanText(source.target_concept_id)
+    || (Array.isArray(source.focal_concept_ids)
+      ? cleanText(source.focal_concept_ids.find((item) => cleanText(item)))
+      : '')
+    || cleanText(defaults.conceptId);
+  const turns = Array.isArray(source.turns)
+    ? source.turns
+    : (Array.isArray(root.turns) ? root.turns : []);
+  const receipts = normaliseConceptQaReceipts(root.receipts || source.receipts || source.latest_receipts);
+
+  return {
+    ...source,
+    session_id: sessionId,
+    chat_session_id: cleanText(source.chat_session_id) || sessionId,
+    interaction_id: cleanText(source.interaction_id) || null,
+    concept_id: conceptId || null,
+    focal_concept_id: conceptId || null,
+    mode: CONCEPT_QA_MODE,
+    origin_kind: CONCEPT_QA_ORIGIN_KIND,
+    lifecycle,
+    status: lifecycle,
+    available_actions: normaliseActionList(
+      source.available_actions || source.allowed_actions,
+      lifecycle,
+    ),
+    conversation_reference: canonicalRef || null,
+    turns,
+    receipts,
+    created: root.created === true || source.created === true,
+    resumed: root.resumed === true || source.resumed === true,
+    updated_at: cleanText(source.updated_at) || cleanText(root.updated_at) || null,
+  };
+}
+
+export function normaliseConceptQaProjection(value, defaults = {}) {
+  const source = firstObject(value) || {};
+  const sessions = Array.isArray(source.sessions)
+    ? source.sessions.map((session) => normaliseConceptQaSession(session, defaults)).filter(Boolean)
+    : [];
+  const activeSession = normaliseConceptQaSession(source.active_session, defaults)
+    || sessions.find((session) => session.lifecycle === 'active')
+    || null;
+  return {
+    sessions,
+    active_session: activeSession,
+    legacy_interactions: Array.isArray(source.legacy_interactions)
+      ? source.legacy_interactions
+      : (Array.isArray(source.legacy_active_interactions) ? source.legacy_active_interactions : []),
+  };
+}
+
+export function isConceptQaSession(value) {
+  const mode = cleanText(value?.mode).toLowerCase().replace(/[\s-]+/g, '_');
+  const originKind = cleanText(value?.origin_kind).toLowerCase().replace(/[\s-]+/g, '_');
+  return mode === CONCEPT_QA_MODE || originKind === CONCEPT_QA_ORIGIN_KIND;
+}
+
+export function getConceptQaElicitationGap(value) {
+  const source = firstObject(value?.session, value) || {};
+  let candidate = firstObject(source.current_gap, source.elicitation_gap);
+  if (!candidate) {
+    const turns = Array.isArray(source.turns) ? source.turns : [];
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+      const turn = turns[index];
+      if (turn?.role !== 'assistant') continue;
+      candidate = firstObject(
+        turn?.concept_q_and_a?.elicitation_predicate,
+        turn?.elicitation_predicate,
+      );
+      if (candidate) break;
+    }
+  }
+  if (!candidate) return null;
+  const predicateId = cleanText(candidate.predicate_concept_id);
+  const predicateLabel = cleanText(candidate.predicate_label) || predicateId;
+  const status = cleanText(candidate.status).toLowerCase();
+  const gapStatus = cleanText(candidate.gap_status).toLowerCase();
+  if (!predicateLabel || (status !== 'missing' && gapStatus !== 'asserted_relation_missing')) {
+    return null;
+  }
+  return {
+    predicate_concept_id: predicateId || null,
+    predicate_label: predicateLabel,
+    status: status || 'missing',
+    gap_status: gapStatus || null,
+    requirement_kind: cleanText(candidate.requirement_kind) || null,
+    priority_class: cleanText(candidate.priority_class) || null,
+    priority: Number.isFinite(Number(candidate.priority)) ? Number(candidate.priority) : null,
+    declared_on_type_concept_id: cleanText(candidate.declared_on_type_concept_id) || null,
+    inherited: candidate.inherited === true,
+  };
+}
+
+export function describeConceptQaElicitationGap(value) {
+  const gap = getConceptQaElicitationGap(value);
+  if (!gap) return '';
+  if (gap.priority_class === 'constitutive'
+      || gap.requirement_kind === 'constitutive_relation') {
+    return [
+      `Current constitutive gap: ${gap.predicate_label} — asserted relation missing.`,
+      'This is a prioritised Q&A target, not an assertion or a creation block.',
+    ].join(' ');
+  }
+  const priority = gap.priority === null ? '' : ` (priority ${gap.priority})`;
+  return [
+    `Current suggested relation: ${gap.predicate_label}${priority}.`,
+    'This is a salient Q&A target, not a requirement or an asserted relation.',
+  ].join(' ');
+}
+
+export function conceptQaActionAllowed(session, action) {
+  const projection = normaliseConceptQaSession(session);
+  if (!projection) return false;
+  const actions = new Set(projection.available_actions);
+  if (actions.has(action)) return true;
+  if (action === 'submit_turn') return projection.lifecycle === 'active';
+  return ['open_transcript', 'copy_reference'].includes(action);
+}
+
+export function createConceptQaTurnId() {
+  try {
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  } catch (_) {
+    // Fall through to a collision-resistant browser-local identifier.
+  }
+  return `qa-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+async function requestJson(url, { method = 'GET', body = null } = {}) {
+  const windowSessionId = await ensureUniqueWindowSessionId();
+  const headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    [WINDOW_SESSION_HEADER]: windowSessionId,
+  };
+  const userConceptId = getCurrentUserConceptId();
+  if (userConceptId) headers['X-User-Concept-ID'] = userConceptId;
+  const response = await fetch(url, {
+    method,
+    headers,
+    cache: 'no-store',
+    ...(body === null ? {} : { body: JSON.stringify(body) }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(payload?.error || payload?.message || `HTTP ${response.status}`);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+  return payload;
+}
+
+function conceptQaBase(conceptId) {
+  return `/api/concepts/${encodeURIComponent(cleanText(conceptId))}/q_and_a`;
+}
+
+export async function fetchConceptQaProjection(conceptId) {
+  const payload = await requestJson(conceptQaBase(conceptId));
+  return normaliseConceptQaProjection(payload, { conceptId });
+}
+
+export async function startConceptQaSession(conceptId, body = {}) {
+  const payload = await requestJson(`${conceptQaBase(conceptId)}/start`, {
+    method: 'POST',
+    body,
+  });
+  const session = normaliseConceptQaSession(payload, { conceptId });
+  if (!session) throw new Error('The server did not return a concept Q&A session.');
+  return session;
+}
+
+export async function submitConceptQaTurn({ conceptId, sessionId, answer, notesInput = '' }) {
+  const turnId = createConceptQaTurnId();
+  const payload = await requestJson(
+    `${conceptQaBase(conceptId)}/sessions/${encodeURIComponent(cleanText(sessionId))}/turns`,
+    {
+      method: 'POST',
+      body: {
+        turn_id: turnId,
+        answer: String(answer || ''),
+        ...(String(notesInput || '').trim() ? { notes_input: String(notesInput) } : {}),
+      },
+    },
+  );
+  const session = normaliseConceptQaSession(payload, { conceptId, sessionId });
+  if (!session) throw new Error('The server did not return the updated concept Q&A session.');
+  return { payload, session, turn_id: turnId, receipts: normaliseConceptQaReceipts(payload) };
+}
+
+export async function transitionConceptQaSession({ conceptId, sessionId, action }) {
+  if (!['finish', 'cancel'].includes(action)) throw new Error('Unsupported concept Q&A transition.');
+  const payload = await requestJson(
+    `${conceptQaBase(conceptId)}/sessions/${encodeURIComponent(cleanText(sessionId))}/${action}`,
+    { method: 'POST', body: {} },
+  );
+  const session = normaliseConceptQaSession(payload, { conceptId, sessionId });
+  if (!session) throw new Error('The server did not return the concept Q&A lifecycle read-back.');
+  return session;
+}
+
+function resolveFormalisationConfirmationUrl({ conceptId, sessionId, assertionId, confirmation }) {
+  const projected = cleanText(confirmation?.action);
+  const expectedPrefix = `${conceptQaBase(conceptId)}/sessions/${encodeURIComponent(cleanText(sessionId))}/formalisations/`;
+  if (projected) {
+    try {
+      const resolved = new URL(projected, globalThis.location?.origin || 'http://localhost');
+      const currentOrigin = globalThis.location?.origin || resolved.origin;
+      if (resolved.origin === currentOrigin && resolved.pathname.startsWith(expectedPrefix)) {
+        return `${resolved.pathname}${resolved.search}`;
+      }
+    } catch (_) {
+      // Use the fixed same-origin route below.
+    }
+  }
+  return `${expectedPrefix}${encodeURIComponent(cleanText(assertionId))}/confirm`;
+}
+
+export async function confirmConceptQaFormalisation({
+  conceptId,
+  sessionId,
+  assertionId,
+  confirmation = null,
+}) {
+  if (!cleanText(assertionId)) throw new Error('A tentative assertion ID is required.');
+  const url = resolveFormalisationConfirmationUrl({
+    conceptId,
+    sessionId,
+    assertionId,
+    confirmation,
+  });
+  const payload = await requestJson(url, {
+    // Confirmation is deliberately a bounded POST even if a malformed client
+    // projection advertises another method.
+    method: 'POST',
+    body: {
+      request_id: createConceptQaTurnId(),
+      ...(Number.isInteger(confirmation?.expected_receipt_revision)
+        ? { expected_receipt_revision: confirmation.expected_receipt_revision }
+        : {}),
+    },
+  });
+  const session = normaliseConceptQaSession(payload, { conceptId, sessionId });
+  if (!session) throw new Error('The server did not return confirmation read-back.');
+  return { payload, session, receipts: normaliseConceptQaReceipts(payload) };
+}
+
+export const _test = {
+  normaliseLifecycle,
+  resolveFormalisationConfirmationUrl,
+};

--- a/src/frontend/web/von_interface/static/js/utils/conversationReference.js
+++ b/src/frontend/web/von_interface/static/js/utils/conversationReference.js
@@ -1,0 +1,69 @@
+function cleanText(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function normaliseCanonicalConversationReference(value) {
+  const candidate = value?.conversation_reference
+    || value?.conversation_ref?.conversation_ref
+    || value?.conversation_ref
+    || value;
+  if (!candidate || typeof candidate !== 'object') return null;
+  if (candidate.schema_version !== 'conversation_reference.v1') return null;
+  const sessionId = cleanText(candidate.session_id);
+  if (!sessionId) return null;
+  return {
+    schema_version: 'conversation_reference.v1',
+    binding_kind: cleanText(candidate.binding_kind) || 'explicit_session_id',
+    session_id: sessionId,
+    user_concept_id: cleanText(candidate.user_concept_id),
+    namespace: cleanText(candidate.namespace),
+    organisation_concept_id: cleanText(candidate.organisation_concept_id),
+    include_legacy: candidate.include_legacy === true,
+  };
+}
+
+/**
+ * Build the same copyable envelope for every conversation entry point.
+ * A server-projected canonical reference wins; context is used only for older
+ * session rows that predate conversation_reference.v1 projections.
+ */
+export function buildConversationReferencePayload(session, context = {}) {
+  const sid = cleanText(session?.session_id) || cleanText(session?.chat_session_id);
+  if (!sid) return null;
+
+  const canonical = normaliseCanonicalConversationReference(session) || {
+    schema_version: 'conversation_reference.v1',
+    binding_kind: 'explicit_session_id',
+    session_id: sid,
+    user_concept_id: cleanText(session?.shared_owner_user_id)
+      || cleanText(context.currentUserConceptId),
+    namespace: cleanText(session?.namespace) || cleanText(context.namespace),
+    organisation_concept_id: cleanText(session?.organisation_concept_id)
+      || cleanText(context.organisationConceptId),
+    include_legacy: false,
+  };
+
+  const ownerUserId = canonical.user_concept_id
+    || cleanText(session?.shared_owner_user_id)
+    || cleanText(context.currentUserConceptId);
+  const namespace = canonical.namespace
+    || cleanText(session?.namespace)
+    || cleanText(context.namespace);
+
+  return {
+    kind: 'von_conversation_ref',
+    schema_version: 'conversation_reference.v1',
+    conversation_ref: canonical,
+    chat_history_lookup: {
+      user_id: ownerUserId,
+      session_id: canonical.session_id,
+      namespace,
+      include_legacy: canonical.include_legacy,
+    },
+    display: {
+      session_name: cleanText(session?.session_name) || cleanText(session?.display_name),
+      last_message_at: cleanText(session?.last_message_at) || cleanText(session?.updated_at),
+      current_user_concept_id: cleanText(context.currentUserConceptId),
+    },
+  };
+}

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -1983,6 +1983,71 @@ body {
     line-height: 1.35;
 }
 
+.concept-qa-session-card {
+    display: grid;
+    gap: 8px;
+    margin: 10px 0 14px;
+    padding: 12px 14px;
+    border: 1px solid #bfdbfe;
+    border-left: 4px solid #2563eb;
+    border-radius: 10px;
+    background: #eff6ff;
+}
+
+.concept-qa-session-header,
+.concept-qa-session-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.concept-qa-session-header {
+    justify-content: space-between;
+}
+
+.concept-qa-session-badge {
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #dbeafe;
+    color: #1e40af;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+
+.concept-qa-session-card[data-state="finished"] .concept-qa-session-badge,
+.concept-qa-session-card[data-state="cancelled"] .concept-qa-session-badge {
+    background: #e2e8f0;
+    color: #475569;
+}
+
+.concept-qa-session-card[data-state="error"] {
+    border-color: #fecaca;
+    background: #fff7f7;
+}
+
+.concept-qa-session-card[data-state="error"] .concept-qa-session-badge {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.concept-qa-session-summary {
+    margin: 0;
+    color: #334155;
+    font-size: 0.86rem;
+}
+
+.concept-qa-gap-status,
+.concept-qa-conversation-gap {
+    margin: 0.35rem 0;
+    color: #704c00;
+    font-size: 0.9rem;
+}
+
+.concept-qa-session-actions button {
+    min-height: 32px;
+}
+
 .task-discuss-btn:hover,
 .message-discuss-btn:hover,
 .concept-discuss-button:hover {
@@ -7713,6 +7778,78 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     border-bottom: 1px solid #e2e8f0;
 }
 
+.concept-qa-conversation-controls {
+    display: grid;
+    gap: 7px;
+    margin-top: 8px;
+    padding: 9px 11px;
+    border: 1px solid #bfdbfe;
+    border-radius: 10px;
+    background: #eff6ff;
+}
+
+.concept-qa-conversation-controls.hidden {
+    display: none;
+}
+
+.concept-qa-conversation-header,
+.concept-qa-conversation-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.concept-qa-conversation-status {
+    color: #475569;
+    font-size: 0.82rem;
+}
+
+.concept-qa-conversation-error {
+    margin: 0;
+    color: #b91c1c;
+    font-size: 0.82rem;
+}
+
+.concept-qa-receipt {
+    display: grid;
+    gap: 6px;
+    margin-top: 10px;
+    padding: 9px 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+}
+
+.concept-qa-receipt-title {
+    margin: 0;
+    color: #334155;
+    font-size: 0.82rem;
+}
+
+.concept-qa-receipt-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    padding-left: 8px;
+    border-left: 3px solid #94a3b8;
+    font-size: 0.8rem;
+}
+
+.concept-qa-receipt-row.tone-success { border-left-color: #16a34a; }
+.concept-qa-receipt-row.tone-warning { border-left-color: #d97706; }
+.concept-qa-receipt-row.tone-error { border-left-color: #dc2626; }
+
+.concept-qa-receipt-copy {
+    display: grid;
+    gap: 2px;
+}
+
+.concept-qa-receipt-copy span {
+    color: #475569;
+}
+
 .chat-header-controls {
     display: flex;
     align-items: center;
@@ -12093,6 +12230,16 @@ button.prompt-vontology-cartouche {
     align-items: baseline;
 }
 
+.concept-effective-assertion-statement.is-complete-statement {
+    display: block;
+}
+
+.concept-effective-assertion-human-statement {
+    color: #0f172a;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+}
+
 .concept-effective-assertion-predicate {
     color: #475569;
     font-size: 0.82rem;
@@ -12102,6 +12249,19 @@ button.prompt-vontology-cartouche {
 .concept-effective-assertion-value {
     color: #0f172a;
     overflow-wrap: anywhere;
+}
+
+.concept-effective-assertion-relevance {
+    grid-column: 1 / -1;
+    margin: 0;
+    color: #92400e;
+    font-size: 0.8rem;
+}
+
+.concept-effective-assertion-relevance.aboutness-only {
+    padding: 6px 8px;
+    border-radius: 7px;
+    background: #fffbeb;
 }
 
 .concept-effective-assertion-scope {
@@ -12114,6 +12274,22 @@ button.prompt-vontology-cartouche {
     font-size: 0.74rem;
     font-weight: 700;
     white-space: nowrap;
+}
+
+.concept-effective-assertion-epistemic {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24px;
+    padding: 2px 9px;
+    border-radius: 999px;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+
+.concept-effective-assertion-epistemic-tentative {
+    background: #fef3c7;
+    color: #92400e;
 }
 
 .concept-effective-assertion-scope-personal {

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -16,6 +16,8 @@
             <div id="chatSessionFocusChips" class="chat-session-focus-chips is-hidden"
               aria-label="Conversation focus"></div>
             <div id="chatSessionMetadata" class="chat-session-metadata" aria-label="Conversation metadata"></div>
+            <section id="conceptQaConversationControls" class="concept-qa-conversation-controls hidden"
+              aria-label="Concept Q&amp;A controls" aria-live="polite"></section>
           </div>
           <div class="chat-header-controls" role="group" aria-label="Conversation tools">
             <button id="importExternalConversationBtn" class="chat-export-btn" type="button"

--- a/src/frontend/web/von_interface/templates/concept_tab.html
+++ b/src/frontend/web/von_interface/templates/concept_tab.html
@@ -26,11 +26,26 @@
   <!-- Ordinary discussion is distinct from the specialised concept-improvement Q&A below. -->
   <button id="discussConceptButton" class="concept-discuss-button"
     title="Discuss this concept with Von">Discuss</button>
-  <button id="startInteractionButton"
-    title="Answer guided questions to improve this concept; supplied knowledge is preserved with provenance and may update its notes">Improve concept by Q&amp;A</button>
-  <p id="conceptInteractionDisclosure" class="concept-interaction-disclosure">
-    Guided Q&amp;A preserves supplied knowledge with provenance and tries to update this concept's notes.
-  </p>
+  <section id="conceptQaSessionCard" class="concept-qa-session-card" aria-labelledby="conceptQaSessionTitle">
+    <div class="concept-qa-session-header">
+      <strong id="conceptQaSessionTitle">Concept Q&amp;A</strong>
+      <span id="conceptQaSessionBadge" class="concept-qa-session-badge" aria-live="polite">Checking…</span>
+    </div>
+    <p id="conceptInteractionDisclosure" class="concept-interaction-disclosure">
+      Guided Q&amp;A keeps a recoverable conversation transcript. Admitted exact claims are stored with provenance; formalisation and notes updates are reported separately.
+    </p>
+    <p id="conceptQaSessionSummary" class="concept-qa-session-summary" role="status" aria-live="polite">
+      Looking for an active Q&amp;A conversation…
+    </p>
+    <p id="conceptQaGapStatus" class="concept-qa-gap-status hidden"></p>
+    <div class="concept-qa-session-actions">
+      <button id="startInteractionButton"
+        title="Answer guided questions in a recoverable conversation; admitted exact claims are stored with provenance">Improve concept by Q&amp;A</button>
+      <button id="resumeConceptQaButton" class="hidden" type="button">Resume Q&amp;A</button>
+      <button id="openConceptQaTranscriptButton" class="hidden" type="button">Open transcript</button>
+      <button id="copyConceptQaReferenceButton" class="hidden" type="button">Copy reference</button>
+    </div>
+  </section>
   <!-- Add Save Notes Button (initially hidden/disabled) -->
   <button id="saveNotesButton" class="concept-save-button" title="Save changes to concept notes">Save</button>
   <button id="suggestInfoButton" class="concept-save-button"
@@ -62,7 +77,7 @@
   <button id="cancelInteractionButton" class="concept-cancel-button"
     title="Cancel the current concept-improvement Q&amp;A">Cancel Q&amp;A</button>
   <button id="endInteractionButton" class="concept-end-button"
-    title="Finish the concept Q&amp;A and apply the gathered information">Finish Q&amp;A</button>
+    title="Finish the concept Q&amp;A while retaining its transcript and recorded outcomes">Finish Q&amp;A</button>
 
   <!-- Display of the last Q&A exchange -->
   <div id="lastQADisplay" class="concept-last-qa-display">

--- a/tests/backend/test_code_concepts_registry.py
+++ b/tests/backend/test_code_concepts_registry.py
@@ -67,6 +67,20 @@ def test_renderer_profile_predicate_is_registered_as_binary_text():
     assert MENTIONED_IN_VON_CODE_ID in inst_of
 
 
+def test_constitutive_requirement_profile_predicate_is_registered_as_binary_text():
+    predicate_id = "#V#has_constitutive_relation_requirements_json"
+
+    assert predicate_id in set(list_code_predicate_ids())
+    doc = build_virtual_concept_doc(predicate_id)
+
+    assert doc is not None
+    assert doc["concept_id"] == predicate_id
+    inst_of = doc.get("relationships", {}).get("is_an_instance_of", [])
+    assert PREDICATE_TYPE_ID in inst_of
+    assert BINARY_TEXT_PREDICATE_TYPE_ID in inst_of
+    assert MENTIONED_IN_VON_CODE_ID in inst_of
+
+
 def test_workflow_runtime_policy_predicates_are_registered():
     ids = set(list_code_predicate_ids())
 

--- a/tests/backend/test_concept_effective_assertion_service.py
+++ b/tests/backend/test_concept_effective_assertion_service.py
@@ -80,10 +80,10 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
     )
 
     assert captured["page"] == {
-        "subject_concept_ids": ["#V#event"],
+        "argument_concept_id": "#V#event",
+        "epistemic_statuses": ("asserted", "tentative"),
         "limit": 2,
         "offset": 0,
-        "limit_per_subject": 2,
     }
     assert captured["find"]["filter"] == {
         "concept_id": {
@@ -123,6 +123,85 @@ def test_load_effective_assertions_projects_scopes_and_batches_names(
     assert result["items"][0]["human_statement"] == (
         "Research event Date of event June 2026"
     )
+    assert result["items"][0]["concept_relevance"] == {
+        "kind": "grounded_subject",
+        "concept_id": "#V#event",
+        "aboutness_only": False,
+    }
+
+
+def test_link_only_text_assertion_is_visible_without_becoming_a_relation(
+    monkeypatch,
+) -> None:
+    collection = mongomock.MongoClient().db.scoped_knowledge_assertions
+    now = datetime.now(timezone.utc)
+    collection.insert_one(
+        {
+            "_id": "ska_q_and_a",
+            "assertion_id": "ska_q_and_a",
+            "assertion_revision": 1,
+            "assertion_form": scoped_service.STANDALONE_TEXT_ASSERTION_FORM,
+            "subject_concept_id": None,
+            "predicate": None,
+            "object_kind": "text",
+            "object_text": {
+                "text": "Primary Labs has a chief scientist.",
+                "language": "en-NZ",
+            },
+            "object_concept_id": None,
+            "concept_links": [
+                {
+                    "concept_id": "#V#primary_labs",
+                    "role": "about",
+                    "status": "active",
+                }
+            ],
+            "scope": {
+                "mode": "user",
+                "audience_key": "user:#V#owner",
+                "audience_keys": ["user:#V#owner"],
+            },
+            "status": "asserted",
+            "canonical_publication": False,
+            "created_at": now,
+            "updated_at": now,
+            "provenance": {"asserted_by_user_concept_id": "#V#owner"},
+        }
+    )
+    monkeypatch.setattr(
+        scoped_service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        scoped_service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+    monkeypatch.setattr(service.ConceptsRepository, "find", lambda *_a, **_kw: [])
+
+    with override_current_actor("#V#owner", None):
+        result = service.load_concept_effective_assertions(
+            concept_id="#V#primary_labs"
+        )
+
+    assert [item["assertion_id"] for item in result["items"]] == ["ska_q_and_a"]
+    assertion = result["items"][0]
+    assert assertion["assertion_form"] == scoped_service.STANDALONE_TEXT_ASSERTION_FORM
+    assert assertion["subject"]["concept_id"] is None
+    assert assertion["predicate"]["concept_id"] is None
+    assert assertion["human_statement"] == "Primary Labs has a chief scientist."
+    assert assertion["concept_relevance"] == {
+        "kind": "aboutness_only",
+        "concept_id": "#V#primary_labs",
+        "aboutness_only": True,
+    }
+
+    with override_current_actor("#V#outsider", None):
+        hidden = service.load_concept_effective_assertions(
+            concept_id="#V#primary_labs"
+        )
+    assert hidden["items"] == []
 
 
 def test_exact_profile_assertion_projects_user_facing_profile(monkeypatch) -> None:

--- a/tests/backend/test_concept_interaction_session_scope.py
+++ b/tests/backend/test_concept_interaction_session_scope.py
@@ -77,7 +77,10 @@ def test_interaction_model_runtime_reuses_exact_persisted_selection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
-    sentinel = object()
+    class _SelectedClient:
+        provider_name = "gemini"
+
+    sentinel = _SelectedClient()
 
     def fake_get_llm_client(**kwargs: Any) -> object:
         captured.update(kwargs)
@@ -100,7 +103,7 @@ def test_interaction_model_runtime_reuses_exact_persisted_selection(
         lambda **_kwargs: pytest.fail("persisted provider must not be re-resolved"),
     )
 
-    client, model, params = concept_service._resolve_interaction_llm_runtime(
+    client, model, params, runtime = concept_service._resolve_interaction_llm_runtime(
         {
             "user_id": "#V#michael_witbrock",
             "organisation_concept_id": "#V#university_of_auckland_strong_ai_lab",
@@ -115,6 +118,10 @@ def test_interaction_model_runtime_reuses_exact_persisted_selection(
     assert client is sentinel
     assert model == "gemini-3.7-flash"
     assert params == {"temperature": 0.2}
+    assert runtime == {
+        "configured_provider": "gemini",
+        "selected_provider": "gemini",
+    }
     assert captured == {
         "client_type": "gemini",
         "user_concept_id": "#V#michael_witbrock",

--- a/tests/backend/test_concept_qa_conversation_service.py
+++ b/tests/backend/test_concept_qa_conversation_service.py
@@ -1,0 +1,1461 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from datetime import UTC, datetime
+
+import mongomock
+import pytest
+
+USER_ID = "#V#user"
+ORG_ID = "#V#org"
+NAMESPACE = "#V#user@org"
+CONCEPT_ID = "#V#primary_labs"
+SESSION_ID = "3ed2de92-cdef-4e76-a800-8cd0af811c91"
+
+
+def _chat_collection():
+    return mongomock.MongoClient()["von_test"]["chat_history"]
+
+
+def _session_doc(*, assistant_metadata=None):
+    now = datetime.now(UTC)
+    history = [
+        {
+            "role": "assistant",
+            "content": "Who is a member of Primary Labs?",
+            "turn_id": "assistant-initial",
+            "concept_q_and_a": assistant_metadata or {"kind": "initial_question"},
+            "timestamp": now,
+        }
+    ]
+    return {
+        "user_id": USER_ID,
+        "session_id": SESSION_ID,
+        "namespace": NAMESPACE,
+        "organisation_concept_id": ORG_ID,
+        "mode": "concept_q_and_a",
+        "origin_kind": "concept_q_and_a",
+        "focal_concept_ids": [CONCEPT_ID],
+        "created_at": now,
+        "updated_at": now,
+        "history": history,
+        "concept_q_and_a": {
+            "schema_version": "concept_q_and_a_session.v1",
+            "concept": {"concept_id": CONCEPT_ID, "name": "Primary Labs"},
+            "lifecycle": {"status": "active", "revision": 0},
+            "turn_receipts": {},
+        },
+    }
+
+
+def _patch_chat_store(monkeypatch, service, collection):
+    monkeypatch.setattr(
+        service.chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: collection,
+    )
+    monkeypatch.setattr(service, "_collection", lambda **_kwargs: collection)
+    monkeypatch.setattr(
+        service,
+        "_load_focal_concept",
+        lambda *_args, **_kwargs: {
+            "_id": "507f1f77bcf86cd799439011",
+            "concept_id": CONCEPT_ID,
+            "name": "Primary Labs",
+        },
+    )
+
+
+def test_question_or_meta_input_is_transcript_only(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    monkeypatch.setattr(
+        service.concept_service,
+        "_store_concept_qa_input_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("a user question must not become a knowledge assertion")
+        ),
+    )
+    receipt = service._aggregate_exact_input_receipt(
+        session_id=SESSION_ID,
+        turn_id="turn-question",
+        answer="Did you represent that in Vontology?",
+        notes_input="",
+        concept={"concept_id": CONCEPT_ID},
+        session_doc=_session_doc(),
+    )
+
+    assert receipt["status"] == "not_admitted"
+    assert receipt["items"][0]["classification"] == "user_question"
+    assert receipt["items"][0]["asserted_knowledge"] is False
+
+
+def test_representation_status_question_is_answered_from_receipt_without_model(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["history"].insert(
+        0,
+        {
+            "role": "user",
+            "content": "Michael Witbrock",
+            "turn_id": "source-turn",
+            "concept_q_and_a": {
+                "kind": "user_input",
+                "input_kind": "asserted_knowledge",
+            },
+        },
+    )
+    doc["concept_q_and_a"]["turn_receipts"]["source-turn"] = {
+        "turn_id": "source-turn",
+        "exact_input": {
+            "status": "stored",
+            "effect_status": "succeeded",
+            "assertion_ids": ["ska_exact_source"],
+        },
+        "formalisation": {
+            "status": "tentative",
+            "effect_status": "succeeded",
+            "assertion_id": "ska_member",
+            "predicate_concept_id": "#V#memberOf",
+            "activation_effect": "organisation_membership",
+            "canonical_publication": False,
+        },
+        "notes": {
+            "status": "not_updated",
+            "effect_status": "not_needed",
+            "notes_updated": False,
+        },
+    }
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(
+        service.concept_service,
+        "_store_concept_qa_input_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("a representation-status question is transcript-only")
+        ),
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "submit_concept_answer",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt-aware status must not be improvised by a model")
+        ),
+    )
+
+    result = service.submit_concept_qa_turn(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        turn_id="status-question",
+        user_id=USER_ID,
+        answer="Did you represent that info in Vontology?",
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    assistant = result["turns"][-1]
+    status = assistant["concept_q_and_a"]["representation_status"]
+    assert assistant["concept_q_and_a"]["kind"] == "representation_status_response"
+    assert "actor-scoped text claim with provenance" in assistant["content"]
+    assert "stored as tentative" in assistant["content"]
+    assert "does not activate organisation membership" in assistant["content"]
+    assert "canonical concept notes were not changed" in assistant["content"]
+    assert status["source_turn_id"] == "source-turn"
+    assert status["exact_assertion_ids"] == ["ska_exact_source"]
+    assert status["formalisation_status"] == "tentative"
+    assert result["receipts"]["exact_input"]["status"] == "not_admitted"
+    assert result["receipts"]["representation_status"] == status
+
+
+def test_autoformalisation_requires_declared_tentative_permission(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    monkeypatch.setattr(
+        service.concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("resolution must not run without declared permission")
+        ),
+    )
+    exact = {
+        "items": [
+            {
+                "input_kind": "answer",
+                "status": "stored",
+                "assertion_id": "ska_source",
+            }
+        ]
+    }
+    result = service._tentative_formalisation_receipt(
+        exact_input=exact,
+        answer="Michael Witbrock",
+        proposed_predicate={
+            "predicate_concept_id": "#V#memberOf",
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "auto_formalisation_allowed": False,
+            "auto_formalisation_target_status": "tentative",
+        },
+        concept_id=CONCEPT_ID,
+        concept_name="Primary Labs",
+        session_id=SESSION_ID,
+        turn_id="turn-1",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+    )
+
+    assert result["status"] == "deferred"
+    assert result["reason_code"] == "auto_formalisation_permission_missing"
+
+
+def test_safe_short_answer_is_stored_as_tentative_direction_aware_relation(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    monkeypatch.setattr(
+        service.concept_resolution_service,
+        "resolve_concept_by_name",
+        lambda **kwargs: {
+            "success": True,
+            "status": "resolved",
+            "resolved_concept_id": "#V#michael_witbrock",
+            "match": {"stage": "exact_name"},
+            "candidates": [],
+        },
+    )
+    captured: dict = {}
+
+    def _upsert(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "assertion_id": "ska_tentative_member",
+            "canonical_read_back": {
+                "assertion_id": "ska_tentative_member",
+                "subject_concept_id": "#V#michael_witbrock",
+                "predicate": "#V#memberOf",
+                "object_concept_id": CONCEPT_ID,
+                "epistemic_status": "tentative",
+            },
+        }
+
+    monkeypatch.setattr(
+        service.scoped_assertion_service, "upsert_scoped_assertion", _upsert
+    )
+    exact = {
+        "items": [
+            {
+                "input_kind": "answer",
+                "status": "stored",
+                "assertion_id": "ska_source_text",
+            }
+        ]
+    }
+    result = service._tentative_formalisation_receipt(
+        exact_input=exact,
+        answer="Michael Witbrock",
+        proposed_predicate={
+            "requirement_id": "organisation_has_von_user",
+            "predicate_concept_id": "#V#memberOf",
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "declared_on_type_concept_id": "#V#von_user_organisation",
+            "declaration_source": "represented",
+            "profile_predicate": "#V#hasConstitutiveRelationRequirement",
+            "auto_formalisation_allowed": True,
+            "auto_formalisation_target_status": "tentative",
+            "confirmation_question_template": (
+                "Should {counterpart_name} be confirmed as a member of {instance_name}?"
+            ),
+        },
+        concept_id=CONCEPT_ID,
+        concept_name="Primary Labs",
+        session_id=SESSION_ID,
+        turn_id="turn-member",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+    )
+
+    assert result["status"] == "tentative"
+    assert result["subject_concept_id"] == "#V#michael_witbrock"
+    assert result["object_concept_id"] == CONCEPT_ID
+    assert result["source_assertion_ids"] == ["ska_source_text"]
+    assert result["confirmation"]["available"] is True
+    assert result["confirmation"]["requires_operational_authority"] is True
+    assert result["requirement_id"] == "organisation_has_von_user"
+    assert result["declaration_source"] == "represented"
+    assert result["profile_predicate"] == "#V#hasConstitutiveRelationRequirement"
+    assert (
+        service._confirmation_question(
+            formalisation=result,
+            answer_text="Michael Witbrock",
+        )
+        == "Should Michael Witbrock be confirmed as a member of Primary Labs?"
+    )
+    assert captured["epistemic_status"] == "tentative"
+    assert captured["scope_mode"] == "user"
+    assert captured["canonical_publication"] is False
+
+
+def test_code_string_answer_cannot_bypass_counterpart_type_resolution(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    captured: dict = {}
+
+    def _resolve(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "status": "not_found",
+            "resolved_concept_id": None,
+            "candidates": [],
+        }
+
+    monkeypatch.setattr(
+        service.concept_resolution_service,
+        "resolve_concept_by_name",
+        _resolve,
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "upsert_scoped_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("an incompatible code string must not become a relation")
+        ),
+    )
+    result = service._tentative_formalisation_receipt(
+        exact_input={
+            "items": [
+                {
+                    "input_kind": "answer",
+                    "status": "stored",
+                    "assertion_id": "ska_source",
+                }
+            ]
+        },
+        answer="#V#some_organisation",
+        proposed_predicate={
+            "predicate_concept_id": "#V#memberOf",
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "auto_formalisation_allowed": True,
+            "auto_formalisation_target_status": "tentative",
+        },
+        concept_id=CONCEPT_ID,
+        concept_name="Primary Labs",
+        session_id=SESSION_ID,
+        turn_id="turn-code",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+    )
+
+    assert captured["match_code_strings"] is False
+    assert captured["instance_of"] == "#V#von_user"
+    assert result["status"] == "deferred"
+    assert result["reason_code"] == "entity_reference_not_found"
+
+
+def test_answer_and_notes_are_distinct_exact_transcript_turns_before_downstream(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    collection.insert_one(_session_doc())
+    _patch_chat_store(monkeypatch, service, collection)
+    assertion_number = 0
+
+    def _store_exact(**kwargs):
+        nonlocal assertion_number
+        assertion_number += 1
+        return {
+            "status": "stored",
+            "effect_status": "succeeded",
+            "assertion_id": f"ska_exact_{assertion_number}",
+            "target_concept_id": CONCEPT_ID,
+            "canonical_publication": False,
+        }
+
+    monkeypatch.setattr(
+        service.concept_service,
+        "_store_concept_qa_input_assertion",
+        _store_exact,
+    )
+    monkeypatch.setattr(service, "_current_elicitation_predicate", lambda _cid: None)
+
+    def _downstream(**kwargs):
+        assert kwargs["allow_canonical_notes_update"] is False
+        stored = collection.find_one({"session_id": SESSION_ID})
+        pending = stored["concept_q_and_a"]["turn_receipts"]["turn-dual"]
+        assert "completed_at" not in pending
+        assert [
+            item["content"] for item in stored["history"] if item["role"] == "user"
+        ] == [
+            "The CEO is Aron D'Souza.",
+            "The website is theprimary.com.",
+        ]
+        return {
+            "status": "success",
+            "next_step_type": "llm_question",
+            "next_step_content": "Who is the CTO?",
+            "representation": {
+                "concept_notes": {
+                    "status": "updated",
+                    "effect_status": "succeeded",
+                    "notes_updated": True,
+                    "source_assertion_id": "ska_exact_1",
+                }
+            },
+            "llm_debug_data": {
+                "schema_version": "concept_q_and_a_llm_debug.v1",
+                "selected": {"provider": "test", "model": "non-sol-test"},
+            },
+        }
+
+    monkeypatch.setattr(service.concept_service, "submit_concept_answer", _downstream)
+
+    result = service.submit_concept_qa_turn(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        turn_id="turn-dual",
+        user_id=USER_ID,
+        answer="The CEO is Aron D'Souza.",
+        notes_input="The website is theprimary.com.",
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    assert result["status"] == "success"
+    assert len(result["receipts"]["exact_input"]["assertion_ids"]) == 2
+    assert len(result["receipts"]["transcript_turn_ids"]) == 2
+    assert result["receipts"]["completed_at"]
+    assistant = result["turns"][-1]
+    assert assistant["content"] == "Who is the CTO?"
+    assert assistant["llm_debug_data"]["selected"]["model"] == "non-sol-test"
+    assert assistant["llm_debug_data"]["selected"]["provider"] == "test"
+    assert assistant["llm_debug_data"]["model"] == "non-sol-test"
+    assert assistant["llm_debug_data"]["provider"] == "test"
+
+    replay = service.submit_concept_qa_turn(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        turn_id="turn-dual",
+        user_id=USER_ID,
+        answer="The CEO is Aron D'Souza.",
+        notes_input="The website is theprimary.com.",
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+    assert replay["replayed"] is True
+    assert collection.count_documents({"session_id": SESSION_ID}) == 1
+
+    with pytest.raises(service.ConceptQAConversationConflict) as conflict:
+        service.submit_concept_qa_turn(
+            concept_id=CONCEPT_ID,
+            session_id=SESSION_ID,
+            turn_id="turn-dual",
+            user_id=USER_ID,
+            answer="A different answer.",
+            notes_input="The website is theprimary.com.",
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+        )
+    assert conflict.value.error_code == "turn_id_content_conflict"
+
+
+def test_membership_activation_success_is_retained_when_promotion_needs_retry(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+    from src.backend.services import (
+        organisation_membership_governance_service,
+        organisation_membership_service,
+    )
+
+    assertion = {
+        "assertion_id": "ska_member",
+        "subject_concept_id": "#V#michael_witbrock",
+        "predicate": "#V#memberOf",
+        "object_concept_id": CONCEPT_ID,
+        "epistemic_status": "tentative",
+    }
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "get_visible_scoped_assertion_by_id",
+        lambda *_args, **_kwargs: assertion,
+    )
+    governed = {
+        "success": True,
+        "effect_status": "succeeded",
+        "canonical_read_back": {
+            "membership_present": True,
+            "role": "member",
+        },
+        "governance_receipt": {"receipt_id": "omr_1", "status": "succeeded"},
+    }
+    monkeypatch.setattr(
+        organisation_membership_governance_service,
+        "manage_organisation_membership",
+        lambda **_kwargs: governed,
+    )
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "promote_scoped_assertion_epistemic_status",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("temporary failure")),
+    )
+    formalisation = {
+        "assertion_id": "ska_member",
+        "subject_concept_id": "#V#michael_witbrock",
+        "predicate_concept_id": "#V#memberOf",
+        "object_concept_id": CONCEPT_ID,
+        "focal_argument": "object",
+        "other_argument_type_concept_id": "#V#von_user",
+        "focal_concept_id": CONCEPT_ID,
+    }
+
+    result = service._confirm_formalisation_effect(
+        formalisation=formalisation,
+        assertion_id="ska_member",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+        request_id="confirm-member",
+        expected_focal_concept_id=CONCEPT_ID,
+    )
+
+    assert result["success"] is False
+    assert result["effect_status"] == "partial_success"
+    assert result["reconciliation_required"] is True
+    assert result["governed_activation"] == governed
+    assert result["canonical_read_back"]["membership_present"] is True
+
+
+def test_generic_confirmation_is_idempotent_and_top_level_receipt_is_coherent(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    formalisation = {
+        "schema_version": "concept_q_and_a_formalisation_receipt.v1",
+        "kind": "formalisation",
+        "status": "tentative",
+        "effect_status": "succeeded",
+        "assertion_id": "ska_relation",
+        "subject_concept_id": CONCEPT_ID,
+        "predicate_concept_id": "#V#hasChiefScientist",
+        "object_concept_id": "#V#michael_witbrock",
+        "requirement_id": "organisation_has_chief_scientist",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#person",
+        "declared_on_type_concept_id": "#V#organisation",
+        "declaration_source": "represented",
+        "profile_predicate": "#V#hasConstitutiveRelationRequirement",
+        "canonical_read_back": {"epistemic_status": "tentative"},
+        "confirmation": {"available": True, "method": "POST"},
+    }
+    doc["concept_q_and_a"]["turn_receipts"]["source-turn"] = {
+        "turn_id": "source-turn",
+        "formalisation": formalisation,
+    }
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    assertion_state = {
+        "assertion_id": "ska_relation",
+        "subject_concept_id": CONCEPT_ID,
+        "predicate": "#V#hasChiefScientist",
+        "object_concept_id": "#V#michael_witbrock",
+        "epistemic_status": "tentative",
+    }
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "get_visible_scoped_assertion_by_id",
+        lambda *_args, **_kwargs: dict(assertion_state),
+    )
+
+    def _promote(**_kwargs):
+        changed = assertion_state["epistemic_status"] != "asserted"
+        assertion_state["epistemic_status"] = "asserted"
+        return {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": changed,
+            "canonical_read_back": dict(assertion_state),
+        }
+
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "promote_scoped_assertion_epistemic_status",
+        _promote,
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: [
+            {
+                **formalisation,
+                "question": "Who is the chief scientist?",
+            },
+            {
+                "requirement_id": "organisation_has_research_lead",
+                "predicate_concept_id": "#V#hasChiefScientist",
+                "focal_argument": "subject",
+                "other_argument_type_concept_id": "#V#research_lead",
+                "declared_on_type_concept_id": "#V#organisation",
+                "question": "Who is the research lead?",
+            },
+        ],
+    )
+
+    first = service.confirm_concept_qa_formalisation(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        assertion_id="ska_relation",
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+    repeated = service.confirm_concept_qa_formalisation(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        assertion_id="ska_relation",
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    confirmed = first["receipts"]["formalisation"]
+    assert first["success"] is True
+    assert confirmed["status"] == "asserted"
+    assert confirmed["effect_status"] == "succeeded"
+    assert confirmed["canonical_read_back"]["epistemic_status"] == "asserted"
+    assert confirmed["confirmation"]["available"] is False
+    assert repeated["success"] is True
+    assert repeated["confirmation"]["idempotent_replay"] is True
+    result_turns = [
+        turn
+        for turn in repeated["turns"]
+        if turn.get("concept_q_and_a", {}).get("kind")
+        == "formalisation_confirmation_result"
+    ]
+    assert len(result_turns) == 1
+    assert "Who is the research lead?" in result_turns[0]["content"]
+    assert (
+        result_turns[0]["concept_q_and_a"]["elicitation_predicate"]["requirement_id"]
+        == "organisation_has_research_lead"
+    )
+    assert (
+        service._pending_confirmation(collection.find_one({"session_id": SESSION_ID}))
+        is None
+    )
+
+
+def test_direct_confirmation_updates_finished_receipt_without_reopening_transcript(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["concept_q_and_a"]["lifecycle"] = {
+        "status": "finished",
+        "revision": 1,
+        "terminal_at": datetime.now(UTC),
+    }
+    formalisation = {
+        "schema_version": "concept_q_and_a_formalisation_receipt.v1",
+        "kind": "formalisation",
+        "status": "tentative",
+        "effect_status": "succeeded",
+        "assertion_id": "ska_finished_relation",
+        "subject_concept_id": CONCEPT_ID,
+        "predicate_concept_id": "#V#hasChiefScientist",
+        "object_concept_id": "#V#michael_witbrock",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#person",
+        "declared_on_type_concept_id": "#V#organisation",
+        "canonical_publication": False,
+        "confirmation": {
+            "available": True,
+            "available_after_finish": True,
+            "available_after_cancel": False,
+        },
+    }
+    doc["concept_q_and_a"]["turn_receipts"]["source-turn"] = {
+        "turn_id": "source-turn",
+        "formalisation": formalisation,
+    }
+    history_count = len(doc["history"])
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(
+        service,
+        "_confirm_formalisation_effect",
+        lambda **_kwargs: {
+            "success": True,
+            "status": "asserted",
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {"epistemic_status": "asserted"},
+        },
+    )
+
+    result = service.confirm_concept_qa_formalisation(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        assertion_id="ska_finished_relation",
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    assert result["success"] is True
+    assert result["confirmed_after_finish"] is True
+    assert result["assistant_turn_id"] is None
+    assert result["lifecycle"]["status"] == "finished"
+    assert len(result["turns"]) == history_count
+    assert result["receipts"]["formalisation"]["status"] == "asserted"
+    assert result["receipts"]["formalisation"]["confirmation"]["available"] is False
+
+
+def test_direct_confirmation_is_not_available_after_cancel(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["concept_q_and_a"]["lifecycle"] = {
+        "status": "cancelled",
+        "revision": 1,
+        "terminal_at": datetime.now(UTC),
+    }
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+
+    with pytest.raises(service.ConceptQAConversationConflict) as exc_info:
+        service.confirm_concept_qa_formalisation(
+            concept_id=CONCEPT_ID,
+            session_id=SESSION_ID,
+            assertion_id="ska_cancelled_relation",
+            user_id=USER_ID,
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+        )
+
+    assert exc_info.value.error_code == "conversation_cancelled"
+
+
+def test_member_confirmation_authority_denial_preserves_tentative_candidate(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+    from src.backend.services import (
+        organisation_membership_governance_service,
+        organisation_membership_service,
+    )
+
+    assertion = {
+        "assertion_id": "ska_member_denied",
+        "subject_concept_id": "#V#person",
+        "predicate": "#V#memberOf",
+        "object_concept_id": CONCEPT_ID,
+        "epistemic_status": "tentative",
+    }
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "get_visible_scoped_assertion_by_id",
+        lambda *_args, **_kwargs: assertion,
+    )
+    monkeypatch.setattr(
+        organisation_membership_governance_service,
+        "manage_organisation_membership",
+        lambda **_kwargs: {
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "organisation_membership_management_authority_required",
+            "authority_decision": {
+                "allowed": False,
+                "required_permissions": ["MANAGE_MEMBERS"],
+            },
+            "governance_receipt": {"status": "denied"},
+        },
+    )
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "promote_scoped_assertion_epistemic_status",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("denied membership must not promote")
+        ),
+    )
+
+    result = service._confirm_formalisation_effect(
+        formalisation={
+            "assertion_id": "ska_member_denied",
+            "subject_concept_id": "#V#person",
+            "predicate_concept_id": "#V#memberOf",
+            "object_concept_id": CONCEPT_ID,
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "focal_concept_id": CONCEPT_ID,
+        },
+        assertion_id="ska_member_denied",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+        request_id="confirm-denied",
+        expected_focal_concept_id=CONCEPT_ID,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "tentative"
+    assert result["authority_decision"]["allowed"] is False
+    assert result["actionable_denial"]["tentative_assertion_preserved"] is True
+    assert result["actionable_denial"]["required_permissions"] == ["MANAGE_MEMBERS"]
+    assert result["actionable_denial"]["mechanism"] == (
+        "canonical_organisation_membership_handoff"
+    )
+    assert (
+        result["actionable_denial"]["same_q_and_a_action_available_to_other_actor"]
+        is False
+    )
+
+
+def test_preexisting_membership_lets_original_actor_confirm_without_self_grant(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+    from src.backend.services import (
+        organisation_membership_governance_service,
+        organisation_membership_service,
+    )
+
+    assertion = {
+        "assertion_id": "ska_member_preexisting",
+        "subject_concept_id": "#V#person",
+        "predicate": "#V#memberOf",
+        "object_concept_id": CONCEPT_ID,
+        "epistemic_status": "tentative",
+    }
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "get_visible_scoped_assertion_by_id",
+        lambda *_args, **_kwargs: assertion,
+    )
+    monkeypatch.setattr(
+        organisation_membership_service,
+        "resolve_user_organisation_membership",
+        lambda *_args, **_kwargs: {
+            "user_concept_id": "#V#person",
+            "organisation_concept_id": CONCEPT_ID,
+            "role": "contributor",
+        },
+    )
+    monkeypatch.setattr(
+        organisation_membership_governance_service,
+        "manage_organisation_membership",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preexisting membership must not request a new grant")
+        ),
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "promote_scoped_assertion_epistemic_status",
+        lambda **_kwargs: {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {
+                **assertion,
+                "epistemic_status": "asserted",
+            },
+        },
+    )
+
+    result = service._confirm_formalisation_effect(
+        formalisation={
+            "assertion_id": "ska_member_preexisting",
+            "subject_concept_id": "#V#person",
+            "predicate_concept_id": "#V#memberOf",
+            "object_concept_id": CONCEPT_ID,
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "focal_concept_id": CONCEPT_ID,
+        },
+        assertion_id="ska_member_preexisting",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+        request_id="confirm-preexisting",
+        expected_focal_concept_id=CONCEPT_ID,
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "asserted"
+    assert result["governed_activation"]["postcondition_preexisting"] is True
+    assert result["governed_activation"]["changed"] is False
+
+
+def test_inverse_membership_alias_never_invokes_governed_membership_add(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+    from src.backend.services import organisation_membership_governance_service
+
+    assertion = {
+        "assertion_id": "ska_inverse_member",
+        "subject_concept_id": CONCEPT_ID,
+        "predicate": "#V#has_member",
+        "object_concept_id": "#V#person",
+        "epistemic_status": "tentative",
+    }
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "get_visible_scoped_assertion_by_id",
+        lambda *_args, **_kwargs: assertion,
+    )
+    monkeypatch.setattr(
+        organisation_membership_governance_service,
+        "manage_organisation_membership",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("inverse/read-compatible aliases must not grant membership")
+        ),
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "promote_scoped_assertion_epistemic_status",
+        lambda **_kwargs: {
+            "success": True,
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {
+                **assertion,
+                "epistemic_status": "asserted",
+            },
+        },
+    )
+
+    result = service._confirm_formalisation_effect(
+        formalisation={
+            "assertion_id": "ska_inverse_member",
+            "subject_concept_id": CONCEPT_ID,
+            "predicate_concept_id": "#V#has_member",
+            "object_concept_id": "#V#person",
+            "focal_argument": "subject",
+            "other_argument_type_concept_id": "#V#von_user",
+            "focal_concept_id": CONCEPT_ID,
+        },
+        assertion_id="ska_inverse_member",
+        user_id=USER_ID,
+        organisation_concept_id=ORG_ID,
+        namespace=NAMESPACE,
+        request_id="confirm-inverse",
+        expected_focal_concept_id=CONCEPT_ID,
+    )
+
+    assert result["success"] is True
+    assert result["governed_activation"] is None
+
+
+@pytest.mark.parametrize(
+    ("reply", "reply_kind", "expected_status"),
+    [
+        ("yes", "affirm", "asserted"),
+        ("not now", "defer", "tentative"),
+        ("I don't know", "defer", "tentative"),
+        ("no", "reject", "rejected"),
+    ],
+)
+def test_conversational_confirmation_reply_binds_to_prior_tentative_without_new_claim(
+    monkeypatch, reply, reply_kind, expected_status
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    pending = {
+        "assertion_id": "ska_pending",
+        "subject_concept_id": CONCEPT_ID,
+        "predicate_concept_id": "#V#hasChiefScientist",
+        "object_concept_id": "#V#michael_witbrock",
+        "requirement_id": "organisation_has_chief_scientist",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#person",
+        "declared_on_type_concept_id": "#V#organisation",
+        "declaration_source": "represented",
+        "profile_predicate": "#V#hasConstitutiveRelationRequirement",
+        "status": "tentative",
+        "epistemic_status": "tentative",
+        "confirmation": {"available": True},
+    }
+    doc = _session_doc(
+        assistant_metadata={
+            "kind": "formalisation_confirmation_request",
+            "formalisation": pending,
+        }
+    )
+    doc["concept_q_and_a"]["turn_receipts"]["source-turn"] = {
+        "turn_id": "source-turn",
+        "formalisation": pending,
+    }
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(
+        service.concept_service,
+        "_store_concept_qa_input_assertion",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("confirmation control must not create a text assertion")
+        ),
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "submit_concept_answer",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("typed confirmation takes priority over fresh elicitation")
+        ),
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: [
+            {
+                "requirement_id": "organisation_has_chief_scientist",
+                "predicate_concept_id": "#V#hasChiefScientist",
+                "focal_argument": "subject",
+                "other_argument_type_concept_id": "#V#person",
+                "declared_on_type_concept_id": "#V#organisation",
+                "question": "Who is the chief scientist?",
+                "requirement_kind": "constitutive_relation",
+            },
+            {
+                "requirement_id": "organisation_has_research_lead",
+                "predicate_concept_id": "#V#hasChiefScientist",
+                "focal_argument": "subject",
+                "other_argument_type_concept_id": "#V#research_lead",
+                "declared_on_type_concept_id": "#V#organisation",
+                "question": "Who is the organisation's research lead?",
+                "requirement_kind": "constitutive_relation",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        service,
+        "_confirm_formalisation_effect",
+        lambda **_kwargs: {
+            "success": True,
+            "status": "asserted",
+            "effect_status": "succeeded",
+            "changed": True,
+            "canonical_read_back": {"epistemic_status": "asserted"},
+        },
+    )
+    monkeypatch.setattr(
+        service.scoped_assertion_service,
+        "retract_scoped_assertion",
+        lambda **_kwargs: {
+            "success": True,
+            "changed": True,
+            "canonical_read_back": {"status": "retracted"},
+        },
+    )
+
+    result = service.submit_concept_qa_turn(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        turn_id=f"confirmation-{reply_kind}",
+        user_id=USER_ID,
+        answer=reply,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    current = result["receipts"]
+    assert current["exact_input"]["status"] == "not_admitted"
+    assert current["exact_input"]["items"][0]["classification"] == "meta_or_control"
+    assert current["formalisation"]["reply_kind"] == reply_kind
+    assert current["formalisation"]["status"] == expected_status
+    assert (
+        result["turns"][-1]["concept_q_and_a"]["kind"]
+        == "formalisation_confirmation_result"
+    )
+    stored = collection.find_one({"session_id": SESSION_ID})
+    original = stored["concept_q_and_a"]["turn_receipts"]["source-turn"][
+        "formalisation"
+    ]
+    if reply_kind in {"affirm", "reject"}:
+        assert original["status"] == expected_status
+    else:
+        assert original["status"] == "tentative"
+    if reply_kind in {"affirm", "defer", "reject"}:
+        assistant = result["turns"][-1]
+        assert "Who is the organisation's research lead?" in assistant["content"]
+        assert "Who is the chief scientist?" not in assistant["content"]
+        assert (
+            assistant["concept_q_and_a"]["elicitation_predicate"][
+                "predicate_concept_id"
+            ]
+            == "#V#hasChiefScientist"
+        )
+        assert (
+            assistant["concept_q_and_a"]["elicitation_predicate"]["requirement_id"]
+            == "organisation_has_research_lead"
+        )
+    if reply_kind in {"defer", "reject"}:
+        assert (
+            service.concept_service._elicitation_requirement_identity(pending)
+            in stored["concept_q_and_a"]["suppressed_requirement_keys"]
+        )
+        assert stored["concept_q_and_a"].get("suppressed_predicate_ids", []) == []
+    if reply_kind == "affirm":
+        assert (
+            service.concept_service._elicitation_requirement_identity(pending)
+            in stored["concept_q_and_a"]["addressed_requirement_keys"]
+        )
+
+
+def test_focal_concept_visibility_failure_is_indistinguishable_from_absence(
+    monkeypatch,
+):
+    from src.backend.security import access_control
+    from src.backend.services import concept_qa_conversation_service as service
+
+    monkeypatch.setattr(
+        service.concept_service,
+        "get_concept_by_concept_id",
+        lambda _concept_id: {"concept_id": CONCEPT_ID},
+    )
+    monkeypatch.setattr(
+        access_control, "override_current_actor", lambda *_args: nullcontext()
+    )
+    monkeypatch.setattr(access_control, "can_access_concept", lambda _concept_id: False)
+
+    with pytest.raises(service.ConceptQAConversationNotFound) as exc_info:
+        service._load_focal_concept(
+            CONCEPT_ID,
+            user_id="#V#other_actor",
+            organisation_concept_id="#V#other_org",
+        )
+
+    assert exc_info.value.error_code == "concept_not_found"
+    assert str(exc_info.value) == "Focal concept was not found"
+
+
+def test_chat_carrier_active_key_is_an_atomic_uniqueness_boundary(monkeypatch):
+    from pymongo.errors import DuplicateKeyError
+
+    from src.backend.services import chat_history_service
+
+    collection = _chat_collection()
+    monkeypatch.setattr(chat_history_service, "_CHAT_HISTORY_INDEXES_READY", False)
+    chat_history_service._ensure_chat_history_indexes(collection)
+    assert (
+        collection.index_information()["concept_q_and_a_active_key_unique_v1"]["unique"]
+        is True
+    )
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: collection,
+    )
+    monkeypatch.setattr(chat_history_service, "get_session_context", dict)
+    state = {
+        "schema_version": "concept_q_and_a_session.v1",
+        "active_key": "concept_q_and_a:one-actor-one-concept",
+        "lifecycle": {"status": "active", "revision": 0},
+    }
+
+    chat_history_service.create_chat_session(
+        user_id=USER_ID,
+        session_id="session-first",
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+        mode="concept_q_and_a",
+        origin_kind="concept_q_and_a",
+        focal_concept_ids=[CONCEPT_ID],
+        concept_q_and_a_state=state,
+    )
+    with pytest.raises(DuplicateKeyError):
+        chat_history_service.create_chat_session(
+            user_id=USER_ID,
+            session_id="session-racing",
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+            mode="concept_q_and_a",
+            origin_kind="concept_q_and_a",
+            focal_concept_ids=[CONCEPT_ID],
+            concept_q_and_a_state=state,
+        )
+
+    assert (
+        collection.count_documents({"concept_q_and_a.lifecycle.status": "active"}) == 1
+    )
+
+
+def test_generic_chat_state_preserves_terminal_q_and_a_mode_and_focal_state(
+    monkeypatch,
+):
+    from src.backend.services import chat_history_service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["concept_q_and_a"]["lifecycle"] = {
+        "status": "finished",
+        "revision": 1,
+        "terminal_at": "2026-09-02T12:00:00+00:00",
+    }
+    collection.insert_one(doc)
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: collection,
+    )
+
+    state = chat_history_service.get_chat_history_session_state(
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        namespace=NAMESPACE,
+    )
+
+    assert state["mode"] == "concept_q_and_a"
+    assert state["origin_kind"] == "concept_q_and_a"
+    assert state["focal_concept_ids"] == [CONCEPT_ID]
+    assert state["concept_q_and_a"]["lifecycle"]["status"] == "finished"
+    assert state["lifecycle"]["status"] == "finished"
+    summary = chat_history_service.get_chat_history_session_summary(
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        namespace=NAMESPACE,
+        summary_mode="light",
+    )
+    assert summary["is_completed"] is True
+    assert summary["completed_at"] == "2026-09-02T12:00:00+00:00"
+
+
+def test_start_resumes_same_active_carrier_and_initial_assistant_is_once(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    collection.create_index(
+        [("concept_q_and_a.active_key", 1)],
+        name="concept_q_and_a_active_key_unique_v1",
+        unique=True,
+        partialFilterExpression={
+            "mode": "concept_q_and_a",
+            "origin_kind": "concept_q_and_a",
+            "concept_q_and_a.lifecycle.status": "active",
+            "concept_q_and_a.active_key": {"$type": "string"},
+        },
+    )
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(service.chat_history_service, "get_session_context", dict)
+    monkeypatch.setattr(
+        service.concept_service,
+        "_normalise_interaction_llm_selection",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "generate_initial_question",
+        lambda *_args, **_kwargs: {
+            "status": "success",
+            "question": "Who is a Von user in this organisation?",
+            "llm_debug_data": {
+                "schema_version": "concept_q_and_a_llm_debug.v1",
+                "selected": {"provider": "test", "model": "non-sol-test"},
+            },
+        },
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: [],
+    )
+
+    first = service.start_concept_qa_conversation(
+        concept_id=CONCEPT_ID,
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+    resumed = service.start_concept_qa_conversation(
+        concept_id=CONCEPT_ID,
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    assert first["created"] is True
+    assert resumed["created"] is False
+    assert resumed["resumed"] is True
+    assert resumed["session_id"] == first["session_id"]
+    assert len([turn for turn in resumed["turns"] if turn["role"] == "assistant"]) == 1
+    assert resumed["turns"][0]["llm_debug_data"]["selected"]["model"] == "non-sol-test"
+    assert resumed["turns"][0]["llm_debug_data"]["model"] == "non-sol-test"
+    assert resumed["turns"][0]["llm_debug_data"]["provider"] == "test"
+    assert (
+        collection.count_documents({"concept_q_and_a.lifecycle.status": "active"}) == 1
+    )
+
+
+def test_initial_assistant_omits_model_debug_when_legacy_generator_has_none(
+    monkeypatch,
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["history"] = []
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(
+        service.concept_service,
+        "generate_initial_question",
+        lambda *_args, **_kwargs: {
+            "status": "success",
+            "question": "What should be recorded?",
+        },
+    )
+    monkeypatch.setattr(
+        service.concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: (_ for _ in ()).throw(
+            AssertionError("the wrapper must not attach the first plan item blindly")
+        ),
+    )
+
+    service._ensure_initial_assistant_turn(
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        session_id=SESSION_ID,
+        concept={"concept_id": CONCEPT_ID},
+        session_doc=doc,
+    )
+
+    stored = collection.find_one({"session_id": SESSION_ID})["history"][0]
+    assert stored["content"] == "What should be recorded?"
+    assert "llm_debug_data" not in stored
+    assert "elicitation_predicate" not in stored["concept_q_and_a"]
+
+
+def test_initial_assistant_uses_question_binding_returned_by_generator(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["history"] = []
+    collection.insert_one(doc)
+    _patch_chat_store(monkeypatch, service, collection)
+    bound = {
+        "requirement_id": "organisation_has_scientist",
+        "predicate_concept_id": "#V#hasChiefScientist",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#person",
+        "declared_on_type_concept_id": "#V#organisation",
+        "question": "Who is the chief scientist of Primary Labs?",
+    }
+    monkeypatch.setattr(
+        service.concept_service,
+        "generate_initial_question",
+        lambda *_args, **_kwargs: {
+            "status": "success",
+            "question": bound["question"],
+            "elicitation_predicate": bound,
+        },
+    )
+
+    service._ensure_initial_assistant_turn(
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        session_id=SESSION_ID,
+        concept={"concept_id": CONCEPT_ID},
+        session_doc=doc,
+    )
+
+    stored = collection.find_one({"session_id": SESSION_ID})["history"][0]
+    assert stored["concept_q_and_a"]["elicitation_predicate"]["requirement_id"] == (
+        "organisation_has_scientist"
+    )
+
+
+@pytest.mark.parametrize("target_status", ["finished", "cancelled"])
+def test_terminal_lifecycle_has_readback_and_rejects_later_turns(
+    monkeypatch, target_status
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    collection.insert_one(_session_doc())
+    _patch_chat_store(monkeypatch, service, collection)
+
+    transitioned = service.transition_concept_qa_conversation(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        user_id=USER_ID,
+        target_status=target_status,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+        expected_revision=0,
+    )
+
+    assert transitioned["changed"] is True
+    assert transitioned["lifecycle"]["status"] == target_status
+    assert transitioned["lifecycle"]["revision"] == 1
+    repeated = service.transition_concept_qa_conversation(
+        concept_id=CONCEPT_ID,
+        session_id=SESSION_ID,
+        user_id=USER_ID,
+        target_status=target_status,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+    assert repeated["changed"] is False
+
+    with pytest.raises(service.ConceptQAConversationConflict) as conflict:
+        service.submit_concept_qa_turn(
+            concept_id=CONCEPT_ID,
+            session_id=SESSION_ID,
+            turn_id="after-terminal",
+            user_id=USER_ID,
+            answer="This must not append.",
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+        )
+    assert conflict.value.error_code == "conversation_terminal"
+
+
+def test_actor_and_namespace_scope_hide_another_users_carrier(monkeypatch):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    collection.insert_one(_session_doc())
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(
+        service.concept_service,
+        "get_active_interactions_for_concept",
+        lambda *_args, **_kwargs: [],
+    )
+
+    result = service.list_concept_qa_conversations(
+        concept_id=CONCEPT_ID,
+        user_id="#V#other_user",
+        namespace="#V#other_user@other_org",
+        organisation_concept_id="#V#other_org",
+    )
+
+    assert result["sessions"] == []
+    assert result["active_session"] is None

--- a/tests/backend/test_concept_qa_routes.py
+++ b/tests/backend/test_concept_qa_routes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from flask import Flask
+
+
+def _app():
+    from src.backend.server.routes.concept_routes import concept_bp
+
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="concept-qa-route-test")
+    app.register_blueprint(concept_bp, url_prefix="/api/concepts")
+    return app
+
+
+def test_canonical_concept_qa_routes_are_registered():
+    rules = {rule.rule for rule in _app().url_map.iter_rules()}
+
+    assert "/api/concepts/<string:concept_id>/q_and_a" in rules
+    assert "/api/concepts/<string:concept_id>/q_and_a/start" in rules
+    assert (
+        "/api/concepts/<string:concept_id>/q_and_a/sessions/<string:session_id>/turns"
+    ) in rules
+    assert (
+        "/api/concepts/<string:concept_id>/q_and_a/sessions/<string:session_id>/finish"
+    ) in rules
+    assert (
+        "/api/concepts/<string:concept_id>/q_and_a/sessions/<string:session_id>/cancel"
+    ) in rules
+    assert (
+        "/api/concepts/<string:concept_id>/q_and_a/sessions/"
+        "<string:session_id>/formalisations/<string:assertion_id>/confirm"
+    ) in rules
+
+
+def test_concept_q_and_a_routes_require_authenticated_actor(monkeypatch):
+    from src.backend.server.routes import concept_routes
+
+    monkeypatch.setattr(concept_routes, "_get_trusted_interaction_user", lambda: None)
+    monkeypatch.setattr(
+        concept_routes.concept_qa_conversation_service,
+        "list_concept_qa_conversations",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unauthenticated requests must not reach the service")
+        ),
+    )
+
+    response = _app().test_client().get("/api/concepts/%23V%23primary_labs/q_and_a")
+
+    assert response.status_code == 401
+
+
+def test_confirm_route_preserves_actionable_authority_denial(monkeypatch):
+    from src.backend.security import access_control
+    from src.backend.server.routes import concept_routes
+
+    monkeypatch.setattr(
+        concept_routes,
+        "_get_trusted_interaction_user",
+        lambda: "#V#actor",
+    )
+    monkeypatch.setattr(
+        concept_routes,
+        "_get_request_namespace",
+        lambda: "#V#actor@org",
+    )
+    monkeypatch.setattr(
+        access_control,
+        "get_effective_organisation_concept_id",
+        lambda: "#V#org",
+    )
+    denial = {
+        "success": False,
+        "status": "tentative",
+        "effect_status": "not_started",
+        "assertion_id": "ska_denied",
+        "confirmation": {
+            "error_code": "organisation_membership_management_authority_required",
+            "authority_decision": {"allowed": False},
+            "actionable_denial": {
+                "who_can_confirm": "an organisation admin or owner",
+                "tentative_assertion_preserved": True,
+            },
+        },
+        "receipts": {"formalisation": {"status": "tentative"}},
+    }
+    monkeypatch.setattr(
+        concept_routes.concept_qa_conversation_service,
+        "confirm_concept_qa_formalisation",
+        lambda **_kwargs: denial,
+    )
+
+    response = (
+        _app()
+        .test_client()
+        .post(
+            "/api/concepts/%23V%23org/q_and_a/sessions/session-1/"
+            "formalisations/ska_denied/confirm",
+            json={"request_id": "confirm-1"},
+        )
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["status"] == "tentative"
+    assert (
+        payload["confirmation"]["actionable_denial"]["tentative_assertion_preserved"]
+        is True
+    )

--- a/tests/backend/test_concept_service_question_prompting.py
+++ b/tests/backend/test_concept_service_question_prompting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import mongomock
 from flask import Flask, session
 
 
@@ -59,9 +60,13 @@ def test_generate_concept_question_prioritises_user_questions_and_salient_predic
         is_initial=False,
         elicitation_plan=[
             {
+                "requirement_id": "organisation_has_member_role",
                 "predicate_concept_id": "#V#has_member_role",
                 "predicate_label": "has member role",
                 "priority": 1,
+                "requirement_kind": "constitutive_relation",
+                "declaration_source": "builtin_compatibility",
+                "profile_predicate": None,
                 "question": "What role do you have in Primary Labs?",
             }
         ],
@@ -71,8 +76,103 @@ def test_generate_concept_question_prioritises_user_questions_and_salient_predic
     assert "do not ignore it" in prompt
     assert "#V#has_member_role" in prompt
     assert "What role do you have in Primary Labs?" in prompt
-    assert "Resolve first-person references such as 'I' to the known current user." in prompt
+    assert (
+        "Resolve first-person references such as 'I' to the known current user."
+        in prompt
+    )
     assert "prefer a useful refinement such as their role or position" in prompt
+    assert '"declaration_source": "builtin_compatibility"' in prompt
+    assert "compatibility metadata, not represented knowledge" in prompt
+
+
+def test_q_and_a_suppression_uses_exact_requirement_identity_not_predicate():
+    from src.backend.services import concept_service
+
+    first = {
+        "requirement_id": "organisation_has_scientist",
+        "predicate_concept_id": "#V#hasLead",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#scientist",
+        "declared_on_type_concept_id": "#V#organisation",
+    }
+    second = {
+        "requirement_id": "organisation_has_editor",
+        "predicate_concept_id": "#V#hasLead",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#editor",
+        "declared_on_type_concept_id": "#V#organisation",
+    }
+
+    result = concept_service._filter_suppressed_elicitation_plan(
+        [first, second],
+        {
+            "suppressed_requirement_keys": [
+                concept_service._elicitation_requirement_identity(first)
+            ]
+        },
+    )
+
+    assert result == [second]
+
+
+def test_emitted_question_binds_only_the_matching_plan_item():
+    from src.backend.services import concept_service
+
+    first = {
+        "requirement_id": "organisation_has_member",
+        "predicate_concept_id": "#V#memberOf",
+        "focal_argument": "object",
+        "other_argument_type_concept_id": "#V#von_user",
+        "declared_on_type_concept_id": "#V#von_user_organisation",
+        "question": "Which Von user is a member of Primary Labs?",
+    }
+    second = {
+        "requirement_id": "organisation_has_scientist",
+        "predicate_concept_id": "#V#hasChiefScientist",
+        "focal_argument": "subject",
+        "other_argument_type_concept_id": "#V#person",
+        "declared_on_type_concept_id": "#V#organisation",
+        "question": "Who is the chief scientist of Primary Labs?",
+    }
+
+    matched = concept_service._match_emitted_elicitation_requirement(
+        "Thanks. Who is the chief scientist of Primary Labs?",
+        [first, second],
+    )
+
+    assert matched is not None
+    assert matched["requirement_id"] == "organisation_has_scientist"
+    assert matched["predicate_concept_id"] == "#V#hasChiefScientist"
+
+
+def test_paraphrased_or_ambiguous_question_is_not_bound_to_formalisation():
+    from src.backend.services import concept_service
+
+    plan = [
+        {
+            "requirement_id": "organisation_has_member",
+            "predicate_concept_id": "#V#memberOf",
+            "focal_argument": "object",
+            "other_argument_type_concept_id": "#V#von_user",
+            "declared_on_type_concept_id": "#V#von_user_organisation",
+            "question": "Which Von user is a member of Primary Labs?",
+        }
+    ]
+
+    assert (
+        concept_service._match_emitted_elicitation_requirement(
+            "Who belongs to Primary Labs?",
+            plan,
+        )
+        is None
+    )
+    assert (
+        concept_service._match_emitted_elicitation_requirement(
+            "Which Von user is a member of Primary Labs?",
+            [plan[0], {**plan[0], "requirement_id": "different_direction"}],
+        )
+        is None
+    )
 
 
 def test_generate_concept_question_allows_second_person_for_current_user(
@@ -132,6 +232,8 @@ def test_generate_initial_question_fallback_uses_minimal_imposition_prompt(
     from src.backend.services import concept_service
 
     class _LLMClient:
+        provider_name = "ollama"
+
         def generate(self, *, prompt: str, model: str, llm_params=None) -> str:
             return ""
 
@@ -175,3 +277,180 @@ def test_generate_initial_question_fallback_uses_minimal_imposition_prompt(
         == "If you can answer from memory, what is one quick, high-value correction or missing fact about Alex Smith?"
     )
     assert "What would you like to tell me about" not in result["question"]
+    assert result["llm_debug_data"]["selected"] == {
+        "provider": "ollama",
+        "model": "test-model",
+        "model_parameters": {},
+    }
+    assert result["llm_debug_data"]["provider"] == "ollama"
+    assert result["llm_debug_data"]["model"] == "test-model"
+
+
+def test_follow_up_debug_reports_actual_selected_provider_after_fallback(monkeypatch):
+    from src.backend.languagemodels import llm_interface
+    from src.backend.services import concept_service, settings_service
+
+    class _FallbackClient:
+        provider_name = "ollama"
+
+        def generate(self, *, prompt: str, model: str, llm_params=None) -> str:
+            return "What should we discuss next?"
+
+    database = mongomock.MongoClient()["concept_question_provider"]
+    concept = {
+        "_id": "507f1f77bcf86cd799439011",
+        "concept_id": "#V#primary_labs",
+        "name": "Primary Labs",
+    }
+    monkeypatch.setattr(concept_service, "get_db", lambda: database)
+    monkeypatch.setattr(concept_service, "get_concept_by_id", lambda _value: concept)
+    monkeypatch.setattr(concept_service, "get_concept_notes", lambda _value: "")
+    monkeypatch.setattr(
+        concept_service,
+        "get_concept_display_name_with_names_fallback",
+        lambda _value: "Primary Labs",
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "generate_concept_question",
+        lambda **_kwargs: "Continue the concept Q&A.",
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: [],
+    )
+    monkeypatch.setattr(
+        settings_service,
+        "resolve_llm_setting",
+        lambda **_kwargs: {"provider": "openai", "model": "configured-model"},
+    )
+    monkeypatch.setattr(
+        llm_interface,
+        "get_active_model_name",
+        lambda **_kwargs: "configured-model",
+    )
+    monkeypatch.setattr(
+        llm_interface,
+        "get_active_model_parameters",
+        lambda **_kwargs: {"temperature": 0.1},
+    )
+    monkeypatch.setattr(
+        llm_interface,
+        "get_llm_client",
+        lambda **_kwargs: _FallbackClient(),
+    )
+
+    result = concept_service.submit_concept_answer(
+        interaction_id="concept-qa-provider-test",
+        user_answer="Did you preserve the exact input?",
+        session={
+            "concept_id": concept["_id"],
+            "user_id": "#V#actor",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#actor@org",
+            "history": [
+                {
+                    "interaction_type": "llm_question",
+                    "details": {"question": "What should be recorded?"},
+                }
+            ],
+        },
+        persist_interaction_session=False,
+    )
+
+    assert result["status"] == "success"
+    assert result["llm_debug_data"]["configured"]["provider"] == "openai"
+    assert result["llm_debug_data"]["selected"]["provider"] == "ollama"
+    assert result["llm_debug_data"]["provider"] == "ollama"
+    assert result["llm_debug_data"]["model"] == "configured-model"
+
+
+def test_canonical_concept_notes_update_can_be_disabled_while_exact_claim_survives(
+    monkeypatch,
+):
+    from src.backend.services import concept_service
+
+    class _Client:
+        provider_name = "test"
+
+        def generate(self, *, prompt: str, model: str, llm_params=None) -> str:
+            return "What else should be recorded?"
+
+    database = mongomock.MongoClient()["concept_question_no_canonical_notes"]
+    concept = {
+        "_id": "507f1f77bcf86cd799439011",
+        "concept_id": "#V#primary_labs",
+        "name": "Primary Labs",
+    }
+    monkeypatch.setattr(concept_service, "get_db", lambda: database)
+    monkeypatch.setattr(concept_service, "get_concept_by_id", lambda _value: concept)
+    monkeypatch.setattr(concept_service, "get_concept_notes", lambda _value: "")
+    monkeypatch.setattr(
+        concept_service,
+        "get_concept_display_name_with_names_fallback",
+        lambda _value: "Primary Labs",
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "generate_concept_question",
+        lambda **_kwargs: "Continue the concept Q&A.",
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "_get_concept_elicitation_plan",
+        lambda _concept_id: [],
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "_resolve_interaction_llm_runtime",
+        lambda _session: (
+            _Client(),
+            "non-sol-test",
+            {},
+            {"configured_provider": "test", "selected_provider": "test"},
+        ),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "synthesize_and_update_concept_notes",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("canonical hasNote synthesis must not run")
+        ),
+    )
+
+    result = concept_service.submit_concept_answer(
+        interaction_id="concept-qa-no-canonical-notes",
+        user_answer="The CEO is Aron D'Souza.",
+        session={
+            "concept_id": concept["_id"],
+            "user_id": "#V#actor",
+            "organisation_concept_id": "#V#org",
+            "namespace": "#V#actor@org",
+            "history": [
+                {
+                    "interaction_type": "llm_question",
+                    "details": {"question": "Who is the CEO?"},
+                }
+            ],
+        },
+        representation_overrides={
+            "exact_answer": {
+                "status": "stored",
+                "effect_status": "succeeded",
+                "assertion_id": "ska_exact_claim",
+                "canonical_publication": False,
+            }
+        },
+        persist_interaction_session=False,
+        allow_canonical_notes_update=False,
+    )
+
+    notes = result["representation"]["concept_notes"]
+    assert result["status"] == "success"
+    assert result["representation"]["exact_answer"]["assertion_id"] == (
+        "ska_exact_claim"
+    )
+    assert notes["status"] == "not_attempted"
+    assert notes["notes_updated"] is False
+    assert notes["reason"] == "canonical_concept_edit_authority_not_delegated"

--- a/tests/backend/test_constitutive_relation_requirement_service.py
+++ b/tests/backend/test_constitutive_relation_requirement_service.py
@@ -1,0 +1,500 @@
+import json
+
+from src.backend.services import constitutive_relation_requirement_service as service
+from src.backend.services.constitutive_relation_requirement_service import (
+    CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID,
+    CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+    CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+    MEMBER_OF_PREDICATE_ID,
+    VON_USER_ORGANISATION_TYPE_ID,
+    VON_USER_TYPE_ID,
+    ConstitutiveRelationRequirementService,
+    canonical_constitutive_requirement_profile_blueprints,
+    ensure_canonical_constitutive_relation_requirement_profiles,
+    ensure_constitutive_relation_requirement_profiles_current_for_startup,
+    reconcile_canonical_constitutive_relation_requirement_profiles,
+)
+
+
+def _empty_text_reader(concept_ids, **_kwargs):
+    return {concept_id: [] for concept_id in concept_ids}
+
+
+def test_builtin_member_requirement_is_incoming_authority_relevant_and_not_visibility():
+    queries = []
+
+    def _find(query, _projection):
+        queries.append(query)
+        return []
+
+    service = ConstitutiveRelationRequirementService(
+        text_reader=_empty_text_reader,
+        concept_finder=_find,
+        descendant_resolver=lambda _type_id: [VON_USER_TYPE_ID],
+    )
+    missing, diagnostics = service.get_missing_requirements(
+        instance={
+            "concept_id": "#V#primary_labs",
+            "name": "Primary Labs",
+            "relationships": {
+                "is_an_instance_of": [VON_USER_ORGANISATION_TYPE_ID],
+                "#V#specific_to_user": ["#V#alice"],
+            },
+        },
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0},
+    )
+
+    assert len(missing) == 1
+    requirement = missing[0]
+    assert requirement["predicate_concept_id"] == MEMBER_OF_PREDICATE_ID
+    assert requirement["focal_argument"] == "object"
+    assert requirement["other_argument_type_concept_id"] == VON_USER_TYPE_ID
+    assert requirement["current_cardinality"] == 0
+    assert requirement["declaration_source"] == "builtin_compatibility"
+    assert requirement["activation_relevance"] == "identity_namespace_activation"
+    assert requirement["authority_relevance"] == "organisation_membership_authority"
+    assert requirement["auto_formalisation_allowed"] is True
+    assert requirement["auto_formalisation_target_status"] == "tentative"
+    assert requirement["formalisation_mode"] == "tentative_candidate"
+    assert requirement["activation_minimum_status"] == "asserted"
+    assert requirement["activation_satisfying_statuses"] == [
+        "asserted",
+        "confirmed",
+    ]
+    assert requirement["confirmation_required_for_activation"] is True
+    assert requirement["confirmation_elicitation_priority"] == "before_fresh_gap"
+    assert requirement["confirmation_effect"] == "promote_existing_candidate"
+    assert requirement["confirmation_creates_new_claim"] is False
+    assert "{counterpart_name}" in requirement["confirmation_question_template"]
+    assert requirement["tentative_counts_as_satisfied"] is False
+    assert requirement["gap_status"] == "asserted_relation_missing"
+    assert requirement["creation_blocking"] is False
+    assert requirement["question"] == "Which Von user is a member of Primary Labs?"
+    assert diagnostics["builtin_profile_type_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+    assert "specific_to_user" not in json.dumps(queries)
+
+
+def test_tentative_autoformalisation_is_advisory_and_non_mutating():
+    instance = {
+        "concept_id": "#V#new_org",
+        "name": "New organisation",
+        "relationships": {"is_an_instance_of": [VON_USER_ORGANISATION_TYPE_ID]},
+    }
+    before = json.loads(json.dumps(instance))
+    service = ConstitutiveRelationRequirementService(
+        text_reader=_empty_text_reader,
+        concept_finder=lambda _query, _projection: [],
+        descendant_resolver=lambda type_id: [type_id],
+    )
+
+    missing, _ = service.get_missing_requirements(
+        instance=instance,
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0},
+    )
+
+    assert instance == before
+    assert missing[0]["auto_formalisation_target_status"] == "tentative"
+    assert missing[0]["activation_minimum_status"] == "asserted"
+    assert missing[0]["confirmation_required_for_activation"] is True
+    assert missing[0]["tentative_counts_as_satisfied"] is False
+    assert missing[0]["gap_status"] == "asserted_relation_missing"
+    assert missing[0]["current_cardinality"] == 0
+    assert missing[0]["creation_blocking"] is False
+
+
+def test_incoming_requirement_counts_only_a_qualified_other_argument_type():
+    candidates = [
+        {
+            "concept_id": "#V#service_account",
+            "relationships": {"is_an_instance_of": ["#V#software_agent"]},
+        }
+    ]
+
+    service = ConstitutiveRelationRequirementService(
+        text_reader=_empty_text_reader,
+        concept_finder=lambda _query, _projection: list(candidates),
+        descendant_resolver=lambda _type_id: [
+            VON_USER_TYPE_ID,
+            "#V#administrator_von_user",
+        ],
+    )
+    instance = {
+        "concept_id": "#V#primary_labs",
+        "name": "Primary Labs",
+        "relationships": {"is_an_instance_of": [VON_USER_ORGANISATION_TYPE_ID]},
+    }
+
+    missing, _ = service.get_missing_requirements(
+        instance=instance,
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0},
+    )
+    assert missing[0]["current_cardinality"] == 0
+
+    candidates.append(
+        {
+            "concept_id": "#V#alice",
+            "relationships": {"is_an_instance_of": ["#V#administrator_von_user"]},
+        }
+    )
+    missing, _ = service.get_missing_requirements(
+        instance=instance,
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0},
+    )
+    assert missing == []
+
+
+def test_represented_parent_requirement_is_inherited_and_supports_subject_focal():
+    parent_type_id = "#V#governed_project"
+    profile = {
+        "schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+        "requirements": [
+            {
+                "requirement_id": "project_has_lead",
+                "predicate_concept_id": "#V#has_lead",
+                "focal_argument": "subject",
+                "other_argument_type_concept_id": "#V#person",
+                "minimum_cardinality": 1,
+                "reason": "A governed project needs a responsible lead.",
+                "activation_relevance": "project_activation",
+                "authority_relevance": "project_governance",
+                "auto_formalisation_allowed": False,
+            }
+        ],
+    }
+
+    def _texts(concept_ids, **_kwargs):
+        return {
+            concept_id: (
+                [
+                    {
+                        "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                        "text": json.dumps(profile),
+                    }
+                ]
+                if concept_id == parent_type_id
+                else []
+            )
+            for concept_id in concept_ids
+        }
+
+    service = ConstitutiveRelationRequirementService(
+        text_reader=_texts,
+        concept_finder=lambda _query, _projection: [
+            {
+                "concept_id": "#V#alice",
+                "relationships": {"is_an_instance_of": ["#V#academic"]},
+            }
+        ],
+        descendant_resolver=lambda _type_id: ["#V#person", "#V#academic"],
+    )
+    type_depths = {"#V#research_project": 0, parent_type_id: 1}
+    requirements, diagnostics = service.load_requirements(type_depth_by_id=type_depths)
+
+    assert requirements[0]["declared_on_type_concept_id"] == parent_type_id
+    assert requirements[0]["declaration_depth"] == 1
+    assert requirements[0]["inherited"] is True
+    assert diagnostics["represented_profile_type_ids"] == [parent_type_id]
+
+    missing, _ = service.get_missing_requirements(
+        instance={
+            "concept_id": "#V#apollo",
+            "name": "Apollo",
+            "relationships": {
+                "is_an_instance_of": ["#V#research_project"],
+                "#V#has_lead": ["#V#alice"],
+            },
+        },
+        type_depth_by_id=type_depths,
+    )
+    assert missing == []
+
+
+def test_valid_live_profile_replaces_builtin_compatibility_profile():
+    empty_live_profile = {
+        "schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+        "requirements": [],
+    }
+
+    def _texts(concept_ids, **_kwargs):
+        return {
+            concept_id: [
+                {
+                    "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                    "text": json.dumps(empty_live_profile),
+                }
+            ]
+            for concept_id in concept_ids
+        }
+
+    service = ConstitutiveRelationRequirementService(text_reader=_texts)
+    requirements, diagnostics = service.load_requirements(
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0}
+    )
+
+    assert requirements == []
+    assert diagnostics["represented_profile_type_ids"] == [
+        VON_USER_ORGANISATION_TYPE_ID
+    ]
+    assert diagnostics["builtin_profile_type_ids"] == []
+
+
+def test_malformed_live_profile_fails_soft_without_laundering_builtin_fallback():
+    def _texts(concept_ids, **_kwargs):
+        return {
+            concept_id: [
+                {
+                    "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                    "text": "not-json",
+                }
+            ]
+            for concept_id in concept_ids
+        }
+
+    service = ConstitutiveRelationRequirementService(text_reader=_texts)
+    requirements, diagnostics = service.load_requirements(
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0}
+    )
+
+    assert requirements == []
+    assert diagnostics["malformed_profile_type_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+    assert diagnostics["builtin_profile_type_ids"] == []
+    assert diagnostics["fallback_suppressed_type_ids"] == [
+        VON_USER_ORGANISATION_TYPE_ID
+    ]
+
+
+def test_unreadable_live_profile_fails_soft_and_suppresses_unknown_fallback():
+    def _failed_reader(_concept_ids, **_kwargs):
+        raise RuntimeError("temporary read failure")
+
+    service = ConstitutiveRelationRequirementService(text_reader=_failed_reader)
+    requirements, diagnostics = service.load_requirements(
+        type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0}
+    )
+
+    assert requirements == []
+    assert diagnostics["profile_read_failed"] is True
+    assert diagnostics["fallback_suppressed_type_ids"] == [
+        VON_USER_ORGANISATION_TYPE_ID
+    ]
+
+
+def test_ensure_canonical_profile_writes_and_reads_back_exact_representation():
+    stored = {}
+
+    def _writer(**kwargs):
+        stored[kwargs["subject_concept_id"]] = {
+            "predicate": kwargs["predicate"],
+            "text": kwargs["text"],
+        }
+        return {"success": True}
+
+    def _reader(concept_ids, **_kwargs):
+        return {
+            concept_id: ([stored[concept_id]] if concept_id in stored else [])
+            for concept_id in concept_ids
+        }
+
+    result = ensure_canonical_constitutive_relation_requirement_profiles(
+        concept_getter=lambda concept_id: {"concept_id": concept_id},
+        text_writer=_writer,
+        text_reader=_reader,
+    )
+
+    assert result["success"] is True
+    assert result["persisted_type_concept_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+    assert result["read_back_type_concept_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+
+    requirements, diagnostics = ConstitutiveRelationRequirementService(
+        text_reader=_reader
+    ).load_requirements(type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0})
+    assert requirements[0]["declaration_source"] == "represented"
+    assert diagnostics["builtin_profile_type_ids"] == []
+
+
+def test_ensure_canonical_profile_reports_read_back_mismatch():
+    represented_empty_profile = json.dumps(
+        {
+            "schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+            "requirements": [],
+        }
+    )
+
+    reads = 0
+
+    def _reader(concept_ids, **_kwargs):
+        nonlocal reads
+        reads += 1
+        return {
+            concept_id: (
+                []
+                if reads == 1
+                else [
+                    {
+                        "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                        "text": represented_empty_profile,
+                    }
+                ]
+            )
+            for concept_id in concept_ids
+        }
+
+    result = ensure_canonical_constitutive_relation_requirement_profiles(
+        concept_getter=lambda concept_id: {"concept_id": concept_id},
+        text_writer=lambda **_kwargs: {"success": True},
+        text_reader=_reader,
+    )
+
+    assert result["success"] is False
+    assert (
+        "profile_read_back_mismatch"
+        in result["errors_by_type_concept_id"][VON_USER_ORGANISATION_TYPE_ID]
+    )
+
+
+def test_seed_bundle_is_the_single_repo_source_for_compatibility_profile():
+    profiles = canonical_constitutive_requirement_profile_blueprints()
+
+    profile = profiles[VON_USER_ORGANISATION_TYPE_ID]
+    assert profile["schema_version"] == CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION
+    assert profile["requirements"][0]["predicate_concept_id"] == (
+        MEMBER_OF_PREDICATE_ID
+    )
+
+
+def test_missing_live_profile_fails_soft_when_seed_fallback_cannot_load(monkeypatch):
+    monkeypatch.setattr(
+        service,
+        "canonical_constitutive_requirement_profile_blueprints",
+        lambda: (_ for _ in ()).throw(ValueError("bad seed")),
+    )
+
+    requirements, diagnostics = ConstitutiveRelationRequirementService(
+        text_reader=_empty_text_reader
+    ).load_requirements(type_depth_by_id={VON_USER_ORGANISATION_TYPE_ID: 0})
+
+    assert requirements == []
+    assert diagnostics["compatibility_profile_load_failed"] is True
+    assert diagnostics["compatibility_profile_load_error_type"] == "ValueError"
+
+
+def test_ensure_preserves_valid_live_profile_as_represented_authority():
+    live_profile = {
+        "schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+        "requirements": [],
+    }
+    writes = []
+
+    result = ensure_canonical_constitutive_relation_requirement_profiles(
+        concept_getter=lambda concept_id: {"concept_id": concept_id},
+        text_writer=lambda **kwargs: writes.append(kwargs) or {"success": True},
+        text_reader=lambda concept_ids, **_kwargs: {
+            concept_id: [
+                {
+                    "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                    "text": json.dumps(live_profile),
+                }
+            ]
+            for concept_id in concept_ids
+        },
+    )
+
+    assert result["success"] is True
+    assert result["changed"] is False
+    assert result["represented_override_type_concept_ids"] == [
+        VON_USER_ORGANISATION_TYPE_ID
+    ]
+    assert writes == []
+
+
+def test_ensure_does_not_overwrite_malformed_live_profile():
+    writes = []
+
+    result = ensure_canonical_constitutive_relation_requirement_profiles(
+        concept_getter=lambda concept_id: {"concept_id": concept_id},
+        text_writer=lambda **kwargs: writes.append(kwargs) or {"success": True},
+        text_reader=lambda concept_ids, **_kwargs: {
+            concept_id: [
+                {
+                    "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                    "text": "not-json",
+                }
+            ]
+            for concept_id in concept_ids
+        },
+    )
+
+    assert result["success"] is False
+    assert result["errors_by_type_concept_id"] == {
+        VON_USER_ORGANISATION_TYPE_ID: "represented_profile_malformed"
+    }
+    assert writes == []
+
+
+def test_startup_check_uses_only_dependency_receipt(monkeypatch):
+    observed = {}
+    monkeypatch.setattr(
+        service.seed_freshness,
+        "check_startup_seed_freshness",
+        lambda **kwargs: (
+            observed.update(kwargs)
+            or {
+                "fresh": True,
+                "reason": "dependency_receipt_current",
+                "metadata": {"counts": {"profiles_read_back": 1}},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        service.seed_freshness,
+        "public_startup_seed_freshness_result",
+        dict,
+    )
+
+    report = ensure_constitutive_relation_requirement_profiles_current_for_startup()
+
+    assert report["ready"] is True
+    assert report["canonical_read_batches"] == {
+        "concepts": 0,
+        "text_assertions": 0,
+    }
+    assert observed["family_id"] == CONSTITUTIVE_REQUIREMENT_STARTUP_FAMILY_ID
+    assert observed["concept_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+    assert observed["text_relation_subject_ids"] == [VON_USER_ORGANISATION_TYPE_ID]
+
+
+def test_reconciliation_rechecks_after_materialising_profile(monkeypatch):
+    canonical_passes = [
+        {
+            "success": True,
+            "changed": True,
+            "freshness_receipt": {
+                "persisted": False,
+                "reason": "canonical_state_changed",
+            },
+        },
+        {
+            "success": True,
+            "changed": False,
+            "freshness_receipt": {
+                "persisted": True,
+                "reason": "freshness_receipt_persisted",
+            },
+        },
+    ]
+    monkeypatch.setattr(
+        service.seed_freshness,
+        "begin_startup_seed_freshness_observation",
+        lambda: {"success": True},
+    )
+    monkeypatch.setattr(
+        service,
+        "ensure_canonical_constitutive_relation_requirement_profiles",
+        lambda **_kwargs: canonical_passes.pop(0),
+    )
+
+    report = reconcile_canonical_constitutive_relation_requirement_profiles()
+
+    assert report["ready"] is True
+    assert report["changed"] is True
+    assert report["reconciliation_pass_count"] == 2

--- a/tests/backend/test_reconcile_startup_seed_materialisations_script.py
+++ b/tests/backend/test_reconcile_startup_seed_materialisations_script.py
@@ -17,6 +17,9 @@ def test_release_reconciliation_runs_selected_families(monkeypatch) -> None:
             script.PUBLICATION_SCOPE_PROFILES: lambda: (
                 calls.append("publication") or {"ready": True}
             ),
+            script.CONSTITUTIVE_RELATION_REQUIREMENTS: lambda: (
+                calls.append("constitutive") or {"ready": True}
+            ),
         },
     )
 
@@ -24,7 +27,11 @@ def test_release_reconciliation_runs_selected_families(monkeypatch) -> None:
 
     assert report["success"] is True
     assert report["state"] == "ready"
-    assert calls == ["summary", "publication"]
+    assert calls == ["summary", "publication", "constitutive"]
+
+
+def test_constitutive_requirement_family_is_a_release_reconciler() -> None:
+    assert script.CONSTITUTIVE_RELATION_REQUIREMENTS in script._RECONCILERS
 
 
 def test_release_reconciliation_returns_nonzero_when_a_family_is_unavailable(

--- a/tests/backend/test_relation_elicitation_service.py
+++ b/tests/backend/test_relation_elicitation_service.py
@@ -1,6 +1,6 @@
 # src/backend/services/tests/test_relation_elicitation_service.py
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.backend.services.relation_elicitation_service import RelationElicitationService
 
@@ -82,9 +82,7 @@ class TestRelationElicitationService(unittest.TestCase):
         self.assertEqual(opportunities, ["hypothesized_relation", "new_opportunity"])
 
     @patch("src.backend.services.concept_service.get_concept_by_id")
-    @patch(
-        "src.backend.services.relation_elicitation_service.ConceptsRepository.find"
-    )
+    @patch("src.backend.services.relation_elicitation_service.ConceptsRepository.find")
     def test_get_elicitation_plan_exposes_predicate_and_question(
         self, mock_repo_find, mock_get_by_id
     ):
@@ -98,9 +96,7 @@ class TestRelationElicitationService(unittest.TestCase):
             [
                 {
                     "concept_id": "#V#organisation",
-                    "inherited_salient_binary_predicates": [
-                        "#V#has_member_role"
-                    ],
+                    "inherited_salient_binary_predicates": ["#V#has_member_role"],
                     "relationships": {},
                 }
             ],
@@ -111,31 +107,34 @@ class TestRelationElicitationService(unittest.TestCase):
                 }
             ],
         ]
-        service = RelationElicitationService(llm_client=False)
+        constitutive_requirements = MagicMock()
+        constitutive_requirements.get_missing_requirements.return_value = ([], {})
+        service = RelationElicitationService(
+            llm_client=False,
+            constitutive_requirement_service=constitutive_requirements,
+        )
 
         assert service.get_elicitation_plan("#V#primary_labs", limit=1) == [
             {
                 "predicate_concept_id": "#V#has_member_role",
                 "predicate_label": "has member role",
                 "priority": 1,
+                "requirement_kind": "salient_relation",
+                "priority_class": "salient",
                 "question": "What is has member role for Primary Labs?",
                 "status": "missing",
             }
         ]
 
     @patch("src.backend.services.concept_service.get_concept_by_id")
-    @patch(
-        "src.backend.services.relation_elicitation_service.ConceptsRepository.find"
-    )
+    @patch("src.backend.services.relation_elicitation_service.ConceptsRepository.find")
     def test_get_elicitation_plan_recovers_from_stale_empty_inherited_cache(
         self, mock_repo_find, mock_get_by_id
     ):
         mock_get_by_id.return_value = {
             "concept_id": "#V#primary_labs",
             "name": "Primary Labs",
-            "relationships": {
-                "is_an_instance_of": ["#V#von_user_organisation"]
-            },
+            "relationships": {"is_an_instance_of": ["#V#von_user_organisation"]},
         }
         mock_repo_find.side_effect = [
             [
@@ -156,14 +155,107 @@ class TestRelationElicitationService(unittest.TestCase):
             [{"concept_id": "#V#has_member", "name": "has member"}],
         ]
 
-        plan = RelationElicitationService(llm_client=False).get_elicitation_plan(
-            "#V#primary_labs",
-            limit=1,
-        )
+        constitutive_requirements = MagicMock()
+        constitutive_requirements.get_missing_requirements.return_value = ([], {})
+        plan = RelationElicitationService(
+            llm_client=False,
+            constitutive_requirement_service=constitutive_requirements,
+        ).get_elicitation_plan("#V#primary_labs", limit=1)
 
         assert plan[0]["predicate_concept_id"] == "#V#has_member"
         assert plan[0]["question"] == "What is has member for Primary Labs?"
         assert mock_repo_find.call_count == 3
+
+    @patch("src.backend.services.concept_service.get_concept_by_id")
+    @patch("src.backend.services.relation_elicitation_service.ConceptsRepository.find")
+    def test_constitutive_requirement_is_inherited_and_ranked_before_salience(
+        self, mock_repo_find, mock_get_by_id
+    ):
+        import json
+
+        from src.backend.services.constitutive_relation_requirement_service import (
+            CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+            CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+            ConstitutiveRelationRequirementService,
+        )
+
+        mock_get_by_id.return_value = {
+            "concept_id": "#V#apollo",
+            "name": "Apollo",
+            "relationships": {"is_an_instance_of": ["#V#research_project"]},
+        }
+        mock_repo_find.side_effect = [
+            [
+                {
+                    "concept_id": "#V#research_project",
+                    "relationships": {
+                        "is_a_type_of": ["#V#governed_project"],
+                        "#V#salient_binary_predicate_for_type": ["#V#homepage"],
+                    },
+                }
+            ],
+            [
+                {
+                    "concept_id": "#V#governed_project",
+                    "relationships": {},
+                }
+            ],
+            [{"concept_id": "#V#homepage", "name": "homepage"}],
+        ]
+        profile = {
+            "schema_version": CONSTITUTIVE_REQUIREMENTS_SCHEMA_VERSION,
+            "requirements": [
+                {
+                    "requirement_id": "project_has_lead",
+                    "predicate_concept_id": "#V#has_lead",
+                    "focal_argument": "subject",
+                    "other_argument_type_concept_id": "#V#person",
+                    "minimum_cardinality": 1,
+                    "reason": "A governed project needs a responsible lead.",
+                    "activation_relevance": "project_activation",
+                    "authority_relevance": "project_governance",
+                    "auto_formalisation_allowed": False,
+                }
+            ],
+        }
+
+        def _text_reader(concept_ids, **_kwargs):
+            return {
+                concept_id: (
+                    [
+                        {
+                            "predicate": CONSTITUTIVE_REQUIREMENTS_PREDICATE,
+                            "text": json.dumps(profile),
+                        }
+                    ]
+                    if concept_id == "#V#governed_project"
+                    else []
+                )
+                for concept_id in concept_ids
+            }
+
+        requirement_service = ConstitutiveRelationRequirementService(
+            text_reader=_text_reader,
+            concept_finder=lambda _query, _projection: [],
+            descendant_resolver=lambda type_id: [type_id],
+        )
+        plan = RelationElicitationService(
+            llm_client=False,
+            constitutive_requirement_service=requirement_service,
+        ).get_elicitation_plan("#V#apollo", limit=2)
+
+        assert [item["priority_class"] for item in plan] == [
+            "constitutive",
+            "salient",
+        ]
+        assert plan[0]["predicate_concept_id"] == "#V#has_lead"
+        assert plan[0]["declared_on_type_concept_id"] == "#V#governed_project"
+        assert plan[0]["inherited"] is True
+        assert plan[0]["declaration_depth"] == 1
+        assert plan[0]["formalisation_mode"] == "candidate_only"
+        assert plan[0]["priority"] == 1
+        assert plan[1]["predicate_concept_id"] == "#V#homepage"
+        assert plan[1]["priority"] == 2
 
     @patch(
         "src.backend.services.relation_elicitation_service.upsert_uncertain_relationship_assertion"

--- a/tests/backend/test_scoped_assertion_service.py
+++ b/tests/backend/test_scoped_assertion_service.py
@@ -1386,3 +1386,163 @@ def test_actor_effective_text_read_merges_visible_scoped_assertions(monkeypatch)
     assert rows[0]["row_kind"] == "scoped_assertion"
     assert rows[0]["canonical_publication"] is False
     assert rows[0]["storage_surface"] == "scoped_knowledge_assertions"
+
+
+def test_tentative_relation_is_explicitly_visible_but_does_not_emit_until_promoted(
+    monkeypatch,
+):
+    from src.backend.services import scoped_assertion_service as service
+    from src.backend.services import workflow_event_integration_service as events
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+    monkeypatch.setattr(
+        service,
+        "validate_predicate_concept",
+        lambda _predicate_id: (True, None, None),
+    )
+    launches: list[dict] = []
+    monkeypatch.setattr(
+        events,
+        "maybe_launch_vontology_mutation_workflow",
+        lambda **kwargs: launches.append(kwargs) or {"success": True},
+    )
+
+    receipt = service.upsert_scoped_assertion(
+        subject_concept_id="#V#person",
+        predicate="#V#memberOf",
+        target_concept_id="#V#organisation",
+        acting_user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+        namespace="#V#author@trusted_org",
+        epistemic_status="tentative",
+    )
+
+    assert receipt["canonical_read_back"]["epistemic_status"] == "tentative"
+    assert service.list_visible_scoped_assertions(
+        user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+    ) == []
+    explicit = service.list_visible_scoped_assertions(
+        epistemic_statuses=("asserted", "tentative"),
+        user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+    )
+    assert [item["assertion_id"] for item in explicit] == [receipt["assertion_id"]]
+    assert launches == []
+
+    promoted = service.promote_scoped_assertion_epistemic_status(
+        assertion_id=receipt["assertion_id"],
+        acting_user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+        namespace="#V#author@trusted_org",
+        request_id="confirm-1",
+    )
+
+    assert promoted["epistemic_status"] == "asserted"
+    assert promoted["canonical_read_back"]["epistemic_status"] == "asserted"
+    assert len(launches) == 1
+    assert launches[0]["mutation_event_type"] == events.EVENT_TYPE_SCOPED_ASSERTION_UPSERTED
+    assert launches[0]["event_payload"]["epistemic_status"] == "asserted"
+    assert launches[0]["event_payload"]["promoted_from_epistemic_status"] == "tentative"
+
+
+def test_asserted_upsert_monotonically_promotes_existing_tentative_once(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+    from src.backend.services import workflow_event_integration_service as events
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        service,
+        "validate_predicate_concept",
+        lambda _predicate_id: (True, None, None),
+    )
+    launches: list[dict] = []
+    monkeypatch.setattr(
+        events,
+        "maybe_launch_vontology_mutation_workflow",
+        lambda **kwargs: launches.append(kwargs) or {"success": True},
+    )
+    kwargs = {
+        "subject_concept_id": "#V#person",
+        "predicate": "#V#memberOf",
+        "target_concept_id": "#V#organisation",
+        "acting_user_concept_id": "#V#author",
+        "organisation_concept_id": "#V#trusted_org",
+        "namespace": "#V#author@trusted_org",
+    }
+
+    tentative = service.upsert_scoped_assertion(
+        **kwargs,
+        epistemic_status="tentative",
+    )
+    asserted = service.upsert_scoped_assertion(**kwargs)
+    replay = service.upsert_scoped_assertion(**kwargs)
+
+    assert tentative["epistemic_status"] == "tentative"
+    assert asserted["changed"] is True
+    assert asserted["canonical_read_back"]["epistemic_status"] == "asserted"
+    assert replay["changed"] is False
+    assert len(launches) == 1
+    assert launches[0]["mutation_event_type"] == events.EVENT_TYPE_SCOPED_ASSERTION_UPSERTED
+    assert launches[0]["event_payload"]["promoted_from_epistemic_status"] == "tentative"
+
+
+def test_retracting_tentative_relation_does_not_fan_out_fact_event(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+    from src.backend.services import workflow_event_integration_service as events
+
+    collection = _collection()
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        service,
+        "validate_predicate_concept",
+        lambda _predicate_id: (True, None, None),
+    )
+    launches: list[dict] = []
+    monkeypatch.setattr(
+        events,
+        "maybe_launch_vontology_mutation_workflow",
+        lambda **kwargs: launches.append(kwargs) or {"success": True},
+    )
+    tentative = service.upsert_scoped_assertion(
+        subject_concept_id="#V#person",
+        predicate="#V#memberOf",
+        target_concept_id="#V#organisation",
+        acting_user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+        namespace="#V#author@trusted_org",
+        epistemic_status="tentative",
+    )
+
+    retracted = service.retract_scoped_assertion(
+        assertion_id=tentative["assertion_id"],
+        acting_user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+        namespace="#V#author@trusted_org",
+    )
+
+    assert retracted["changed"] is True
+    assert retracted["canonical_read_back"]["status"] == "retracted"
+    assert launches == []

--- a/tests/backend/test_set_chat_session_endpoint.py
+++ b/tests/backend/test_set_chat_session_endpoint.py
@@ -197,6 +197,54 @@ def test_set_chat_session_skips_history_when_requested(monkeypatch, app_client):
         assert sess.get("session_id") == "s1"
 
 
+def test_set_chat_session_projects_terminal_concept_q_and_a_state(
+    monkeypatch, app_client
+):
+    _, client = app_client
+
+    class _FakeColl:
+        def find_one(self, query, projection=None):
+            if query.get("user_id") != "#V#u" or query.get("session_id") != "qa-1":
+                return None
+            return {
+                "session_id": "qa-1",
+                "session_name": "Primary Labs Q&A",
+                "mode": "concept_q_and_a",
+                "origin_kind": "concept_q_and_a",
+                "focal_concept_ids": ["#V#primary_labs"],
+                "concept_q_and_a": {
+                    "schema_version": "concept_q_and_a_session.v1",
+                    "concept": {
+                        "concept_id": "#V#primary_labs",
+                        "name": "Primary Labs",
+                    },
+                    "lifecycle": {"status": "finished", "revision": 1},
+                },
+            }
+
+    import src.backend.services.chat_history_service as chat_history_service
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: _FakeColl(),
+    )
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#u"
+
+    response = client.post(
+        "/von/api/session/set_chat_session",
+        json={"session_id": "qa-1", "include_history": False},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["mode"] == "concept_q_and_a"
+    assert body["origin_kind"] == "concept_q_and_a"
+    assert body["focal_concept_ids"] == ["#V#primary_labs"]
+    assert body["qa_session"]["lifecycle"]["status"] == "finished"
+
+
 def test_set_chat_session_allows_shared_invite(monkeypatch, app_client):
     _, client = app_client
 

--- a/tests/backend/test_utils_flask_health_agent_test_marker.py
+++ b/tests/backend/test_utils_flask_health_agent_test_marker.py
@@ -313,6 +313,14 @@ def test_health_projects_startup_seed_family_readiness_without_raw_report() -> N
                 "receipt_reason": "source_digest_mismatch",
                 "duration_ms": 8,
             },
+            "constitutive_relation_requirements": {
+                "ready": False,
+                "state": "not_checked",
+                "reason": None,
+                "reconciliation_required": False,
+                "receipt_reason": None,
+                "duration_ms": None,
+            },
         },
     }
     assert "private_checkpoint" not in json.dumps(payload)

--- a/tests/backend/test_utils_flask_orchestrator_startup.py
+++ b/tests/backend/test_utils_flask_orchestrator_startup.py
@@ -163,6 +163,9 @@ def test_create_flask_app_defers_durable_workflow_startup(monkeypatch):
     monkeypatch.setenv("VON_PREWARM_DISABLE", "1")
     monkeypatch.setenv("VON_CONCEPT_SUMMARY_FIELD_BOOTSTRAP_ENABLE", "0")
     monkeypatch.setenv("VON_PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_ENABLE", "0")
+    monkeypatch.setenv(
+        "VON_CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_ENABLE", "0"
+    )
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_ENABLE", "1")
     monkeypatch.setenv("VON_DURABLE_WORKFLOWS_BLOCKING_STARTUP", "0")
 
@@ -390,6 +393,7 @@ def test_agent_test_startup_helpers_skip_remote_infrastructure(monkeypatch):
     utils_flask._maybe_start_startup_rag_requeue(app)
     utils_flask._bootstrap_concept_summary_fields_for_startup(app)
     utils_flask._bootstrap_publication_scope_profiles_for_startup(app)
+    utils_flask._bootstrap_constitutive_relation_requirements_for_startup(app)
     utils_flask._log_prompt_concept_health(app)
     utils_flask._register_optional_prewarm(app)
 
@@ -399,6 +403,11 @@ def test_agent_test_startup_helpers_skip_remote_infrastructure(monkeypatch):
         "reason": "agent_test_instance",
     }
     assert app.config["PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"] == {
+        "success": True,
+        "skipped": True,
+        "reason": "agent_test_instance",
+    }
+    assert app.config["CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"] == {
         "success": True,
         "skipped": True,
         "reason": "agent_test_instance",
@@ -428,3 +437,33 @@ def test_publication_scope_profile_startup_records_bootstrap_report(
     utils_flask._bootstrap_publication_scope_profiles_for_startup(app)
 
     assert app.config["PUBLICATION_SCOPE_PROFILE_BOOTSTRAP_REPORT"] == expected
+
+
+def test_constitutive_requirement_startup_records_freshness_report(
+    monkeypatch,
+) -> None:
+    import src.backend.server.utils_flask as utils_flask
+    from src.backend.services import constitutive_relation_requirement_service
+
+    monkeypatch.setattr(utils_flask, "_is_running_under_pytest", lambda: False)
+    monkeypatch.setattr(utils_flask, "_is_agent_test_instance", lambda: False)
+    monkeypatch.setenv(
+        "VON_CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_ENABLE", "1"
+    )
+    expected = {"success": True, "ready": True, "seed_version": "test"}
+    monkeypatch.setattr(
+        constitutive_relation_requirement_service,
+        "ensure_constitutive_relation_requirement_profiles_current_for_startup",
+        lambda: expected,
+    )
+    app = types.SimpleNamespace(
+        logger=types.SimpleNamespace(warning=lambda *_args, **_kwargs: None),
+        config={},
+    )
+
+    utils_flask._bootstrap_constitutive_relation_requirements_for_startup(app)
+
+    assert (
+        app.config["CONSTITUTIVE_RELATION_REQUIREMENT_BOOTSTRAP_REPORT"]
+        == expected
+    )

--- a/tests/backend/test_von_history_debug_endpoint.py
+++ b/tests/backend/test_von_history_debug_endpoint.py
@@ -70,6 +70,63 @@ def test_history_exposes_conversation_situation_without_message_segments(
     }
 
 
+def test_history_projects_terminal_concept_q_and_a_carrier_state(monkeypatch):
+    from src.backend.server.routes import von_routes
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#test_user"},
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_resolve_shared_conversation_owner",
+        lambda **_kwargs: ("#V#test_user", None),
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_state",
+        lambda **kwargs: {
+            "session_id": kwargs["session_id"],
+            "history": [],
+            "mode": "concept_q_and_a",
+            "origin_kind": "concept_q_and_a",
+            "focal_concept_ids": ["#V#primary_labs"],
+            "concept_q_and_a": {
+                "schema_version": "concept_q_and_a_session.v1",
+                "concept": {
+                    "concept_id": "#V#primary_labs",
+                    "name": "Primary Labs",
+                },
+                "lifecycle": {"status": "cancelled", "revision": 1},
+            },
+        },
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+    response = app.test_client().get(
+        "/von/history",
+        query_string={"session_id": "qa-terminal"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["session"]["mode"] == "concept_q_and_a"
+    assert body["session"]["focal_concept_ids"] == ["#V#primary_labs"]
+    assert body["qa_session"]["lifecycle"]["status"] == "cancelled"
+
+
 def test_history_endpoint_returns_compact_debug_refs_without_hydration(monkeypatch):
     from src.backend.server.routes.von_routes import von_bp
 
@@ -314,7 +371,10 @@ def test_history_debug_returns_stored_turn_execution_diagnostics(monkeypatch):
     body = response.get_json()
     assert isinstance(body, dict)
     assert body.get("success") is True
-    assert body.get("history_location") == {"session_id": "session-1", "history_index": 3}
+    assert body.get("history_location") == {
+        "session_id": "session-1",
+        "history_index": 3,
+    }
 
     returned = body.get("llm_debug_data")
     assert isinstance(returned, dict)

--- a/tests/frontend/chatTabConceptQa.test.js
+++ b/tests/frontend/chatTabConceptQa.test.js
@@ -1,0 +1,434 @@
+/** @jest-environment jsdom */
+
+const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
+const qaModulePath = '../../src/frontend/web/von_interface/static/js/utils/conceptQaSession.js';
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    annotateTurn: jest.fn(),
+    fetchWithTimeout: jest.fn(),
+    getJsonDetailed: jest.fn(),
+    getUserContext: jest.fn(() => ({ user_id: '#V#qa_tester', org_id: '#V#lab' })),
+    getWindowSessionId: jest.fn(() => 'qa-window'),
+    postJson: jest.fn(),
+    WINDOW_SESSION_HEADER: 'X-Von-Window-Session',
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    elements: {},
+    getCurrentUserConceptId: jest.fn(() => '#V#qa_tester'),
+    renderSpanSuggestions: jest.fn(),
+}));
+
+jest.mock(qaModulePath, () => {
+    const actual = jest.requireActual(qaModulePath);
+    return {
+        ...actual,
+        transitionConceptQaSession: jest.fn(),
+        submitConceptQaTurn: jest.fn(),
+        confirmConceptQaFormalisation: jest.fn(),
+    };
+});
+
+function fixture() {
+    window.scrollTo = jest.fn();
+    document.body.innerHTML = `
+        <div id="chatTab">
+            <div id="conversationWorkspace">
+                <div id="chatSessionTabs"></div>
+                <div id="chatSessionMetadata"></div>
+                <div id="conceptQaConversationControls" class="hidden"></div>
+                <div id="scrollableField"></div>
+                <textarea id="promptInput" placeholder="Talk with Von here..."></textarea>
+                <button id="sendButton">Send Prompt</button>
+            </div>
+        </div>
+    `;
+}
+
+function activeSession(overrides = {}) {
+    return {
+        session_id: 'qa-chat-1',
+        chat_session_id: 'qa-chat-1',
+        session_name: 'Primary Labs Q&A',
+        focal_concept_id: '#V#primary_labs',
+        lifecycle: 'active',
+        mode: 'concept_q_and_a',
+        origin_kind: 'concept_q_and_a',
+        conversation_reference: {
+            schema_version: 'conversation_reference.v1',
+            binding_kind: 'explicit_session_id',
+            session_id: 'qa-chat-1',
+            user_concept_id: '#V#qa_tester',
+        },
+        ...overrides,
+    };
+}
+
+describe('chat workspace concept Q&A mode', () => {
+    beforeEach(() => {
+        fixture();
+        jest.useFakeTimers();
+        global.fetch = jest.fn(async () => ({ ok: true, json: async () => ({}) }));
+        const qa = require(qaModulePath);
+        qa.transitionConceptQaSession.mockReset();
+        qa.submitConceptQaTurn.mockReset();
+        qa.confirmConceptQaFormalisation.mockReset();
+    });
+
+    afterEach(() => {
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_resetConceptQaState();
+        chat.__testOnly_resetChatRequestState();
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.resetModules();
+    });
+
+    test('renders Q&A mode and waits for canonical finish read-back', async () => {
+        const qa = require(qaModulePath);
+        let resolveFinish;
+        qa.transitionConceptQaSession.mockReturnValue(new Promise((resolve) => {
+            resolveFinish = resolve;
+        }));
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession({
+            turns: [{
+                role: 'assistant',
+                content: 'Which organisation is it a member of?',
+                concept_q_and_a: {
+                    elicitation_predicate: {
+                        predicate_concept_id: '#V#memberOf',
+                        predicate_label: 'member of',
+                        status: 'missing',
+                        gap_status: 'asserted_relation_missing',
+                        requirement_kind: 'constitutive_relation',
+                        priority_class: 'constitutive',
+                        priority: 0,
+                    },
+                },
+            }],
+        }));
+
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('Concept Q&A');
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('not an assertion or a creation block');
+        expect(document.getElementById('sendButton').textContent).toBe('Submit answer');
+
+        const pending = chat.__testOnly_transitionActiveConceptQa('finish');
+        await Promise.resolve();
+        expect(qa.transitionConceptQaSession).toHaveBeenCalledWith({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-chat-1',
+            action: 'finish',
+        });
+        expect(chat.__testOnly_getConceptQaSession().lifecycle).toBe('active');
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('Saving…');
+
+        resolveFinish(activeSession({ lifecycle: 'finished' }));
+        await pending;
+        expect(chat.__testOnly_getConceptQaSession().lifecycle).toBe('finished');
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('transcript and prior knowledge are retained');
+        expect(document.getElementById('sendButton').disabled).toBe(true);
+
+        chat.__testOnly_updateExternalConversationUi();
+        expect(document.getElementById('promptInput').disabled).toBe(true);
+    });
+
+    test('rehydrates stable turn IDs, LLM access and separate receipts in the normal transcript', () => {
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession());
+        chat.__test_only__rehydrateHistory(document.getElementById('scrollableField'), [
+            {
+                role: 'assistant',
+                turn_id: 'qa-turn-stable-7',
+                content: 'Would you like to confirm the tentative relation?',
+                timestamp: '2026-09-02T12:00:00Z',
+                history_location: { session_id: 'qa-chat-1', history_index: 7 },
+                receipts: {
+                    exact_input: { status: 'not_admitted' },
+                    formalisation: {
+                        status: 'tentative',
+                        assertion_id: 'tentative-7',
+                        predicate_id: '#V#memberOf',
+                        confirmation: {
+                            available: true,
+                            method: 'POST',
+                            action: '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-chat-1/formalisations/tentative-7/confirm',
+                        },
+                    },
+                    notes: { status: 'no_update' },
+                },
+            },
+        ]);
+
+        const turn = document.querySelector('[data-turn-id="qa-turn-stable-7"]');
+        expect(turn).not.toBeNull();
+        expect(turn.querySelector('.llm-debug-button')).not.toBeNull();
+        expect(turn.textContent).toContain('Transcript only');
+        expect(turn.textContent).toContain('Tentative typed relation recorded');
+        expect(turn.textContent).toContain('Confirm relation');
+    });
+
+    test('does not offer or dispatch confirmation from a cancelled Q&A receipt', async () => {
+        const qa = require(qaModulePath);
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession({ lifecycle: 'cancelled' }));
+        chat.__test_only__rehydrateHistory(document.getElementById('scrollableField'), [
+            {
+                role: 'assistant',
+                turn_id: 'qa-turn-terminal-confirmation',
+                content: 'The tentative relation remains recorded.',
+                receipts: {
+                    formalisation: {
+                        status: 'tentative',
+                        assertion_id: 'tentative-terminal-7',
+                        confirmation: {
+                            available: true,
+                            available_after_cancel: false,
+                        },
+                    },
+                },
+            },
+        ]);
+
+        const button = document.querySelector('.concept-qa-receipt-confirm');
+        expect(button.disabled).toBe(true);
+        expect(button.textContent).toBe('Unavailable — Q&A cancelled');
+        button.click();
+        await Promise.resolve();
+        expect(qa.confirmConceptQaFormalisation).not.toHaveBeenCalled();
+
+        await expect(chat.__testOnly_confirmActiveConceptQaFormalisation({
+            status: 'tentative',
+            assertion_id: 'tentative-terminal-7',
+            confirmation: {
+                available: true,
+                available_after_cancel: false,
+            },
+        })).resolves.toBe(false);
+        expect(qa.confirmConceptQaFormalisation).not.toHaveBeenCalled();
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('receipt can no longer confirm');
+    });
+
+    test('allows post-finish confirmation only when the receipt explicitly supports it', async () => {
+        const qa = require(qaModulePath);
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession({ lifecycle: 'finished' }));
+
+        const receipt = {
+            status: 'tentative',
+            assertion_id: 'tentative-finished-7',
+            confirmation: {
+                available: true,
+                available_after_finish: true,
+            },
+        };
+        const historyTurn = (formalisation) => ({
+            role: 'assistant',
+            turn_id: 'qa-turn-finished-confirmation',
+            content: 'The tentative relation remains recorded.',
+            receipts: { formalisation },
+        });
+
+        chat.__test_only__rehydrateHistory(
+            document.getElementById('scrollableField'),
+            [historyTurn({
+                ...receipt,
+                confirmation: { available: true },
+            })],
+        );
+        expect(document.querySelector('.concept-qa-receipt-confirm').disabled).toBe(true);
+        expect(document.querySelector('.concept-qa-receipt-confirm').textContent)
+            .toBe('Unavailable — Q&A finished');
+
+        chat.__test_only__rehydrateHistory(
+            document.getElementById('scrollableField'),
+            [historyTurn(receipt)],
+        );
+        expect(document.querySelector('.concept-qa-receipt-confirm').disabled).toBe(false);
+        expect(document.querySelector('.concept-qa-receipt-confirm').textContent)
+            .toBe('Confirm relation');
+
+        const canonicalReadBack = { epistemic_status: 'asserted' };
+        qa.confirmConceptQaFormalisation.mockResolvedValue({
+            session: activeSession({
+                lifecycle: 'finished',
+                turns: [{
+                    role: 'assistant',
+                    turn_id: 'qa-turn-confirmed-after-finish',
+                    content: 'Confirmed and read back.',
+                }],
+            }),
+            receipts: {
+                formalisation: {
+                    status: 'asserted',
+                    canonical_read_back: canonicalReadBack,
+                    confirmation: { available: false },
+                },
+            },
+            payload: {
+                success: true,
+                confirmation: { canonical_read_back: canonicalReadBack },
+            },
+        });
+
+        await expect(chat.__testOnly_confirmActiveConceptQaFormalisation(receipt))
+            .resolves.toBe(true);
+        expect(qa.confirmConceptQaFormalisation).toHaveBeenCalledWith({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-chat-1',
+            assertionId: 'tentative-finished-7',
+            confirmation: receipt.confirmation,
+        });
+    });
+
+    test('routes the composer through the Q&A turn endpoint and refreshes concept knowledge', async () => {
+        const qa = require(qaModulePath);
+        const updated = activeSession({
+            turns: [
+                {
+                    role: 'user',
+                    turn_id: 'qa-saved-user-1',
+                    content: 'Primary Labs is a research company.',
+                    receipts: {
+                        exact_input: { status: 'stored' },
+                        formalisation: { status: 'deferred' },
+                        notes: { status: 'not_updated' },
+                    },
+                },
+                {
+                    role: 'assistant',
+                    turn_id: 'qa-saved-assistant-1',
+                    content: 'What field does it work in?',
+                    history_location: { session_id: 'qa-chat-1', history_index: 1 },
+                },
+            ],
+        });
+        qa.submitConceptQaTurn.mockResolvedValue({
+            session: updated,
+            receipts: {
+                exact_input: { status: 'stored' },
+                formalisation: { status: 'deferred' },
+                notes: { status: 'not_updated' },
+            },
+        });
+        const knowledgeEvents = [];
+        document.addEventListener('von:conceptKnowledgeChanged', (event) => {
+            knowledgeEvents.push(event.detail);
+        }, { once: true });
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession());
+        document.getElementById('promptInput').value = 'Primary Labs is a research company.';
+
+        await chat.__testOnly_sendChatPrompt();
+
+        expect(qa.submitConceptQaTurn).toHaveBeenCalledWith({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-chat-1',
+            answer: 'Primary Labs is a research company.',
+        });
+        expect(document.getElementById('promptInput').value).toBe('');
+        expect(document.querySelector('[data-turn-id="qa-saved-user-1"]').textContent)
+            .toContain('Exact text claim stored');
+        expect(knowledgeEvents).toHaveLength(1);
+        expect(knowledgeEvents[0].conceptId).toBe('#V#primary_labs');
+    });
+
+    test('keeps denied membership tentative and shows the canonical handoff and retry path', async () => {
+        const qa = require(qaModulePath);
+        qa.confirmConceptQaFormalisation.mockRejectedValue(Object.assign(
+            new Error('organisation_membership_confirmation_denied'),
+            {
+                status: 403,
+                payload: {
+                    ...activeSession(),
+                    success: false,
+                    confirmation: {
+                        error_code: 'organisation_membership_confirmation_denied',
+                        actionable_denial: {
+                            who_can_add_membership: (
+                                'an organisation admin or owner with the represented '
+                                + 'MANAGE_MEMBERS permission'
+                            ),
+                            required_permissions: ['MANAGE_MEMBERS'],
+                            mechanism: 'canonical_organisation_membership_handoff',
+                            membership_management_path: (
+                                'canonical organisation membership management'
+                            ),
+                            same_q_and_a_action_available_to_other_actor: false,
+                            original_actor_next_step: (
+                                'After an authorised actor adds the membership, the '
+                                + 'original Q&A actor can retry this Confirm action; it '
+                                + 'will reconcile the membership and promote the '
+                                + 'source-linked tentative assertion.'
+                            ),
+                            tentative_assertion_preserved: true,
+                        },
+                    },
+                },
+            },
+        ));
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession());
+
+        await expect(chat.__testOnly_confirmActiveConceptQaFormalisation({
+            status: 'tentative',
+            assertion_id: 'ska_tentative_1',
+            confirmation: { available: true },
+        })).resolves.toBe(false);
+
+        const controls = document.getElementById('conceptQaConversationControls').textContent;
+        expect(controls).toContain('The tentative relation was retained');
+        expect(controls).toContain(
+            'Membership handoff: an organisation admin or owner with the represented '
+            + 'MANAGE_MEMBERS permission must add the membership through canonical '
+            + 'organisation membership management.'
+        );
+        expect(controls).toContain(
+            'The authorised membership manager cannot use this actor-scoped Q&A Confirm '
+            + 'action on behalf of the original actor.'
+        );
+        expect(controls).toContain(
+            'Next step for the original Q&A actor: After an authorised actor adds the '
+            + 'membership, the original Q&A actor can retry this Confirm action; it will '
+            + 'reconcile the membership and promote the source-linked tentative assertion.'
+        );
+        expect(controls).toContain('MANAGE_MEMBERS');
+    });
+
+    test('retains generic confirmer guidance for non-membership denials', async () => {
+        const qa = require(qaModulePath);
+        qa.confirmConceptQaFormalisation.mockRejectedValue(Object.assign(
+            new Error('formalisation_confirmation_actor_required'),
+            {
+                status: 403,
+                payload: {
+                    ...activeSession(),
+                    success: false,
+                    confirmation: {
+                        error_code: 'formalisation_confirmation_actor_required',
+                        actionable_denial: {
+                            who_can_confirm: 'the original asserting actor',
+                            tentative_assertion_preserved: true,
+                        },
+                    },
+                },
+            },
+        ));
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession());
+
+        await expect(chat.__testOnly_confirmActiveConceptQaFormalisation({
+            status: 'tentative',
+            assertion_id: 'ska_generic_tentative_1',
+            confirmation: { available: true },
+        })).resolves.toBe(false);
+
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('Confirmation requires the original asserting actor.');
+    });
+});

--- a/tests/frontend/conceptEffectiveAssertionsPanel.test.js
+++ b/tests/frontend/conceptEffectiveAssertionsPanel.test.js
@@ -85,6 +85,9 @@ describe('concept actor-effective assertions panel', () => {
         });
 
         expect(result).toEqual({ rendered: true, contextView: 'actor_effective' });
+        expect(api.getJsonDetailed.mock.calls[0][0]).toContain(
+            'argument_concept_id=%23V%23event'
+        );
         const panel = document.getElementById('conceptEffectiveAssertionsPanel_test');
         expect(panel.classList.contains('hidden')).toBe(false);
         expect(panel.querySelectorAll('.concept-effective-assertion-row')).toHaveLength(2);
@@ -217,5 +220,165 @@ describe('concept actor-effective assertions panel', () => {
         expect(panel.classList.contains('hidden')).toBe(false);
         expect(panel.textContent).toContain('Organisation — Example Lab');
         expect(panel.textContent).not.toContain('Personal — visible only to you');
+    });
+
+    test('labels aboutness-only text without implying a typed relation', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                context_view: 'actor_effective',
+                items: [assertion({
+                    concept_relevance: {
+                        kind: 'aboutness_only',
+                        concept_id: '#V#event',
+                        aboutness_only: true,
+                    },
+                })],
+                has_more: false,
+            },
+        });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#event', suffix: 'test' });
+        expect(document.body.textContent).toContain(
+            'Exact text linked to this concept; no typed relation asserted.'
+        );
+    });
+
+    test('labels a projected tentative typed relation as non-authority-active', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                context_view: 'actor_effective',
+                items: [assertion({
+                    epistemic_status: 'tentative',
+                    concept_relevance: {
+                        kind: 'grounded_subject',
+                        concept_id: '#V#event',
+                        aboutness_only: false,
+                    },
+                })],
+                has_more: false,
+            },
+        });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#event', suffix: 'test' });
+        expect(document.body.textContent).toContain(
+            'Tentative typed relation; not confirmed/authority-active'
+        );
+        expect(document.querySelector('.concept-effective-assertion-epistemic-tentative'))
+            .not.toBeNull();
+    });
+
+    test('renders incoming and outgoing typed relations as complete direction-aware statements', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                context_view: 'actor_effective',
+                items: [
+                    assertion({
+                        assertion_id: 'ska_member',
+                        epistemic_status: 'tentative',
+                        subject: {
+                            concept_id: '#V#michael_witbrock',
+                            display_name: 'Michael Witbrock',
+                        },
+                        predicate: {
+                            concept_id: '#V#memberOf',
+                            storage_id: '#V#memberOf',
+                            display_name: 'member of',
+                        },
+                        object: {
+                            kind: 'concept',
+                            concept_id: '#V#primary_labs',
+                            display_name: 'Primary Labs',
+                        },
+                        human_statement: 'Michael Witbrock member of Primary Labs',
+                        concept_relevance: {
+                            kind: 'grounded_object',
+                            concept_id: '#V#primary_labs',
+                            aboutness_only: false,
+                        },
+                    }),
+                    assertion({
+                        assertion_id: 'ska_location',
+                        subject: {
+                            concept_id: '#V#primary_labs',
+                            display_name: 'Primary Labs',
+                        },
+                        predicate: {
+                            concept_id: '#V#locatedIn',
+                            storage_id: '#V#locatedIn',
+                            display_name: 'located in',
+                        },
+                        object: {
+                            kind: 'concept',
+                            concept_id: '#V#auckland',
+                            display_name: 'Auckland',
+                        },
+                        concept_relevance: {
+                            kind: 'grounded_subject',
+                            concept_id: '#V#primary_labs',
+                            aboutness_only: false,
+                        },
+                    }),
+                ],
+                has_more: false,
+            },
+        });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({
+            conceptId: '#V#primary_labs',
+            suffix: 'test',
+        });
+
+        const incoming = document.querySelector('[data-assertion-id="ska_member"]');
+        expect(incoming.dataset.relationDirection).toBe('incoming');
+        expect(incoming.querySelector('.concept-effective-assertion-human-statement').textContent)
+            .toBe('Michael Witbrock member of Primary Labs');
+        expect(incoming.textContent).toContain(
+            'Tentative typed relation; not confirmed/authority-active'
+        );
+        expect(incoming.textContent).toContain('Personal — visible only to you');
+
+        const outgoing = document.querySelector('[data-assertion-id="ska_location"]');
+        expect(outgoing.dataset.relationDirection).toBe('outgoing');
+        expect(outgoing.querySelector('.concept-effective-assertion-human-statement').textContent)
+            .toBe('Primary Labs located in Auckland');
+    });
+
+    test('refreshes only the matching concept after a knowledge-change event', async () => {
+        const api = require('../../src/frontend/web/von_interface/static/js/apiService.js');
+        api.getJsonDetailed.mockResolvedValue({
+            data: {
+                context_view: 'actor_effective',
+                items: [assertion()],
+                has_more: false,
+            },
+        });
+        const { ensureConceptEffectiveAssertionsPanel } = require(
+            '../../src/frontend/web/von_interface/static/js/components/conceptEffectiveAssertionsPanel.js'
+        );
+
+        await ensureConceptEffectiveAssertionsPanel({ conceptId: '#V#event', suffix: 'test' });
+        document.dispatchEvent(new CustomEvent('von:conceptKnowledgeChanged', {
+            detail: { conceptId: '#V#other' },
+        }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(api.getJsonDetailed).toHaveBeenCalledTimes(1);
+
+        document.dispatchEvent(new CustomEvent('von:conceptKnowledgeChanged', {
+            detail: { conceptId: '#V#event' },
+        }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(api.getJsonDetailed).toHaveBeenCalledTimes(2);
     });
 });

--- a/tests/frontend/conceptInteractionQandAReframe.test.js
+++ b/tests/frontend/conceptInteractionQandAReframe.test.js
@@ -3,6 +3,8 @@ const path = require('path');
 
 const {
     describeConceptQaRepresentation,
+    isUnmistakableMissingConceptQaRoute,
+    refreshConceptQaSessionCard,
 } = require('../../src/frontend/web/von_interface/static/js/conceptTab.js');
 
 const conceptTemplate = fs.readFileSync(
@@ -24,13 +26,14 @@ describe('concept-improvement Q&A entry point', () => {
 
         expect(discuss.textContent.trim()).toBe('Discuss');
         expect(improveByQa.textContent.trim()).toBe('Improve concept by Q&A');
-        expect(improveByQa.title).toContain('preserved with provenance');
-        expect(disclosure.textContent).toMatch(/preserves supplied knowledge with provenance/i);
+        expect(improveByQa.title).toContain('recoverable conversation');
+        expect(disclosure.textContent).toMatch(/exact claims are stored with provenance/i);
+        expect(disclosure.textContent).toMatch(/formalisation and notes updates are reported separately/i);
         expect(submitAnswer.title).toContain('continue the concept Q&A');
         expect(cancelQa.textContent.trim()).toBe('Cancel Q&A');
         expect(cancelQa.title).toContain('concept-improvement Q&A');
         expect(finishQa.textContent.trim()).toBe('Finish Q&A');
-        expect(finishQa.title).toContain('apply the gathered information');
+        expect(finishQa.title).toContain('retaining its transcript');
         expect(restart.textContent.trim()).toBe('Improve concept by Q&A again');
 
         const visibleControlCopy = [improveByQa, submitAnswer, cancelQa, finishQa, restart]
@@ -53,7 +56,8 @@ describe('concept-improvement Q&A entry point', () => {
             "Primary Labs' main product is the news site theprimary.com."
         );
         expect(presentation.synthesisText).toContain('notes update failed');
-        expect(presentation.statusText).toContain('preserved as scoped knowledge');
+        expect(presentation.statusText).toContain('stored as scoped knowledge');
+        expect(presentation.statusText).toContain('No typed relation is implied');
         expect(presentation.statusText).not.toContain('No synthesis generated');
     });
 
@@ -67,8 +71,79 @@ describe('concept-improvement Q&A entry point', () => {
             },
         });
 
-        expect(presentation.statusText).toContain('represented with provenance');
+        expect(presentation.statusText).toContain('Exact text claim stored with provenance');
         expect(presentation.statusText).toContain('concept notes updated');
         expect(presentation.statusColor).toBe('green');
+    });
+
+    test('uses the legacy path only for an unmistakably absent canonical route', () => {
+        expect(isUnmistakableMissingConceptQaRoute({ status: 404, payload: {} })).toBe(true);
+        expect(isUnmistakableMissingConceptQaRoute({
+            status: 404,
+            payload: {
+                error: 'Q&A conversation was not found for this concept',
+                error_code: 'conversation_not_found',
+            },
+        })).toBe(false);
+        expect(isUnmistakableMissingConceptQaRoute({
+            status: 403,
+            payload: { error_code: 'actor_context_required' },
+        })).toBe(false);
+        expect(isUnmistakableMissingConceptQaRoute({ status: 405, payload: {} })).toBe(false);
+    });
+
+    test('projects an active Q&A as resume, transcript and canonical-reference actions', async () => {
+        document.body.innerHTML = conceptTemplate;
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                sessions: [{
+                    session_id: 'qa-primary-labs-1',
+                    focal_concept_ids: ['#V#primary_labs'],
+                    lifecycle: { status: 'active', revision: 1 },
+                    mode: 'concept_q_and_a',
+                    origin_kind: 'concept_q_and_a',
+                    conversation_reference: {
+                        schema_version: 'conversation_reference.v1',
+                        binding_kind: 'explicit_session_id',
+                        session_id: 'qa-primary-labs-1',
+                    },
+                    turns: [{
+                        role: 'assistant',
+                        content: 'Which organisation is it a member of?',
+                        concept_q_and_a: {
+                            elicitation_predicate: {
+                                predicate_concept_id: '#V#memberOf',
+                                predicate_label: 'member of',
+                                status: 'missing',
+                                gap_status: 'asserted_relation_missing',
+                                requirement_kind: 'constitutive_relation',
+                                priority_class: 'constitutive',
+                                priority: 0,
+                            },
+                        },
+                    }],
+                }],
+            }),
+        }));
+        try {
+            await refreshConceptQaSessionCard('#V#primary_labs');
+        } finally {
+            global.fetch = originalFetch;
+        }
+
+        expect(document.getElementById('conceptQaSessionBadge').textContent).toBe('Active');
+        expect(document.getElementById('startInteractionButton').classList).toContain('hidden');
+        expect(document.getElementById('resumeConceptQaButton').classList).not.toContain('hidden');
+        expect(document.getElementById('openConceptQaTranscriptButton').classList).not.toContain('hidden');
+        expect(document.getElementById('copyConceptQaReferenceButton').classList).not.toContain('hidden');
+        expect(document.getElementById('conceptQaGapStatus').textContent).toContain(
+            'Current constitutive gap: member of — asserted relation missing'
+        );
+        expect(document.getElementById('conceptQaGapStatus').textContent).toContain(
+            'not an assertion or a creation block'
+        );
     });
 });

--- a/tests/frontend/conceptQaReceipt.test.js
+++ b/tests/frontend/conceptQaReceipt.test.js
@@ -1,0 +1,169 @@
+/** @jest-environment jsdom */
+
+const {
+    renderConceptQaReceipt,
+} = require('../../src/frontend/web/von_interface/static/js/components/conceptQaReceipt.js');
+
+describe('concept Q&A representation receipt', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="target"></div>';
+    });
+
+    test('distinguishes transcript-only input from an admitted knowledge claim', () => {
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                exact_input: { status: 'not_admitted' },
+                formalisation: { status: 'not_attempted' },
+                notes: { status: 'no_update' },
+            },
+        });
+
+        expect(document.body.textContent).toContain('Transcript only');
+        expect(document.body.textContent).toContain('not stored as a knowledge claim');
+        expect(document.body.textContent).toContain('No typed relation was asserted');
+        expect(document.body.textContent).not.toMatch(/\brepresented\b/i);
+    });
+
+    test('keeps exact text, candidate formalisation and failed notes as separate outcomes', () => {
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                exact_input: { status: 'stored', assertion_id: 'ska-exact' },
+                formalisation: { status: 'candidate' },
+                notes: { status: 'failed' },
+            },
+        });
+
+        expect(document.body.textContent).toContain('Exact text claim stored');
+        expect(document.body.textContent).toContain('source wording remains visible');
+        expect(document.body.textContent).toContain('Formalisation candidate');
+        expect(document.body.textContent).toContain('no typed relation was asserted');
+        expect(document.body.textContent).toContain('Concept notes update failed');
+    });
+
+    test('renders tentative membership as non-activating and offers idempotent confirmation', async () => {
+        const onConfirm = jest.fn(async () => true);
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                formalisation: {
+                    status: 'tentative',
+                    assertion_id: 'tentative-member-1',
+                    predicate_concept_id: '#V#memberOf',
+                    confirmation: {
+                        available: true,
+                        method: 'POST',
+                        action: '/api/concepts/x/q_and_a/sessions/y/formalisations/tentative-member-1/confirm',
+                    },
+                },
+            },
+        }, { onConfirm });
+
+        expect(document.body.textContent).toContain('Tentative typed relation recorded');
+        expect(document.body.textContent).toContain('does not activate identity or namespace');
+        const button = document.querySelector('.concept-qa-receipt-confirm');
+        expect(button.textContent).toBe('Confirm relation');
+        button.click();
+        await Promise.resolve();
+        expect(onConfirm).toHaveBeenCalledWith(
+            expect.objectContaining({ assertion_id: 'tentative-member-1' }),
+            expect.objectContaining({ button }),
+        );
+    });
+
+    test('shows a non-actionable confirmation state when the Q&A lifecycle disallows it', () => {
+        const onConfirm = jest.fn();
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                formalisation: {
+                    status: 'tentative',
+                    assertion_id: 'tentative-terminal-1',
+                    confirmation: { available: true },
+                },
+            },
+        }, {
+            onConfirm,
+            confirmationState: {
+                available: false,
+                label: 'Unavailable — Q&A finished',
+                reason: 'This concept Q&A is finished; start an active Q&A to confirm.',
+            },
+        });
+
+        const button = document.querySelector('.concept-qa-receipt-confirm');
+        expect(button.disabled).toBe(true);
+        expect(button.textContent).toBe('Unavailable — Q&A finished');
+        expect(button.title).toContain('Q&A is finished');
+        button.click();
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    test('rechecks lifecycle state after a confirmation attempt instead of re-enabling stale UI', async () => {
+        let active = true;
+        const onConfirm = jest.fn(async () => {
+            active = false;
+            return false;
+        });
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                formalisation: {
+                    status: 'tentative',
+                    assertion_id: 'tentative-race-1',
+                    confirmation: { available: true },
+                },
+            },
+        }, {
+            onConfirm,
+            getConfirmationState: () => active
+                ? { available: true }
+                : {
+                    available: false,
+                    label: 'Unavailable — Q&A cancelled',
+                    reason: 'This concept Q&A is cancelled.',
+                },
+        });
+
+        const button = document.querySelector('.concept-qa-receipt-confirm');
+        button.click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(button.disabled).toBe(true);
+        expect(button.textContent).toBe('Unavailable — Q&A cancelled');
+    });
+
+    test('claims typed success only when canonical read-back is present', () => {
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                exact_input: { status: 'stored' },
+                formalisation: { status: 'succeeded', read_back: { verified: true } },
+            },
+        });
+        expect(document.body.textContent).toContain('Typed assertion succeeded');
+        expect(document.body.textContent).toContain('exact source claim remains visible');
+    });
+
+    test('accepts canonical backend aliases without overstating outcomes', () => {
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                exact_input: { status: 'partial_or_failed' },
+                formalisation: { status: 'not_applicable' },
+                notes: { status: 'not_updated' },
+            },
+        });
+
+        expect(document.body.textContent).toContain('Exact text claim partially stored');
+        expect(document.body.textContent).toContain('Formalisation not attempted');
+        expect(document.body.textContent).toContain('Concept notes unchanged');
+
+        document.body.innerHTML = '<div id="target"></div>';
+        renderConceptQaReceipt(document.getElementById('target'), {
+            receipts: {
+                formalisation: {
+                    status: 'asserted',
+                    canonical_read_back: { epistemic_status: 'asserted' },
+                },
+            },
+        });
+        expect(document.body.textContent).toContain('Typed assertion succeeded');
+    });
+});

--- a/tests/frontend/conceptQaSession.test.js
+++ b/tests/frontend/conceptQaSession.test.js
@@ -1,0 +1,222 @@
+/** @jest-environment jsdom */
+
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    ensureUniqueWindowSessionId: jest.fn(async () => 'window-qa-test'),
+    WINDOW_SESSION_HEADER: 'X-Von-Window-Session',
+}));
+
+jest.mock('../../src/frontend/web/von_interface/static/js/domUtils.js', () => ({
+    getCurrentUserConceptId: jest.fn(() => '#V#tester'),
+}));
+
+const {
+    confirmConceptQaFormalisation,
+    describeConceptQaElicitationGap,
+    fetchConceptQaProjection,
+    normaliseConceptQaProjection,
+    normaliseConceptQaSession,
+    startConceptQaSession,
+    submitConceptQaTurn,
+    transitionConceptQaSession,
+} = require('../../src/frontend/web/von_interface/static/js/utils/conceptQaSession.js');
+
+function response(payload, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => payload,
+    };
+}
+
+describe('concept Q&A frontend contract', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    test('normalises the active canonical session without collapsing separate receipts', () => {
+        const projection = normaliseConceptQaProjection({
+            sessions: [{
+                session_id: 'qa-session-1',
+                mode: 'concept_q_and_a',
+                origin_kind: 'concept_q_and_a',
+                focal_concept_id: '#V#primary_labs',
+                lifecycle: 'active',
+                conversation_reference: {
+                    schema_version: 'conversation_reference.v1',
+                    binding_kind: 'explicit_session_id',
+                    session_id: 'qa-session-1',
+                },
+            }],
+        });
+
+        expect(projection.active_session).toEqual(expect.objectContaining({
+            session_id: 'qa-session-1',
+            concept_id: '#V#primary_labs',
+            lifecycle: 'active',
+            origin_kind: 'concept_q_and_a',
+        }));
+        expect(projection.active_session.available_actions).toContain('submit_turn');
+
+        const turn = normaliseConceptQaSession({
+            session: projection.active_session,
+            receipts: {
+                exact_input: { status: 'stored', assertion_id: 'ska-1' },
+                formalisation: { status: 'candidate' },
+                notes: { status: 'failed' },
+            },
+        });
+        expect(turn.receipts).toEqual({
+            exact_input: { status: 'stored', assertion_id: 'ska-1' },
+            formalisation: { status: 'candidate' },
+            notes: { status: 'failed' },
+        });
+    });
+
+    test('accepts the compatibility legacy-active list field', () => {
+        const projection = normaliseConceptQaProjection({
+            legacy_active_interactions: [{ interaction_id: 'legacy-1' }],
+        });
+        expect(projection.legacy_interactions).toEqual([{ interaction_id: 'legacy-1' }]);
+    });
+
+    test('describes only a structured missing-relation target as a Q&A gap', () => {
+        const session = {
+            turns: [{
+                role: 'assistant',
+                content: 'Who is it a member of?',
+                concept_q_and_a: {
+                    elicitation_predicate: {
+                        predicate_concept_id: '#V#memberOf',
+                        predicate_label: 'member of',
+                        status: 'missing',
+                        gap_status: 'asserted_relation_missing',
+                        requirement_kind: 'constitutive_relation',
+                        priority_class: 'constitutive',
+                        priority: 0,
+                    },
+                },
+            }],
+        };
+        expect(describeConceptQaElicitationGap(session)).toBe(
+            'Current constitutive gap: member of — asserted relation missing. '
+            + 'This is a prioritised Q&A target, not an assertion or a creation block.'
+        );
+        expect(describeConceptQaElicitationGap({
+            turns: [{
+                role: 'assistant',
+                concept_q_and_a: {
+                    elicitation_predicate: {
+                        predicate_concept_id: '#V#homepage',
+                        predicate_label: 'homepage',
+                        status: 'missing',
+                        requirement_kind: 'salient_relation',
+                        priority_class: 'salient',
+                        priority: 2,
+                    },
+                },
+            }],
+        })).toBe(
+            'Current suggested relation: homepage (priority 2). '
+            + 'This is a salient Q&A target, not a requirement or an asserted relation.'
+        );
+        expect(describeConceptQaElicitationGap({
+            turns: [{ role: 'assistant', content: 'Who is it a member of?' }],
+        })).toBe('');
+    });
+
+    test('uses the canonical projection, start, turn, finish and cancel routes', async () => {
+        global.fetch
+            .mockResolvedValueOnce(response({ sessions: [], active_session: null }))
+            .mockResolvedValueOnce(response({
+                session_id: 'qa-session-2',
+                lifecycle: 'active',
+                focal_concept_id: '#V#primary_labs',
+            }))
+            .mockResolvedValueOnce(response({
+                session: {
+                    session_id: 'qa-session-2',
+                    lifecycle: 'active',
+                    focal_concept_id: '#V#primary_labs',
+                },
+                receipts: { exact_input: { status: 'not_admitted' } },
+            }))
+            .mockResolvedValueOnce(response({
+                session_id: 'qa-session-2',
+                lifecycle: 'finished',
+                focal_concept_id: '#V#primary_labs',
+            }))
+            .mockResolvedValueOnce(response({
+                session_id: 'qa-session-3',
+                lifecycle: 'cancelled',
+                focal_concept_id: '#V#primary_labs',
+            }));
+
+        await fetchConceptQaProjection('#V#primary_labs');
+        await startConceptQaSession('#V#primary_labs');
+        await submitConceptQaTurn({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-session-2',
+            answer: 'Is that represented?',
+        });
+        await transitionConceptQaSession({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-session-2',
+            action: 'finish',
+        });
+        await transitionConceptQaSession({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-session-3',
+            action: 'cancel',
+        });
+
+        expect(global.fetch.mock.calls.map(([url]) => url)).toEqual([
+            '/api/concepts/%23V%23primary_labs/q_and_a',
+            '/api/concepts/%23V%23primary_labs/q_and_a/start',
+            '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-session-2/turns',
+            '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-session-2/finish',
+            '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-session-3/cancel',
+        ]);
+        const turnBody = JSON.parse(global.fetch.mock.calls[2][1].body);
+        expect(turnBody.answer).toBe('Is that represented?');
+        expect(turnBody.turn_id).toMatch(/^(qa-|[0-9a-f]{8}-)/i);
+    });
+
+    test('prefers a safe server confirmation action and requires canonical read-back', async () => {
+        global.fetch.mockResolvedValue(response({
+            session: {
+                session_id: 'qa-session-4',
+                focal_concept_id: '#V#primary_labs',
+                lifecycle: 'active',
+            },
+            receipts: {
+                formalisation: {
+                    status: 'succeeded',
+                    assertion_id: 'tentative-1',
+                    read_back: { verified: true },
+                },
+            },
+        }));
+
+        const result = await confirmConceptQaFormalisation({
+            conceptId: '#V#primary_labs',
+            sessionId: 'qa-session-4',
+            assertionId: 'tentative-1',
+            confirmation: {
+                available: true,
+                method: 'POST',
+                action: '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-session-4/formalisations/tentative-1/confirm',
+                expected_receipt_revision: 3,
+            },
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/concepts/%23V%23primary_labs/q_and_a/sessions/qa-session-4/formalisations/tentative-1/confirm',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual(expect.objectContaining({
+            expected_receipt_revision: 3,
+            request_id: expect.stringMatching(/^(qa-|[0-9a-f]{8}-)/i),
+        }));
+        expect(result.receipts.formalisation.read_back.verified).toBe(true);
+    });
+});

--- a/tests/frontend/interactionSessionRecovery.test.js
+++ b/tests/frontend/interactionSessionRecovery.test.js
@@ -79,6 +79,9 @@ describe("Concept interaction session recovery", () => {
 
         global.fetch = jest.fn(async (url) => {
             const u = String(url);
+            if (u.endsWith("/q_and_a/start")) {
+                return errorJson(404, {});
+            }
             if (u.includes("/start_interaction")) {
                 return okJson({ interaction_id: "interaction-1" });
             }
@@ -128,10 +131,14 @@ describe("Concept interaction session recovery", () => {
         const startCall = global.fetch.mock.calls.find(([url]) =>
             String(url).includes("/start_interaction")
         );
+        const canonicalStartCall = global.fetch.mock.calls.find(([url]) =>
+            String(url).endsWith("/q_and_a/start")
+        );
         const questionCall = global.fetch.mock.calls.find(([url]) =>
             String(url).includes("/generate_initial_question")
         );
 
+        expect(canonicalStartCall).toBeDefined();
         expect(startCall).toBeDefined();
         expect(questionCall).toBeDefined();
         expect(startCall[1].headers["X-Von-Window-Session"]).toMatch(/^ws_/);
@@ -151,6 +158,9 @@ describe("Concept interaction session recovery", () => {
         document.getElementById("conceptNotes_s1").value = "I'm a member of Primary Labs.";
         global.fetch = jest.fn(async (url) => {
             const u = String(url);
+            if (u.endsWith("/q_and_a/start")) {
+                return errorJson(404, {});
+            }
             if (u.includes("/start_interaction")) {
                 return okJson({
                     interaction_id: "interaction-notes-1",
@@ -195,6 +205,9 @@ describe("Concept interaction session recovery", () => {
     it("submits notes-only input for representation and keeps it visible", async () => {
         global.fetch = jest.fn(async (url) => {
             const u = String(url);
+            if (u.endsWith("/q_and_a/start")) {
+                return errorJson(404, {});
+            }
             if (u.includes("/start_interaction")) {
                 return okJson({ interaction_id: "interaction-notes-only" });
             }
@@ -233,7 +246,7 @@ describe("Concept interaction session recovery", () => {
             notes_input: "I'm a member of Primary Labs.",
         });
         expect(document.getElementById("conceptStep2Status_s1").textContent).toContain(
-            "represented with provenance"
+            "stored with provenance"
         );
         expect(document.getElementById("followUpQuestion_s1").textContent).toBe(
             "What role do you have in Primary Labs?"


### PR DESCRIPTION
> Merge impact: concept Q&A becomes a durable, actor-scoped conversation with a copyable structured reference, truthful representation receipts, conservative tentative autoformalisation, and strongly prioritised constitutive relation elicitation.
>
> Merge decision: ready — the exact user path and affected backend/frontend suites pass, and an independent review found and then cleared all five candidate-caused stop-ship defects.

## User outcome

A concept-page Q&A is no longer a transient notes-edit interaction. It is a specialised mode on the normal conversation carrier: every turn is durable, the full transcript can be opened, and the same structured von_conversation_ref used by full conversations can be copied.

User-presented factual answers are preserved first as exact actor-scoped text claims with provenance. Safe short answers to structurally bound known-predicate questions may also be autoformalised without per-action permission, but only as tentative relations. Tentative relations are visibly labelled and excluded from asserted consumers until explicitly confirmed. Questions, requests, uncertainty, and control turns remain conversation state rather than claims.

For Von-user organisations, the incoming Von user memberOf organisation relation is represented as a constitutive requirement and strongly prioritised in Q&A. It remains a readiness gap, not an instance-creation gate.

## Material changes

- Add a canonical actor-scoped concept-Q&A conversation service, lifecycle routes, idempotent turn receipts, full-history projection, legacy route-miss fallback, and shared structured conversation references.
- Separate transcript/control content, exact scoped text claims, tentative formalisation candidates, canonical notes, and confirmed assertions.
- Bind formalisation metadata only when the emitted question uniquely matches the represented elicitation requirement; otherwise defer formalisation.
- Answer representation-status questions deterministically from durable receipts rather than allowing an unsupported model-authored “yes”.
- Add explicit relation confirmation, conversational confirmation, finished-session retrospective confirmation, cancelled-session denial, and canonical membership handoff/reconciliation without self-grant.
- Add represented constitutive-relation profiles and a deployment-time reconciliation/read-back path. Seed activation is not performed by this PR.
- Show direction-complete subject–predicate–object assertions, tentative/provenance state, copy/open controls, and actionable confirmation denial guidance in the UI.
- Preserve ordinary Discuss behaviour and asserted-only defaults outside explicit tentative-aware concept-page projections.

Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-1035

The architecture follows the observation/inference/invariant and outcome-test discipline in [The Reliability Ratchet](https://michaelwitbrock.com/2026/08/01/the-reliability-ratchet/): preserve source observations, diagnose the failure class, compare against the simpler text-claim baseline, and avoid turning constitutive importance into a universal creation gate.

## Evidence

- 270 affected backend/history tests passed.
- 46 affected frontend tests passed.
- Focused ESLint over the repaired frontend contract passed with no findings.
- Ruff and format checks passed for the new/materially rewritten Q&A services and focused tests; Python compilation, seed JSON validation, and staged diff checks passed.
- Actual branch templates and modules were exercised in Chrome through start, exact constitutive prompt, gap display, transcript, finish, full reload, and terminal-state recovery with no browser/page errors and no model or legacy interaction call.
- Structured clipboard payload is covered deterministically in the frontend suite; the in-app browser environment did not expose clipboard read-back.
- Independent staged-diff review identified five stop-ship defects (predicate binding, receipt truthfulness, relation direction, confirmation viability, and canonical-note authority); all were repaired and the reviewer found no remaining stop-ship defect.

## Ship boundary

- **Minimum ship criteria:** durable/reopenable actor-scoped conversations; truthful separate receipts; exact source preservation; only structurally bound conservative tentative formalisation; visible and viable confirmation; constitutive memberOf priority without a creation block; readable relation direction.
- **Stop-ship conditions:** unsupported claims that representation succeeded; arbitrary predicate attachment; tentative membership activating a namespace; an advertised confirmation path that cannot succeed; cross-actor Q&A disclosure; ordinary Q&A silently replacing canonical notes; regression of ordinary Discuss/history behaviour.
- **Non-blocking observations:** this repository change does not deploy or activate the seed profile in a running environment. The normal deployment reconciliation path performs materialisation and read-back. Existing full-file Python lint debt outside the new/materially rewritten surfaces remains unchanged.
- **Non-goals:** universal free-text formalisation, constitutive relations as creation gates, cross-actor access to another actor’s Q&A session, owner/bootstrap authority redesign, bulk migration of legacy interactions, or deployment.
