### PR TITLE
Support Google OAuth behind TLS-terminating proxies

### DIFF
--- a/src/backend/auth_service.py
+++ b/src/backend/auth_service.py
@@ -60,8 +60,10 @@ class GoogleAuthService:
             self.canonical_origin = (
                 f"{parsed_redirect.scheme}://{parsed_redirect.netloc}"
             )
+            self._canonical_netloc = parsed_redirect.netloc.casefold()
         else:
             self.canonical_origin = None
+            self._canonical_netloc = None
         # Persist base path/query so dynamic hosts can reuse the callback path safely.
         self._redirect_path = parsed_redirect.path or "/von/api/auth/google/callback"
         self._redirect_query = (
@@ -132,6 +134,37 @@ class GoogleAuthService:
             self.canonical_origin = (
                 f"{parsed_redirect.scheme}://{parsed_redirect.netloc}"
             )
+            self._canonical_netloc = parsed_redirect.netloc.casefold()
+        else:
+            self.canonical_origin = None
+            self._canonical_netloc = None
+
+    def request_host_matches_canonical_origin(self, host: str) -> bool:
+        """Return whether ``host`` exactly names the configured OAuth origin."""
+        return bool(
+            host
+            and self._canonical_netloc
+            and host.casefold() == self._canonical_netloc
+        )
+
+    def canonicalise_authorization_response_url(self, request_url: str) -> str:
+        """Restore the configured external scheme after trusted TLS termination.
+
+        The rewrite is deliberately limited to the configured callback path on
+        the exact configured host. Requests for any other host or path retain
+        their observed URL and continue through the existing failure path.
+        """
+        configured = urlparse(self.redirect_uri)
+        observed = urlparse(request_url)
+        if (
+            not self.request_host_matches_canonical_origin(observed.netloc)
+            or observed.path != configured.path
+        ):
+            return request_url
+        return observed._replace(
+            scheme=configured.scheme,
+            netloc=configured.netloc,
+        ).geturl()
 
     def allows_dynamic_host(self, host: str) -> bool:
         """Return True when dynamic redirects are enabled and the host is trusted."""

--- a/src/backend/server/routes/auth_routes.py
+++ b/src/backend/server/routes/auth_routes.py
@@ -123,7 +123,10 @@ def login():
         proto = proto or request.scheme
         current_origin = f"{proto}://{request.host}"
         configured = getattr(service, "canonical_origin", None)
-        if configured and current_origin != configured:
+        canonical_host_matches = service.request_host_matches_canonical_origin(
+            request.host
+        )
+        if configured and current_origin != configured and not canonical_host_matches:
             if service.allows_dynamic_host(request.host):
                 new_redirect = service.build_redirect_for_host(proto, request.host)
                 service.update_redirect(new_redirect)
@@ -208,7 +211,10 @@ def callback():
 
     try:
         print(f"[auth_callback] exchanging_code state={received_state}")
-        id_info = service.exchange_code_for_tokens(request.url)
+        authorization_response_url = service.canonicalise_authorization_response_url(
+            request.url
+        )
+        id_info = service.exchange_code_for_tokens(authorization_response_url)
         print(
             f"[auth_callback] id_info_keys={list(id_info.keys()) if id_info else 'None'}"
         )

--- a/tests/backend/test_google_auth_proxy_routes.py
+++ b/tests/backend/test_google_auth_proxy_routes.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+from flask import Flask
+
+from src.backend.server.routes import auth_routes
+
+
+class _ProxyAwareGoogleAuthService:
+    canonical_origin = "https://spark.example.test"
+    redirect_uri = "https://spark.example.test/von/api/auth/google/callback"
+
+    def __init__(self) -> None:
+        self.exchanged_url: str | None = None
+
+    def request_host_matches_canonical_origin(self, host: str) -> bool:
+        return host.casefold() == "spark.example.test"
+
+    def allows_dynamic_host(self, host: str) -> bool:
+        del host
+        return False
+
+    def get_authorization_url(self) -> tuple[str, str]:
+        return (
+            "https://accounts.google.test/o/oauth2/auth?state=proxy-state",
+            "proxy-state",
+        )
+
+    def canonicalise_authorization_response_url(self, request_url: str) -> str:
+        if request_url.startswith("http://spark.example.test/"):
+            return request_url.replace(
+                "http://spark.example.test/",
+                "https://spark.example.test/",
+                1,
+            )
+        return request_url
+
+    def exchange_code_for_tokens(
+        self, authorization_response_url: str
+    ) -> dict[str, str]:
+        self.exchanged_url = authorization_response_url
+        return {"email": "user@example.test", "name": "Example User"}
+
+
+@pytest.fixture
+def app_client(monkeypatch: pytest.MonkeyPatch):
+    app = Flask(__name__)
+    app.secret_key = "proxy-oauth-test-secret"
+    app.config["TESTING"] = True
+    app.register_blueprint(auth_routes.auth_bp, url_prefix="/von")
+    service = _ProxyAwareGoogleAuthService()
+    auth_routes._set_google_auth_service(service)
+    auth_routes._oauth_states.clear()
+    monkeypatch.setattr(
+        auth_routes,
+        "set_current_user_by_email",
+        lambda email, name: {
+            "concept_id": "#V#example_user",
+            "email": email,
+            "name": name,
+        },
+    )
+
+    with app.test_client() as client:
+        yield client, service
+
+    auth_routes._set_google_auth_service(None)
+    auth_routes._oauth_states.clear()
+
+
+def test_login_accepts_internal_http_for_exact_configured_proxy_host(
+    app_client,
+) -> None:
+    client, _ = app_client
+
+    response = client.get(
+        "/von/api/auth/google/login",
+        base_url="http://spark.example.test",
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("https://accounts.google.test/")
+
+
+def test_login_rejects_a_different_proxy_host(app_client) -> None:
+    client, _ = app_client
+
+    response = client.get(
+        "/von/api/auth/google/login",
+        base_url="http://other.example.test",
+    )
+
+    assert response.status_code == 400
+    assert b"Host Mismatch Detected" in response.data
+
+
+def test_callback_exchanges_using_configured_external_https_url(app_client) -> None:
+    client, service = app_client
+    auth_routes._oauth_states["proxy-state"] = {
+        "timestamp": time.time(),
+        "used": False,
+    }
+
+    response = client.get(
+        "/von/api/auth/google/callback?code=abc&state=proxy-state",
+        base_url="http://spark.example.test",
+    )
+
+    assert response.status_code == 302
+    assert service.exchanged_url == (
+        "https://spark.example.test/von/api/auth/google/callback"
+        "?code=abc&state=proxy-state"
+    )

--- a/tests/backend/test_google_auth_service.py
+++ b/tests/backend/test_google_auth_service.py
@@ -97,3 +97,37 @@ def test_google_oauth_clock_skew_env_override_is_bounded(
     _install_dummy_flow(monkeypatch)
 
     assert GoogleAuthService().clock_skew_seconds == expected
+
+
+def test_google_oauth_proxy_canonicalisation_requires_exact_host_and_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_google_oauth_env(monkeypatch)
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI",
+        "https://spark.example.test/von/api/auth/google/callback",
+    )
+    _install_dummy_flow(monkeypatch)
+    service = GoogleAuthService()
+
+    assert service.request_host_matches_canonical_origin("spark.example.test")
+    assert not service.request_host_matches_canonical_origin("other.example.test")
+    assert not service.request_host_matches_canonical_origin("spark.example.test:5000")
+    assert (
+        service.canonicalise_authorization_response_url(
+            "http://spark.example.test/von/api/auth/google/callback?code=abc&state=xyz"
+        )
+        == "https://spark.example.test/von/api/auth/google/callback?code=abc&state=xyz"
+    )
+    assert (
+        service.canonicalise_authorization_response_url(
+            "http://other.example.test/von/api/auth/google/callback?code=abc"
+        )
+        == "http://other.example.test/von/api/auth/google/callback?code=abc"
+    )
+    assert (
+        service.canonicalise_authorization_response_url(
+            "http://spark.example.test/not-the-callback?code=abc"
+        )
+        == "http://spark.example.test/not-the-callback?code=abc"
+    )


### PR DESCRIPTION
## Summary
- accept the configured OAuth origin when the incoming host exactly matches but TLS was terminated upstream
- canonicalise the callback URL to the configured HTTPS scheme before exchanging the code
- retain fail-closed behaviour for different hosts and paths

## Validation
- 41 targeted and neighbouring authentication tests passed
- Python compilation and diff checks passed