### PR TITLE
Split Mongo ping latency from server RTT

### DIFF
--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -652,6 +652,7 @@ def get_db_location_info():
         sanitized_uri = _sanitize_mongo_uri_for_display(effective_uri)
         # Attempt a quick ping
         ping_ok = False
+        mongo_ping_latency_ms = None
         error_message = None
         try:
             db = get_db()
@@ -678,6 +679,11 @@ def get_db_location_info():
                     ping_error_type = type(ping_exc).__name__
                     raise
                 finally:
+                    if ping_success:
+                        mongo_ping_latency_ms = round(
+                            (time.perf_counter() - ping_started_at) * 1000.0,
+                            3,
+                        )
                     observe_mongo_operation(
                         service="settings_routes",
                         collection="$cmd",
@@ -725,6 +731,10 @@ def get_db_location_info():
             "sanitized_uri": sanitized_uri,
             "database_name": DATABASE_NAME,
             "ping_ok": ping_ok,
+            # This is measured inside the Von server around the Mongo ping.
+            # Browser-to-server round-trip latency is measured separately by
+            # the frontend and must not be presented as database latency.
+            "mongo_ping_latency_ms": mongo_ping_latency_ms,
             "error": error_message,
             "classification": classification,
             "connection_location": connection_location,

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -358,8 +358,8 @@ let footerDbLoadGeneration = 0;
 let footerServerReachability = null;
 let footerLlmExecutionRefreshScheduled = false;
 let footerWorkflowCapabilityRetryTimerId = null;
-const FOOTER_DB_PROBE_STATS_KEY = 'von_footer_db_probe_stats_v1';
-const FOOTER_DB_PROBE_SAMPLE_LIMIT = 32;
+const FOOTER_SERVER_RTT_STATS_KEY = 'von_footer_server_rtt_stats_v1';
+const FOOTER_SERVER_RTT_SAMPLE_LIMIT = 32;
 const FOOTER_DB_RETRY_MIN_MS = 1500;
 const FOOTER_DB_RETRY_MAX_MS = 20000;
 
@@ -499,10 +499,10 @@ export function setFooterServerReachability(isReachable) {
   }
 }
 
-function readFooterDbProbeStats() {
+function readFooterServerRttStats() {
   const fallback = { successes: 0, failures: 0, samples_ms: [] };
   try {
-    const raw = localStorage.getItem(FOOTER_DB_PROBE_STATS_KEY);
+    const raw = localStorage.getItem(FOOTER_SERVER_RTT_STATS_KEY);
     if (!raw) return fallback;
     const parsed = JSON.parse(raw);
     const samples = Array.isArray(parsed?.samples_ms)
@@ -511,16 +511,16 @@ function readFooterDbProbeStats() {
     return {
       successes: Number.isFinite(Number(parsed?.successes)) ? Math.max(0, Number(parsed.successes)) : 0,
       failures: Number.isFinite(Number(parsed?.failures)) ? Math.max(0, Number(parsed.failures)) : 0,
-      samples_ms: samples.slice(-FOOTER_DB_PROBE_SAMPLE_LIMIT),
+      samples_ms: samples.slice(-FOOTER_SERVER_RTT_SAMPLE_LIMIT),
     };
   } catch (_) {
     return fallback;
   }
 }
 
-function persistFooterDbProbeStats(stats) {
+function persistFooterServerRttStats(stats) {
   try {
-    localStorage.setItem(FOOTER_DB_PROBE_STATS_KEY, JSON.stringify(stats));
+    localStorage.setItem(FOOTER_SERVER_RTT_STATS_KEY, JSON.stringify(stats));
   } catch (_) {
     // Non-fatal: stats persistence is best-effort only.
   }
@@ -534,8 +534,8 @@ function computePercentile(values, percentile) {
   return Number.isFinite(value) ? Math.round(value) : null;
 }
 
-function getFooterDbProbeSummary() {
-  const stats = readFooterDbProbeStats();
+function getFooterServerRttSummary() {
+  const stats = readFooterServerRttStats();
   return {
     sampleCount: stats.samples_ms.length,
     p50Ms: computePercentile(stats.samples_ms, 0.5),
@@ -545,19 +545,19 @@ function getFooterDbProbeSummary() {
   };
 }
 
-function recordFooterDbProbeSuccess(elapsedMs) {
-  const stats = readFooterDbProbeStats();
-  const nextSamples = [...stats.samples_ms, Math.round(elapsedMs)].slice(-FOOTER_DB_PROBE_SAMPLE_LIMIT);
-  persistFooterDbProbeStats({
+function recordFooterServerRttSuccess(elapsedMs) {
+  const stats = readFooterServerRttStats();
+  const nextSamples = [...stats.samples_ms, Math.round(elapsedMs)].slice(-FOOTER_SERVER_RTT_SAMPLE_LIMIT);
+  persistFooterServerRttStats({
     successes: stats.successes + 1,
     failures: stats.failures,
     samples_ms: nextSamples,
   });
 }
 
-function recordFooterDbProbeFailure() {
-  const stats = readFooterDbProbeStats();
-  persistFooterDbProbeStats({
+function recordFooterServerRttFailure() {
+  const stats = readFooterServerRttStats();
+  persistFooterServerRttStats({
     successes: stats.successes,
     failures: stats.failures + 1,
     samples_ms: stats.samples_ms,
@@ -566,7 +566,7 @@ function recordFooterDbProbeFailure() {
 
 function computeFooterDbRetryDelayMs(attempt) {
   const safeAttempt = Math.max(0, Number(attempt) || 0);
-  const summary = getFooterDbProbeSummary();
+  const summary = getFooterServerRttSummary();
   const adaptiveBaseMs = Number.isFinite(summary.p90Ms)
     ? Math.min(6000, Math.max(2000, summary.p90Ms * 8))
     : 2500;
@@ -575,10 +575,10 @@ function computeFooterDbRetryDelayMs(attempt) {
 }
 
 function formatFooterDbRetryHint(attempt, delayMs) {
-  const summary = getFooterDbProbeSummary();
+  const summary = getFooterServerRttSummary();
   const waitSec = Math.max(1, Math.round(delayMs / 1000));
   if (summary.sampleCount > 0 && Number.isFinite(summary.p50Ms) && Number.isFinite(summary.p90Ms)) {
-    return `Waiting for DB status. Retry #${attempt + 1} in ${waitSec}s. Recent db/info latency p50=${summary.p50Ms}ms p90=${summary.p90Ms}ms (n=${summary.sampleCount}).`;
+    return `Waiting for DB status. Retry #${attempt + 1} in ${waitSec}s. Recent browser ↔ Von RTT p50=${summary.p50Ms}ms p90=${summary.p90Ms}ms (n=${summary.sampleCount}).`;
   }
   return `Waiting for DB status. Retry #${attempt + 1} in ${waitSec}s.`;
 }
@@ -873,14 +873,15 @@ function ensureFooterDbLoadingBadge(footer) {
   const badge = document.createElement('span');
   badge.className = 'db-conn-badge loading';
   badge.style.marginLeft = '12px';
-  badge.innerHTML = '<span class="db-label">🕓 Mongo: loading...</span> <span class="db-latency" aria-label="DB latency" title="Waiting for DB status">...</span>';
+  badge.innerHTML = '<span class="db-label">🕓 Mongo: loading...</span> <span class="server-rtt-latency" aria-label="Server round-trip latency" title="Waiting for Von server response">RTT …</span> <span class="db-latency" aria-label="Mongo ping latency" title="Waiting for MongoDB status">DB …</span>';
   setKeptNativeTitle(badge, 'Loading database status...');
-  setKeptNativeTitle(badge.querySelector('.db-latency'), 'Waiting for DB status');
+  setKeptNativeTitle(badge.querySelector('.server-rtt-latency'), 'Waiting for Von server response');
+  setKeptNativeTitle(badge.querySelector('.db-latency'), 'Waiting for MongoDB status');
   footer.appendChild(badge);
   return badge;
 }
 
-function attachFooterDbBadge(footer, dbInfo) {
+function attachFooterDbBadge(footer, dbInfo, initialServerRoundTripMs = null) {
   if (!footer || !dbInfo || typeof dbInfo !== 'object') return;
 
   const sanitized = dbInfo.sanitized_uri || '';
@@ -899,14 +900,21 @@ function attachFooterDbBadge(footer, dbInfo) {
   const buildLabelText = (icon, text) => `${icon} ${text}`;
   const fallbackNote = usingFallback ? ' (fallback)' : '';
   // Build badge content with dedicated label span so we can mutate text later
-  badge.innerHTML = `<span class="db-label">${buildLabelText(labelIcon, `Mongo: ${classification}${fallbackNote}`)}</span> <span class="db-latency" aria-label="DB latency" title="Recent DB ping latency">…</span>`;
-  const latencySpan = () => badge.querySelector('.db-latency');
+  badge.innerHTML = `<span class="db-label">${buildLabelText(labelIcon, `Mongo: ${classification}${fallbackNote}`)}</span> <span class="server-rtt-latency" aria-label="Server round-trip latency" title="Browser to Von server round-trip latency">RTT …</span> <span class="db-latency" aria-label="Mongo ping latency" title="MongoDB ping measured inside the Von server">DB …</span>`;
+  const serverRttSpan = () => badge.querySelector('.server-rtt-latency');
+  const dbLatencySpan = () => badge.querySelector('.db-latency');
   const labelSpan = () => badge.querySelector('.db-label');
   let lastClassification = classification;
   let lastUsingFallback = usingFallback;
   let lastPingOk = !!pingOk;
   let lastServerReachable = normaliseFooterServerReachability(footerServerReachability);
-  let lastMeasuredLatencyMs = null;
+  const normaliseLatencyMs = (value) => {
+    if (value === null || value === undefined || value === '') return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+  };
+  let lastServerRoundTripMs = normaliseLatencyMs(initialServerRoundTripMs);
+  let lastMongoPingLatencyMs = normaliseLatencyMs(dbInfo.mongo_ping_latency_ms);
 
   const status = pingOk ? 'Connected' : 'Unavailable';
   const err = dbInfo.error ? `\nError: ${String(dbInfo.error).slice(0, 300)}` : '';
@@ -981,40 +989,66 @@ function attachFooterDbBadge(footer, dbInfo) {
     return 'normal';
   };
 
-  const applyLatencyState = (state, elapsedMs = null) => {
-    const span = latencySpan();
-    if (!span) return;
+  const formatDbLatency = (latencyMs) => {
+    if (!Number.isFinite(latencyMs)) return null;
+    return latencyMs < 10 ? latencyMs.toFixed(1) : String(Math.round(latencyMs));
+  };
 
-    span.classList.remove('fatal', 'warn', 'slow');
+  const applyLatencyState = (state, serverRoundTripMs = null, mongoPingLatencyMs = null) => {
+    const rttSpan = serverRttSpan();
+    const dbSpan = dbLatencySpan();
+    if (!rttSpan || !dbSpan) return;
+
+    rttSpan.classList.remove('fatal', 'warn', 'slow');
+    dbSpan.classList.remove('fatal', 'warn', 'slow');
 
     if (state === 'fatal_atlas') {
-      span.textContent = 'offline';
-      span.classList.add('fatal');
-      setKeptNativeTitle(span, 'MongoDB Atlas unreachable');
+      dbSpan.textContent = 'DB offline';
+      dbSpan.classList.add('fatal');
+      setKeptNativeTitle(dbSpan, 'MongoDB Atlas unreachable');
+      if (Number.isFinite(serverRoundTripMs)) {
+        rttSpan.textContent = `RTT ${Math.round(serverRoundTripMs)}ms`;
+      } else {
+        rttSpan.textContent = 'RTT …';
+      }
+      setKeptNativeTitle(rttSpan, 'Browser to Von server round-trip latency; the server responded but MongoDB did not');
       return;
     }
 
     if (state === 'server_down_unknown') {
-      span.textContent = 'unknown';
-      span.classList.add('warn');
-      setKeptNativeTitle(span, 'Mongo status unknown because Von server is unreachable');
+      rttSpan.textContent = 'RTT unknown';
+      rttSpan.classList.add('warn');
+      dbSpan.textContent = 'DB unknown';
+      dbSpan.classList.add('warn');
+      setKeptNativeTitle(rttSpan, 'Von server is unreachable, so round-trip latency is unknown');
+      setKeptNativeTitle(dbSpan, 'Mongo status is unknown because the Von server is unreachable');
       return;
     }
 
-    if (!Number.isFinite(elapsedMs)) {
-      span.textContent = '...';
-      setKeptNativeTitle(span, 'Waiting for DB status');
-      return;
-    }
-
-    span.textContent = `${elapsedMs}ms`;
-    span.classList.toggle('warn', elapsedMs > 250);
-    span.classList.toggle('slow', elapsedMs > 600);
-    const summary = getFooterDbProbeSummary();
-    if (summary.sampleCount > 0 && Number.isFinite(summary.p50Ms) && Number.isFinite(summary.p90Ms)) {
-      setKeptNativeTitle(span, `Recent DB latency: ${elapsedMs} ms (p50 ${summary.p50Ms} ms, p90 ${summary.p90Ms} ms, n=${summary.sampleCount})`);
+    if (Number.isFinite(serverRoundTripMs)) {
+      rttSpan.textContent = `RTT ${Math.round(serverRoundTripMs)}ms`;
+      rttSpan.classList.toggle('warn', serverRoundTripMs > 250);
+      rttSpan.classList.toggle('slow', serverRoundTripMs > 600);
+      const summary = getFooterServerRttSummary();
+      if (summary.sampleCount > 0 && Number.isFinite(summary.p50Ms) && Number.isFinite(summary.p90Ms)) {
+        setKeptNativeTitle(rttSpan, `Browser ↔ Von server round trip: ${Math.round(serverRoundTripMs)} ms (p50 ${summary.p50Ms} ms, p90 ${summary.p90Ms} ms, n=${summary.sampleCount}). Includes network, relay, TLS and server request handling.`);
+      } else {
+        setKeptNativeTitle(rttSpan, `Browser ↔ Von server round trip: ${Math.round(serverRoundTripMs)} ms. Includes network, relay, TLS and server request handling.`);
+      }
     } else {
-      setKeptNativeTitle(span, `Recent DB latency: ${elapsedMs} ms`);
+      rttSpan.textContent = 'RTT …';
+      setKeptNativeTitle(rttSpan, 'Waiting for Von server round-trip measurement');
+    }
+
+    const formattedDbLatency = formatDbLatency(mongoPingLatencyMs);
+    if (formattedDbLatency !== null) {
+      dbSpan.textContent = `DB ${formattedDbLatency}ms`;
+      dbSpan.classList.toggle('warn', mongoPingLatencyMs > 100);
+      dbSpan.classList.toggle('slow', mongoPingLatencyMs > 500);
+      setKeptNativeTitle(dbSpan, `MongoDB ping measured inside the Von server: ${formattedDbLatency} ms. A cached status response may show the most recent server-side ping for up to 10 seconds.`);
+    } else {
+      dbSpan.textContent = 'DB …';
+      setKeptNativeTitle(dbSpan, 'Waiting for a server-side MongoDB ping measurement');
     }
   };
 
@@ -1022,31 +1056,36 @@ function attachFooterDbBadge(footer, dbInfo) {
     const nextReachable = normaliseFooterServerReachability(event?.detail?.isReachable);
     if (nextReachable === null) return;
     const state = applyBadgeState(lastPingOk, lastClassification, lastUsingFallback, nextReachable);
-    applyLatencyState(state, lastMeasuredLatencyMs);
+    applyLatencyState(state, lastServerRoundTripMs, lastMongoPingLatencyMs);
   };
 
   document.addEventListener('von:serverReachabilityChanged', handleServerReachabilityChanged);
   const initialState = applyBadgeState(lastPingOk, lastClassification, lastUsingFallback, lastServerReachable);
-  applyLatencyState(initialState, null);
+  applyLatencyState(initialState, lastServerRoundTripMs, lastMongoPingLatencyMs);
 
-  // Latency measurement (lightweight HEAD /db/info ping timing)
+  // The browser measures end-to-end Von server RTT. The response separately
+  // carries Mongo ping latency measured inside the server.
   async function measureLatency() {
-    const span = latencySpan(); if (!span) return;
+    if (!serverRttSpan() || !dbLatencySpan()) return;
     try {
       const t0 = performance.now();
       const resp = await fetch('/api/settings/db/info', { cache: 'no-store', method: 'GET' });
       if (!resp.ok) throw new Error('bad status ' + resp.status);
       const payload = await resp.json().catch(() => null);
       const elapsed = Math.round(performance.now() - t0);
-      lastMeasuredLatencyMs = elapsed;
-      recordFooterDbProbeSuccess(elapsed);
+      lastServerRoundTripMs = elapsed;
+      recordFooterServerRttSuccess(elapsed);
+      const reportedMongoPingLatencyMs = normaliseLatencyMs(payload?.mongo_ping_latency_ms);
+      if (reportedMongoPingLatencyMs !== null) {
+        lastMongoPingLatencyMs = reportedMongoPingLatencyMs;
+      }
       const nextClassification = (payload && typeof payload.classification === 'string') ? payload.classification : lastClassification;
       const nextFallback = (payload && typeof payload.using_fallback === 'boolean') ? payload.using_fallback : lastUsingFallback;
       const nextPingOk = (payload && typeof payload.ping_ok === 'boolean') ? payload.ping_ok : lastPingOk;
       const state = applyBadgeState(!!nextPingOk, nextClassification, !!nextFallback, true);
-      applyLatencyState(state, elapsed);
+      applyLatencyState(state, lastServerRoundTripMs, lastMongoPingLatencyMs);
     } catch (_) {
-      recordFooterDbProbeFailure();
+      recordFooterServerRttFailure();
       const inferredServerReachable = normaliseFooterServerReachability(footerServerReachability);
       const state = applyBadgeState(
         false,
@@ -1054,7 +1093,7 @@ function attachFooterDbBadge(footer, dbInfo) {
         lastUsingFallback,
         inferredServerReachable === null ? false : inferredServerReachable
       );
-      applyLatencyState(state, null);
+      applyLatencyState(state, null, null);
     }
   }
 
@@ -1748,12 +1787,12 @@ export async function setModelInfoFooterText() {
     if (dbLoadGeneration !== footerDbLoadGeneration) return;
 
     if (dbInfo) {
-      recordFooterDbProbeSuccess(requestElapsedMs);
+      recordFooterServerRttSuccess(requestElapsedMs);
       const existingBadge = footer.querySelector('.db-conn-badge');
       if (existingBadge) {
         try { existingBadge.remove(); } catch (_) { /* ignore */ }
       }
-      attachFooterDbBadge(footer, dbInfo);
+      attachFooterDbBadge(footer, dbInfo, requestElapsedMs);
       readinessIssues.delete('db');
       updateFooterReadinessState(footerContainer, readinessIssues);
       clearFooterDbRetryTimer();
@@ -1769,7 +1808,7 @@ export async function setModelInfoFooterText() {
         labelNode.textContent = attempt > 0 ? '🕓 Mongo: retrying...' : '🕓 Mongo: loading...';
       }
     }
-    recordFooterDbProbeFailure();
+    recordFooterServerRttFailure();
 
     const inJest = typeof globalThis.process !== 'undefined' && globalThis.process?.env?.JEST_WORKER_ID;
     if (inJest) return;

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -6857,7 +6857,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     50% { opacity: 1; }
 }
 
-.db-conn-badge.loading .db-latency {
+.db-conn-badge.loading .db-latency,
+.db-conn-badge.loading .server-rtt-latency {
     animation: db-conn-loading-pulse 1.2s ease-in-out infinite;
 }
 
@@ -7000,7 +7001,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     animation: dbBadgeFlash 1.2s ease-in-out infinite;
 }
 
-.db-conn-badge.fatal .db-latency {
+.db-conn-badge.fatal .db-latency,
+.db-conn-badge.fatal .server-rtt-latency {
     padding: 2px 6px;
     margin-left: 6px;
     border-radius: 8px;
@@ -7045,8 +7047,9 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     white-space: nowrap;
 }
 
-/* Latency indicator inside DB badge */
-.db-conn-badge .db-latency {
+/* User-facing server RTT and developer-facing Mongo ping indicators. */
+.db-conn-badge .db-latency,
+.db-conn-badge .server-rtt-latency {
     display: inline-block;
     margin-left: 4px;
     padding: 1px 4px;
@@ -7058,25 +7061,30 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     letter-spacing: 0;
 }
 
-.db-conn-badge.degraded .db-latency {
+.db-conn-badge.degraded .db-latency,
+.db-conn-badge.degraded .server-rtt-latency {
     background: rgba(255, 255, 255, 0.35);
 }
 
-.db-conn-badge.warning .db-latency {
+.db-conn-badge.warning .db-latency,
+.db-conn-badge.warning .server-rtt-latency {
     background: rgba(255, 255, 255, 0.45);
 }
 
-.db-conn-badge .db-latency.warn {
+.db-conn-badge .db-latency.warn,
+.db-conn-badge .server-rtt-latency.warn {
     background: #fde68a;
     color: #92400e;
 }
 
-.db-conn-badge .db-latency.slow {
+.db-conn-badge .db-latency.slow,
+.db-conn-badge .server-rtt-latency.slow {
     background: #fca5a5;
     color: #7f1d1d;
 }
 
-.db-conn-badge.compact .db-latency {
+.db-conn-badge.compact .db-latency,
+.db-conn-badge.compact .server-rtt-latency {
     margin-left: 3px;
     padding: 0 3px;
     font-size: 9px;

--- a/tests/backend/test_mongo_uri_redaction.py
+++ b/tests/backend/test_mongo_uri_redaction.py
@@ -215,6 +215,8 @@ def test_db_info_snapshots_route_after_ping_recovery(monkeypatch) -> None:
     assert payload["fallback_kind"] == "ssh_tunnel"
     assert payload["classification"] == "atlas"
     assert payload["connection_location"]["upstream_sanitized_uri"] == SAFE_URI
+    assert isinstance(payload["mongo_ping_latency_ms"], float)
+    assert payload["mongo_ping_latency_ms"] >= 0.0
     _assert_no_secret_fragments(payload)
 
 

--- a/tests/frontend/footerDbBadgeOutageStates.test.js
+++ b/tests/frontend/footerDbBadgeOutageStates.test.js
@@ -7,10 +7,12 @@ function buildDbInfo({
     classification = 'atlas',
     pingOk = true,
     usingFallback = false,
+    mongoPingLatencyMs = 0.08,
 } = {}) {
     return {
         classification,
         ping_ok: pingOk,
+        mongo_ping_latency_ms: mongoPingLatencyMs,
         using_fallback: usingFallback,
         sanitized_uri: 'mongodb+srv://cluster.example.mongodb.net',
         database_name: 'von_db',
@@ -86,7 +88,7 @@ describe('footer DB badge outage state handling', () => {
         expect(badge.classList.contains('fatal')).toBe(true);
         expect(badge.classList.contains('warning')).toBe(false);
         expect(badge.getAttribute('data-keep-title')).toBe('true');
-        expect(latency?.textContent).toBe('offline');
+        expect(latency?.textContent).toBe('DB offline');
         expect(latency?.getAttribute('data-keep-title')).toBe('true');
         expect(latency?.title).toContain('Atlas unreachable');
     });
@@ -107,9 +109,32 @@ describe('footer DB badge outage state handling', () => {
         expect(badge.classList.contains('warning')).toBe(true);
         expect(badge.classList.contains('fatal')).toBe(false);
         expect(badge.textContent).toContain('Mongo status unknown (Von down)');
-        expect(latency?.textContent).toBe('unknown');
+        expect(latency?.textContent).toBe('DB unknown');
         expect(badge.getAttribute('data-keep-title')).toBe('true');
         expect(latency?.getAttribute('data-keep-title')).toBe('true');
         expect(latency?.title).toContain('Von server is unreachable');
+    });
+
+    test('separates user-facing server RTT from server-side Mongo ping latency', async () => {
+        installFetchMock(buildDbInfo({
+            classification: 'local',
+            pingOk: true,
+            mongoPingLatencyMs: 0.08,
+        }));
+        const { setModelInfoFooterText, setFooterServerReachability } = require(domUtilsPath);
+
+        setFooterServerReachability(true);
+        await setModelInfoFooterText();
+
+        const badge = await waitForDbBadgeReady();
+        const serverRtt = badge?.querySelector('.server-rtt-latency');
+        const dbLatency = badge?.querySelector('.db-latency');
+        expect(badge).toBeTruthy();
+        expect(serverRtt?.textContent).toMatch(/^RTT \d+ms$/);
+        expect(dbLatency?.textContent).toBe('DB 0.1ms');
+        expect(serverRtt?.getAttribute('aria-label')).toBe('Server round-trip latency');
+        expect(dbLatency?.getAttribute('aria-label')).toBe('Mongo ping latency');
+        expect(serverRtt?.title).toContain('Browser ↔ Von server round trip');
+        expect(dbLatency?.title).toContain('measured inside the Von server');
     });
 });


### PR DESCRIPTION
## Summary
- measure Mongo ping latency inside the Von backend
- show browser-to-Von RTT separately from Mongo ping latency in the footer
- preserve distinct outage and accessibility states for both measurements

## Validation
- `pdm run pytest -q tests/backend/test_mongo_uri_redaction.py`
- `npm test -- --runInBand tests/frontend/footerDbBadgeOutageStates.test.js tests/frontend/footerLlmExecutionStatus.test.js tests/frontend/footerLlmServerLink.test.js tests/frontend/footerOrgContextFallback.test.js`
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/domUtils.js`
- rendered browser check on an isolated Von instance