### PR TITLE
JVNAUTOSCI-2704: Drive user identity from login

### DIFF
--- a/docs/engineering/frontend_browser_user_view_validation.md
+++ b/docs/engineering/frontend_browser_user_view_validation.md
@@ -6,7 +6,7 @@
   apply it at the validation tier justified by the claim
 - **Created:** 2026-04-06
 - **Last substantive content update before this metadata review:** 2026-06-08
-- **Last reviewed:** 2026-07-25
+- **Last reviewed:** 2026-09-02
 - **Evidence boundary:** Each acceptance claim still requires its own dated
   user-view evidence
 
@@ -122,12 +122,17 @@ Important:
   - `VON_BROWSER_TEST_PSEUDOUSER_CONCEPT_ID`
   - `VON_BROWSER_TEST_ORGANISATION_CONCEPT_ID`
 - restart Von so the launcher picks the values up from `.env`;
-- open the Settings tab in a browser served directly from `localhost` or
+- open the main Von page in a browser served directly from `localhost` or
   `127.0.0.1`;
-- confirm the Settings authentication area reports the browser-test mode
-  status, target pseudouser identity, and any unavailable reason before trying
-  to log in;
-- use the `Browser Test Login` control in the authentication area.
+- while signed out, confirm that the sign-in gate replaces the working home UI
+  and reports whether browser-test login is available;
+- use the `Browser test login` control on that gate, then confirm the normal
+  home UI appears and Settings shows the resulting identity read-only.
+
+If the canonical authentication-status request fails or times out, the gate
+must remain closed and expose `Retry status check`. Treat this as an unknown
+transport result, not as confirmed logout: a saved actor-bound organisation
+preference may remain inert until status is recovered.
 
 This route is intentionally:
 
@@ -160,8 +165,8 @@ Repeated use is designed to be stable rather than destructive:
 - unread fixture messages are reset to unread so the Messages pane remains
   useful for acceptance checks.
 
-If the `Browser Test Login` button is missing, do not assume the feature is
-absent. Check the status line in the Settings authentication area first. The
+If the `Browser test login` button is missing, do not assume the feature is
+absent. Check the status text on the signed-out home gate first. The
 running app should now report whether browser-test auth is:
 
 - available;

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -3,7 +3,7 @@
 - **Kind:** Security guidance with dated deployment-posture observations
 - **Lifecycle:** Active
 - **Authority:** Canonical security guidance routed by [`AGENTS.md`](../../AGENTS.md)
-- **Last reviewed:** 23 August 2026
+- **Last reviewed:** 2 September 2026
 - **Evidence boundary:** Statements about current users, deployments, and
   implemented controls are dated observations and must be revalidated; the
   security requirements do not expire merely because implementation evidence
@@ -128,12 +128,21 @@ if not user_concept_id:
     # RAG tools will return "namespace_required" error
 ```
 
-**Unauthenticated User Experience**:
-- ✅ Can still use chat interface (no RAG access)
-- ✅ Agent is **informed** about authentication status
-- ✅ Agent explains RAG tools require login
-- ✅ No access to user-scoped data (RAG, sessions, history)
-- ✅ Clear error messages guide user to log in
+**Unauthenticated browser experience**:
+- The main Von page is replaced by a sign-in gate.
+- Chat, search, Messages, Settings, and actor-scoped background work are not
+  initialised until the server session reports both authentication and a
+  resolved Von user concept.
+- Browser storage is only a compatibility projection of the login-bound actor;
+  it cannot select or replace that actor.
+- Authentication-status transport failures leave the application fail-closed
+  and offer retry without treating an unknown result as logout or erasing the
+  last actor-bound organisation preference.
+- User-scoped Settings profile and recommendation-review routes require a
+  matching authenticated session actor (or the existing explicit privileged
+  role); legacy endpoints that enumerated or fabricated users are absent.
+- Explicitly public, read-only API or knowledge surfaces may remain available
+  separately; the home gate is not a substitute for endpoint authorisation.
 
 **Important limitation**:
 
@@ -632,6 +641,15 @@ be added before broader external contribution or partner deployment.
 
 ## Change Log
 
+- **2026-09-02**: Documented the login-gated main browser experience
+  - Made the authenticated server session authoritative for the Settings user
+    identity instead of a browser-selected list
+  - Recorded that actor-scoped home modules do not initialise while signed out
+  - Made user-scoped recommendation routes fail closed and removed legacy
+    enumerated or fabricated-user endpoints
+  - Distinguished an unavailable authentication-status read from confirmed
+    logout, retaining inert browser scope mirrors while the gate offers retry
+  - Preserved organisation selection as a separate actor-bound scope choice
 - **2026-08-22**: Documented model-selectable governed creation scope and
   independent publication-scope controls
   - Kept omitted ordinary-turn creation actor-private while allowing explicit

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1049,7 +1049,7 @@ def _get_context(**kwargs):
         "language": get_preferred_language(),
         "fetch_counts_on_load": get_setting("fetch_counts_on_load"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "note": "User and organisation context managed client-side (localStorage) per JVNAUTOSCI-628",
+        "note": "Browser user identity is derived from the authenticated server session; organisation selection may remain window-scoped.",
     }
 
     # Try to get user info if available (deprecated, but kept for backward compatibility)
@@ -39022,11 +39022,11 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                     "note": (str, type(None)),
                 },
                 allow_unknown=True,
-                description="get_context output: context info including user, org, llm_model (string), llm_provider, language. User/org managed client-side per JVNAUTOSCI-628.",
+                description="get_context output: server-visible context including user, organisation, llm_model (string), llm_provider, and language. Browser user identity is login-derived; organisation selection may be window-scoped.",
             ),
             category="read",
             ordinary_turn_excluded_reason="server_runtime_context",
-            description="Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. NOTE: User and organisation information is managed client-side (localStorage) per JVNAUTOSCI-628 and may not be available here. Use when you need to know what model/language is configured.",
+            description="Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. Browser user identity is derived from the authenticated session; organisation selection may be window-scoped and unavailable here. Use when you need to know what model/language is configured.",
         ),
         MethodDefinition(
             name="get_client_capabilities",

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1307,7 +1307,7 @@ async def _handle_get_context(arguments: dict[str, Any]) -> list[TextContent]:
         "language_preference": get_preferred_language(),
         "fetch_counts_on_load": get_setting("fetch_counts_on_load"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "note": "User and organisation context managed client-side (localStorage) per JVNAUTOSCI-628",
+        "note": "Standalone stdio has no browser login session; any explicit user or organisation context is caller-scoped.",
     }
     return [_json_text(context)]
 

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -2860,7 +2860,7 @@
         },
         {
             "name": "get_context",
-            "description": "Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. NOTE: User and organisation information is managed client-side (localStorage) per JVNAUTOSCI-628 and may not be available here. Use when you need to know what model/language is configured.",
+            "description": "Get current server-side context: active LLM model (string), provider, language preference, and runtime settings. Browser user identity is derived from the authenticated session; organisation selection may be window-scoped and unavailable here. Use when you need to know what model/language is configured.",
             "inputSchema": {
                 "type": "object",
                 "properties": {},

--- a/src/backend/server/routes/settings_routes.py
+++ b/src/backend/server/routes/settings_routes.py
@@ -5,10 +5,7 @@ import time
 from datetime import datetime, timezone
 from flask import Blueprint, request, jsonify, current_app, send_file, session
 import tempfile
-from ...vontology.utils_vontology import (
-    get_concept_notes,
-    EXAMPLE_USER_CONCEPT_ID,
-)  # relative import
+from ...vontology.utils_vontology import get_concept_notes  # relative import
 from typing import Optional, Tuple, Dict, Any, Mapping
 from werkzeug.datastructures import FileStorage
 from ...services.settings_service import (
@@ -384,19 +381,14 @@ def _authorise_active_llm_scope(
 
 
 def _can_access_user_scoped_profile(user_concept_id: str) -> bool:
-    """Allow the current user (or admin/owner) to access a user-scoped profile.
-
-    When no session user is established yet, remain permissive so the existing
-    settings flow can bootstrap the selected user context before the profile is
-    first loaded.
-    """
+    """Allow only the authenticated user (or admin/owner) to access a profile."""
 
     requested_id = str(user_concept_id or "").strip()
     if not requested_id:
         return False
     session_user_id = str(session.get("user_concept_id") or "").strip()
     if not session_user_id:
-        return True
+        return False
     return session_user_id == requested_id or _is_admin_or_owner_session()
 
 
@@ -1033,9 +1025,10 @@ def _get_entity_with_fallback(
 
 
 def get_all_settings_data():
-    """Get all settings (user/org/language now excluded - browser-local).
+    """Get settings that are independent of login-derived actor identity.
 
-    Uses batch DB fetch to reduce ~10 individual queries to 1.
+    Organisation and language remain separate actor preferences. Uses a batch
+    DB fetch to reduce ~10 individual queries to 1.
     """
     try:
         # Batch fetch all DB-stored settings in one query
@@ -2829,80 +2822,6 @@ def verify_ollama_host():
         )
 
 
-@settings_bp.route("/people", methods=["GET"])
-def get_available_people():
-    """API endpoint to retrieve all available person entities for selection."""
-    try:
-        if ConceptsRepository.collection() is None:
-            current_app.logger.warning(
-                "People selector unavailable: concepts collection could not be reached."
-            )
-            response = _jsonify_no_store(
-                {
-                    "error": "People are temporarily unavailable. Please retry shortly.",
-                    "retryable": True,
-                    "reason": "concepts_collection_unavailable",
-                    "retry_after_seconds": 5,
-                },
-                503,
-            )
-            response.headers["Retry-After"] = "5"
-            return response
-
-        # Get all Von user entities by using the specific Von user concept ID
-        concepts, total_count = list_concepts(
-            concept_id="#V#von_user",  # Use the specific Von user concept ID
-            sort_by="name",
-            sort_order=1,  # Ascending
-            per_page=100,  # Get a reasonable number of users
-        )
-
-        # Filter and format for dropdown - use simple name extraction without per-concept DB calls
-        people_options = []
-        for concept in concepts:
-            # Use get_concept_display_name_with_names_fallback directly on existing data
-            # without expensive enrichment (avoids O(n) DB calls)
-            from ...vontology.utils_vontology import (
-                get_concept_display_name_with_names_fallback,
-            )
-
-            display_name = get_concept_display_name_with_names_fallback(concept)
-            people_options.append(
-                {
-                    "id": concept.get("_id"),
-                    "concept_id": concept.get("concept_id"),
-                    "name": display_name or "Unknown",
-                    "notes": (get_concept_notes(concept) or "")[
-                        :100
-                    ],  # Truncate notes for display
-                    "concept_type": concept.get("direct_concept_name", "Person"),
-                    "system_tags": concept.get(
-                        "system_tags", []
-                    ),  # Include system_tags for filtering
-                }
-            )
-
-        return (
-            jsonify(
-                {
-                    "people": people_options,
-                    "total_count": len(people_options),
-                    "available": True,
-                }
-            ),
-            200,
-        )
-
-    except Exception as e:
-        current_app.logger.error(
-            f"Error retrieving people for selection: {e}", exc_info=True
-        )
-        return (
-            jsonify({"error": "An unexpected error occurred while retrieving people."}),
-            500,
-        )
-
-
 @settings_bp.route("/organisations", methods=["GET"])
 def get_available_organisations():
     """API endpoint to retrieve all available organisation entities for selection."""
@@ -3739,46 +3658,6 @@ def _serialize_document(doc):
         return doc.isoformat()
     else:
         return doc
-
-
-@settings_bp.route("/user/current", methods=["GET"])
-def get_current_user():
-    """Return current user / organisation context placeholder values.
-
-    Post JVNAUTOSCI-628: Server-side user/org storage removed - client localStorage
-    is now sole authority. This endpoint returns placeholder values for backward
-    compatibility with any remaining frontend code.
-    """
-    try:
-        user_id = session.get("user_concept_id", EXAMPLE_USER_CONCEPT_ID)
-        user_name = session.get("user_name", "Default User")
-        org_id = session.get("organisation_concept_id", "#V#example_organization")
-        org_name = session.get("organisation_name", "Example Organization")
-
-        return (
-            jsonify(
-                {
-                    "user_id": user_id,
-                    "username": user_name,
-                    "organization_id": org_id,
-                    "organization_name": org_name,
-                }
-            ),
-            200,
-        )
-    except Exception as e:
-        current_app.logger.error(f"Error getting current user: {e}", exc_info=True)
-        return (
-            jsonify(
-                {
-                    "user_id": EXAMPLE_USER_CONCEPT_ID,
-                    "username": "Default User",
-                    "organization_id": "#V#example_organization",
-                    "organization_name": "Example Organization",
-                }
-            ),
-            200,
-        )
 
 
 @settings_bp.route("/metrics/deprecations", methods=["GET"])

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -190,7 +190,9 @@ RAG_LLM_SETTING_NAME = "rag_llm"
 # CURRENT_ORGANISATION_SETTING_NAME = "current_organisation_id"
 OLLAMA_HOSTS_LIST_SETTING_NAME = "ollama_hosts_list"
 ACTIVE_OLLAMA_HOST_SETTING_NAME = "active_ollama_host"
-# Removed: CURRENT_USER_PERSON_CONCEPT_SETTING_NAME, CURRENT_ORGANISATION_* constants (client localStorage authority)
+# Removed: CURRENT_USER_PERSON_CONCEPT_SETTING_NAME; authenticated session identity
+# replaces a mutable global user setting. CURRENT_ORGANISATION_* remains
+# browser-managed compatibility state.
 PREFERRED_LANGUAGE_SETTING_NAME = "preferred_language"
 FETCH_COUNTS_ON_LOAD_SETTING_NAME = "fetch_counts_on_load"
 PRELOAD_VONTOLOGY_TREE_SETTING_NAME = "preload_vontology_tree"
@@ -1662,7 +1664,8 @@ def get_current_user_person_concept_id() -> Optional[str]:  # legacy accessor
     return None
 
 
-# Removed: get/set_current_user_person_concept_id functions (client localStorage authority)
+# Legacy accessors now project only the authenticated session identity; browser
+# state is not an authority for the current user.
 
 
 # The following functions are deprecated as organisation is managed on the client.

--- a/src/frontend/web/von_interface/static/js/homeAuthGate.js
+++ b/src/frontend/web/von_interface/static/js/homeAuthGate.js
@@ -1,0 +1,324 @@
+const AUTH_STATUS_ENDPOINT = '/von/api/auth/status';
+const AUTH_REQUEST_TIMEOUT_MS = 10000;
+const AUTH_LOGIN_TIMEOUT_MS = 60000;
+
+function getFetch(fetchImpl, windowObject) {
+  if (typeof fetchImpl === 'function') return fetchImpl;
+  if (typeof windowObject?.fetch === 'function') {
+    return windowObject.fetch.bind(windowObject);
+  }
+  throw new Error('Authentication status cannot be checked in this browser.');
+}
+
+async function readJsonResponse(response) {
+  if (!response?.ok) {
+    throw new Error(`Authentication request failed (${response?.status || 'unknown status'}).`);
+  }
+  return response.json();
+}
+
+async function requestAuthJson(request, url, options, {
+  windowObject,
+  timeoutMs = AUTH_REQUEST_TIMEOUT_MS,
+} = {}) {
+  const setTimer = windowObject?.setTimeout?.bind(windowObject) || globalThis.setTimeout;
+  const clearTimer = windowObject?.clearTimeout?.bind(windowObject) || globalThis.clearTimeout;
+  const AbortControllerClass = windowObject?.AbortController || globalThis.AbortController;
+  const controller = typeof AbortControllerClass === 'function'
+    ? new AbortControllerClass()
+    : null;
+  let timer = null;
+
+  const timeout = new Promise((_, reject) => {
+    timer = setTimer(() => {
+      const timeoutError = new Error('Authentication request timed out. Retry the status check.');
+      reject(timeoutError);
+      controller?.abort(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    const response = await Promise.race([
+      request(url, {
+        ...options,
+        ...(controller ? { signal: controller.signal } : {}),
+      }),
+      timeout,
+    ]);
+    return await readJsonResponse(response);
+  } finally {
+    if (timer !== null) clearTimer(timer);
+  }
+}
+
+export function hasAuthenticatedVonActor(authStatus) {
+  return authStatus?.authenticated === true
+    && typeof authStatus?.user_concept_id === 'string'
+    && authStatus.user_concept_id.trim().length > 0;
+}
+
+export function shouldClearHomeIdentityMirrors(authStatus) {
+  return authStatus?.authenticated === false
+    || (authStatus?.authenticated === true && !hasAuthenticatedVonActor(authStatus));
+}
+
+export async function fetchHomeAuthStatus({
+  fetchImpl,
+  windowObject = window,
+  timeoutMs = AUTH_REQUEST_TIMEOUT_MS,
+} = {}) {
+  const request = getFetch(fetchImpl, windowObject);
+  return requestAuthJson(request, AUTH_STATUS_ENDPOINT, {
+    cache: 'no-store',
+    credentials: 'same-origin',
+  }, { windowObject, timeoutMs });
+}
+
+function setGateMessage(documentObject, message, kind = 'info') {
+  const status = documentObject.getElementById('vonAuthenticationGateStatus');
+  if (!status) return;
+  status.textContent = message;
+  status.dataset.kind = kind;
+}
+
+function setGateBusy(documentObject, busy) {
+  const gate = documentObject.getElementById('vonAuthenticationGate');
+  if (gate) gate.setAttribute('aria-busy', busy ? 'true' : 'false');
+  for (const id of ['vonGoogleLoginButton', 'vonBrowserTestLoginButton', 'vonAuthRetryButton']) {
+    const button = documentObject.getElementById(id);
+    if (button) button.disabled = !!busy;
+  }
+}
+
+export function applyHomeAuthState(authStatus, { documentObject = document } = {}) {
+  const authenticated = hasAuthenticatedVonActor(authStatus);
+  const gate = documentObject.getElementById('vonAuthenticationGate');
+  const app = documentObject.getElementById('vonAuthenticatedApp');
+  const browserTestButton = documentObject.getElementById('vonBrowserTestLoginButton');
+  const retryButton = documentObject.getElementById('vonAuthRetryButton');
+  const body = documentObject.body;
+
+  if (gate) {
+    gate.hidden = authenticated;
+    gate.setAttribute('aria-busy', 'false');
+  }
+  if (app) {
+    app.hidden = !authenticated;
+    app.setAttribute('aria-hidden', authenticated ? 'false' : 'true');
+  }
+  if (body) {
+    body.classList.toggle('von-authenticated', authenticated);
+    body.classList.toggle('von-signed-out', !authenticated);
+    body.classList.remove('von-auth-pending');
+  }
+  if (browserTestButton) {
+    browserTestButton.hidden = authenticated || authStatus?.browser_test_mode?.available !== true;
+  }
+  if (retryButton) retryButton.hidden = true;
+
+  if (!authenticated) {
+    setGateBusy(documentObject, false);
+    setGateMessage(
+      documentObject,
+      authStatus?.authenticated === true
+        ? 'Your login succeeded, but Von could not resolve a user identity. Sign in again or retry the status check.'
+        : 'Sign in to establish your identity and continue to Von.',
+      authStatus?.authenticated === true ? 'error' : 'info',
+    );
+  }
+
+  return authenticated;
+}
+
+export function applyHomeAuthUnavailable(error, { documentObject = document } = {}) {
+  applyHomeAuthState({ authenticated: false }, { documentObject });
+  const retryButton = documentObject.getElementById('vonAuthRetryButton');
+  if (retryButton) retryButton.hidden = false;
+  setGateMessage(
+    documentObject,
+    error?.message
+      ? `Von could not confirm your sign-in: ${error.message}`
+      : 'Von could not confirm your sign-in. Retry before continuing.',
+    'error',
+  );
+}
+
+export async function exchangeGoogleAuthToken(token, {
+  fetchImpl,
+  windowObject = window,
+  timeoutMs = AUTH_LOGIN_TIMEOUT_MS,
+} = {}) {
+  const cleanToken = typeof token === 'string' ? token.trim() : '';
+  if (!cleanToken) return null;
+  const request = getFetch(fetchImpl, windowObject);
+  return requestAuthJson(request, '/von/api/auth/exchange-token', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: cleanToken }),
+  }, { windowObject, timeoutMs });
+}
+
+export async function loginWithBrowserTestIdentity({
+  fetchImpl,
+  windowObject = window,
+  timeoutMs = AUTH_LOGIN_TIMEOUT_MS,
+} = {}) {
+  const request = getFetch(fetchImpl, windowObject);
+  return requestAuthJson(request, '/von/api/auth/browser-test-login', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  }, { windowObject, timeoutMs });
+}
+
+function openGoogleLoginPopup(windowObject) {
+  const width = 500;
+  const height = 650;
+  const left = Math.max(0, Math.round((windowObject.screen?.width || width) / 2 - width / 2));
+  const top = Math.max(0, Math.round((windowObject.screen?.height || height) / 2 - height / 2));
+  return windowObject.open(
+    '/von/api/auth/google/login',
+    'vonGoogleLogin',
+    `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`,
+  );
+}
+
+async function confirmAuthenticatedActor({ fetchImpl, windowObject }) {
+  const authStatus = await fetchHomeAuthStatus({ fetchImpl, windowObject });
+  if (!hasAuthenticatedVonActor(authStatus)) {
+    throw new Error('The server did not confirm a signed-in Von identity.');
+  }
+  return authStatus;
+}
+
+function bindHomeAuthActions({
+  authStatus,
+  documentObject,
+  windowObject,
+  fetchImpl,
+  onAuthenticated,
+}) {
+  const googleButton = documentObject.getElementById('vonGoogleLoginButton');
+  const browserTestButton = documentObject.getElementById('vonBrowserTestLoginButton');
+  const retryButton = documentObject.getElementById('vonAuthRetryButton');
+
+  if (retryButton && retryButton.dataset.authBound !== 'true') {
+    retryButton.dataset.authBound = 'true';
+    retryButton.addEventListener('click', () => windowObject.location.reload());
+  }
+
+  if (browserTestButton) {
+    browserTestButton.hidden = authStatus?.browser_test_mode?.available !== true;
+    if (browserTestButton.dataset.authBound !== 'true') {
+      browserTestButton.dataset.authBound = 'true';
+      browserTestButton.addEventListener('click', async () => {
+        setGateBusy(documentObject, true);
+        setGateMessage(documentObject, 'Signing in with the browser test identity…');
+        try {
+          await loginWithBrowserTestIdentity({ fetchImpl, windowObject });
+          const confirmed = await confirmAuthenticatedActor({ fetchImpl, windowObject });
+          onAuthenticated(confirmed);
+        } catch (error) {
+          setGateBusy(documentObject, false);
+          setGateMessage(documentObject, error?.message || 'Browser test login failed.', 'error');
+        }
+      });
+    }
+  }
+
+  if (!googleButton || googleButton.dataset.authBound === 'true') return;
+  googleButton.dataset.authBound = 'true';
+  googleButton.addEventListener('click', () => {
+    const popup = openGoogleLoginPopup(windowObject);
+    if (!popup) {
+      setGateMessage(documentObject, 'The sign-in window was blocked. Allow pop-ups and try again.', 'error');
+      return;
+    }
+
+    setGateBusy(documentObject, true);
+    setGateMessage(documentObject, 'Complete sign-in in the Google window…');
+    let completed = false;
+    let closeTimer = null;
+
+    const cleanup = () => {
+      windowObject.removeEventListener('message', handleMessage);
+      if (closeTimer !== null) windowObject.clearInterval(closeTimer);
+    };
+
+    const finish = async (token = null) => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      try {
+        let exchangeError = null;
+        if (token) {
+          try {
+            await exchangeGoogleAuthToken(token, { fetchImpl, windowObject });
+          } catch (error) {
+            // The callback may already have established the same-origin session;
+            // the canonical status read below decides whether login succeeded.
+            exchangeError = error;
+          }
+        }
+        let confirmed;
+        try {
+          confirmed = await confirmAuthenticatedActor({ fetchImpl, windowObject });
+        } catch (statusError) {
+          throw exchangeError || statusError;
+        }
+        onAuthenticated(confirmed);
+      } catch (error) {
+        completed = false;
+        setGateBusy(documentObject, false);
+        setGateMessage(documentObject, error?.message || 'Sign-in did not complete.', 'error');
+      }
+    };
+
+    const handleMessage = (event) => {
+      if (event.origin !== windowObject.location.origin) return;
+      if (event.data?.type !== 'googleLoginSuccess') return;
+      void finish(event.data?.authToken || null);
+    };
+
+    windowObject.addEventListener('message', handleMessage);
+    closeTimer = windowObject.setInterval(() => {
+      if (!popup.closed) return;
+      void finish();
+    }, 500);
+    try { popup.focus(); } catch { }
+  });
+}
+
+export async function initialiseHomeAuthentication({
+  documentObject = document,
+  windowObject = window,
+  fetchImpl,
+  onAuthenticated = () => windowObject.location.reload(),
+} = {}) {
+  try {
+    const authStatus = await fetchHomeAuthStatus({ fetchImpl, windowObject });
+    const authenticated = applyHomeAuthState(authStatus, { documentObject });
+    if (!authenticated) {
+      bindHomeAuthActions({
+        authStatus,
+        documentObject,
+        windowObject,
+        fetchImpl,
+        onAuthenticated,
+      });
+    }
+    return authStatus;
+  } catch (error) {
+    applyHomeAuthUnavailable(error, { documentObject });
+    bindHomeAuthActions({
+      authStatus: null,
+      documentObject,
+      windowObject,
+      fetchImpl,
+      onAuthenticated,
+    });
+    return null;
+  }
+}

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -11,6 +11,11 @@ import './suppressTooltips.js';
 import { activateTab, loadTabData, setupTabNavigation } from './tabNavigation.js';
 import { evaluateServerHealthState } from './utils/serverHealthState.js';
 import { handleSelectConceptByIdDetail } from './utils/selectConceptByIdHandler.js';
+import {
+  hasAuthenticatedVonActor,
+  initialiseHomeAuthentication,
+  shouldClearHomeIdentityMirrors,
+} from './homeAuthGate.js';
 import { formatBackgroundTaskSummary, formatBackgroundTaskTooltip, subscribeBackgroundTaskUpdates } from './backgroundTaskTracker.js';
 import {
   copyJsonTextWithButtonFeedback,
@@ -19,6 +24,7 @@ import {
   resetCopyJsonButtonPreCopyState
 } from './utils/copyJsonButtonState.js';
 import {
+  clearAllOrgContext,
   getSessionScopedNamespace,
   getSessionScopedOrgContext,
   hasSessionOrgContext,
@@ -44,6 +50,21 @@ const getCurrentNamespace = getSessionScopedNamespace;
 document.addEventListener('DOMContentLoaded', async () => {
   console.log("DOM fully loaded and parsed.");
 
+  const authStatus = await initialiseHomeAuthentication();
+  if (!hasAuthenticatedVonActor(authStatus)) {
+    if (shouldClearHomeIdentityMirrors(authStatus)) {
+      clearAllOrgContext();
+      try {
+        localStorage.removeItem('von_current_user');
+        sessionStorage.removeItem('von_current_user');
+      } catch {
+        // Browser mirrors carry no authority; remain signed out if storage is unavailable.
+      }
+    }
+    console.log('[main] Home application initialization stopped until login establishes an actor.');
+    return;
+  }
+
   initializeDomElements();
   initializeInfoPopup();
   applyExpertTabGuards();
@@ -57,13 +78,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Dynamic positioning: calculate header height and position tabs accordingly
   setupDynamicLayout();
 
-  // Resolve duplicate-tab identity and bind this tab's explicit organisation
-  // (including Personal) before any child frame or actor-scoped bootstrap read.
-  await initialiseWindowActorContext();
-
   // Ensure user context is loaded BEFORE initializing chat to prevent race condition
   // where conversation history loads with null user_id
-  await ensureUserContext();
+  await ensureUserContext(authStatus);
   loadDeferredSettingsFrame();
 
   // JVNAUTOSCI-954: report bounded, client-reported capability hints (speech/audio)
@@ -200,19 +217,6 @@ function loadDeferredSettingsFrame() {
   if (!deferredSrc || settingsFrame.dataset.actorContextReady === 'true') return;
   settingsFrame.dataset.actorContextReady = 'true';
   settingsFrame.src = deferredSrc;
-}
-
-async function initialiseWindowActorContext() {
-  try {
-    initSessionStorageFromLocalStorage();
-    const { ensureUniqueWindowSessionId } = await import('./apiService.js');
-    await ensureUniqueWindowSessionId();
-    await syncFlaskSessionOrg();
-  } catch (error) {
-    // Keep the outer page usable, but do not eagerly load the Settings frame
-    // until the bounded identity attempt has completed.
-    console.warn('[main] Failed to initialise the window actor context:', error);
-  }
 }
 
 window.addEventListener('von:windowSessionIdentityChanged', () => {
@@ -414,27 +418,15 @@ async function syncFlaskSessionOrg() {
   }
 }
 
-async function fetchBootstrapAuthStatus(getJsonImpl) {
-  try {
-    return await getJsonImpl('/von/api/auth/status');
-  } catch (_) {
-    try {
-      return await getJsonImpl('/api/auth/status');
-    } catch {
-      return null;
-    }
-  }
-}
-
 /**
- * Ensure user context is available in storage before app initialization.
- * Fetches settings if localStorage is empty.
- * ALWAYS syncs session org to avoid race conditions with session fetch.
+ * Mirror the authenticated actor into compatibility storage before app initialization.
+ * The login-bound server session remains authoritative; browser state may retain only
+ * the matching user projection and organisation/language preferences.
  *
  * JVNAUTOSCI-1011: Now uses sessionStorage for org context (window-scoped),
- * while user info remains in localStorage (shared across windows).
+ * while the derived user projection remains in localStorage (shared across windows).
  */
-async function ensureUserContext() {
+async function ensureUserContext(authStatus) {
   try {
     // JVNAUTOSCI-1011: On new window/restart, copy org preference from localStorage
     // This ensures the user's last-used org is restored even in a new window
@@ -445,20 +437,34 @@ async function ensureUserContext() {
     // Resolve a copied duplicate-tab ID before any actor-scoped bootstrap call.
     await ensureUniqueWindowSessionId();
 
-    const storedUser = parseStoredContextValue(localStorage.getItem('von_current_user'));
-    if (storedUser?.concept_id) {
-      try {
-        await hydrateStoredSelectionsFromUserPreferences(storedUser.concept_id);
-      } catch (e) {
-        console.warn('[main] Failed to hydrate stored selections from user preferences:', e);
-      }
-    } else if (localStorage.getItem('von_current_user')) {
+    let storedUser = parseStoredContextValue(localStorage.getItem('von_current_user'));
+    const authenticatedUser = resolveBrowserBootstrapUserContext({
+      authStatus,
+      storedUser,
+    });
+    if (!authenticatedUser?.concept_id) {
+      throw new Error('Authenticated login did not resolve a Von user identity.');
+    }
+
+    if (storedUser?.concept_id !== authenticatedUser.concept_id) {
+      clearAllOrgContext();
       try {
         localStorage.removeItem('von_current_user');
         sessionStorage.removeItem('von_current_user');
       } catch {
-        // Ignore storage cleanup failures and continue with settings fetch.
+        // Ignore compatibility-cache cleanup failures; the session remains authoritative.
       }
+    }
+
+    const encodedAuthenticatedUser = JSON.stringify(authenticatedUser);
+    localStorage.setItem('von_current_user', encodedAuthenticatedUser);
+    sessionStorage.setItem('von_current_user', encodedAuthenticatedUser);
+    storedUser = authenticatedUser;
+
+    try {
+      await hydrateStoredSelectionsFromUserPreferences(authenticatedUser.concept_id);
+    } catch (e) {
+      console.warn('[main] Failed to hydrate stored selections from authenticated user preferences:', e);
     }
 
     // Preference hydration may have supplied an organisation for an otherwise
@@ -468,16 +474,9 @@ async function ensureUserContext() {
 
     console.log('[main] Fetching settings to populate user context...');
     const settings = await getJson('/api/settings/');
-    const needsIdentityFallback = !settings.current_user_person_concept_id || !settings.current_organisation_concept_id;
-    const [authStatus, sessionContext] = needsIdentityFallback
-      ? await Promise.all([
-        fetchBootstrapAuthStatus(getJson),
-        getJson('/von/api/session/context').catch(() => null)
-      ])
-      : [null, null];
+    const sessionContext = await getJson('/von/api/session/context').catch(() => null);
 
     const resolvedUser = resolveBrowserBootstrapUserContext({
-      settings,
       authStatus,
       storedUser
     });
@@ -519,16 +518,6 @@ async function ensureUserContext() {
     if (resolvedNamespace) {
       setSessionScopedNamespace(resolvedNamespace);
       console.log('[main] Populated current_user_namespace from browser bootstrap context:', resolvedNamespace);
-    }
-
-    // Namespace fallback: if server does not provide user info, but a namespace is already
-    // set locally (e.g., via manual selection), propagate it so downstream calls use it.
-    if (!resolvedUser?.concept_id) {
-      const ns = sessionStorage.getItem('von_namespace') || localStorage.getItem('von_namespace');
-      if (ns && !sessionStorage.getItem('current_user_namespace')) {
-        setSessionScopedNamespace(ns);
-        console.log('[main] Using existing von_namespace as current_user_namespace:', ns);
-      }
     }
 
     // CRITICAL: Sync the session's organisation_concept_id to avoid race conditions

--- a/src/frontend/web/von_interface/static/js/settings.js
+++ b/src/frontend/web/von_interface/static/js/settings.js
@@ -154,11 +154,6 @@ export function renderOpenRouterModelOptions(selectElementId, models = [], selec
   renderPremiumModelSelect(select, 'openrouter', models, selectedModel);
 }
 
-export async function loadAvailablePeople() {
-  const { data } = await getJsonDetailed('/api/settings/people');
-  return data;
-}
-
 export async function loadAvailableOrganisations() {
   const { data } = await getJsonDetailed('/api/settings/organisations');
   return data;
@@ -368,59 +363,6 @@ export async function populateOpenRouterModelDropdown(selectElementId, selectedM
       error: err,
       fallbackMessage: 'OpenRouter models are temporarily unavailable.',
       retryAction: () => populateOpenRouterModelDropdown(selectElementId, selectedModel)
-    });
-  }
-}
-
-export async function populatePeopleDropdown(selectElementId, selectedPersonId = null) {
-  const select = document.getElementById(selectElementId);
-  if (!select) return;
-
-  try {
-    const data = await loadAvailablePeople();
-    select.innerHTML = '<option value="">-- No user selected --</option>';
-
-    if (data.people?.length > 0) {
-      const realPeople = data.people.filter(person => 
-        !person.system_tags?.includes('demo_data')
-      );
-
-      if (realPeople.length > 0) {
-        realPeople.forEach(person => {
-          const option = document.createElement('option');
-          // Store both ids in value as JSON, and data attributes for quick access
-          const dbId = person.id || person._id || '';
-          const cid  = person.concept_id || '';
-          option.value = JSON.stringify({ id: dbId, concept_id: cid });
-          option.dataset.id = dbId;
-          option.dataset.conceptId = cid;
-          // Display name: prefer backend-provided display name.
-          option.textContent = person.name || cid || dbId;
-          select.appendChild(option);
-        });
-      } else {
-        select.innerHTML = '<option value="">No non-test people found</option>';
-      }
-    } else {
-      select.innerHTML = '<option value="">No people found</option>';
-    }
-
-    if (selectedPersonId) {
-      // Options store JSON in value; match using data attribute for DB id
-      for (const opt of select.options) {
-        if (opt.dataset && opt.dataset.id === String(selectedPersonId)) {
-          opt.selected = true;
-          break;
-        }
-      }
-    }
-    clearSelectRetryState(select);
-  } catch (err) {
-    console.error('Error populating people dropdown:', err);
-    renderRetryableSelectFailure(select, {
-      error: err,
-      fallbackMessage: 'People are temporarily unavailable.',
-      retryAction: () => populatePeopleDropdown(selectElementId, selectedPersonId)
     });
   }
 }

--- a/src/frontend/web/von_interface/static/js/settingsPage.js
+++ b/src/frontend/web/von_interface/static/js/settingsPage.js
@@ -23,7 +23,6 @@ import {
   renderOpenRouterModelOptions,
   renderOpenAIModelOptions,
   populateOrganisationsDropdown,
-  populatePeopleDropdown,
   saveOllamaHosts,
   setOllamaHostManagementWritable,
   showStatusMessage,
@@ -43,6 +42,7 @@ import {
   loadConversationHistorySettings
 } from './utils/conversationHistoryPreferences.js';
 import {
+  clearAllOrgContext,
   getSessionScopedOrgContext,
   getSessionScopedNamespace,
   hasSessionPersonalOrgContext,
@@ -50,7 +50,6 @@ import {
   setSessionScopedNamespace,
 } from './utils/sessionScopedStorage.js';
 import {
-  fetchUserPreferences,
   hydrateStoredSelectionsFromUserPreferences,
 } from './utils/userPreferenceBootstrap.js';
 import {
@@ -98,7 +97,8 @@ async function buildSettingsFetchHeaders(extraHeaders = {}) {
   };
 }
 
-// LocalStorage keys for client-side persistence (no DB storage)
+// The user key is a compatibility projection of the authenticated server actor.
+// Organisation and preference keys remain browser-managed state.
 const LS_USER_KEY = 'von_current_user';
 const LS_ORG_KEY = 'von_current_org';
 const LS_LANG_KEY = 'von_preferred_language';
@@ -335,13 +335,76 @@ function getActiveSettingsConcernId() {
 
 function getSettingsConcernIdentitySnapshot() {
   return {
-    user: getSelectedUserContextFromUi() || getStoredJson(LS_USER_KEY),
+    user: getStoredJson(LS_USER_KEY),
     organisation:
       getSelectedOrganisationContextFromUi()
       || getStoredJson(LS_ORG_KEY)
       || getSessionScopedOrgContext(),
     authStatus: latestSettingsAuthStatus,
   };
+}
+
+const ACTOR_SCOPE_MIRROR_KEYS = Object.freeze([
+  LS_USER_KEY,
+  LS_ORG_KEY,
+  'von_org_context',
+  'current_user_namespace',
+  'von_namespace',
+  'von_org_switching',
+  'von_org_selection',
+]);
+
+function getSettingsStorageWindows() {
+  const storageWindows = [window];
+  try {
+    if (window.parent && window.parent !== window && window.parent.location.origin === window.location.origin) {
+      storageWindows.push(window.parent);
+    }
+  } catch {
+    // Cross-origin parents are not part of this settings session.
+  }
+  return storageWindows;
+}
+
+function clearActorScopeBrowserMirrors() {
+  clearAllOrgContext();
+  for (const storageWindow of getSettingsStorageWindows()) {
+    for (const storageName of ['sessionStorage', 'localStorage']) {
+      try {
+        const storage = storageWindow[storageName];
+        for (const key of ACTOR_SCOPE_MIRROR_KEYS) storage.removeItem(key);
+      } catch { }
+    }
+  }
+}
+
+function syncAuthenticatedUserProjection(authStatus) {
+  latestSettingsAuthStatus = authStatus || null;
+  if (typeof authStatus?.authenticated !== 'boolean') {
+    return null;
+  }
+
+  const projection = resolveBrowserBootstrapUserContext({
+    authStatus,
+    storedUser: getStoredJson(LS_USER_KEY),
+  });
+  if (!projection?.concept_id) {
+    clearActorScopeBrowserMirrors();
+    actorSessionReady = false;
+    scopedModelStateReady = false;
+    updateScopedModelSaveAvailability();
+    return null;
+  }
+
+  const previousActor = getStoredJson(LS_USER_KEY)?.concept_id || null;
+  const hasScopeWithoutActor = !previousActor && Boolean(
+    getStoredJson(LS_ORG_KEY) || getSessionScopedNamespace(),
+  );
+  if ((previousActor && previousActor !== projection.concept_id) || hasScopeWithoutActor) {
+    clearActorScopeBrowserMirrors();
+  }
+  setStoredJson(LS_USER_KEY, projection);
+  return projection;
 }
 
 const PREMIUM_PROVIDER_CONFIG = Object.freeze({
@@ -478,11 +541,11 @@ function buildTemporarySettingsConcernRecommendation(concernId) {
       if (!user?.concept_id) {
         return {
           kicker: 'Suggested next step',
-          title: 'Choose the current user for this browser',
-          description: 'This keeps preferences, scoped history, and later setup steps anchored to one person instead of an anonymous browser state.',
-          actionLabel: 'Choose current user',
+          title: 'Sign in to establish your identity',
+          description: 'Von takes the current user from the authenticated server session. Identity cannot be selected or changed in Settings.',
+          actionLabel: 'Open sign-in controls',
           actionTarget: 'current-user-settings',
-          focusSelector: '#currentUserSelect',
+          focusSelector: '#authenticationStatus button',
           source: 'temporary-placeholder',
         };
       }
@@ -502,8 +565,8 @@ function buildTemporarySettingsConcernRecommendation(concernId) {
       if (authKnown && !authStatus.authenticated) {
         return {
           kicker: 'Suggested next step',
-          title: 'Log in to unlock user-scoped tools',
-          description: 'Your browser knows the user and organisation to act as. Authenticate next if you want server-backed sessions, RAG, and Messages.',
+          title: 'Sign in to establish your identity',
+          description: 'The signed-in session is the authority for user-scoped settings, conversations, RAG, and Messages.',
           actionLabel: 'Open sign-in controls',
           actionTarget: 'current-user-settings',
           focusSelector: '#authenticationStatus button',
@@ -769,7 +832,7 @@ function setActiveSettingsConcern(concernId, options = {}) {
 }
 
 document.addEventListener('authStatusChanged', (event) => {
-  latestSettingsAuthStatus = event?.detail || null;
+  syncAuthenticatedUserProjection(event?.detail || null);
   refreshActiveSettingsConcernGuidance();
 });
 
@@ -940,16 +1003,6 @@ function readOptionIdentity(option) {
   return { id, conceptId };
 }
 
-function buildStoredUserContextFromOption(option) {
-  const { id, conceptId } = readOptionIdentity(option);
-  if (!id && !conceptId) return null;
-  return {
-    id,
-    concept_id: conceptId,
-    name: readOptionText(option),
-  };
-}
-
 function buildStoredOrganisationContextFromOption(option) {
   const { id, conceptId } = readOptionIdentity(option);
   if (!id && !conceptId) return null;
@@ -958,11 +1011,6 @@ function buildStoredOrganisationContextFromOption(option) {
     concept_id: conceptId,
     name: normaliseOrganisationDisplayName(option.textContent) || readOptionText(option),
   };
-}
-
-function getSelectedUserContextFromUi() {
-  const userSelect = document.getElementById('currentUserSelect');
-  return buildStoredUserContextFromOption(userSelect?.selectedOptions?.[0]);
 }
 
 function getOrganisationSelectFromUi() {
@@ -1028,7 +1076,7 @@ async function syncInitialScopedSelections({
   actorSessionReady = false;
   scopedModelStateReady = false;
   updateScopedModelSaveAvailability();
-  const userData = getSelectedUserContextFromUi() || getStoredJson(LS_USER_KEY);
+  const userData = getStoredJson(LS_USER_KEY);
   const orgSelect = getOrganisationSelectFromUi();
   const orgData = getSelectedOrganisationContextFromUi()
     || (!orgSelect ? (getStoredJson(LS_ORG_KEY) || getSessionScopedOrgContext()) : null);
@@ -2266,7 +2314,7 @@ function renderModelPoolTargetScopeNote() {
   const note = document.getElementById('modelPoolTargetScopeNote');
   if (!note) return;
   if (!actorSessionReady) {
-    note.textContent = 'Waiting for the selected user and organisation to be committed to the server session.';
+    note.textContent = 'Waiting for the authenticated user and selected organisation to be committed to the server session.';
     return;
   }
   if (!scopedModelStateReady) {
@@ -4395,11 +4443,6 @@ export function __testOnly_readRuntimeModelSettingFromForm(prefix, options = {})
 }
 
 // Export for testing
-export function __testOnly_buildStoredUserContextFromOption(option) {
-  return buildStoredUserContextFromOption(option);
-}
-
-// Export for testing
 export function __testOnly_applyStoredSelection(selectId, stored, fallbackSelected = true) {
   return applyStoredSelection(selectId, stored, fallbackSelected);
 }
@@ -4407,6 +4450,10 @@ export function __testOnly_applyStoredSelection(selectId, stored, fallbackSelect
 // Export for testing
 export async function __testOnly_syncInitialScopedSelections(overrides = {}) {
   return syncInitialScopedSelections(overrides);
+}
+
+export function __testOnly_syncAuthenticatedUserProjection(authStatus) {
+  return syncAuthenticatedUserProjection(authStatus);
 }
 
 export function __testOnly_applySettingsActorRole(role) {
@@ -4616,27 +4663,27 @@ function setStoredJson(key, value) {
     setSessionScopedOrgContext(value);
     return;
   }
-  // JVNAUTOSCI-1011: Write to both sessionStorage (window-scoped) and localStorage (persistent)
-  try {
-    if (value == null) {
-      sessionStorage.removeItem(key);
-      localStorage.removeItem(key);
-    } else {
-      const json = JSON.stringify(value);
-      sessionStorage.setItem(key, json);
-      localStorage.setItem(key, json);
-    }
-  } catch { }
+  const storageWindows = key === LS_USER_KEY ? getSettingsStorageWindows() : [window];
+  for (const storageWindow of storageWindows) {
+    try {
+      if (value == null) {
+        storageWindow.sessionStorage.removeItem(key);
+        storageWindow.localStorage.removeItem(key);
+      } else {
+        const json = JSON.stringify(value);
+        storageWindow.sessionStorage.setItem(key, json);
+        storageWindow.localStorage.setItem(key, json);
+      }
+    } catch { }
+  }
 }
 
 function snapshotActorBrowserContext() {
-  const userSelect = document.getElementById('currentUserSelect');
   const organisationSelect = document.getElementById('currentOrganisationSelect');
   return {
     user: getStoredJson(LS_USER_KEY),
     organisation: getStoredJson(LS_ORG_KEY),
     organisationRole: currentActorOrganisationRole,
-    userSelectedIndex: userSelect?.selectedIndex ?? -1,
     organisationSelectedIndex: organisationSelect?.selectedIndex ?? -1,
   };
 }
@@ -4644,14 +4691,7 @@ function snapshotActorBrowserContext() {
 function restoreActorBrowserContext(snapshot) {
   setStoredJson(LS_USER_KEY, snapshot?.user || null);
   setStoredJson(LS_ORG_KEY, snapshot?.organisation || null);
-  const userSelect = document.getElementById('currentUserSelect');
   const organisationSelect = document.getElementById('currentOrganisationSelect');
-  if (userSelect) {
-    const applied = applyStoredSelection('currentUserSelect', snapshot?.user, false);
-    if (!applied && Number.isInteger(snapshot?.userSelectedIndex)) {
-      userSelect.selectedIndex = snapshot.userSelectedIndex;
-    }
-  }
   if (organisationSelect) {
     const applied = applyStoredSelection('currentOrganisationSelect', snapshot?.organisation, false);
     if (!applied && Number.isInteger(snapshot?.organisationSelectedIndex)) {
@@ -4710,14 +4750,11 @@ function failClosedActorTransition(error, snapshot) {
 
 function queueActorContextTransition({
   snapshot,
-  requestedUser,
   requestedOrganisation,
-  hydrateUserPreferences = false,
   setUserConceptFn = (userConceptId) => postJson('/von/api/session/set_user_concept', {
     user_concept_id: userConceptId,
   }),
   switchOrganisationFn = switchOrganisation,
-  loadUserPreferencesFn = loadUserConceptPreferences,
   reloadScopedModelsFn = reloadScopedModelSettings,
   rollbackActorFn = rollbackServerActorContext,
   refreshRagStatusFn = () => loadRagStatus(null),
@@ -4739,23 +4776,17 @@ function queueActorContextTransition({
       }
 
       try {
-        const userConceptId = requestedUser?.concept_id || null;
+        const authenticatedUser = getStoredJson(LS_USER_KEY) || snapshot?.user || null;
+        const userConceptId = authenticatedUser?.concept_id || null;
         if (!userConceptId) {
-          throw new Error('The selected user does not have a valid concept ID.');
+          throw new Error('The authenticated user does not have a valid concept ID.');
         }
         const userSession = await setUserConceptFn(userConceptId);
         if (actorGeneration !== actorContextGeneration) {
           return { applied: false, stale: true };
         }
 
-        let organisation = requestedOrganisation || null;
-        if (hydrateUserPreferences) {
-          await loadUserPreferencesFn(userConceptId, { actorGeneration });
-          if (actorGeneration !== actorContextGeneration) {
-            return { applied: false, stale: true };
-          }
-          organisation = getSelectedOrganisationContextFromUi();
-        }
+        const organisation = requestedOrganisation || null;
 
         suppressActorOrgSwitchReload = true;
         let organisationSession = null;
@@ -4774,7 +4805,7 @@ function queueActorContextTransition({
           return { applied: false, stale: true };
         }
 
-        setStoredJson(LS_USER_KEY, requestedUser);
+        setStoredJson(LS_USER_KEY, authenticatedUser);
         setStoredJson(LS_ORG_KEY, organisation);
         renderActiveNamespace();
         void refreshRagStatusFn();
@@ -4882,10 +4913,10 @@ function applyStoredSelection(selectId, stored, fallbackSelected = true) {
       if (optionMatchesStoredContext(opt, stored)) {
         opt.selected = true;
         const { conceptId } = readOptionIdentity(opt);
-        // Backfill concept_id if missing (required for per-user model saves)
+        // Backfill concept_id for legacy organisation options that expose only a DB id.
         if (!stored.concept_id && conceptId) {
           stored.concept_id = conceptId;
-          setStoredJson(selectId === 'currentUserSelect' ? LS_USER_KEY : LS_ORG_KEY, stored);
+          setStoredJson(LS_ORG_KEY, stored);
         }
         return stored;
       }
@@ -4895,10 +4926,8 @@ function applyStoredSelection(selectId, stored, fallbackSelected = true) {
   if (fallbackSelected) {
     const current = sel.selectedOptions?.[0];
     if (current && (current.dataset?.id || current.dataset?.conceptId)) {
-      const storedVal = selectId === 'currentUserSelect'
-        ? buildStoredUserContextFromOption(current)
-        : buildStoredOrganisationContextFromOption(current);
-      setStoredJson(selectId === 'currentUserSelect' ? LS_USER_KEY : LS_ORG_KEY, storedVal);
+      const storedVal = buildStoredOrganisationContextFromOption(current);
+      setStoredJson(LS_ORG_KEY, storedVal);
       return storedVal;
     }
   }
@@ -5027,24 +5056,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     notifyLocalModelPreferenceChanged();
     renderModelScopeOverview();
   });
-  document.getElementById('currentUserSelect')?.addEventListener('change', () => {
-    const snapshot = snapshotActorBrowserContext();
-    const sel = document.getElementById('currentUserSelect');
-    const opt = sel?.selectedOptions?.[0];
-    void queueActorContextTransition({
-      snapshot,
-      requestedUser: buildStoredUserContextFromOption(opt),
-      requestedOrganisation: getSelectedOrganisationContextFromUi() || snapshot.organisation,
-      hydrateUserPreferences: true,
-    });
-  });
   document.getElementById('currentOrganisationSelect')?.addEventListener('change', () => {
     const snapshot = snapshotActorBrowserContext();
     const sel = document.getElementById('currentOrganisationSelect');
     const opt = sel?.selectedOptions?.[0];
     void queueActorContextTransition({
       snapshot,
-      requestedUser: getSelectedUserContextFromUi() || snapshot.user,
       requestedOrganisation: buildStoredOrganisationContextFromOption(opt),
     }).then((result) => {
       if (result?.applied) persistCurrentUserPreferences();
@@ -5313,8 +5330,8 @@ document.getElementById('refreshDeprecationMetricsButton')?.addEventListener('cl
 // Reset local preferences button
 document.getElementById('resetLocalPrefsButton')?.addEventListener('click', () => {
   try {
-    localStorage.removeItem(LS_USER_KEY);
-    localStorage.removeItem(LS_ORG_KEY);
+    setStoredJson(LS_ORG_KEY, null);
+    setSessionScopedNamespace(null);
     localStorage.removeItem(LS_LANG_KEY);
     localStorage.removeItem(LS_GMAIL_PROFILE);
     localStorage.removeItem(LS_SHOW_CODE_NAMES);
@@ -5325,7 +5342,6 @@ document.getElementById('resetLocalPrefsButton')?.addEventListener('click', () =
     localStorage.removeItem(LS_CARTOUCHE_SHOW_KIND);
     localStorage.removeItem(LS_CARTOUCHE_KIND_AS_BG);
     // Reset selects visually
-    const userSel = document.getElementById('currentUserSelect'); if (userSel) userSel.selectedIndex = 0;
     const orgSel = document.getElementById('currentOrganisationSelect'); if (orgSel) orgSel.selectedIndex = 0;
     const langSel = document.getElementById('preferredLanguageSelect'); if (langSel) langSel.value = 'en-NZ';
     const gmailProfileSelect = document.getElementById('gmailProfileSelect');
@@ -5388,11 +5404,16 @@ async function loadModelLlmTimeout(provider, model) {
 async function loadAndDisplaySettings() {
   const scopedModelGeneration = invalidateScopedModelState();
   try {
-    // Pass user context to get properly resolved LLM setting (user > org > global precedence)
-    const storedUser = getStoredJson(LS_USER_KEY);
-    const storedOrg = getStoredJson(LS_ORG_KEY);
+    // Read the authenticated actor before asking for actor-scoped settings. A stale
+    // browser cache must never choose which user's settings are requested.
+    const [sessionContext, authStatus] = await Promise.all([
+      _fetchSessionContextForRole(),
+      fetchSettingsAuthStatus(),
+    ]);
+    const bootstrapUser = syncAuthenticatedUserProjection(authStatus);
+    const storedOrg = bootstrapUser ? getStoredJson(LS_ORG_KEY) : null;
     const params = new URLSearchParams();
-    if (storedUser?.concept_id) params.set('user_concept_id', storedUser.concept_id);
+    if (bootstrapUser?.concept_id) params.set('user_concept_id', bootstrapUser.concept_id);
     if (storedOrg?.concept_id) params.set('organisation_concept_id', storedOrg.concept_id);
     const settingsUrl = '/api/settings/' + (params.toString() ? '?' + params.toString() : '');
 
@@ -5402,37 +5423,28 @@ async function loadAndDisplaySettings() {
     });
     if (!response.ok) throw new Error(`Failed to fetch settings: ${response.statusText}`);
     const settings = await response.json();
-    const [sessionContext, authStatus] = await Promise.all([
-      _fetchSessionContextForRole(),
-      fetchSettingsAuthStatus()
-    ]);
 
-    const bootstrapUser = resolveBrowserBootstrapUserContext({
-      settings,
-      authStatus,
-      storedUser
-    });
-    if (bootstrapUser) {
-      setStoredJson(LS_USER_KEY, bootstrapUser);
-    }
-
-    const bootstrapOrg = resolveBrowserBootstrapOrganisationContext({
-      settings,
-      sessionContext,
-      storedOrganisation: storedOrg,
-      explicitPersonal: hasSessionPersonalOrgContext(),
-    });
+    const bootstrapOrg = bootstrapUser
+      ? resolveBrowserBootstrapOrganisationContext({
+        settings,
+        sessionContext,
+        storedOrganisation: storedOrg,
+        explicitPersonal: hasSessionPersonalOrgContext(),
+      })
+      : null;
     if (bootstrapOrg) {
       setStoredJson(LS_ORG_KEY, bootstrapOrg);
     }
 
-    const bootstrapNamespace = resolveBrowserBootstrapNamespace({
-      settings,
-      sessionContext,
-      userContext: bootstrapUser,
-      organisationContext: bootstrapOrg,
-      explicitPersonal: hasSessionPersonalOrgContext(),
-    });
+    const bootstrapNamespace = bootstrapUser
+      ? resolveBrowserBootstrapNamespace({
+        settings,
+        sessionContext,
+        userContext: bootstrapUser,
+        organisationContext: bootstrapOrg,
+        explicitPersonal: hasSessionPersonalOrgContext(),
+      })
+      : '';
     try {
       if (bootstrapNamespace) {
         sessionStorage.setItem('current_user_namespace', bootstrapNamespace);
@@ -5534,27 +5546,11 @@ async function loadAndDisplaySettings() {
       }
     }
 
-    // Populate People and select the saved one
-    await populatePeopleDropdown('currentUserSelect', settings.current_user_person_id);
-    // If we have concept_id too, attempt to match based on data attribute
-    try {
-      const userSelect = document.getElementById('currentUserSelect');
-      const targetCid = settings.current_user_person_concept_id;
-      if (userSelect && targetCid) {
-        for (const opt of userSelect.options) {
-          if (opt.dataset?.conceptId === targetCid) { opt.selected = true; break; }
-        }
-      }
-    } catch { }
-    // Override with stored local selection if present
-    applyStoredSelection('currentUserSelect', getStoredJson(LS_USER_KEY));
-
     // Restore missing org/language context from persisted per-user preferences
     // before populating organisation-dependent UI or namespace state.
     try {
-      const selectedUser = getSelectedUserContextFromUi();
-      if (selectedUser?.concept_id) {
-        await hydrateStoredSelectionsFromUserPreferences(selectedUser.concept_id);
+      if (bootstrapUser?.concept_id) {
+        await hydrateStoredSelectionsFromUserPreferences(bootstrapUser.concept_id);
       }
     } catch (e) {
       console.warn('Failed to hydrate stored selections from user preferences', e);
@@ -6211,42 +6207,6 @@ async function saveAllSettings({
 }
 
 // --- User concept preference helpers (server-side stored) ---
-
-async function loadUserConceptPreferences(userConceptId, { actorGeneration = null } = {}) {
-  try {
-    const data = await fetchUserPreferences(userConceptId);
-    if (!data) return;
-    if (actorGeneration !== null && actorGeneration !== actorContextGeneration) return;
-    if (data.preferred_language) {
-      const langSel = document.getElementById('preferredLanguageSelect');
-      if (langSel) {
-        langSel.value = data.preferred_language;
-        localStorage.setItem(LS_LANG_KEY, data.preferred_language);
-      }
-    }
-    if (data.organisation_concept_id) {
-      const orgSel = document.getElementById('currentOrganisationSelect');
-      if (orgSel) {
-        for (const opt of orgSel.options) {
-          if (opt.dataset?.conceptId === data.organisation_concept_id) { opt.selected = true; break; }
-        }
-        const selOpt = orgSel.selectedOptions?.[0];
-        if (selOpt) {
-          setStoredJson(LS_ORG_KEY, buildStoredOrganisationContextFromOption(selOpt));
-        }
-      }
-    } else {
-      const orgSel = document.getElementById('currentOrganisationSelect');
-      if (orgSel) {
-        orgSel.selectedIndex = 0;
-      }
-      setStoredJson(LS_ORG_KEY, null);
-      if (window.parent?.updateModelInfoFooterDisplay) { window.parent.updateModelInfoFooterDisplay(); }
-    }
-  } catch (e) {
-    console.warn('Failed to load user concept preferences', e);
-  }
-}
 
 async function persistCurrentUserPreferences() {
   try {

--- a/src/frontend/web/von_interface/static/js/test/settingsPageRagStatus.test.js
+++ b/src/frontend/web/von_interface/static/js/test/settingsPageRagStatus.test.js
@@ -2,7 +2,6 @@ import {
     __testOnly_applyStoredSelection,
     __testOnly_buildPersistedLlmSelections,
     __testOnly_buildServerDefaultLlmPayload,
-    __testOnly_buildStoredUserContextFromOption,
     __testOnly_formatGmailOAuthStoredStatus,
     __testOnly_formatServerDefaultSummary,
     __testOnly_formatRagSummaryForSettings,
@@ -20,6 +19,7 @@ import {
     __testOnly_resolvePersistedActiveLlm,
     __testOnly_renderRuntimeModelSummaries,
     __testOnly_setModelScopeState,
+    __testOnly_syncAuthenticatedUserProjection,
     __testOnly_syncInitialScopedSelections,
     __testOnly_setupInternalMcpCapAutoSave,
 } from '../settingsPage.js';
@@ -79,6 +79,77 @@ describe('settingsPage RAG status summary', () => {
         expect(sessionStorage.getItem('current_user_namespace')).toBe(
             '#V#michael_witbrock@university_of_auckland_strong_ai_lab',
         );
+    });
+
+    test('authenticated status replaces a stale user cache and clears its organisation scope', () => {
+        const staleUser = JSON.stringify({ concept_id: '#V#stale_user', name: 'Stale User' });
+        const staleOrg = JSON.stringify({ concept_id: '#V#stale_org', name: 'Stale Org' });
+        sessionStorage.setItem('von_current_user', staleUser);
+        localStorage.setItem('von_current_user', staleUser);
+        sessionStorage.setItem('von_current_org', staleOrg);
+        localStorage.setItem('von_current_org', staleOrg);
+        sessionStorage.setItem('current_user_namespace', '#V#stale_user@stale_org');
+        localStorage.setItem('current_user_namespace', '#V#stale_user@stale_org');
+
+        expect(__testOnly_syncAuthenticatedUserProjection({
+            authenticated: true,
+            user_concept_id: '#V#authenticated_user',
+            name: 'Authenticated User',
+            email: 'authenticated@example.org',
+        })).toEqual({
+            id: null,
+            concept_id: '#V#authenticated_user',
+            name: 'Authenticated User',
+        });
+
+        expect(JSON.parse(sessionStorage.getItem('von_current_user'))).toMatchObject({
+            concept_id: '#V#authenticated_user',
+            name: 'Authenticated User',
+        });
+        expect(JSON.parse(localStorage.getItem('von_current_user'))).toMatchObject({
+            concept_id: '#V#authenticated_user',
+        });
+        expect(sessionStorage.getItem('von_current_org')).toBeNull();
+        expect(localStorage.getItem('von_current_org')).toBeNull();
+        expect(sessionStorage.getItem('current_user_namespace')).toBeNull();
+        expect(localStorage.getItem('current_user_namespace')).toBeNull();
+    });
+
+    test('signed-out auth status clears user, organisation, and namespace mirrors', () => {
+        for (const storage of [sessionStorage, localStorage]) {
+            storage.setItem('von_current_user', JSON.stringify({ concept_id: '#V#user' }));
+            storage.setItem('von_current_org', JSON.stringify({ concept_id: '#V#org' }));
+            storage.setItem('von_org_context', JSON.stringify({ concept_id: '#V#org' }));
+            storage.setItem('current_user_namespace', '#V#user@org');
+            storage.setItem('von_namespace', '#V#user@org');
+        }
+
+        expect(__testOnly_syncAuthenticatedUserProjection({ authenticated: false })).toBeNull();
+
+        for (const storage of [sessionStorage, localStorage]) {
+            expect(storage.getItem('von_current_user')).toBeNull();
+            expect(storage.getItem('von_current_org')).toBeNull();
+            expect(storage.getItem('von_org_context')).toBeNull();
+            expect(storage.getItem('current_user_namespace')).toBeNull();
+            expect(storage.getItem('von_namespace')).toBeNull();
+        }
+    });
+
+    test('refreshing the same authenticated actor preserves organisation selection', () => {
+        sessionStorage.setItem('von_current_user', JSON.stringify({ concept_id: '#V#user' }));
+        sessionStorage.setItem('von_current_org', JSON.stringify({ concept_id: '#V#org' }));
+        sessionStorage.setItem('current_user_namespace', '#V#user@org');
+
+        __testOnly_syncAuthenticatedUserProjection({
+            authenticated: true,
+            user_concept_id: '#V#user',
+            name: 'Current User',
+        });
+
+        expect(JSON.parse(sessionStorage.getItem('von_current_org'))).toMatchObject({
+            concept_id: '#V#org',
+        });
+        expect(sessionStorage.getItem('current_user_namespace')).toBe('#V#user@org');
     });
 
     test('formats KA + Conversation summary when chat counts available', () => {
@@ -371,11 +442,14 @@ describe('settingsPage RAG status summary', () => {
         });
     });
 
-    test('initial scoped selection sync backfills storage and composite namespace from selected user and org', async () => {
+    test('initial scoped selection sync uses the login-derived user and selected organisation', async () => {
+        const authenticatedUser = {
+            concept_id: '#V#michael_witbrock',
+            name: 'Michael Witbrock',
+        };
+        localStorage.setItem('von_current_user', JSON.stringify(authenticatedUser));
+        sessionStorage.setItem('von_current_user', JSON.stringify(authenticatedUser));
         document.body.innerHTML = `
-            <select id="currentUserSelect">
-                <option data-id="user-1" data-concept-id="#V#michael_witbrock" selected>Michael Witbrock</option>
-            </select>
             <select id="currentOrganisationSelect">
                 <option value="">Personal</option>
                 <option data-id="org-1" data-concept-id="#V#university_of_auckland_strong_ai_lab" selected>
@@ -420,10 +494,13 @@ describe('settingsPage RAG status summary', () => {
     });
 
     test('initial scoped selection sync reads the visible Phase 2 org selector when the legacy org select is absent', async () => {
+        const authenticatedUser = {
+            concept_id: '#V#michael_witbrock',
+            name: 'Michael Witbrock',
+        };
+        localStorage.setItem('von_current_user', JSON.stringify(authenticatedUser));
+        sessionStorage.setItem('von_current_user', JSON.stringify(authenticatedUser));
         document.body.innerHTML = `
-            <select id="currentUserSelect">
-                <option data-id="user-1" data-concept-id="#V#michael_witbrock" selected>Michael Witbrock</option>
-            </select>
             <select id="orgSelect">
                 <option value="">Personal (No Org)</option>
                 <option value="#V#university_of_auckland_strong_ai_lab" data-role="admin" selected>
@@ -460,17 +537,6 @@ describe('settingsPage RAG status summary', () => {
             'University Of Auckland Strong Ai Lab',
         );
         expect(refreshRagStatus).toHaveBeenCalled();
-    });
-
-    test('placeholder user option is treated as no selection rather than stored user context', () => {
-        document.body.innerHTML = `
-            <select id="currentUserSelect">
-                <option value="" selected>-- No user selected --</option>
-            </select>
-        `;
-
-        const option = document.querySelector('#currentUserSelect option');
-        expect(__testOnly_buildStoredUserContextFromOption(option)).toBeNull();
     });
 
     test('internal MCP caps default and clamp to the UI/backend contract', () => {
@@ -600,29 +666,29 @@ describe('settingsPage RAG status summary', () => {
         expect(saveFn).toHaveBeenCalledTimes(1);
     });
 
-    test('stored browser-test user is re-injected and selected when the dropdown is rebuilt without it', () => {
+    test('stored organisation is re-injected and selected when the dropdown is rebuilt without it', () => {
         document.body.innerHTML = `
-            <select id="currentUserSelect">
-                <option value="" selected>-- No user selected --</option>
-                <option data-id="user-1" data-concept-id="#V#michael_witbrock">Michael Witbrock</option>
+            <select id="currentOrganisationSelect">
+                <option value="" selected>Personal</option>
+                <option data-id="org-1" data-concept-id="#V#older_org">Older Org</option>
             </select>
         `;
 
-        const storedUser = {
+        const storedOrganisation = {
             id: null,
-            concept_id: '#V#zhan_von_witbrock',
-            name: 'Zhan von Witbrock',
+            concept_id: '#V#university_of_auckland_strong_ai_lab',
+            name: 'University Of Auckland Strong Ai Lab',
         };
 
-        const applied = __testOnly_applyStoredSelection('currentUserSelect', storedUser);
-        const select = document.getElementById('currentUserSelect');
+        const applied = __testOnly_applyStoredSelection('currentOrganisationSelect', storedOrganisation);
+        const select = document.getElementById('currentOrganisationSelect');
 
-        expect(applied).toEqual(storedUser);
-        expect(select.selectedOptions[0].dataset.conceptId).toBe('#V#zhan_von_witbrock');
-        expect([...select.options].map((option) => option.textContent)).toContain('Zhan von Witbrock');
+        expect(applied).toEqual(storedOrganisation);
+        expect(select.selectedOptions[0].dataset.conceptId).toBe('#V#university_of_auckland_strong_ai_lab');
+        expect([...select.options].map((option) => option.textContent)).toContain('University Of Auckland Strong Ai Lab');
     });
 
-    test('initial scoped selection sync preserves stored browser-test user when the visible select is still on the placeholder option', async () => {
+    test('initial scoped selection sync preserves the login-derived browser-test user without a user selector', async () => {
         localStorage.setItem(
             'von_current_user',
             JSON.stringify({ concept_id: '#V#zhan_von_witbrock', name: 'Zhan von Witbrock' }),
@@ -632,9 +698,6 @@ describe('settingsPage RAG status summary', () => {
             JSON.stringify({ concept_id: '#V#zhan_von_witbrock', name: 'Zhan von Witbrock' }),
         );
         document.body.innerHTML = `
-            <select id="currentUserSelect">
-                <option value="" selected>-- No user selected --</option>
-            </select>
             <select id="currentOrganisationSelect">
                 <option value="">Personal</option>
                 <option data-id="org-1" data-concept-id="#V#university_of_auckland_strong_ai_lab" selected>

--- a/src/frontend/web/von_interface/static/js/test/settingsRetryableLoads.test.js
+++ b/src/frontend/web/von_interface/static/js/test/settingsRetryableLoads.test.js
@@ -7,13 +7,8 @@ import {
     loadAndRenderOllamaHosts,
     populateModelDropdown,
     populateOpenAIModelDropdown,
-    populatePeopleDropdown,
 } from '../settings.js';
 import { getJsonDetailed } from '../apiService.js';
-
-function flushMicrotasks() {
-    return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 describe('settings retryable load states', () => {
     let consoleErrorSpy;
@@ -26,46 +21,6 @@ describe('settings retryable load states', () => {
 
     afterEach(() => {
         consoleErrorSpy.mockRestore();
-    });
-
-    test('people dropdown shows retryable error state and reloads on focus', async () => {
-        document.body.innerHTML = '<select id="currentUserSelect"></select>';
-
-        getJsonDetailed
-            .mockRejectedValueOnce({
-                message: 'HTTP 503',
-                status: 503,
-                payload: {
-                    error: 'People are temporarily unavailable. Please retry shortly.',
-                    retryable: true,
-                    retry_after_seconds: 0,
-                },
-            })
-            .mockResolvedValueOnce({
-                data: {
-                    people: [
-                        {
-                            id: '682de9200a04490dc7afee09',
-                            concept_id: '#V#michael_witbrock',
-                            name: 'Michael Witbrock',
-                            system_tags: [],
-                        },
-                    ],
-                    total_count: 1,
-                },
-            });
-
-        await populatePeopleDropdown('currentUserSelect');
-
-        const select = document.getElementById('currentUserSelect');
-        expect(select.options[0].textContent).toContain('Click to retry');
-
-        select.dispatchEvent(new Event('focus'));
-        await flushMicrotasks();
-        await flushMicrotasks();
-
-        expect(getJsonDetailed).toHaveBeenCalledTimes(2);
-        expect(select.options[1].textContent).toBe('Michael Witbrock');
     });
 
     test('openai model dropdown distinguishes load failure from a true empty list', async () => {

--- a/src/frontend/web/von_interface/static/js/utils/runtimeIdentityBootstrap.js
+++ b/src/frontend/web/von_interface/static/js/utils/runtimeIdentityBootstrap.js
@@ -52,28 +52,29 @@ export function buildNamespaceFromConcepts(userConceptId, organisationConceptId 
 }
 
 export function resolveBrowserBootstrapUserContext({
-    settings = null,
     authStatus = null,
     storedUser = null,
 } = {}) {
-    const conceptId = trimString(
-        settings?.current_user_person_concept_id
-        || authStatus?.user_concept_id
-        || storedUser?.concept_id
-    );
-    const id = trimString(settings?.current_user_person_id || storedUser?.id) || null;
-    const name = normaliseDisplayName(
-        settings?.current_user_person_name,
-        authStatus?.name || storedUser?.name
-    );
-
-    if (!conceptId && !id) {
+    if (authStatus?.authenticated !== true) {
         return null;
     }
 
+    const conceptId = trimString(authStatus?.user_concept_id);
+    if (!conceptId) return null;
+
+    const cachedConceptId = trimString(storedUser?.concept_id);
+    const cacheMatchesAuthenticatedActor = cachedConceptId === conceptId;
+    const id = cacheMatchesAuthenticatedActor
+        ? (trimString(storedUser?.id) || null)
+        : null;
+    const name = normaliseDisplayName(
+        authStatus?.name || authStatus?.email,
+        cacheMatchesAuthenticatedActor ? storedUser?.name : null
+    );
+
     return {
         id,
-        concept_id: conceptId || null,
+        concept_id: conceptId,
         name,
     };
 }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -66,6 +66,86 @@ body {
     /* ADDED: Space for the fixed footer */
 }
 
+body.von-auth-pending,
+body.von-signed-out {
+    padding-bottom: 0;
+    background:
+        radial-gradient(circle at 15% 15%, rgba(74, 144, 226, 0.13), transparent 34rem),
+        linear-gradient(145deg, #f8fafc 0%, #eef3f8 100%);
+}
+
+.von-authentication-gate {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 32px 20px;
+}
+
+.von-authentication-gate[hidden],
+#vonAuthenticatedApp[hidden] {
+    display: none;
+}
+
+.von-authentication-card {
+    width: min(100%, 480px);
+    box-sizing: border-box;
+    padding: clamp(28px, 6vw, 48px);
+    border: 1px solid #d8e1eb;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 24px 60px rgba(38, 55, 74, 0.13);
+    text-align: center;
+}
+
+.von-authentication-kicker {
+    margin: 0 0 4px;
+    color: #2563a5;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.von-authentication-card h1 {
+    margin: 0;
+    color: #1f2937;
+    font-size: clamp(1.75rem, 5vw, 2.35rem);
+    line-height: 1.2;
+}
+
+.von-authentication-summary {
+    margin: 18px auto 0;
+    color: #526172;
+    font-size: 1rem;
+    line-height: 1.65;
+}
+
+.von-authentication-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 28px;
+}
+
+.von-authentication-actions button {
+    min-height: 44px;
+    padding: 10px 18px;
+}
+
+.von-authentication-status {
+    min-height: 1.5em;
+    margin: 18px 0 0;
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+.von-authentication-status[data-kind="error"] {
+    color: #b42318;
+}
+
 /* Accessibility utility: visually hidden but screen-reader accessible */
 .visually-hidden {
     position: absolute !important;
@@ -15242,6 +15322,23 @@ body.settings-body {
     color: #666;
     margin-top: 0;
     margin-bottom: 4px;
+}
+
+.settings-identity-card {
+    display: grid;
+    gap: 0.35rem;
+    margin: 0.85rem 0 1.15rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid #d8e1eb;
+    border-left: 4px solid #2563a5;
+    border-radius: 0.7rem;
+    background: #f8fafc;
+    color: #475569;
+}
+
+.settings-identity-card strong {
+    color: #1f2937;
+    font-size: 1rem;
 }
 
 @media (max-width: 900px) {

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -17,7 +17,7 @@
                 <p class="settings-shell-kicker">Settings</p>
                 <h1>Set up Von for this browser</h1>
                 <p class="settings-shell-summary">Choose a concern, then use the suggested next step below to finish
-                    identity, model, and tool setup without guessing what matters next.</p>
+                    scope, model, and tool setup without guessing what matters next.</p>
             </div>
         </header>
 
@@ -40,7 +40,7 @@
         <nav id="settingsSectionRail" class="settings-section-rail" aria-label="Sections in this settings concern"></nav>
 
         <section id="current-user-settings" data-settings-concern="identity">
-            <h2>Current User Configuration</h2>
+            <h2>Signed-in Identity</h2>
 
             <!-- Authentication Status -->
             <div id="authenticationStatus">
@@ -51,12 +51,16 @@
             </div>
             <div id="browserTestModeStatus" class="settings-note mt-2" aria-live="polite"></div>
 
-            <p class="settings-note"><strong>Note:</strong> User, Organisation and Language selections are stored only
-                in this browser (localStorage) and are not saved on the server.</p>
-            <label for="currentUserSelect">Current User:</label>
-            <select id="currentUserSelect" name="current_user_person">
-                <option value="">Loading people...</option>
-            </select>
+            <p class="settings-note"><strong>Note:</strong> Your identity comes from sign-in and cannot be changed in
+                Settings. Organisation and Language selections remain browser preferences.</p>
+            <div id="currentUserIdentity" class="settings-note settings-identity-card" aria-live="polite">
+                <strong id="currentUserIdentityName">Checking signed-in identity…</strong>
+                <div id="currentUserIdentityEmailRow" hidden>Email: <span id="currentUserIdentityEmail"></span></div>
+                <div id="currentUserIdentityConceptRow" hidden>User concept:
+                    <code id="currentUserIdentityConcept"></code>
+                </div>
+                <div id="currentUserIdentityHint">Identity is verified by the server session.</div>
+            </div>
 
             <label for="preferredLanguageSelect">Preferred Language:</label>
             <select id="preferredLanguageSelect" name="preferred_language">
@@ -84,7 +88,7 @@
 
             <div class="inline-form inline-form-tight mt-8-align-center">
                 <button type="button" id="resetLocalPrefsButton" class="btn-danger"
-                    title="Clear stored user/org/language preferences for this browser">Reset Local Preferences</button>
+                    title="Clear stored organisation, language, and display preferences for this browser">Reset Local Preferences</button>
             </div>
 
             <div id="currentUserStatusMessage" class="status-message" role="alert">
@@ -958,16 +962,30 @@
     <script>
         // Check authentication status on page load
         async function checkAuthenticationStatus() {
+            let timeoutId = null;
             try {
                 console.log('Checking authentication status...');
-                const response = await fetch('/von/api/auth/status');
+                const controller = new AbortController();
+                timeoutId = window.setTimeout(() => controller.abort(), 10000);
+                const response = await fetch('/von/api/auth/status', {
+                    cache: 'no-store',
+                    signal: controller.signal,
+                });
+                if (!response.ok) {
+                    throw new Error(`Authentication status failed (${response.status})`);
+                }
                 const authStatus = await response.json();
 
                 console.log('Authentication status received:', authStatus);
                 await updateAuthenticationDisplay(authStatus);
             } catch (error) {
                 console.error('Failed to fetch authentication status:', error);
-                await updateAuthenticationDisplay({ authenticated: false });
+                await updateAuthenticationDisplay({
+                    status_unavailable: true,
+                    error_message: error?.message || 'Authentication status is unavailable.',
+                });
+            } finally {
+                if (timeoutId !== null) window.clearTimeout(timeoutId);
             }
         }
 
@@ -1139,34 +1157,10 @@
         }
 
         function syncBrowserTestSelections(payload) {
-            const user = payload && payload.user_concept_id
-                ? {
-                    concept_id: payload.user_concept_id,
-                    name: payload.name || payload.email || payload.user_concept_id,
-                    email: payload.email || null,
-                }
-                : null;
             const organisation = payload?.organisation || null;
             const namespace = payload?.namespace || null;
 
             try {
-                if (user?.concept_id) {
-                    const storedUser = {
-                        id: null,
-                        concept_id: user.concept_id,
-                        name: user.name,
-                    };
-                    const hostWindow = getSettingsHostWindow();
-                    const hostSessionStorage = hostWindow?.sessionStorage || sessionStorage;
-                    const hostLocalStorage = hostWindow?.localStorage || localStorage;
-
-                    sessionStorage.setItem('von_current_user', JSON.stringify(storedUser));
-                    localStorage.setItem('von_current_user', JSON.stringify(storedUser));
-                    hostSessionStorage.setItem('von_current_user', JSON.stringify(storedUser));
-                    hostLocalStorage.setItem('von_current_user', JSON.stringify(storedUser));
-                    upsertSelectOption('currentUserSelect', user);
-                }
-
                 if (organisation?.concept_id) {
                     const storedOrg = {
                         id: null,
@@ -1251,10 +1245,56 @@
             container.innerHTML = lines.join('');
         }
 
+        function renderCurrentUserIdentity(authStatus) {
+            const name = document.getElementById('currentUserIdentityName');
+            const email = document.getElementById('currentUserIdentityEmail');
+            const emailRow = document.getElementById('currentUserIdentityEmailRow');
+            const concept = document.getElementById('currentUserIdentityConcept');
+            const conceptRow = document.getElementById('currentUserIdentityConceptRow');
+            const hint = document.getElementById('currentUserIdentityHint');
+            if (!name || !email || !emailRow || !concept || !conceptRow || !hint) return;
+
+            const conceptId = typeof authStatus?.user_concept_id === 'string'
+                ? authStatus.user_concept_id.trim()
+                : '';
+            const isAuthenticatedActor = authStatus?.authenticated === true && !!conceptId;
+            if (!isAuthenticatedActor) {
+                const statusKnown = typeof authStatus?.authenticated === 'boolean';
+                name.textContent = !statusKnown
+                    ? 'Sign-in status unavailable'
+                    : (authStatus?.authenticated === true ? 'Signed-in identity unavailable' : 'Not signed in');
+                email.textContent = '';
+                concept.textContent = '';
+                emailRow.hidden = true;
+                conceptRow.hidden = true;
+                hint.textContent = !statusKnown
+                    ? 'Von could not verify the current session. Retry the status check; your saved scope has not been changed.'
+                    : (authStatus?.authenticated === true
+                        ? 'The authenticated session did not provide a user concept. Sign in again before using user-scoped settings.'
+                        : 'Sign in to establish the current user. Identity cannot be selected in Settings.');
+                return;
+            }
+
+            name.textContent = authStatus.name || authStatus.email || conceptId;
+            email.textContent = authStatus.email || '';
+            concept.textContent = conceptId;
+            emailRow.hidden = !authStatus.email;
+            conceptRow.hidden = false;
+            hint.textContent = 'Verified from the authenticated server session.';
+        }
+
         // Update authentication display based on status
         async function updateAuthenticationDisplay(authStatus) {
             const authContainer = document.getElementById('authenticationStatus');
             console.log('Updating authentication display. Container found:', !!authContainer, 'Status:', authStatus);
+            // Render the canonical identity and publish the status before optional
+            // footer/organisation refreshes, which may be slow or temporarily unavailable.
+            renderCurrentUserIdentity(authStatus);
+            renderBrowserTestModeStatus(authStatus);
+            try {
+                document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
+            } catch { }
+
             const browserTestMode = authStatus?.browser_test_mode || {};
             const browserTestAvailable = !!browserTestMode.available;
             const browserTestButtonLabel = authStatus?.auth_provider === 'browser_test_fixture'
@@ -1264,12 +1304,12 @@
                 ? `<button onclick="loginWithBrowserTestUser()" class="btn-secondary ml-2">${browserTestButtonLabel}</button>`
                 : '';
 
-            if (authStatus.authenticated) {
+            if (authStatus.authenticated === true) {
                 // User is logged in - show status and logout button
                 console.log('Showing authenticated state for:', authStatus.email);
                 authContainer.innerHTML = `
                     <div class="auth-status">
-                        <span class="auth-info">Logged in as: <strong>${authStatus.email}</strong></span>
+                        <span class="auth-info">Logged in as: <strong data-authenticated-email></strong></span>
                         ${authStatus.auth_provider === 'browser_test_fixture'
                             ? '<span class="settings-note ml-2">Browser test fixture active</span>'
                             : ''}
@@ -1277,8 +1317,10 @@
                         ${browserTestButtonHtml}
                     </div>
                 `;
-
-                // Do not overwrite current user selection with auth email; keep user selection independent of Gmail auth
+                const authenticatedEmail = authContainer.querySelector('[data-authenticated-email]');
+                if (authenticatedEmail) {
+                    authenticatedEmail.textContent = authStatus.email || authStatus.name || authStatus.user_concept_id || 'authenticated user';
+                }
 
                 // Immediately add authentication highlighting to footer
                 const userSegments = [...getSettingsHostDocument().querySelectorAll('.footer-segment')]
@@ -1298,20 +1340,22 @@
                 if (window.refreshOrgSelector) {
                     try { await window.refreshOrgSelector(); } catch (e) { console.warn('Org selector refresh failed', e); }
                 }
-            } else {
+            } else if (authStatus.authenticated === false) {
                 // User is not logged in - show login button
                 console.log('Showing unauthenticated state - login button');
                 authContainer.innerHTML = `
                     <button onclick="loginWithGoogle()" class="btn-primary">Login with Google</button>
                     ${browserTestButtonHtml}
                 `;
+            } else {
+                authContainer.innerHTML = `
+                    <div class="auth-status" role="alert">
+                        <span class="auth-info">Sign-in status is temporarily unavailable.</span>
+                        <button onclick="checkAuthenticationStatus()" class="btn-secondary ml-2">Retry status check</button>
+                    </div>
+                `;
             }
 
-            renderBrowserTestModeStatus(authStatus);
-
-            try {
-                document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
-            } catch { }
         }
 
         function authoriseAgentGmail() {
@@ -1407,6 +1451,31 @@
             await refreshAgentGmailOauthStatus();
         }
 
+        const IDENTITY_SCOPE_STORAGE_KEYS = [
+            'von_current_user',
+            'von_current_org',
+            'von_org_context',
+            'current_user_namespace',
+            'von_namespace',
+            'von_org_switching',
+            'von_org_selection',
+        ];
+
+        function clearIdentityScopeMirrors() {
+            const storageWindows = [window];
+            const hostWindow = getSettingsHostWindow();
+            if (hostWindow && hostWindow !== window) storageWindows.push(hostWindow);
+
+            for (const storageWindow of storageWindows) {
+                for (const storageName of ['sessionStorage', 'localStorage']) {
+                    try {
+                        const storage = storageWindow[storageName];
+                        for (const key of IDENTITY_SCOPE_STORAGE_KEYS) storage.removeItem(key);
+                    } catch { }
+                }
+            }
+        }
+
         // Handle logout
         async function logoutUser() {
             try {
@@ -1417,7 +1486,7 @@
                 if (response.ok) {
                     console.log('Logout successful');
 
-                    // Do not touch stored user selection on logout; only update auth display
+                    clearIdentityScopeMirrors();
                     await updateAuthenticationDisplay({ authenticated: false });
 
                     // Immediately remove authentication highlighting from footer
@@ -1429,6 +1498,10 @@
 
                     // Also refresh the full footer to ensure consistency
                     await refreshBrowserTestHostUi();
+
+                    // Re-run the host bootstrap so the signed-out gate replaces the app.
+                    const hostWindow = getSettingsHostWindow();
+                    hostWindow.location.reload();
                 } else {
                     console.error('Logout failed:', response.statusText);
                     alert('Logout failed. Please try again.');
@@ -1456,8 +1529,8 @@
                     throw new Error(message);
                 }
 
+                await checkAuthenticationStatus();
                 syncBrowserTestSelections(payload);
-                await updateAuthenticationDisplay(payload);
 
                 if (window.refreshOrgSelector) {
                     try { await window.refreshOrgSelector(); } catch (e) { console.warn('Org selector refresh failed', e); }
@@ -1565,8 +1638,9 @@
                             const result = await response.json();
                             if (result.success) {
                                 console.log('Auth token exchange successful:', result);
-                                // Update authentication display immediately with the result
-                                await updateAuthenticationDisplay(result);
+                                // The exchange response nests user data. Read back the canonical
+                                // session projection before rendering or caching the actor.
+                                await checkAuthenticationStatus();
                             } else {
                                 console.error('Auth token exchange failed:', result);
                                 // Fall back to checking status

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -19,7 +19,27 @@
 
 </head>
 
-<body>
+<body class="von-auth-pending">
+  <main id="vonAuthenticationGate" class="von-authentication-gate" aria-busy="true">
+    <section class="von-authentication-card" aria-labelledby="vonAuthenticationGateTitle">
+      <p class="von-authentication-kicker">Von</p>
+      <h1 id="vonAuthenticationGateTitle">Sign in to continue</h1>
+      <p class="von-authentication-summary">
+        Your sign-in establishes your Von identity and determines which personal and organisation-scoped work you can
+        access.
+      </p>
+      <div class="von-authentication-actions">
+        <button id="vonGoogleLoginButton" class="btn-primary" type="button" disabled>Sign in with Google</button>
+        <button id="vonBrowserTestLoginButton" class="btn-secondary" type="button" hidden>Browser test login</button>
+        <button id="vonAuthRetryButton" class="btn-secondary" type="button" hidden>Retry status check</button>
+      </div>
+      <p id="vonAuthenticationGateStatus" class="von-authentication-status" role="status" aria-live="polite">
+        Checking your sign-in…
+      </p>
+    </section>
+  </main>
+
+  <div id="vonAuthenticatedApp" hidden>
   <!-- Fixed Global Header (title + search above tabs) JVNAUTOSCI-550 -->
   <div class="global-header" id="globalHeader">
     <div class="global-header-shell">
@@ -235,6 +255,8 @@
     </div>
   </div>
   {% endif %}
+
+  </div>
 
   <!-- Link to external JavaScript (fixed endpoint spacing) -->
   <script type='module' src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/tests/backend/test_recommendation_profile_routes.py
+++ b/tests/backend/test_recommendation_profile_routes.py
@@ -33,6 +33,8 @@ def test_get_recommendation_profile_returns_payload(monkeypatch):
     )
 
     with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["user_concept_id"] = "#V#lu_yunli"
         resp = client.get("/api/settings/recommendation_profile/%23V%23lu_yunli")
 
     assert resp.status_code == 200
@@ -41,6 +43,49 @@ def test_get_recommendation_profile_returns_payload(monkeypatch):
     assert payload["derived_context"]["research_interest_concepts"][0]["name"] == (
         "Knowledge Graph"
     )
+
+
+def test_get_recommendation_profile_requires_authenticated_actor(monkeypatch):
+    app = _make_settings_app()
+    called = {"hit": False}
+
+    def _fake_load(**_kwargs):
+        called["hit"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.load_paper_recommendation_profile",
+        _fake_load,
+    )
+
+    with app.test_client() as client:
+        resp = client.get("/api/settings/recommendation_profile/%23V%23lu_yunli")
+
+    assert resp.status_code == 403
+    assert called["hit"] is False
+
+
+def test_post_recommendation_profile_requires_authenticated_actor(monkeypatch):
+    app = _make_settings_app()
+    called = {"hit": False}
+
+    def _fake_upsert(**_kwargs):
+        called["hit"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.upsert_paper_recommendation_profile",
+        _fake_upsert,
+    )
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/settings/recommendation_profile/%23V%23lu_yunli",
+            json={"project_description": "Graph reasoning"},
+        )
+
+    assert resp.status_code == 403
+    assert called["hit"] is False
 
 
 def test_post_recommendation_profile_forbidden_for_different_non_admin_session(
@@ -177,6 +222,29 @@ def test_post_recommendation_review_returns_payload(monkeypatch):
         "include_all_candidates": True,
         "trigger_source": "manual_review",
     }
+
+
+def test_post_recommendation_review_requires_authenticated_actor(monkeypatch):
+    app = _make_settings_app()
+    called = {"hit": False}
+
+    def _fake_build_review(**_kwargs):
+        called["hit"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "src.backend.server.routes.settings_routes.build_paper_recommendation_review",
+        _fake_build_review,
+    )
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/settings/recommendation_review/%23V%23lu_yunli",
+            json={},
+        )
+
+    assert resp.status_code == 403
+    assert called["hit"] is False
 
 
 def test_post_recommendation_review_forbidden_for_different_non_admin_session(

--- a/tests/backend/test_settings_selector_routes.py
+++ b/tests/backend/test_settings_selector_routes.py
@@ -13,27 +13,22 @@ def _make_settings_app() -> Flask:
     return app
 
 
-def test_people_selector_returns_retryable_503_when_concepts_collection_unavailable(
-    monkeypatch,
-):
-    import src.backend.server.routes.settings_routes as settings_routes
-
+def test_people_selector_route_is_absent():
     app = _make_settings_app()
-    monkeypatch.setattr(
-        settings_routes.ConceptsRepository,
-        "collection",
-        staticmethod(lambda: None),
-    )
 
     with app.test_client() as client:
         response = client.get("/api/settings/people")
 
-    payload = response.get_json() or {}
-    assert response.status_code == 503
-    assert payload["retryable"] is True
-    assert payload["reason"] == "concepts_collection_unavailable"
-    assert payload["retry_after_seconds"] == 5
-    assert response.headers["Retry-After"] == "5"
+    assert response.status_code == 404
+
+
+def test_legacy_current_user_route_is_absent():
+    app = _make_settings_app()
+
+    with app.test_client() as client:
+        response = client.get("/api/settings/user/current")
+
+    assert response.status_code == 404
 
 
 def test_organisation_selector_returns_retryable_503_when_concepts_collection_unavailable(

--- a/tests/frontend/homeAuthGate.test.js
+++ b/tests/frontend/homeAuthGate.test.js
@@ -1,0 +1,202 @@
+/** @jest-environment jsdom */
+
+import {
+    applyHomeAuthState,
+    fetchHomeAuthStatus,
+    hasAuthenticatedVonActor,
+    initialiseHomeAuthentication,
+    shouldClearHomeIdentityMirrors,
+} from '../../src/frontend/web/von_interface/static/js/homeAuthGate.js';
+
+function renderGate() {
+    document.body.className = 'von-auth-pending';
+    document.body.innerHTML = `
+        <main id="vonAuthenticationGate" aria-busy="true">
+            <button id="vonGoogleLoginButton" disabled>Sign in with Google</button>
+            <button id="vonBrowserTestLoginButton" hidden>Browser test login</button>
+            <button id="vonAuthRetryButton" hidden>Retry</button>
+            <p id="vonAuthenticationGateStatus"></p>
+        </main>
+        <div id="vonAuthenticatedApp" hidden>Private application</div>
+    `;
+}
+
+function jsonResponse(payload, { ok = true, status = 200 } = {}) {
+    return {
+        ok,
+        status,
+        json: jest.fn().mockResolvedValue(payload),
+    };
+}
+
+describe('home authentication gate', () => {
+    beforeEach(() => {
+        renderGate();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('uses the canonical same-origin auth status endpoint', async () => {
+        const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ authenticated: false }));
+
+        await expect(fetchHomeAuthStatus({ fetchImpl, windowObject: window })).resolves.toEqual({
+            authenticated: false,
+        });
+        expect(fetchImpl).toHaveBeenCalledWith('/von/api/auth/status', expect.objectContaining({
+            cache: 'no-store',
+            credentials: 'same-origin',
+        }));
+    });
+
+    test('requires both authentication and a resolved Von actor', () => {
+        expect(hasAuthenticatedVonActor({ authenticated: true })).toBe(false);
+        expect(hasAuthenticatedVonActor({
+            authenticated: true,
+            user_concept_id: '#V#authenticated_user',
+        })).toBe(true);
+    });
+
+    test('clears browser mirrors only for a confirmed signed-out or invalid-actor status', () => {
+        expect(shouldClearHomeIdentityMirrors(null)).toBe(false);
+        expect(shouldClearHomeIdentityMirrors({ status_unavailable: true })).toBe(false);
+        expect(shouldClearHomeIdentityMirrors({ authenticated: false })).toBe(true);
+        expect(shouldClearHomeIdentityMirrors({ authenticated: true })).toBe(true);
+        expect(shouldClearHomeIdentityMirrors({
+            authenticated: true,
+            user_concept_id: '#V#authenticated_user',
+        })).toBe(false);
+    });
+
+    test('times out a status request so the blocking gate can offer retry', async () => {
+        const fetchImpl = jest.fn(() => new Promise(() => {}));
+
+        await expect(fetchHomeAuthStatus({
+            fetchImpl,
+            windowObject: window,
+            timeoutMs: 5,
+        })).rejects.toThrow('timed out');
+    });
+
+    test('signed-out state replaces the application with enabled login controls', () => {
+        const authenticated = applyHomeAuthState({
+            authenticated: false,
+            browser_test_mode: { available: true },
+        });
+
+        expect(authenticated).toBe(false);
+        expect(document.getElementById('vonAuthenticationGate').hidden).toBe(false);
+        expect(document.getElementById('vonAuthenticatedApp').hidden).toBe(true);
+        expect(document.getElementById('vonGoogleLoginButton').disabled).toBe(false);
+        expect(document.getElementById('vonBrowserTestLoginButton').hidden).toBe(false);
+        expect(document.body.classList.contains('von-signed-out')).toBe(true);
+        expect(document.getElementById('vonAuthenticationGateStatus').textContent).toContain('Sign in');
+    });
+
+    test('resolved login reveals the application and removes the gate', () => {
+        const authenticated = applyHomeAuthState({
+            authenticated: true,
+            user_concept_id: '#V#authenticated_user',
+        });
+
+        expect(authenticated).toBe(true);
+        expect(document.getElementById('vonAuthenticationGate').hidden).toBe(true);
+        expect(document.getElementById('vonAuthenticatedApp').hidden).toBe(false);
+        expect(document.getElementById('vonAuthenticatedApp').getAttribute('aria-hidden')).toBe('false');
+        expect(document.body.classList.contains('von-authenticated')).toBe(true);
+    });
+
+    test('browser-test login is followed by canonical status read-back', async () => {
+        const onAuthenticated = jest.fn();
+        const fetchImpl = jest.fn()
+            .mockResolvedValueOnce(jsonResponse({
+                authenticated: false,
+                browser_test_mode: { available: true },
+            }))
+            .mockResolvedValueOnce(jsonResponse({ success: true, authenticated: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                authenticated: true,
+                user_concept_id: '#V#browser_test_user',
+            }));
+
+        await initialiseHomeAuthentication({
+            documentObject: document,
+            windowObject: window,
+            fetchImpl,
+            onAuthenticated,
+        });
+        document.getElementById('vonBrowserTestLoginButton').click();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(fetchImpl.mock.calls[1][0]).toBe('/von/api/auth/browser-test-login');
+        expect(fetchImpl.mock.calls[1][1]).toMatchObject({
+            method: 'POST',
+            credentials: 'same-origin',
+        });
+        expect(fetchImpl.mock.calls[2][0]).toBe('/von/api/auth/status');
+        expect(onAuthenticated).toHaveBeenCalledWith({
+            authenticated: true,
+            user_concept_id: '#V#browser_test_user',
+        });
+    });
+
+    test('Google popup token exchange is confirmed against canonical session status', async () => {
+        const popup = { closed: false, focus: jest.fn() };
+        jest.spyOn(window, 'open').mockReturnValue(popup);
+        const onAuthenticated = jest.fn();
+        const fetchImpl = jest.fn()
+            .mockResolvedValueOnce(jsonResponse({ authenticated: false }))
+            .mockResolvedValueOnce(jsonResponse({ success: true, authenticated: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                authenticated: true,
+                user_concept_id: '#V#google_user',
+            }));
+
+        await initialiseHomeAuthentication({
+            documentObject: document,
+            windowObject: window,
+            fetchImpl,
+            onAuthenticated,
+        });
+        document.getElementById('vonGoogleLoginButton').click();
+        window.dispatchEvent(new MessageEvent('message', {
+            origin: window.location.origin,
+            data: { type: 'googleLoginSuccess', authToken: 'temporary-token' },
+        }));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(window.open).toHaveBeenCalledWith(
+            '/von/api/auth/google/login',
+            'vonGoogleLogin',
+            expect.stringContaining('resizable=yes'),
+        );
+        expect(fetchImpl.mock.calls[1][0]).toBe('/von/api/auth/exchange-token');
+        expect(JSON.parse(fetchImpl.mock.calls[1][1].body)).toEqual({ token: 'temporary-token' });
+        expect(fetchImpl.mock.calls[2][0]).toBe('/von/api/auth/status');
+        expect(onAuthenticated).toHaveBeenCalledWith({
+            authenticated: true,
+            user_concept_id: '#V#google_user',
+        });
+    });
+
+    test('status failure remains fail-closed and exposes retry', async () => {
+        const onAuthenticated = jest.fn();
+        const fetchImpl = jest.fn().mockResolvedValue(jsonResponse(
+            { error: 'unavailable' },
+            { ok: false, status: 503 },
+        ));
+
+        await expect(initialiseHomeAuthentication({
+            documentObject: document,
+            windowObject: window,
+            fetchImpl,
+            onAuthenticated,
+        })).resolves.toBeNull();
+
+        expect(document.getElementById('vonAuthenticatedApp').hidden).toBe(true);
+        expect(document.getElementById('vonAuthRetryButton').hidden).toBe(false);
+        expect(document.getElementById('vonAuthenticationGateStatus').dataset.kind).toBe('error');
+        expect(onAuthenticated).not.toHaveBeenCalled();
+    });
+});

--- a/tests/frontend/loginDrivenIdentityTemplates.test.js
+++ b/tests/frontend/loginDrivenIdentityTemplates.test.js
@@ -1,0 +1,53 @@
+/** @jest-environment node */
+
+const fs = require('fs');
+const path = require('path');
+
+const interfaceTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/von_interface.html'),
+    'utf8',
+);
+const settingsTemplate = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/settings_tab.html'),
+    'utf8',
+);
+const settingsSource = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/js/settings.js'),
+    'utf8',
+);
+const settingsPageSource = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/js/settingsPage.js'),
+    'utf8',
+);
+const mainSource = fs.readFileSync(
+    path.resolve(__dirname, '../../src/frontend/web/von_interface/static/js/main.js'),
+    'utf8',
+);
+
+describe('login-driven identity templates', () => {
+    test('home starts fail-closed with a dedicated sign-in gate', () => {
+        expect(interfaceTemplate).toContain('<body class="von-auth-pending">');
+        expect(interfaceTemplate).toContain('id="vonAuthenticationGate"');
+        expect(interfaceTemplate).toContain('id="vonAuthenticatedApp" hidden');
+        expect(interfaceTemplate).toContain('Sign in to continue');
+    });
+
+    test('auth is checked before the working application is initialised', () => {
+        const authCheck = mainSource.indexOf('await initialiseHomeAuthentication()');
+        const domInitialisation = mainSource.indexOf('initializeDomElements()');
+        const actorGuard = mainSource.indexOf('if (!hasAuthenticatedVonActor(authStatus))');
+
+        expect(authCheck).toBeGreaterThan(-1);
+        expect(actorGuard).toBeGreaterThan(authCheck);
+        expect(domInitialisation).toBeGreaterThan(actorGuard);
+        expect(mainSource).not.toContain("authStatus?.authenticated === true && authStatus?.user_concept_id");
+    });
+
+    test('Settings presents login identity read-only and has no people enumeration path', () => {
+        expect(settingsTemplate).toContain('id="currentUserIdentity"');
+        expect(settingsTemplate).not.toContain('id="currentUserSelect"');
+        expect(settingsSource).not.toContain('/api/settings/people');
+        expect(settingsSource).not.toContain('populatePeopleDropdown');
+        expect(settingsPageSource).not.toContain('currentUserSelect');
+    });
+});

--- a/tests/frontend/runtimeIdentityBootstrap.test.js
+++ b/tests/frontend/runtimeIdentityBootstrap.test.js
@@ -11,12 +11,12 @@ describe('runtimeIdentityBootstrap', () => {
         });
     });
 
-    test('prefers settings identity and falls back to auth identity when settings is sparse', () => {
+    test('derives user identity only from authenticated status', () => {
         const { resolveBrowserBootstrapUserContext } = require(modulePath);
 
         expect(resolveBrowserBootstrapUserContext({
-            settings: {},
             authStatus: {
+                authenticated: true,
                 user_concept_id: '#V#codex_browser_fixture',
                 name: 'Codex Browser Test'
             },
@@ -25,6 +25,43 @@ describe('runtimeIdentityBootstrap', () => {
             id: null,
             concept_id: '#V#codex_browser_fixture',
             name: 'Codex Browser Test'
+        });
+    });
+
+    test('does not recover a signed-out identity from settings or browser storage', () => {
+        const { resolveBrowserBootstrapUserContext } = require(modulePath);
+
+        expect(resolveBrowserBootstrapUserContext({
+            settings: {
+                current_user_person_concept_id: '#V#settings_actor',
+                current_user_person_name: 'Settings Actor',
+            },
+            authStatus: { authenticated: false },
+            storedUser: {
+                concept_id: '#V#stored_actor',
+                name: 'Stored Actor',
+            },
+        })).toBeNull();
+    });
+
+    test('overwrites stale actor details with the canonical authenticated identity', () => {
+        const { resolveBrowserBootstrapUserContext } = require(modulePath);
+
+        expect(resolveBrowserBootstrapUserContext({
+            authStatus: {
+                authenticated: true,
+                user_concept_id: '#V#authenticated_actor',
+                email: 'actor@example.org',
+            },
+            storedUser: {
+                id: 'stale-db-id',
+                concept_id: '#V#stale_actor',
+                name: 'Stale Actor',
+            },
+        })).toEqual({
+            id: null,
+            concept_id: '#V#authenticated_actor',
+            name: 'actor@example.org',
         });
     });
 

--- a/tests/frontend/settingsConcernNavigation.test.js
+++ b/tests/frontend/settingsConcernNavigation.test.js
@@ -5,6 +5,7 @@ import {
     __testOnly_getSettingsSectionRailTargets,
     __testOnly_getVisibleSettingsSectionIds,
     __testOnly_initialiseSettingsConcernNavigation,
+    __testOnly_syncAuthenticatedUserProjection,
 } from '../../src/frontend/web/von_interface/static/js/settingsPage.js';
 
 function renderSettingsNavigationFixture() {
@@ -22,11 +23,9 @@ function renderSettingsNavigationFixture() {
             <nav id="settingsSectionRail"></nav>
 
             <section id="current-user-settings" data-settings-concern="identity">
-                <h2>Current User Configuration</h2>
+                <h2>Signed-in Identity</h2>
                 <div id="authenticationStatus"><button type="button">Login</button></div>
-                <select id="currentUserSelect">
-                    <option value="">Loading people...</option>
-                </select>
+                <div id="currentUserIdentity">Not signed in</div>
             </section>
             <section id="current-organisation-settings" data-settings-concern="identity">
                 <h2>Current Organisation Configuration</h2>
@@ -105,9 +104,9 @@ describe('settings concern navigation', () => {
         ]);
         const summary = document.getElementById('settingsConcernSummary');
         expect(summary.dataset.guidanceSource).toBe('temporary-placeholder');
-        expect(summary.textContent).toContain('Choose the current user for this browser');
+        expect(summary.textContent).toContain('Sign in to establish your identity');
         expect(summary.textContent).toContain('Suggested next step');
-        expect(summary.querySelector('[data-settings-guidance-target]')?.textContent).toBe('Choose current user');
+        expect(summary.querySelector('[data-settings-guidance-target]')?.textContent).toBe('Open sign-in controls');
         expect(__testOnly_getSettingsSectionRailTargets('identity')).toEqual([
             'current-user-settings',
             'current-organisation-settings',
@@ -170,5 +169,26 @@ describe('settings concern navigation', () => {
             'current-organisation-settings',
         ]);
         expect(loginButton.focus).toHaveBeenCalled();
+    });
+
+    test('an unavailable auth-status read preserves inert actor and organisation mirrors', () => {
+        const user = JSON.stringify({ concept_id: '#V#signed_in_user', name: 'Signed In User' });
+        const organisation = JSON.stringify({ concept_id: '#V#selected_org', name: 'Selected Org' });
+        localStorage.setItem('von_current_user', user);
+        sessionStorage.setItem('von_current_user', user);
+        localStorage.setItem('von_current_org', organisation);
+        sessionStorage.setItem('von_current_org', organisation);
+        sessionStorage.setItem('current_user_namespace', '#V#signed_in_user@selected_org');
+
+        expect(__testOnly_syncAuthenticatedUserProjection({
+            status_unavailable: true,
+            error_message: 'Authentication status failed (503)',
+        })).toBeNull();
+
+        expect(localStorage.getItem('von_current_user')).toBe(user);
+        expect(sessionStorage.getItem('von_current_user')).toBe(user);
+        expect(localStorage.getItem('von_current_org')).toBe(organisation);
+        expect(sessionStorage.getItem('von_current_org')).toBe(organisation);
+        expect(sessionStorage.getItem('current_user_namespace')).toBe('#V#signed_in_user@selected_org');
     });
 });

--- a/tests/frontend/settingsModelPoolControls.test.js
+++ b/tests/frontend/settingsModelPoolControls.test.js
@@ -477,7 +477,11 @@ describe('settings model scope and workflow pool controls', () => {
         });
     });
 
-    test('actor transition commits server user and organisation before scoped GET', async () => {
+    test('organisation transition commits the authenticated server user and organisation before scoped GET', async () => {
+        sessionStorage.setItem('von_current_user', JSON.stringify({
+            concept_id: '#V#new-user',
+            name: 'New User',
+        }));
         const order = [];
         let releaseUserCommit;
         const userCommit = new Promise((resolve) => { releaseUserCommit = resolve; });
@@ -497,8 +501,7 @@ describe('settings model scope and workflow pool controls', () => {
         });
 
         const transition = __testOnly_queueActorContextTransition({
-            snapshot: { user: { concept_id: '#V#old-user' }, organisation: null },
-            requestedUser: { concept_id: '#V#new-user', name: 'New User' },
+            snapshot: { user: { concept_id: '#V#new-user' }, organisation: null },
             requestedOrganisation: { concept_id: '#V#new-org', name: 'New Org' },
             setUserConceptFn,
             switchOrganisationFn,
@@ -533,10 +536,8 @@ describe('settings model scope and workflow pool controls', () => {
             snapshot: {
                 user: { concept_id: '#V#old-user' },
                 organisation: { concept_id: '#V#old-org' },
-                userSelectedIndex: -1,
                 organisationSelectedIndex: -1,
             },
-            requestedUser: { concept_id: '#V#new-user' },
             requestedOrganisation: { concept_id: '#V#new-org' },
             setUserConceptFn: jest.fn(async () => ({ namespace: '#V#new-user' })),
             switchOrganisationFn: jest.fn(async () => { throw new Error('organisation commit failed'); }),
@@ -554,10 +555,15 @@ describe('settings model scope and workflow pool controls', () => {
     });
 
     test('failed initial actor commit restores committed context and leaves Save disabled', async () => {
+        sessionStorage.setItem('von_current_user', JSON.stringify({
+            concept_id: '#V#restored-user',
+            name: 'Restored User',
+        }));
+        localStorage.setItem('von_current_user', JSON.stringify({
+            concept_id: '#V#restored-user',
+            name: 'Restored User',
+        }));
         document.body.insertAdjacentHTML('beforeend', `
-            <select id="currentUserSelect">
-                <option data-concept-id="#V#restored-user" selected>Restored User</option>
-            </select>
             <select id="currentOrganisationSelect">
                 <option data-concept-id="#V#restored-org" selected>Restored Org</option>
             </select>

--- a/tests/frontend/settingsOpenAiModelChange.test.js
+++ b/tests/frontend/settingsOpenAiModelChange.test.js
@@ -59,7 +59,6 @@ describe('settingsPage OpenAI model change handling', () => {
             <button id="addOpenAiToWorkflowPoolButton" type="button"></button>
             <button id="addOllamaToWorkflowPoolButton" type="button"></button>
             <select id="globalModelSelect"></select>
-            <select id="currentUserSelect"></select>
             <select id="currentOrganisationSelect"></select>
             <select id="preferredLanguageSelect"></select>
             <div id="settingsStatusMessage"></div>
@@ -85,9 +84,6 @@ describe('settingsPage OpenAI model change handling', () => {
             }
             if (String(url).includes('/api/settings/ollama/hosts')) {
                 return { data: { hosts: [], active_host: null } };
-            }
-            if (String(url).includes('/api/settings/people')) {
-                return { data: [] };
             }
             if (String(url).includes('/api/settings/organisations')) {
                 return { data: [] };
@@ -162,7 +158,13 @@ describe('settingsPage OpenAI model change handling', () => {
                 return jsonResponse({ role: 'user', namespace: null });
             }
             if (target.startsWith('/von/api/auth/status')) {
-                return jsonResponse({ authenticated: false, browser_test_mode: { enabled: false } });
+                return jsonResponse({
+                    authenticated: true,
+                    email: 'settings-test-user@example.org',
+                    name: 'Settings Test User',
+                    user_concept_id: '#V#settings-test-user',
+                    browser_test_mode: { enabled: false },
+                });
             }
             if (target.startsWith('/api/workflows/capability-index/status')) {
                 return jsonResponse({ status: 'idle' });


### PR DESCRIPTION
## Outcome

- replace the signed-out Von home application with a fail-closed sign-in gate
- derive the current user only from the authenticated server session and render it read-only in Settings
- keep organisation selection separate while clearing stale actor-bound scope on confirmed actor changes/logout
- remove legacy people enumeration and fabricated-current-user endpoints
- require an authenticated matching actor for user-scoped recommendation profile and review routes
- update security, browser-validation, and MCP context documentation

## Acceptance evidence

- 7 focused frontend suites: 61 tests passed
- focused authentication/model-transition subset: 11 tests passed
- focused backend identity/authority suite: 18 tests passed
- frontend static lint, changed JavaScript syntax, Settings inline-script syntax, MCP JSON parse, and `git diff --check`: passed
- independent candidate review: no remaining material findings
- local AgentTest browser replay: signed-out gate replaced the app; browser-test login restored the app after canonical status read-back; Settings showed the authenticated name/email/concept with no user selector; logout restored the gate; no browser console warnings/errors
- live unauthenticated probes: removed identity endpoints returned 404 and recommendation-profile access returned 403

## Known non-blocking evidence

- a broader Settings run retains the pre-existing `pending.get(...) is not a function` harness failure at `tests/frontend/settingsModelPoolControls.test.js:449`; the affected transition tests pass
- initial broader backend checks without the project environment failed only on unavailable Mongo/window-binding services; the normal local AgentTest environment subsequently reached healthy state

Jira: [JVNAUTOSCI-2704](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2704)

No deployment or live activation is included.


[JVNAUTOSCI-2704]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ