### PR TITLE
Make Von title organisation neutral

### DIFF
--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Von, Strong AI Lab's AI Assistant</title>
+  <title>Von</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 
   <!-- Favicon -->
@@ -70,7 +70,9 @@
         <h1 class="global-organisation-title" title="Current organisation">
           <span class="global-product-name">Von</span>
           <span class="global-organisation-separator" aria-hidden="true">·</span>
-          <span id="headerOrgName">...</span>
+          <!-- Organisation-specific byline, populated from the active
+               Vontology-backed organisation context. -->
+          <span id="headerOrgName" class="global-organisation-byline">...</span>
         </h1>
         <button class="info-icon" id="infoIcon" type="button" title="About this organisation"
           aria-label="About this organisation">i</button>

--- a/tests/frontend/chatConversationLayout.test.js
+++ b/tests/frontend/chatConversationLayout.test.js
@@ -82,6 +82,8 @@ describe('conversation single-scroll layout', () => {
         const headerShell = fragment.querySelector('.global-header-shell');
         const search = headerShell?.querySelector('#globalConceptSearchRegion');
         const organisation = headerShell?.querySelector('.main-container');
+        const productName = organisation?.querySelector('.global-product-name');
+        const organisationByline = organisation?.querySelector('#headerOrgName');
 
         expect(headerShell).toBeTruthy();
         expect(search).toBeTruthy();
@@ -89,7 +91,14 @@ describe('conversation single-scroll layout', () => {
         expect(
             search.compareDocumentPosition(organisation) & Node.DOCUMENT_POSITION_FOLLOWING
         ).toBeTruthy();
-        expect(organisation.querySelector('#headerOrgName')).toBeTruthy();
+        expect(productName?.textContent.trim()).toBe('Von');
+        expect(organisationByline).toBeTruthy();
+        expect(organisationByline.classList.contains('global-organisation-byline')).toBe(true);
+    });
+
+    test('keeps the global document name organisation-neutral', () => {
+        expect(interfaceTemplate).toContain('<title>Von</title>');
+        expect(interfaceTemplate).not.toContain("Strong AI Lab's AI Assistant");
     });
 
     test('keeps the scrollable vertical conversation rail clear of the fixed footer', () => {

--- a/tests/frontend/footerOrgContextFallback.test.js
+++ b/tests/frontend/footerOrgContextFallback.test.js
@@ -4,7 +4,7 @@ const domUtilsPath = '../../src/frontend/web/von_interface/static/js/domUtils.js
 
 describe('footer org context fallback', () => {
     beforeEach(() => {
-        document.body.innerHTML = '<div id="modelInfoFooter"></div>';
+        document.body.innerHTML = '<span id="headerOrgName">...</span><div id="modelInfoFooter"></div>';
         localStorage.clear();
         localStorage.setItem('von_org_context', JSON.stringify({
             concept_id: '#V#the_lu_witbrock_household',
@@ -32,10 +32,13 @@ describe('footer org context fallback', () => {
     });
 
     test('uses von_org_context to render org footer segment', async () => {
-        const { setModelInfoFooterText } = require(domUtilsPath);
+        const { setModelInfoFooterText, updateHeaderOrgName } = require(domUtilsPath);
 
+        updateHeaderOrgName();
         await setModelInfoFooterText();
 
+        expect(document.querySelector('#headerOrgName')?.textContent)
+            .toBe('The Lu Witbrock Household');
         const orgSegment = Array.from(document.querySelectorAll('.footer-segment'))
             .find((seg) => seg.querySelector('.footer-label-inline')?.textContent?.trim() === 'Org:');
         expect(orgSegment).toBeTruthy();


### PR DESCRIPTION
## Summary
- make the global browser document name simply `Von`
- retain the active organisation as the Vontology-backed header byline
- cover a household organisation so SAIL branding cannot leak globally

## Validation
- `npm test -- --runInBand tests/frontend/chatConversationLayout.test.js tests/frontend/footerOrgContextFallback.test.js`
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/domUtils.js`
- isolated server HTML read-back