### PR TITLE
JVNAUTOSCI-2673: Harden structural evidence introspection

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -18469,6 +18469,28 @@ def _conversation_search(**kwargs):
             "authenticated_actor_context_required",
             "Conversation search requires a trusted authenticated user.",
         )
+    filters = (
+        dict(kwargs.get("filters"))
+        if isinstance(kwargs.get("filters"), dict)
+        else {}
+    )
+    name_present = kwargs.get("name_present")
+    if name_present is not None:
+        if not isinstance(name_present, bool):
+            return make_error_response(
+                "conversation_search_failed",
+                "name_present must be true, false, or omitted.",
+            )
+        nested_name_present = filters.get("name_present")
+        if (
+            nested_name_present is not None
+            and nested_name_present is not name_present
+        ):
+            return make_error_response(
+                "conversation_search_failed",
+                "Conflicting name_present values were supplied.",
+            )
+        filters["name_present"] = name_present
     try:
         return search_actor_conversations(
             actor_user_id=str(actor_scope.user_concept_id),
@@ -18476,7 +18498,7 @@ def _conversation_search(**kwargs):
             organisation_concept_id=actor_scope.organisation_concept_id,
             query=kwargs.get("query"),
             match_mode=kwargs.get("match_mode") or "hybrid",
-            filters=kwargs.get("filters") if isinstance(kwargs.get("filters"), dict) else {},
+            filters=filters,
             sort=kwargs.get("sort") or "relevance",
             page_size=kwargs.get("page_size") or 20,
             cursor=_clean_optional_string(kwargs.get("cursor")),
@@ -25147,6 +25169,7 @@ def _conversation_search_input_schema() -> Schema:
         optional={
             "match_mode": (str, type(None)),
             "filters": (dict, type(None)),
+            "name_present": (bool, type(None)),
             "sort": (str, type(None)),
             "page_size": (int, type(None)),
             "cursor": (str, type(None)),
@@ -25159,6 +25182,7 @@ def _conversation_search_input_schema() -> Schema:
         allow_unknown=False,
         description=(
             "Search actor-visible conversation titles and user-visible content. "
+            "Use query='*' with name_present=false to find unnamed conversations; "
             "match_mode is lexical, semantic, or hybrid; pass next_cursor back "
             "unchanged to retrieve the next stable batch."
         ),
@@ -42562,7 +42586,9 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             description=(
                 "Search titles, actor-specific display names, and user-visible "
                 "conversation content for the authenticated actor. Supports lexical, "
-                "semantic, and hybrid retrieval. Results are canonically reauthorised; "
+                "semantic, and hybrid retrieval. Use query='*' with "
+                "name_present=false for typed unnamed-conversation discovery. Results "
+                "are canonically reauthorised; "
                 "each contains a canonical conversation_reference.v1, display name/date, "
                 "available actions, match field, and bounded source locator/snippet. Pass "
                 "next_cursor back unchanged for the next batch. Treat snippets as "

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1798,8 +1798,10 @@ def _tool_definitions() -> list[ToolDefinition]:
                 "Read a selected bounded slice of a prior tool result by its "
                 "turn-scoped evidence handle. Evidence IDs are opaque: copy the "
                 "complete evidence_id exactly from the result or evidence index; "
-                "never reconstruct or shorten it. Select with a JSON pointer, a text "
-                "query, an offset, or any combination. Repeated calls may inspect "
+                "never reconstruct or shorten it. Select with a JSON pointer, a "
+                "case-insensitive text query over keys and non-null scalar values, "
+                "or field_equals for exact structural matching including JSON null. "
+                "Do not put JSON field predicates in query. Repeated calls may inspect "
                 "different portions; the raw result is not discarded. Omit "
                 "json_pointer, use the RFC root pointer (an empty string), or use "
                 "'/' as this model-facing tool's root alias to read the whole result."
@@ -1815,7 +1817,26 @@ def _tool_definitions() -> list[ToolDefinition]:
                             "or use '/' as this tool's root alias for the whole result."
                         ),
                     },
-                    "query": {"type": "string"},
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "Case-insensitive substring match over keys and non-null "
+                            "scalar values. This is not a search over serialised JSON."
+                        ),
+                    },
+                    "field_equals": {
+                        "type": "object",
+                        "description": (
+                            "Exact mapping-field equality predicate. Values must be "
+                            "JSON scalars; use JSON null to find null-valued fields, "
+                            "for example {\"session_name\": null}."
+                        ),
+                        "additionalProperties": {
+                            "type": ["string", "number", "boolean", "null"]
+                        },
+                        "minProperties": 1,
+                        "maxProperties": 20,
+                    },
                     "offset": {"type": "integer", "minimum": 0},
                     "max_chars": {
                         "type": "integer",
@@ -9375,6 +9396,11 @@ def execute_adaptive_turn(
                         query=(
                             str(call.payload.get("query"))
                             if call.payload.get("query") is not None
+                            else None
+                        ),
+                        field_equals=(
+                            dict(call.payload["field_equals"])
+                            if isinstance(call.payload.get("field_equals"), Mapping)
                             else None
                         ),
                         offset=int(call.payload.get("offset") or 0),

--- a/src/backend/services/conversation_search_service.py
+++ b/src/backend/services/conversation_search_service.py
@@ -227,9 +227,14 @@ def search_actor_conversations(
     if sort_mode not in _VALID_SORTS:
         raise ConversationSearchError(f"sort must be one of {sorted(_VALID_SORTS)}.")
     safe_page_size = max(1, min(int(page_size), 100))
+    raw_filters = dict(filters or {})
+    if "name_present" in raw_filters and not isinstance(
+        raw_filters["name_present"], bool
+    ):
+        raise ConversationSearchError("name_present must be true or false.")
     clean_filters = {
         key: value
-        for key, value in dict(filters or {}).items()
+        for key, value in raw_filters.items()
         if key
         in {
             "date_from",

--- a/src/backend/services/turn_evidence_store.py
+++ b/src/backend/services/turn_evidence_store.py
@@ -455,6 +455,95 @@ def _iter_query_matches(
         }
 
 
+def _json_scalar_equals(actual: Any, expected: Any) -> bool:
+    if expected is None:
+        return actual is None
+    if isinstance(expected, bool):
+        return isinstance(actual, bool) and actual is expected
+    if isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        return (
+            isinstance(actual, (int, float))
+            and not isinstance(actual, bool)
+            and actual == expected
+        )
+    return isinstance(actual, type(expected)) and actual == expected
+
+
+def _normalise_field_equals(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("field_equals must be a non-empty object.")
+    if len(value) > 20:
+        raise ValueError("field_equals accepts at most 20 fields.")
+    normalised: dict[str, Any] = {}
+    for raw_field, expected in value.items():
+        if not isinstance(raw_field, str) or not raw_field.strip():
+            raise ValueError("field_equals field names must be non-empty strings.")
+        field = raw_field.strip()
+        if len(field) > 256:
+            raise ValueError("field_equals field names may not exceed 256 characters.")
+        if expected is not None and not isinstance(expected, (str, int, float, bool)):
+            raise ValueError(
+                "field_equals values must be JSON scalars: string, number, boolean, or null."
+            )
+        normalised[field] = expected
+    return normalised
+
+
+def _iter_field_equals_matches(
+    value: Any,
+    field_equals: Mapping[str, Any],
+    *,
+    pointer: str = "",
+    depth: int = 0,
+) -> Iterator[dict[str, Any]]:
+    if depth > 64:
+        return
+    if isinstance(value, Mapping):
+        if all(
+            field in value and _json_scalar_equals(value.get(field), expected)
+            for field, expected in field_equals.items()
+        ):
+            yield {
+                "json_pointer": pointer[:_MAX_QUERY_POINTER_CHARS],
+                "match_kind": "mapping_fields",
+                "matched_fields": sorted(field_equals),
+                "field_values": dict(field_equals),
+            }
+        for key, item in value.items():
+            token = _escape_json_pointer_token(key)
+            yield from _iter_field_equals_matches(
+                item,
+                field_equals,
+                pointer=f"{pointer}/{token}",
+                depth=depth + 1,
+            )
+        return
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        for index, item in enumerate(value):
+            yield from _iter_field_equals_matches(
+                item,
+                field_equals,
+                pointer=f"{pointer}/{index}",
+                depth=depth + 1,
+            )
+
+
+def _parse_structural_query_fragment(query: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(f"{{{query}}}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    try:
+        return _normalise_field_equals(parsed)
+    except ValueError:
+        return None
+
+
 def _bounded_positive_int(
     value: Any,
     *,
@@ -518,7 +607,7 @@ class TurnEvidenceStore:
         value_kind = _value_kind(stored_value)
         selectors = ["offset", "query"]
         if isinstance(stored_value, (Mapping, list, tuple)):
-            selectors.insert(0, "json_pointer")
+            selectors[:0] = ["json_pointer", "field_equals"]
 
         with self._lock:
             while True:
@@ -663,6 +752,81 @@ class TurnEvidenceStore:
                 ),
                 "has_more": has_more,
                 "next_offset": offset + len(matches) if has_more else None,
+                "conclusion": self._selector_conclusion(record),
+            }
+        )
+        return result
+
+    @staticmethod
+    def _selector_conclusion(record: _StoredEvidence) -> dict[str, Any]:
+        diagnostics = record.envelope.source_diagnostics
+        source_coverage_complete = diagnostics.get("coverage_complete")
+        source_has_more = diagnostics.get("has_more")
+        return {
+            "scope": "selected_evidence",
+            "source_coverage_complete": (
+                source_coverage_complete
+                if isinstance(source_coverage_complete, bool)
+                else None
+            ),
+            "source_has_more": (
+                source_has_more if isinstance(source_has_more, bool) else None
+            ),
+            "global_conclusion_supported": (
+                source_coverage_complete is True and source_has_more is not True
+            ),
+        }
+
+    def _read_field_equals(
+        self,
+        record: _StoredEvidence,
+        *,
+        value: Any,
+        field_equals: Mapping[str, Any],
+        json_pointer: str | None,
+        offset: int,
+        max_chars: int,
+    ) -> dict[str, Any]:
+        matches: list[dict[str, Any]] = []
+        has_more = False
+        skipped = 0
+        for match in _iter_field_equals_matches(
+            value,
+            field_equals,
+            pointer=json_pointer or "",
+        ):
+            if skipped < offset:
+                skipped += 1
+                continue
+            candidate_matches = [*matches, match]
+            rendered = json.dumps(
+                candidate_matches,
+                ensure_ascii=True,
+                separators=(",", ":"),
+            )
+            if len(rendered) > max_chars:
+                has_more = True
+                break
+            matches.append(match)
+
+        result = self._slice_metadata(record)
+        result.update(
+            {
+                "selector": {
+                    "json_pointer": json_pointer,
+                    "field_equals": dict(field_equals),
+                    "offset": offset,
+                    "max_chars": max_chars,
+                },
+                "content_format": "field_matches",
+                "matches": matches,
+                "returned_match_count": len(matches),
+                "returned_chars": len(
+                    json.dumps(matches, ensure_ascii=True, separators=(",", ":"))
+                ),
+                "has_more": has_more,
+                "next_offset": offset + len(matches) if has_more else None,
+                "conclusion": self._selector_conclusion(record),
             }
         )
         return result
@@ -673,6 +837,7 @@ class TurnEvidenceStore:
         *,
         json_pointer: str | None = None,
         query: str | None = None,
+        field_equals: Mapping[str, Any] | None = None,
         offset: int = 0,
         max_chars: int = DEFAULT_READ_MAX_CHARS,
         trusted_scope: TrustedTurnScope,
@@ -692,6 +857,26 @@ class TurnEvidenceStore:
             json_pointer if isinstance(json_pointer, str) else None
         )
         clean_query = _clean_optional_text(query)
+        try:
+            clean_field_equals = (
+                _normalise_field_equals(field_equals)
+                if field_equals is not None
+                else None
+            )
+        except ValueError as exc:
+            return {
+                **self._slice_metadata(record),
+                "success": False,
+                "error_code": "invalid_field_equals",
+                "message": str(exc),
+            }
+        if clean_query is not None and clean_field_equals is not None:
+            return {
+                **self._slice_metadata(record),
+                "success": False,
+                "error_code": "conflicting_evidence_selectors",
+                "message": "Use query or field_equals, not both.",
+            }
 
         bounded_offset = _bounded_positive_int(
             offset,
@@ -728,7 +913,32 @@ class TurnEvidenceStore:
                     "json_pointer": clean_pointer,
                 }
 
+        if clean_field_equals is not None:
+            return self._read_field_equals(
+                record,
+                value=selected_value,
+                field_equals=clean_field_equals,
+                json_pointer=clean_pointer,
+                offset=bounded_offset,
+                max_chars=bounded_max_chars,
+            )
+
         if clean_query is not None:
+            structural_recovery = _parse_structural_query_fragment(clean_query)
+            if structural_recovery is not None:
+                return {
+                    **self._slice_metadata(record),
+                    "success": False,
+                    "error_code": "structural_query_requires_field_equals",
+                    "message": (
+                        "query performs case-insensitive text matching over keys and "
+                        "non-null scalar values; use field_equals for exact JSON fields."
+                    ),
+                    "recovery": {
+                        "selector": "field_equals",
+                        "field_equals": structural_recovery,
+                    },
+                }
             return self._read_query(
                 record,
                 value=selected_value,

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -1677,6 +1677,68 @@ class _RootAliasHydrationClient:
         raise AssertionError("unexpected model call")
 
 
+class _FieldEqualsHydrationClient(_RootAliasHydrationClient):
+    def generate_with_tools(
+        self,
+        prompt: str,
+        available_tools: list[Any],
+        **kwargs: Any,
+    ) -> LLMResponse:
+        call_number = len(self.calls)
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "available_tools": list(available_tools),
+                **kwargs,
+            }
+        )
+        if call_number == 0:
+            return LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_invoke_capability",
+                        call_id="field-source",
+                        payload={
+                            "name": "general_read",
+                            "arguments": {"query": "list conversations"},
+                        },
+                    )
+                ],
+                continuation=LLMContinuation(
+                    provider="test",
+                    api_surface="responses",
+                    model="test-model",
+                    response_id="field-source-response",
+                ),
+            )
+        if call_number == 1:
+            envelope = self._latest_tool_output(kwargs)
+            return LLMResponse(
+                text_response="",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="turn_read_evidence",
+                        call_id="field-hydration",
+                        payload={
+                            "evidence_id": envelope["evidence_id"],
+                            "field_equals": {"session_name": None},
+                        },
+                    )
+                ],
+                continuation=LLMContinuation(
+                    provider="test",
+                    api_surface="responses",
+                    model="test-model",
+                    response_id="field-hydration-response",
+                ),
+            )
+        if call_number == 2:
+            self.hydrated_slice = self._latest_tool_output(kwargs)
+            return LLMResponse(text_response="The unnamed conversation was found.")
+        raise AssertionError("unexpected model call")
+
+
 def test_plain_answer_gets_trusted_scope_and_generic_read_doorway() -> None:
     client = _SequenceClient(LLMResponse(text_response="A useful answer."))
     gateway = _gateway(lambda **_kwargs: {"success": True})
@@ -2182,9 +2244,46 @@ def test_model_slash_evidence_pointer_hydrates_the_whole_result() -> None:
         if tool.name == "turn_read_evidence"
     )
     assert "root alias" in read_tool.description
+    assert "field_equals" in read_tool.input_schema["properties"]
+    assert "JSON null" in (
+        read_tool.input_schema["properties"]["field_equals"]["description"]
+    )
     assert "root alias" in (
         read_tool.input_schema["properties"]["json_pointer"]["description"]
     )
+
+
+def test_model_field_equals_hydrates_null_mapping_through_adaptive_tool() -> None:
+    client = _FieldEqualsHydrationClient()
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(
+            lambda **_kwargs: {
+                "coverage_complete": True,
+                "has_more": False,
+                "conversations": [
+                    {"session_id": "unnamed", "session_name": None},
+                    {"session_id": "named", "session_name": "Named conversation"},
+                ],
+            }
+        ),
+        prompt="Find unnamed conversations.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        user_namespace="#V#person@org",
+        user_concept_id="#V#person",
+        org_concept_id="#V#org",
+        turn_id="field-equals-hydration",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.response_text == "The unnamed conversation was found."
+    assert client.hydrated_slice is not None
+    assert client.hydrated_slice["success"] is True
+    assert client.hydrated_slice["matches"][0]["json_pointer"] == "/conversations/0"
+    assert client.hydrated_slice["conclusion"]["global_conclusion_supported"] is True
 
 
 def test_ordinary_delegation_is_actor_capability_not_every_read_method() -> None:

--- a/tests/backend/test_conversation_search_service.py
+++ b/tests/backend/test_conversation_search_service.py
@@ -32,6 +32,54 @@ def _accessible_result(**_kwargs):
     }
 
 
+def test_star_search_filters_unnamed_conversations_structurally(monkeypatch):
+    from src.backend.services import conversation_search_service as service
+
+    monkeypatch.setattr(
+        service,
+        "list_actor_conversations",
+        lambda **_kwargs: {
+            "success": True,
+            "conversations": [
+                {
+                    "session_id": "unnamed",
+                    "session_name": None,
+                    "last_message_at": "2026-09-02T12:00:00+00:00",
+                    "conversation_search_index_version": 1,
+                    "trashed": False,
+                },
+                {
+                    "session_id": "named",
+                    "session_name": "Named conversation",
+                    "last_message_at": "2026-09-02T11:00:00+00:00",
+                    "conversation_search_index_version": 1,
+                    "trashed": False,
+                },
+            ],
+            "has_more": False,
+            "coverage_complete": True,
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "search_conversation_preference_session_ids",
+        lambda **_kwargs: [],
+    )
+
+    result = service.search_actor_conversations(
+        actor_user_id="#V#alice",
+        organisation_concept_id="#V#org",
+        namespace="#V#alice@org",
+        query="*",
+        match_mode="lexical",
+        filters={"name_present": False},
+    )
+
+    assert [row["session_id"] for row in result["results"]] == ["unnamed"]
+    assert result["filters"] == {"name_present": False}
+    assert result["coverage_complete"] is True
+
+
 def test_search_combines_indexed_title_content_and_override_with_stable_cursor(
     monkeypatch,
 ):

--- a/tests/backend/test_internal_mcp_conversation_management.py
+++ b/tests/backend/test_internal_mcp_conversation_management.py
@@ -125,6 +125,7 @@ def test_conversation_search_uses_trusted_actor_scope_and_returns_cursor(monkeyp
             organisation_concept_id="#V#org",
             namespace="#V#alice@org",
             query="detector calibration",
+            name_present=False,
             page_size=25,
         )
 
@@ -132,6 +133,10 @@ def test_conversation_search_uses_trusted_actor_scope_and_returns_cursor(monkeyp
     assert captured["organisation_concept_id"] == "#V#org"
     assert captured["namespace"] == "#V#alice@org"
     assert captured["query"] == "detector calibration"
+    assert captured["filters"] == {"name_present": False}
+    definition = build_default_catalogue().get("conversation_search")
+    assert definition.input_schema.expect("name_present") == (bool, type(None))
+    assert "name_present=false" in definition.description
     _assert_success_schema("conversation_search", payload)
 
 

--- a/tests/backend/test_openai_structured_tool_transport.py
+++ b/tests/backend/test_openai_structured_tool_transport.py
@@ -735,6 +735,15 @@ def test_responses_serialises_actual_adaptive_tools_with_explicit_strictness() -
         read_tool["parameters"]["properties"]["arguments"]["additionalProperties"]
         is True
     )
+    evidence_tool = next(tool for tool in tools if tool["name"] == "turn_read_evidence")
+    assert evidence_tool["strict"] is False
+    field_equals_schema = evidence_tool["parameters"]["properties"]["field_equals"]
+    assert field_equals_schema["additionalProperties"]["type"] == [
+        "string",
+        "number",
+        "boolean",
+        "null",
+    ]
 
 
 def test_responses_maps_reasoning_effort_and_disables_storage(

--- a/tests/backend/test_turn_evidence_store.py
+++ b/tests/backend/test_turn_evidence_store.py
@@ -57,6 +57,7 @@ def test_record_returns_opaque_bounded_provenance_envelope() -> None:
     assert projected["preview_truncated"] is True
     assert projected["available_selectors"] == [
         "json_pointer",
+        "field_equals",
         "offset",
         "query",
     ]
@@ -382,6 +383,99 @@ def test_read_query_returns_bounded_model_selectable_matches() -> None:
     } == {
         "/records/1/name",
         "/records/1/text",
+    }
+
+
+def test_read_field_equals_finds_json_null_without_serialised_text_matching() -> None:
+    scope = _scope()
+    store = TurnEvidenceStore(scope, "turn-structural-null")
+    envelope = store.record(
+        "conversation_list",
+        "call-conversation-list",
+        {
+            "coverage_complete": True,
+            "has_more": False,
+            "conversations": [
+                {"session_id": "unnamed", "session_name": None},
+                {"session_id": "named", "session_name": "Named conversation"},
+            ],
+        },
+    )
+
+    result = store.read(
+        envelope.evidence_id,
+        field_equals={"session_name": None},
+        max_chars=2_000,
+        trusted_scope=scope,
+        turn_id="turn-structural-null",
+    )
+
+    assert result["success"] is True
+    assert result["content_format"] == "field_matches"
+    assert result["returned_match_count"] == 1
+    assert result["matches"] == [
+        {
+            "json_pointer": "/conversations/0",
+            "match_kind": "mapping_fields",
+            "matched_fields": ["session_name"],
+            "field_values": {"session_name": None},
+        }
+    ]
+    assert result["conclusion"]["global_conclusion_supported"] is True
+
+
+def test_structural_text_query_returns_executable_field_equals_recovery() -> None:
+    scope = _scope()
+    store = TurnEvidenceStore(scope, "turn-structural-query")
+    envelope = store.record(
+        "conversation_list",
+        "call-conversation-list",
+        {"conversations": [{"session_name": None}]},
+    )
+
+    for query in ('"session_name":null', '"session_name": null'):
+        result = store.read(
+            envelope.evidence_id,
+            query=query,
+            trusted_scope=scope,
+            turn_id="turn-structural-query",
+        )
+
+        assert result["success"] is False
+        assert result["error_code"] == "structural_query_requires_field_equals"
+        assert result["recovery"] == {
+            "selector": "field_equals",
+            "field_equals": {"session_name": None},
+        }
+
+
+def test_empty_query_on_incomplete_source_cannot_support_global_conclusion() -> None:
+    scope = _scope()
+    store = TurnEvidenceStore(scope, "turn-incomplete-query")
+    envelope = store.record(
+        "conversation_list",
+        "call-incomplete-list",
+        {
+            "coverage_complete": False,
+            "has_more": True,
+            "conversations": [{"session_name": "Named conversation"}],
+        },
+    )
+
+    result = store.read(
+        envelope.evidence_id,
+        query="missing term",
+        trusted_scope=scope,
+        turn_id="turn-incomplete-query",
+    )
+
+    assert result["success"] is True
+    assert result["matches"] == []
+    assert result["conclusion"] == {
+        "scope": "selected_evidence",
+        "source_coverage_complete": False,
+        "source_has_more": True,
+        "global_conclusion_supported": False,
     }
 
 


### PR DESCRIPTION
Merge decision: ready — structural null discovery is typed and recoverable, and incomplete evidence can no longer present as support for a corpus-wide empty conclusion.

## User outcome

When Von searches conversation-list evidence for unnamed conversations, JSON null is handled structurally rather than through a whitespace-sensitive or impossible text query. The model also gets an explicit typed conversation-search route.

## Material changes

- Add `field_equals` to `turn_read_evidence` for exact JSON-scalar predicates, including null.
- Return typed `structural_query_requires_field_equals` recovery for JSON-shaped predicates sent to the text selector.
- Attach conclusion scope and source-coverage sufficiency to query and structural-match results.
- Expose top-level `name_present` on `conversation_search`; document `query="*", name_present=false` as the unnamed-conversation route.
- Reject invalid `name_present` values while preserving the existing nested-filter contract.

Jira: JVNAUTOSCI-2673.

## Evidence

- Consolidated affected run: 327 passed, one existing Google client deprecation warning.
- Covered the complete adaptive-turn suite, evidence store, conversation search, internal MCP catalogue and management, stdio registration, and OpenAI provider schema serialisation.
- `git diff --check`, critical Ruff undefined-name checks, and Python compilation passed.
- Exact regressions cover null matching, whitespace variants, typed recovery, incomplete source coverage, adaptive dispatch, MCP discoverability, and provider transport.

## Ship boundary

- **Minimum ship criteria:** null-valued fields are discoverable without serialised-text matching; structural-looking text queries recover to the typed selector; incomplete source coverage does not support a global conclusion; unnamed conversation search is explicit in the MCP contract.
- **Stop-ship conditions:** regression in existing pointer/text hydration, provider schema transport, actor-scoped conversation search, or false `global_conclusion_supported=true` on incomplete evidence.
- **Non-blocking observations:** the existing 500-candidate accessible window remains honestly reported as incomplete and is not expanded here.
- **Non-goals:** title generation, workflow creation, data migration, deployment, changing actor authority, or completing the broader evidence-bound batch-rename programme.