### PR TITLE
JVNAUTOSCI-2703 Preserve active turn during history hydration

### DIFF
--- a/src/backend/server/routes/generate_route_support.py
+++ b/src/backend/server/routes/generate_route_support.py
@@ -384,14 +384,17 @@ def _persist_generate_turn_messages(
     if history_user_id:
         if persist_user_message and not user_message_persisted_early:
             with _maybe_span(operation_name="persist_user_message"):
+                user_message = {
+                    "role": "user",
+                    "content": prompt_text,
+                    "author_user_id": user_concept_id,
+                }
+                if request_id:
+                    user_message["turn_id"] = f"u-{request_id}"
                 add_chat_history_message_fn(
                     user_id=history_user_id,
                     session_id=session_id,
-                    message={
-                        "role": "user",
-                        "content": prompt_text,
-                        "author_user_id": user_concept_id,
-                    },
+                    message=user_message,
                     namespace=user_namespace,
                     organisation_concept_id=org_concept_id,
                     role_in_org=role_in_org,
@@ -414,18 +417,21 @@ def _persist_generate_turn_messages(
         if callable(refresh_llm_debug_timing_fn):
             refresh_llm_debug_timing_fn(llm_debug_payload)
         with _maybe_span(operation_name="persist_assistant_message"):
+            assistant_message = {
+                "role": "assistant",
+                "content": response_text,
+                **(
+                    dict(assistant_message_metadata)
+                    if isinstance(assistant_message_metadata, Mapping)
+                    else {}
+                ),
+            }
+            if request_id:
+                assistant_message["turn_id"] = f"a-{request_id}"
             add_chat_history_message_fn(
                 user_id=history_user_id,
                 session_id=session_id,
-                message={
-                    "role": "assistant",
-                    "content": response_text,
-                    **(
-                        dict(assistant_message_metadata)
-                        if isinstance(assistant_message_metadata, Mapping)
-                        else {}
-                    ),
-                },
+                message=assistant_message,
                 llm_debug_data=llm_debug_payload,
                 namespace=user_namespace,
                 organisation_concept_id=org_concept_id,

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -12697,6 +12697,7 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
                     "role": "user",
                     "content": prompt_text,
                     "author_user_id": user_concept_id,
+                    "turn_id": f"u-{request_id}",
                 },
                 namespace=history_namespace,
                 organisation_concept_id=org_concept_id,

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -1630,6 +1630,9 @@ def _split_history_into_segments_with_locations(
             "content": entry.get("content"),
             "timestamp": entry.get("timestamp"),
         }
+        turn_id = entry.get("turn_id")
+        if isinstance(turn_id, str) and turn_id.strip():
+            copied["turn_id"] = turn_id.strip()
         author_user_id = entry.get("author_user_id")
         if not isinstance(author_user_id, str) or not author_user_id.strip():
             author_user_id = None

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -29409,6 +29409,55 @@ function selectRecentChatPair(historyMessages) {
     return eligible.slice(lastUserIndex);
 }
 
+function normaliseChatTurnId(value) {
+    return (typeof value === 'string' && value.trim()) ? value.trim() : null;
+}
+
+function buildChatRequestTurnId(role, requestId) {
+    const normalisedRequestId = normaliseChatTurnId(requestId);
+    if (!normalisedRequestId) {
+        return null;
+    }
+    return `${role === 'assistant' ? 'a' : 'u'}-${normalisedRequestId}`;
+}
+
+function restoreLiveUserTurnAfterHistoryHydration(historyMessages) {
+    const request = getLiveChatRequestForSession(activeChatSessionId);
+    if (
+        !request
+        || !isRequestInActiveChatSession(request)
+        || request.userTurnShouldRender !== true
+    ) {
+        return false;
+    }
+
+    const userTurnId = normaliseChatTurnId(request.userTurnId)
+        || buildChatRequestTurnId('user', request.clientRequestId);
+    const promptText = (typeof request.promptText === 'string' && request.promptText)
+        ? request.promptText
+        : (typeof request.promptRaw === 'string' ? request.promptRaw.trim() : '');
+    if (!userTurnId || !promptText) {
+        return false;
+    }
+
+    const canonicalTurnPresent = historyMessages.some((message) => (
+        normaliseChatTurnId(message?.turn_id) === userTurnId
+    ));
+    if (canonicalTurnPresent) {
+        return false;
+    }
+
+    appendMessage(
+        'User',
+        promptText,
+        userTurnId,
+        false,
+        false,
+        request.userTurnTimestamp || null
+    );
+    return true;
+}
+
 function rehydrateHistory(scrollableField, historyMessages, options = {}) {
     const {
         scrollToBottom = true,
@@ -29509,6 +29558,13 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
     // their user-visible late-result cards after transcript rehydration, which
     // clears the scrollable field after accepting the carrier snapshot.
     _renderLateWorkflowOutcomesForActiveSession();
+
+    // A history request may have started before the active prompt was sent and
+    // finish afterwards. Keep the optimistic user turn as an explicit
+    // session-bound overlay until canonical history contains its stable ID.
+    // The active Thinking card is restored in the animation-frame callback
+    // below, so this preserves the visible user -> Thinking ordering.
+    restoreLiveUserTurnAfterHistoryHydration(historyMessages);
 
     // JVNAUTOSCI-2128: rehydrate the per-conversation ArrowUp recall buffer
     // from history so the most recent user prompt is recallable after a
@@ -37016,6 +37072,12 @@ async function handleSendPrompt(options = {}) {
     )
         ? options.enqueueSubmissionId.trim()
         : createClientRequestId();
+    const userTurnId = buildChatRequestTurnId('user', clientRequestId);
+    const assistantTurnId = buildChatRequestTurnId('assistant', clientRequestId);
+    const userTurnShouldRender = Boolean(
+        !assistantOpening && !observeServerDispatch && promptText
+    );
+    const userTurnTimestamp = userTurnShouldRender ? new Date().toISOString() : null;
     const executionContextBinding = synchroniseLlmExecutionContext();
     const explicitFileCopyConceptId = normaliseTrustedUploadedFileCopyConceptId(
         options?.fileCopyConceptId
@@ -37046,6 +37108,11 @@ async function handleSendPrompt(options = {}) {
         sessionKey: getChatRequestSessionKey(targetSessionId),
         sessionName: targetSessionName,
         promptRaw,
+        promptText,
+        userTurnId,
+        assistantTurnId,
+        userTurnShouldRender,
+        userTurnTimestamp,
         turnKind,
         initiationId,
         promptQueueRecordId,
@@ -37161,13 +37228,9 @@ async function handleSendPrompt(options = {}) {
         syncActiveChatSessionThinkingState();
     }
 
-    // Create turn IDs for user and assistant
-    const userTurnId = `u-${Date.now()}`;
-    const assistantTurnId = `a-${Date.now()}`;
-
     // Add user message to chat with turnId
-    if (isRequestVisible() && !assistantOpening && !observeServerDispatch && promptText) {
-        appendMessage('User', promptText, userTurnId);
+    if (isRequestVisible() && userTurnShouldRender) {
+        appendMessage('User', promptText, userTurnId, false, false, userTurnTimestamp);
         // Fire-and-forget annotate user turn (do not await) - only if toggle is enabled
         const annotationToggle = document.getElementById('annotationToggle');
         if (annotationToggle && annotationToggle.checked) {
@@ -37780,6 +37843,23 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
     const externalActor = (
         options.externalActor && typeof options.externalActor === 'object'
     ) ? options.externalActor : null;
+    const normalisedTurnId = normaliseChatTurnId(turnId);
+    if (normalisedTurnId) {
+        const matchingContainers = Array.from(
+            scrollableField.querySelectorAll('.message-container[data-turn-id]')
+        ).filter((container) => container.dataset.turnId === normalisedTurnId);
+        if (matchingContainers.length > 0) {
+            if (isHistory) {
+                return matchingContainers[0];
+            }
+            matchingContainers.forEach((container) => container.remove());
+            for (let index = transcriptTurns.length - 1; index >= 0; index -= 1) {
+                if (transcriptTurns[index]?.turnId === normalisedTurnId) {
+                    transcriptTurns.splice(index, 1);
+                }
+            }
+        }
+    }
     const renderAsAssistant = sender === 'Von'
         || (isHistory && sender === 'assistant')
         || options.assistantMessage === true;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -7704,6 +7704,178 @@ describe('thinking card toggle accessibility', () => {
         expect(fetchCalls.some(({ url }) => String(url).includes('/finish'))).toBe(false);
     });
 
+    test('preserves the active user turn when a delayed history load finishes after send', async () => {
+        const { getUserContext } = require('../apiService.js');
+        jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+        getUserContext.mockReturnValue({
+            user_id: 'user',
+            org_id: 'org',
+            language: 'en-NZ',
+            gmail_profile: null
+        });
+        document.getElementById('promptInput').value = 'Current prompt';
+
+        let resolveHistory;
+        let resolveGenerate;
+        let clientRequestId = null;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/von/history?')) {
+                return new Promise((resolve) => {
+                    resolveHistory = () => resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            history: [
+                                {
+                                    role: 'user',
+                                    content: 'Previous prompt',
+                                    turn_id: 'u-previous-request',
+                                    timestamp: '2026-09-01T21:31:32Z'
+                                },
+                                {
+                                    role: 'assistant',
+                                    content: 'Previous answer',
+                                    turn_id: 'a-previous-request',
+                                    timestamp: '2026-09-01T21:33:40Z'
+                                }
+                            ],
+                            segments_returned: 1,
+                            total_segments: 1,
+                            has_more_history: false
+                        })
+                    });
+                });
+            }
+            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                const requestBody = JSON.parse(options.body);
+                clientRequestId = requestBody.client_request_id;
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        item: {
+                            queue_id: 'queue-history-race',
+                            session_id: 'thinking-card-test-session',
+                            prompt_raw: 'Current prompt',
+                            client_request_id: clientRequestId,
+                            status: 'queued'
+                        }
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                const requestBody = JSON.parse(options.body);
+                clientRequestId = requestBody.client_request_id;
+                return new Promise((resolve) => {
+                    resolveGenerate = () => resolve({
+                        ok: true,
+                        json: async () => ({
+                            response: 'Current answer',
+                            request_id: clientRequestId,
+                            llm_debug: { request_id: clientRequestId, model: 'test-model' }
+                        })
+                    });
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/api/settings/')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ show_tool_use_during_thinking: true })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/progress/')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 202,
+                    json: async () => ({ status: 'thinking', phase: 'context_build' })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ history_length: 2, authenticated: true })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        const historyPromise = __testOnly_loadChatHistory({ segments: 1 });
+        const sendPromise = sendMessage();
+        for (
+            let flush = 0;
+            flush < 12 && (!clientRequestId || typeof resolveHistory !== 'function');
+            flush += 1
+        ) {
+            await Promise.resolve();
+        }
+
+        expect(clientRequestId).toBeTruthy();
+        expect(typeof resolveHistory).toBe('function');
+        expect(document.querySelectorAll('.user-turn')).toHaveLength(1);
+        expect(document.querySelector('.user-turn').textContent).toContain('Current prompt');
+
+        resolveHistory();
+        await expect(historyPromise).resolves.toBe(true);
+
+        const visibleTurns = Array.from(
+            document.querySelectorAll('#scrollableField .message-container')
+        );
+        expect(visibleTurns).toHaveLength(3);
+        expect(visibleTurns[0].textContent).toContain('Previous prompt');
+        expect(visibleTurns[1].querySelector('.chat-message-text').dataset.originalText).toBe(
+            'Previous answer'
+        );
+        expect(visibleTurns[2].textContent).toContain('Current prompt');
+        expect(visibleTurns[2].dataset.turnId).toBe(`u-${clientRequestId}`);
+        expect(document.querySelectorAll(
+            `.message-container[data-turn-id="u-${clientRequestId}"]`
+        )).toHaveLength(1);
+        expect(document.getElementById('thinkingCardWrapper').getAttribute('aria-hidden')).toBe('false');
+
+        for (let flush = 0; flush < 8 && !resolveGenerate; flush += 1) {
+            await Promise.resolve();
+        }
+        expect(typeof resolveGenerate).toBe('function');
+        resolveGenerate();
+        await expect(sendPromise).resolves.toBeUndefined();
+
+        const currentAnswerTurns = document.querySelectorAll(
+            `.message-container[data-turn-id="a-${clientRequestId}"]`
+        );
+        expect(currentAnswerTurns).toHaveLength(1);
+        expect(currentAnswerTurns[0].querySelector('.chat-message-text').dataset.originalText).toBe(
+            'Current answer'
+        );
+    });
+
+    test('replaces a history projection when live delivery has the same stable turn id', () => {
+        jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+        __testOnly_appendMessage(
+            'Von',
+            'Persisted answer',
+            'a-stable-request',
+            false,
+            true,
+            '2026-09-02T12:28:38Z'
+        );
+        __testOnly_appendMessage(
+            'Von',
+            'Live answer',
+            'a-stable-request',
+            false,
+            false,
+            '2026-09-02T12:28:38Z'
+        );
+
+        const matchingTurns = document.querySelectorAll(
+            '.message-container[data-turn-id="a-stable-request"]'
+        );
+        expect(matchingTurns).toHaveLength(1);
+        expect(matchingTurns[0].querySelector('.chat-message-text').dataset.originalText).toBe(
+            'Live answer'
+        );
+        expect(matchingTurns[0].textContent).not.toContain('(history)');
+    });
+
     test('shows concise critic review from completed thinking card on demand', async () => {
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,

--- a/tests/backend/test_chat_history_service_segments.py
+++ b/tests/backend/test_chat_history_service_segments.py
@@ -326,6 +326,7 @@ def test_get_chat_history_segments_strips_debug_when_requested(monkeypatch):
                 {
                     "role": "assistant",
                     "content": "ok",
+                    "turn_id": "a-req-history-identity",
                     "llm_debug_data": {"model": "demo"},
                 }
             ],
@@ -350,6 +351,7 @@ def test_get_chat_history_segments_strips_debug_when_requested(monkeypatch):
     assert len(segments) == 1
     assert len(segments[0]) == 1
     assert "llm_debug_data" not in segments[0][0]
+    assert segments[0][0]["turn_id"] == "a-req-history-identity"
 
 
 def test_get_chat_history_debug_entry_hydrates_blob_refs(monkeypatch):

--- a/tests/backend/test_generate_route_support_debug_payload_offload.py
+++ b/tests/backend/test_generate_route_support_debug_payload_offload.py
@@ -103,8 +103,50 @@ def test_persist_generate_turn_messages_offloads_tool_message_content(
         stored_tool_message["content"]["schema_version"] == "debug_payload_blob_ref.v1"
     )
     assert stored_tool_message["content"]["field_path"] == "content"
-    assert captured_messages[1] == {"role": "assistant", "content": "answer"}
+    assert captured_messages[1] == {
+        "role": "assistant",
+        "content": "answer",
+        "turn_id": "a-req-tool-offload",
+    }
     assert updated_context == []
+
+
+def test_persist_generate_turn_messages_uses_request_bound_turn_ids() -> None:
+    captured_messages: list[dict[str, Any]] = []
+
+    _persist_generate_turn_messages(
+        history_user_id="#V#michael_witbrock",
+        user_message_persisted_early=False,
+        prompt_text="prompt",
+        user_concept_id="#V#michael_witbrock",
+        session_id="session-stable-turn-ids",
+        tool_messages=[],
+        response_text="answer",
+        llm_debug_info={"request_id": "req-stable-turn-ids"},
+        user_namespace="#V#michael@org",
+        org_concept_id="#V#org",
+        role_in_org=None,
+        current_context=[],
+        truncate_large_tool_results_fn=lambda messages, **_kwargs: messages,
+        add_chat_history_message_fn=lambda **kwargs: captured_messages.append(
+            dict(kwargs["message"])
+        ),
+        limit_context_size_fn=lambda messages, **_kwargs: list(messages),
+    )
+
+    assert captured_messages == [
+        {
+            "role": "user",
+            "content": "prompt",
+            "author_user_id": "#V#michael_witbrock",
+            "turn_id": "u-req-stable-turn-ids",
+        },
+        {
+            "role": "assistant",
+            "content": "answer",
+            "turn_id": "a-req-stable-turn-ids",
+        },
+    ]
 
 
 def test_persist_generate_assistant_opening_does_not_write_a_synthetic_user_message():


### PR DESCRIPTION
## Summary

- preserve the active optimistic user turn when a delayed history response rehydrates the transcript
- give persisted user and assistant messages request-bound stable turn IDs and retain those IDs in history projections
- replace an existing history projection when the matching live assistant result arrives, preventing duplicate rendering

## User outcome

A history refresh that completes while Von is still thinking no longer erases or duplicates the active turn. Historical messages remain ordered before the current user message, followed by the active Thinking card and eventual answer.

## Validation

- `NODE_PATH=/Users/mjw/Development/Von/node_modules /Users/mjw/Development/Von/node_modules/.bin/jest --runInBand --silent src/frontend/web/von_interface/static/js/test/chatTab.test.js` — 276 passed
- targeted backend persistence/history tests — 22 passed
- repository frontend static lint on `chatTab.js` — passed
- headless Chrome against the isolated AgentTest candidate at `http://127.0.0.1:5010/von/`, with delayed history plus mocked queue/generate endpoints — current user turn remained once after rehydration, Thinking remained visible, and terminal assistant turn rendered once; no page errors and no model call
- `git diff --check` — passed

A neighbouring backend test file has 14 failures on both this branch and untouched `main`; the identical authentication/context harness failures are pre-existing and not caused by this change.

## Jira

[JVNAUTOSCI-2703](https://strong-ai-lab.atlassian.net/browse/JVNAUTOSCI-2703)


[JVNAUTOSCI-2703]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ