### PR TITLE
Separate Von login and organisation authority predicates

### DIFF
--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -25,7 +25,11 @@ Authoritative namespace contract:
 
 - Vontology concept visibility is filtered by canonical Vontology predicates under `relationships.#V#specific_to_user` and `relationships.#V#specific_to_organisation`.
 - Legacy storage keys such as `relationships.specific_to_user` and `relationships.specific_to_org` remain readable only for migration compatibility; new writes should use the canonical predicates.
-- User identity comes from the **server session** (fallback: validated `X-User-Concept-ID` header), not from client JSON.
+- Google OAuth identity is bound to a Vontology user only through the narrow
+  `#V#hasVonLoginEmail` predicate. Ordinary `#V#has_email` contact facts and
+  client/session hints cannot select or create an authenticated actor.
+- Effective user identity comes from the **server session** (fallback:
+  validated `X-User-Concept-ID` header), not from client JSON.
 - RAG tools are **fail-closed** without a namespace.
 - RAG query backends (e.g., LlamaIndex) can additionally filter by metadata keys like `user_id` and `organisation_concept_id`, but only if those keys are provided via `permissions_context`.
 - Effective namespace resolution is now centralised for `/von/generate` and propagated into persistence and RAG paths, with mismatch diagnostics available for migration hardening.
@@ -36,6 +40,17 @@ Authoritative namespace contract:
 
 The authoritative identity is derived by the backend.
 
+- `src/backend/services/von_user_authentication_service.py` resolves Google
+  OAuth email addresses only through `#V#hasVonLoginEmail`.
+  - The predicate specialises and entails descriptive `#V#has_email`.
+  - The reverse inference is forbidden: `#V#has_email` never grants login.
+  - One user may have several explicit login-email values, but an address bound
+    to more than one user is rejected as ambiguous.
+  - An unbound address does not inherit the browser's prior user concept and
+    does not auto-create a new Von user.
+  - Sessions issued through the old email-resolution path do not carry the
+    versioned login-assurance marker and fail closed after the cutover; users
+    must authenticate again.
 - `src/backend/security/access_control.py` provides `get_effective_user_concept_id()`.
   - Primary: `session["user_concept_id"]` (set on login).
   - Fallback: `X-User-Concept-ID` header, **only if validated** as a person/von_user concept.
@@ -46,6 +61,23 @@ The authoritative identity is derived by the backend.
 The `/generate` endpoint explicitly does **not** trust client-provided `user_id` for security reasons. Unauthenticated users can still chat, but RAG access is unavailable.
 
 See: docs/engineering/security_considerations.md.
+
+### Operator migration and recovery
+
+The login-email migration accepts only an explicit reviewed allow-list. It
+never scans or copies `#V#has_email`:
+
+```sh
+python -m src.backend.utilities.migrate_von_login_email_bindings \
+  --binding '#V#person_id=person@example.org'
+
+python -m src.backend.utilities.migrate_von_login_email_bindings \
+  --binding '#V#person_id=person@example.org' --apply --approved
+```
+
+Run the first command before applying. If it reports a missing user or an
+address already bound to another user, correct that exact conflict and rerun
+the dry run; do not work around it by adding a generic email relation.
 
 ## 2) Vontology access control (concepts + relationships)
 
@@ -171,9 +203,14 @@ requirements are recorded in
 RBAC is present but **not a complete system** yet.
 
 - `src/backend/security/role_resolver.py` contains a Phase 1 stub mapping (hardcoded user/org → role → permissions).
-- `src/backend/services/organisation_membership_service.py` persists membership and roles in the Vontology:
-  - membership relationship: `memberOf`
-  - role stored via a text relation predicate like `#V#hasRole` with a context containing the organisation ID
+- `src/backend/services/organisation_membership_service.py` persists operational
+  membership and roles in the Vontology:
+  - authority-bearing membership relationship: `#V#memberOfVonOrg`
+  - operational role: `#V#hasVonOrgRole`, with context containing the exact
+    organisation ID
+  - `#V#memberOfVonOrg` specialises and entails the descriptive
+    `#V#memberOf` predicate; generic `memberOf`, `member_of_organisation`, and
+    `hasRole` assertions never grant Von access or an operational role
 
 Practical consequence:
 - Some code paths can read role/permissions from stubs, while the Vontology contains a richer representation that is not consistently used everywhere.

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -104,7 +104,24 @@ Use different controls for different data and capability classes.
 
 ## Known Security Limitations
 
-### 1. Narrow authentication safeguard implemented in December 2024
+### 1. Authentication identity boundary
+
+Google OAuth email addresses must resolve only through the dedicated
+`#V#hasVonLoginEmail` predicate. The ordinary `#V#has_email` predicate is
+descriptive contact information: adding it to a person must never let that
+address authenticate as the person. Login-email bindings are an explicit
+operator-reviewed allow-list, are unique across user concepts, and fail closed
+when absent, stale, or ambiguous. An unbound OAuth identity must not inherit a
+browser-supplied or prior-session concept and must not auto-create a user.
+
+`#V#hasVonLoginEmail` specialises and entails `#V#has_email`; the reverse
+inference is forbidden. Generic ontology mutation surfaces reserve the narrow
+predicate so only the dedicated identity-binding lifecycle can change it.
+Newly resolved Google sessions carry a versioned login-assurance marker at the
+trusted session boundary. Pre-cutover email sessions lack that evidence and
+must fail closed rather than retaining an actor or organisation scope.
+
+### 1a. Narrow endpoint safeguard implemented in December 2024
 
 **Location**: `src/backend/server/routes/von_routes.py` - `/generate` endpoint
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -38980,7 +38980,8 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "and returns an actor-bound idempotency receipt plus canonical "
                 "read-back. Semantic ontology-administrator authority does not grant "
                 "membership-management authority. Generic relationship tools remain "
-                "ineligible for memberOf or hasRole."
+                "ineligible for memberOfVonOrg or hasVonOrgRole. Generic "
+                "memberOf and hasRole assertions are descriptive only."
             ),
         ),
         MethodDefinition(

--- a/src/backend/security/access_control.py
+++ b/src/backend/security/access_control.py
@@ -17,6 +17,9 @@ from .visibility_predicates import (
     get_specific_to_org_values,
     get_specific_to_user_values,
 )
+from .authentication_assurance import (
+    session_has_required_authentication_assurance,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -402,6 +405,10 @@ def get_effective_user_concept_id_with_source() -> tuple[str | None, str | None]
     if not has_request_context():
         return None, None
 
+    if not session_has_required_authentication_assurance(session):
+        _log.warning("Rejected pre-cutover or unassured email-authenticated session")
+        return None, None
+
     # Primary authority is the server-side session which is populated during the
     # authenticated login flow.
     session_user = _normalise_concept_id(session.get("user_concept_id"))
@@ -453,6 +460,8 @@ def get_effective_organisation_concept_id() -> Optional[str]:
     if _MANUAL_ACTOR_BOUND.get() or manual is not None:
         return manual
     if not has_request_context():
+        return None
+    if not session_has_required_authentication_assurance(session):
         return None
     try:
         window_session_id = request.headers.get("X-Von-Window-Session")

--- a/src/backend/security/authentication_assurance.py
+++ b/src/backend/security/authentication_assurance.py
@@ -1,0 +1,45 @@
+"""Versioned server-session assurance for interactive authentication."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+AUTHENTICATION_ASSURANCE_SESSION_KEY = "von_authentication_assurance"
+GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE = "hasVonLoginEmail.v1"
+BROWSER_TEST_AUTH_PROVIDER = "browser_test_fixture"
+GOOGLE_OAUTH_AUTH_PROVIDER = "google_oauth"
+
+
+def session_requires_login_email_assurance(session_data: Mapping[str, Any]) -> bool:
+    """Whether this session claims an interactive email-based identity."""
+
+    provider = str(session_data.get("auth_provider") or "").strip()
+    if provider == BROWSER_TEST_AUTH_PROVIDER:
+        return False
+    return provider == GOOGLE_OAUTH_AUTH_PROVIDER or bool(
+        session_data.get("user_email")
+    )
+
+
+def session_has_required_authentication_assurance(
+    session_data: Mapping[str, Any],
+) -> bool:
+    """Reject pre-cutover email sessions lacking the narrow-binding proof."""
+
+    if not session_requires_login_email_assurance(session_data):
+        return True
+    return (
+        session_data.get(AUTHENTICATION_ASSURANCE_SESSION_KEY)
+        == GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE
+    )
+
+
+__all__ = [
+    "AUTHENTICATION_ASSURANCE_SESSION_KEY",
+    "BROWSER_TEST_AUTH_PROVIDER",
+    "GOOGLE_OAUTH_AUTH_PROVIDER",
+    "GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE",
+    "session_has_required_authentication_assurance",
+    "session_requires_login_email_assurance",
+]

--- a/src/backend/server/routes/auth_routes.py
+++ b/src/backend/server/routes/auth_routes.py
@@ -1,10 +1,17 @@
 from flask import Blueprint, current_app, request, redirect, session, url_for, jsonify
 
 from ...auth_service import GoogleAuthService
-from ...services.settings_service import (
-    set_current_user_by_email,
+from ...security.authentication_assurance import (
+    AUTHENTICATION_ASSURANCE_SESSION_KEY,
+    GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE,
+    session_has_required_authentication_assurance,
 )
 from ...services.exceptions import MultipleUsersForEmailError
+from ...services.von_user_authentication_service import (
+    find_user_concept_by_login_email,
+    login_email_log_fingerprint,
+    normalise_von_login_email,
+)
 import time
 
 auth_bp = Blueprint("auth_bp", __name__)
@@ -54,9 +61,7 @@ def _clear_scope_if_authenticated_identity_changes(
     new_email: object,
 ) -> None:
     """Drop prior actor scope unless the new login proves the same identity."""
-    previous_concept_id = _normalise_session_identity(
-        session.get("user_concept_id")
-    )
+    previous_concept_id = _normalise_session_identity(session.get("user_concept_id"))
     previous_email = _normalise_session_identity(session.get("user_email"))
     next_concept_id = _normalise_session_identity(new_user_concept_id)
     next_email = _normalise_session_identity(new_email)
@@ -100,12 +105,21 @@ def _build_auth_status_payload() -> dict:
             else ("google_oauth" if user_email else None)
         )
 
+    authenticated = bool(
+        user_email
+        and user_concept_id
+        and session_has_required_authentication_assurance(session)
+    )
     return {
-        "authenticated": bool(user_email),
-        "email": user_email,
-        "name": user_info.get("name") if isinstance(user_info, dict) else None,
-        "user_concept_id": user_concept_id,
-        "auth_provider": auth_provider,
+        "authenticated": authenticated,
+        "email": user_email if authenticated else None,
+        "name": (
+            user_info.get("name")
+            if authenticated and isinstance(user_info, dict)
+            else None
+        ),
+        "user_concept_id": user_concept_id if authenticated else None,
+        "auth_provider": auth_provider if authenticated else None,
         "browser_test_mode": browser_test_mode,
     }
 
@@ -160,16 +174,14 @@ def login():
 
     authorization_url, state = service.get_authorization_url()
     # Keep a single concise log for traceability
-    print(
-        f"[auth_login] start state={authorization_url.split('state=')[1].split('&')[0] if 'state=' in authorization_url else 'unknown'} redirect={service.redirect_uri}"
-    )
+    print(f"[auth_login] start redirect={service.redirect_uri}")
 
     # Store state in both session AND in-memory backup (for popup windows)
     session["oauth_state"] = state
     _oauth_states[state] = {"timestamp": time.time(), "used": False}
 
     # Minimal debug line (state + session keys only)
-    print(f"[auth_login] state_saved={state} session_keys={list(session.keys())}")
+    print(f"[auth_login] state_saved session_keys={list(session.keys())}")
 
     return redirect(authorization_url)
 
@@ -183,7 +195,10 @@ def callback():
 
     # Condensed debug
     print(
-        f"[auth_callback] session_state={session_state} received_state={received_state} session_keys={list(session.keys())}"
+        "[auth_callback] state_present="
+        f"{bool(received_state)} state_matches_session="
+        f"{bool(session_state and session_state == received_state)} "
+        f"session_keys={list(session.keys())}"
     )
 
     # Check session first, then fallback to in-memory storage for popup windows
@@ -204,13 +219,16 @@ def callback():
 
     if not valid_state:
         print("[auth_callback] Invalid state - no valid session or memory match")
-        return (
-            f"Invalid state. Session: {session_state}, Received: {received_state}",
-            400,
-        )
+        return "Invalid OAuth state.", 400
+
+    # OAuth state is single-use regardless of whether it was validated through
+    # the cookie session or the popup fallback store.
+    session.pop("oauth_state", None)
+    if received_state:
+        _oauth_states.pop(received_state, None)
 
     try:
-        print(f"[auth_callback] exchanging_code state={received_state}")
+        print("[auth_callback] exchanging_code")
         authorization_response_url = service.canonicalise_authorization_response_url(
             request.url
         )
@@ -221,24 +239,49 @@ def callback():
 
         email = id_info.get("email")
         name = id_info.get("name", "")
-        print(f"[auth_callback] user_email={email}")
-
         if not email:
             print("[auth_callback] No email found in Google profile")
             return "Email not found in Google profile.", 400
-
         try:
-            # Find or create the user in the Von database and set them as current.
-            user = set_current_user_by_email(email, name)
-        except MultipleUsersForEmailError as e:
+            login_email = normalise_von_login_email(email)
+        except ValueError:
             return (
                 jsonify(
                     {
-                        "error": "Multiple users found for this email",
-                        "conflicting_users": e.user_ids,
+                        "error": "Google returned an invalid email address",
+                        "error_code": "google_email_invalid",
+                    }
+                ),
+                400,
+            )
+
+        try:
+            # Resolve only the explicit, operator-controlled login-email
+            # predicate. Ordinary has_email contact facts carry no identity.
+            user = find_user_concept_by_login_email(login_email)
+        except MultipleUsersForEmailError:
+            return (
+                jsonify(
+                    {
+                        "error": "This Google account has an ambiguous Von login binding",
+                        "error_code": "von_login_email_binding_ambiguous",
                     }
                 ),
                 409,
+            )
+        if not user or not user.get("concept_id"):
+            print(
+                "[auth_callback] rejected_unbound_login_email fingerprint="
+                f"{login_email_log_fingerprint(login_email)}"
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "This Google account is not authorised for a Von user",
+                        "error_code": "von_login_email_not_authorised",
+                    }
+                ),
+                403,
             )
 
         # Never carry organisation/namespace/chat authority across accounts in
@@ -246,22 +289,37 @@ def callback():
         user_concept_id = user.get("concept_id") if user else None
         _clear_scope_if_authenticated_identity_changes(
             new_user_concept_id=user_concept_id,
-            new_email=email,
+            new_email=login_email,
         )
 
         # Set session variables for web authentication
-        session["user_email"] = email
-        session["google_user_info"] = {"name": name, "email": email}
+        session["user_email"] = login_email
+        session["google_user_info"] = {"name": name, "email": login_email}
         session["user_concept_id"] = user_concept_id
         session["auth_provider"] = "google_oauth"
+        session[AUTHENTICATION_ASSURANCE_SESSION_KEY] = (
+            GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE
+        )
         session.pop("browser_test_fixture_id", None)
-        print(f"[auth_callback] session_updated user_email={email}")
+        print(
+            "[auth_callback] session_updated user_concept_id="
+            f"{user_concept_id} email_fingerprint="
+            f"{login_email_log_fingerprint(login_email)}"
+        )
 
         # Create a temporary auth token for the popup to send to the parent window
         import secrets
 
         temp_token = secrets.token_urlsafe(32)
-        _oauth_states[temp_token] = {"timestamp": time.time(), "user": user}
+        login_identity = {
+            "concept_id": user_concept_id,
+            "email": login_email,
+            "name": name,
+        }
+        _oauth_states[temp_token] = {
+            "timestamp": time.time(),
+            "user": login_identity,
+        }
         print(f"[auth_callback] temp_token_created len={len(temp_token)}")
 
         # Redirect to success page with the temp token
@@ -283,12 +341,10 @@ def callback():
 def success():
     """Simple success page for OAuth callback."""
     token = request.args.get("token")
-    print(f"[auth_success] Success page loaded with token: {token}")
+    print(f"[auth_success] Success page loaded token_present={bool(token)}")
 
     # Properly escape the token for JavaScript
     js_token = token.replace("'", "\\'").replace('"', '\\"') if token else ""
-    js_token_display = token[:20] + "..." if token else "None"
-
     response = f"""
     <!DOCTYPE html>
     <html>
@@ -304,7 +360,6 @@ def success():
             <h2>✓ Login Successful!</h2>
             <p>You have been successfully logged in with Google.</p>
             <p>This window will close automatically...</p>
-            <p style="font-size: 12px; color: #666;">Token: {js_token_display}</p>
         </div>
 
         <script>
@@ -390,10 +445,38 @@ def exchange_auth_token():
         return jsonify({"success": False, "error": "Token expired"}), 400
 
     user = token_info.get("user")
-    if not user:
+    if not isinstance(user, dict):
         return (
             jsonify({"success": False, "error": "User information not found in token"}),
             400,
+        )
+
+    email = user.get("email")
+    concept_id = user.get("concept_id")
+    if not isinstance(email, str) or not isinstance(concept_id, str):
+        _oauth_states.pop(token, None)
+        return (
+            jsonify({"success": False, "error": "Invalid login identity in token"}),
+            400,
+        )
+    try:
+        current_binding = find_user_concept_by_login_email(email)
+    except (MultipleUsersForEmailError, ValueError):
+        current_binding = None
+    if (
+        not isinstance(current_binding, dict)
+        or current_binding.get("concept_id") != concept_id
+    ):
+        _oauth_states.pop(token, None)
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Von login-email binding is no longer valid",
+                    "error_code": "von_login_email_binding_invalid",
+                }
+            ),
+            403,
         )
 
     # The parent window may already hold another user's org/session context.
@@ -407,6 +490,7 @@ def exchange_auth_token():
     session["google_user_info"] = {"name": user.get("name"), "email": user.get("email")}
     session["user_concept_id"] = user.get("concept_id")
     session["auth_provider"] = "google_oauth"
+    session[AUTHENTICATION_ASSURANCE_SESSION_KEY] = GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE
     session.pop("browser_test_fixture_id", None)
 
     # Provide a consistent slug-style user_id for downstream session-aware routes
@@ -421,8 +505,10 @@ def exchange_auth_token():
     if user_slug:
         session["user_id"] = user_slug.strip().lower().replace(" ", "_")
 
-    print(f"[auth_exchange] Successfully set session for {user.get('email')}")
-    print(f"[auth_exchange] Session contents: {dict(session)}")
+    print(
+        "[auth_exchange] session_updated user_concept_id="
+        f"{concept_id} email_fingerprint={login_email_log_fingerprint(email)}"
+    )
 
     # Clean up the temporary token
     _oauth_states.pop(token, None)
@@ -439,7 +525,8 @@ def get_auth_status():
         host_hdr = "UNKNOWN"
     cookie_keys = list(request.cookies.keys()) if request.cookies else []
     print(
-        f"[auth_status] Host={host_hdr} Cookies={cookie_keys} Session={dict(session)}"
+        f"[auth_status] Host={host_hdr} Cookies={cookie_keys} "
+        f"SessionKeys={list(session.keys())}"
     )
     return jsonify(_build_auth_status_payload())
 
@@ -573,9 +660,7 @@ def logout():
         {
             "success": True,
             "message": "Logged out successfully",
-            "window_context_cleanup": (
-                "deferred" if cleanup_deferred else "completed"
-            ),
+            "window_context_cleanup": ("deferred" if cleanup_deferred else "completed"),
         }
     )
 

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -17866,6 +17866,11 @@ def set_user_concept():
             LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
             get_effective_user_concept_id_with_source,
         )
+        from ...security.authentication_assurance import (
+            AUTHENTICATION_ASSURANCE_SESSION_KEY,
+            GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE,
+            session_requires_login_email_assurance,
+        )
 
         data = request.get_json(silent=True) or {}
         user_concept_id = data.get("user_concept_id")
@@ -17878,14 +17883,19 @@ def set_user_concept():
 
         # This endpoint may backfill the canonical concept ID for a legacy
         # authenticated session, but it is not an account switcher. Resolve the
-        # server-side login identity (including its durable email relation) and
-        # require an exact match before changing any actor/session scope.
+        # server-side login identity only through its narrow, durable
+        # hasVonLoginEmail binding and require an exact match before changing
+        # any actor/session scope.
         authenticated_id, authenticated_id_source = (
             get_effective_user_concept_id_with_source()
         )
+        requires_login_email_assurance = session_requires_login_email_assurance(
+            session
+        )
+        resolved_via_login_email = False
         if authenticated_id_source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
             authenticated_id = None
-        if not authenticated_id:
+        if not authenticated_id and not requires_login_email_assurance:
             stored_concept_id = session.get("user_concept_id")
             if isinstance(stored_concept_id, str) and stored_concept_id.strip():
                 authenticated_id = stored_concept_id.strip()
@@ -17899,7 +17909,8 @@ def set_user_concept():
                     authenticated_id = email_user.get("concept_id") or email_user.get(
                         "id"
                     )
-        if not authenticated_id:
+                    resolved_via_login_email = bool(authenticated_id)
+        if not authenticated_id and not requires_login_email_assurance:
             legacy_user_id = session.get("user_id")
             if isinstance(legacy_user_id, str) and legacy_user_id.strip():
                 legacy_user_id = legacy_user_id.strip()
@@ -17964,6 +17975,10 @@ def set_user_concept():
 
         # Store the concept id for authoritative identity.
         session["user_concept_id"] = user_concept_id
+        if resolved_via_login_email:
+            session[AUTHENTICATION_ASSURANCE_SESSION_KEY] = (
+                GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE
+            )
         # Keep backward compatibility with code that still reads session['user_id'].
         session["user_id"] = user_concept_id
 

--- a/src/backend/services/browser_test_auth_service.py
+++ b/src/backend/services/browser_test_auth_service.py
@@ -41,10 +41,6 @@ from ..services.paper_recommendation_vontology_service import (
     upsert_paper_recommendation_assertion,
 )
 from ..services.relationship_write_service import add_relationship
-from ..services.settings_service import (
-    MultipleUsersForEmailError,
-    _find_user_concept_by_email,
-)
 from ..services.text_value_service import upsert_text_for_concept
 from ..services.window_session_context_service import (
     set_window_chat_session,
@@ -286,28 +282,19 @@ def _ensure_person_concept(
     email: str,
 ) -> dict[str, Any]:
     with bypass_access_control():
+        # Browser-test authentication is an independently gated localhost-only
+        # fixture. Its explicit configured concept ID, not any email relation,
+        # selects the pseudouser. The email written below is contact data only.
         try:
-            existing_email_concept = _find_user_concept_by_email(email)
-        except MultipleUsersForEmailError:
-            raise
-
-        if isinstance(existing_email_concept, dict) and existing_email_concept.get(
-            "concept_id"
-        ):
-            concept_doc = existing_email_concept
-        else:
-            try:
-                concept_doc = get_concept_by_concept_id(concept_id)
-            except ConceptNotFoundError:
-                concept_doc = create_concept(
-                    name=name,
-                    concept_id=concept_id,
-                    parent_concept_ids=["#V#person"],
-                )
-            if not isinstance(concept_doc, dict):
-                raise RuntimeError(
-                    f"Browser-test concept lookup failed for {concept_id}"
-                )
+            concept_doc = get_concept_by_concept_id(concept_id)
+        except ConceptNotFoundError:
+            concept_doc = create_concept(
+                name=name,
+                concept_id=concept_id,
+                parent_concept_ids=["#V#person"],
+            )
+        if not isinstance(concept_doc, dict):
+            raise RuntimeError(f"Browser-test concept lookup failed for {concept_id}")
 
         resolved_concept_id = str(concept_doc.get("concept_id") or concept_id).strip()
         if not resolved_concept_id:

--- a/src/backend/services/concept_qa_conversation_service.py
+++ b/src/backend/services/concept_qa_conversation_service.py
@@ -934,7 +934,7 @@ def _tentative_formalisation_receipt(
             resolution=resolution,
         )
     membership_predicate = bool(
-        predicate_id.casefold() == "#v#memberof"
+        predicate_id.casefold() == "#v#memberofvonorg"
         and focal_argument == "object"
         and other_type.casefold() == "#v#von_user"
         and object_id == concept_id
@@ -1476,7 +1476,7 @@ def _confirm_formalisation_effect(
         expected_focal_concept_id or formalisation.get("focal_concept_id") or ""
     ).strip()
     is_membership = bool(
-        predicate_id.casefold() == "#v#memberof"
+        predicate_id.casefold() == "#v#memberofvonorg"
         and str(formalisation.get("focal_argument") or "").strip() == "object"
         and str(formalisation.get("other_argument_type_concept_id") or "").casefold()
         == "#v#von_user"

--- a/src/backend/services/constitutive_relation_requirement_service.py
+++ b/src/backend/services/constitutive_relation_requirement_service.py
@@ -47,7 +47,7 @@ CONSTITUTIVE_REQUIREMENTS_TEXT_PREDICATES: tuple[str, ...] = (
 
 VON_USER_ORGANISATION_TYPE_ID = "#V#von_user_organisation"
 VON_USER_TYPE_ID = "#V#von_user"
-MEMBER_OF_PREDICATE_ID = "#V#memberOf"
+MEMBER_OF_PREDICATE_ID = "#V#memberOfVonOrg"
 
 _SEED_ASSET_PATH = (
     Path(__file__).resolve().parents[1]
@@ -554,22 +554,6 @@ def _predicate_storage_keys(predicate_concept_id: str) -> list[str]:
     keys = [predicate_concept_id]
     if predicate_concept_id.startswith("#V#"):
         keys.append(predicate_concept_id[3:])
-    if predicate_concept_id in {
-        MEMBER_OF_PREDICATE_ID,
-        "memberOf",
-        "#V#member_of_organisation",
-    }:
-        # Reads remain compatible with both the current membership edge key and
-        # the historical ontology predicate.  This does not equate membership
-        # with visibility predicates such as #V#specific_to_user.
-        keys.extend(
-            [
-                "memberOf",
-                "#V#memberOf",
-                "#V#member_of_organisation",
-                "member_of_organisation",
-            ]
-        )
     return list(dict.fromkeys(key for key in keys if key))
 
 

--- a/src/backend/services/ontology_authority_role_migration_service.py
+++ b/src/backend/services/ontology_authority_role_migration_service.py
@@ -318,7 +318,9 @@ def _text_privileged_role_assignments() -> list[dict[str, Any]]:
 
 
 def _relationship_operational_role_assignments() -> list[dict[str, Any]]:
-    predicate_names = ("#V#hasRole", "hasRole")
+    # Generic hasRole assertions are semantic descriptions, not operational
+    # authority.  Only the narrow Von organisation role predicate is eligible.
+    predicate_names = (ROLE_PREDICATE,)
     role_tokens = tuple(
         sorted({*_OPERATIONAL_ROLE_TOKENS, VON_ADMINISTRATOR_CONCEPT_ID})
     )

--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -75,10 +75,9 @@ RESERVED_AUTHORITY_PREDICATES = frozenset(
     {
         AUTHORITY_ROLE_PREDICATE,
         "#V#has_von_operational_administrator",
-        "#V#hasRole",
-        "#V#memberOf",
-        "memberOf",
-        "#V#member_of_organisation",
+        "#V#hasVonLoginEmail",
+        "#V#hasVonOrgRole",
+        "#V#memberOfVonOrg",
     }
 )
 RESERVED_SCOPE_PREDICATES = frozenset(

--- a/src/backend/services/organisation_membership_predicate_migration_service.py
+++ b/src/backend/services/organisation_membership_predicate_migration_service.py
@@ -1,0 +1,476 @@
+"""Migrate operational organisation membership to narrow predicates.
+
+The historical implementation treated generic ``memberOf`` assertions as Von
+access grants.  This migration deliberately does not copy every generic
+membership edge.  An old edge is eligible only when it is paired with the
+scoped legacy role relation written by the former governed membership
+lifecycle.  Generic-only ontology facts remain descriptive and grant nothing.
+
+The migration is non-destructive and idempotent.  It creates the narrow
+predicate vocabulary, represents that ``memberOfVonOrg`` specialises (and
+therefore entails) ``memberOf``, and copies eligible operational records to the
+narrow membership and role predicates.  Legacy assertions are retained as
+historical semantic data but are no longer read for authority after cutover.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import bypass_access_control
+from ..security.role_resolver import AVAILABLE_ROLES
+from . import concept_service
+from .organisation_membership_service import (
+    GENERIC_MEMBERSHIP_PREDICATE,
+    LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS,
+    LEGACY_ROLE_PREDICATES,
+    MEMBERSHIP_RELATIONSHIP_KIND,
+    PREDICATE_SPECIALISATION_PREDICATE,
+    ROLE_PREDICATE,
+    create_organisation_membership,
+    parse_organisation_role_storage_text,
+    resolve_user_organisation_membership,
+)
+from .relationship_write_service import add_dynamic_relationship
+
+MIGRATION_SCHEMA_VERSION = "von_organisation_membership_predicate_migration.v1"
+AUDIT_SCHEMA_VERSION = "von_organisation_membership_predicate_audit.v1"
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned.startswith("#V#") else f"#V#{cleaned}"
+
+
+def _normalise_values(value: object) -> list[str]:
+    values = value if isinstance(value, list) else [value]
+    output: list[str] = []
+    for item in values:
+        normalised = _normalise_concept_id(item)
+        if normalised and normalised not in output:
+            output.append(normalised)
+    return output
+
+
+def _legacy_edge_pairs() -> dict[tuple[str, str], set[str]]:
+    query = {
+        "$or": [
+            {f"relationships.{predicate}": {"$exists": True}}
+            for predicate in LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS
+        ]
+    }
+    projection = {
+        "_id": 0,
+        "concept_id": 1,
+        **{
+            f"relationships.{predicate}": 1
+            for predicate in LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS
+        },
+    }
+    pairs: dict[tuple[str, str], set[str]] = {}
+    with bypass_access_control():
+        documents = ConceptsRepository.find(query, projection=projection)
+        for document in documents:
+            if not isinstance(document, Mapping):
+                continue
+            user_id = _normalise_concept_id(document.get("concept_id"))
+            relationships = document.get("relationships")
+            if user_id is None or not isinstance(relationships, Mapping):
+                continue
+            for predicate in LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS:
+                for organisation_id in _normalise_values(relationships.get(predicate)):
+                    pairs.setdefault((user_id, organisation_id), set()).add(predicate)
+    return pairs
+
+
+def _legacy_role_pairs() -> tuple[
+    dict[tuple[str, str], set[str]],
+    list[dict[str, Any]],
+]:
+    roles: dict[tuple[str, str], set[str]] = {}
+    invalid: list[dict[str, Any]] = []
+    relations = TextRelationsRepository.find(
+        {"predicate": {"$in": list(LEGACY_ROLE_PREDICATES)}}
+    )
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        user_id = _normalise_concept_id(relation.get("subject_concept_id"))
+        context = relation.get("context")
+        context_map = dict(context) if isinstance(context, Mapping) else {}
+        organisation_id = _normalise_concept_id(
+            context_map.get("organisation_concept_id")
+            or context_map.get("organisation_id")
+        )
+        text_value_id = relation.get("object_text_id")
+        text_value = (
+            TextValuesRepository.find_one_by_id(text_value_id)
+            if text_value_id is not None
+            else None
+        )
+        role = None
+        stored_organisation_id = None
+        if isinstance(text_value, Mapping):
+            role, stored_organisation_id = parse_organisation_role_storage_text(
+                text_value.get("text"),
+                context_map,
+            )
+        if stored_organisation_id is not None:
+            organisation_id = stored_organisation_id
+        if user_id is None or organisation_id is None or role not in AVAILABLE_ROLES:
+            invalid.append(
+                {
+                    "relation_id": str(relation.get("_id") or ""),
+                    "user_concept_id": user_id,
+                    "organisation_concept_id": organisation_id,
+                    "reason_code": "legacy_role_relation_invalid",
+                }
+            )
+            continue
+        roles.setdefault((user_id, organisation_id), set()).add(role)
+    return roles, invalid
+
+
+def _narrow_membership_pairs() -> set[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    with bypass_access_control():
+        documents = ConceptsRepository.find(
+            {f"relationships.{MEMBERSHIP_RELATIONSHIP_KIND}": {"$exists": True}},
+            projection={
+                "_id": 0,
+                "concept_id": 1,
+                f"relationships.{MEMBERSHIP_RELATIONSHIP_KIND}": 1,
+            },
+        )
+        for document in documents:
+            if not isinstance(document, Mapping):
+                continue
+            user_id = _normalise_concept_id(document.get("concept_id"))
+            relationships = document.get("relationships")
+            if user_id is None or not isinstance(relationships, Mapping):
+                continue
+            for organisation_id in _normalise_values(
+                relationships.get(MEMBERSHIP_RELATIONSHIP_KIND)
+            ):
+                pairs.add((user_id, organisation_id))
+    return pairs
+
+
+def audit_von_organisation_membership_predicates(
+    *, sample_limit: int = 20
+) -> dict[str, Any]:
+    """Classify legacy facts without treating generic membership as authority."""
+
+    sample_limit = max(0, int(sample_limit))
+    edge_pairs = _legacy_edge_pairs()
+    role_pairs, invalid_roles = _legacy_role_pairs()
+    narrow_pairs = _narrow_membership_pairs()
+
+    eligible: list[dict[str, Any]] = []
+    generic_only: list[dict[str, Any]] = []
+    role_only: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+
+    for pair in sorted(set(edge_pairs) | set(role_pairs)):
+        user_id, organisation_id = pair
+        predicates = sorted(edge_pairs.get(pair, set()))
+        roles = sorted(role_pairs.get(pair, set()))
+        common = {
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+        }
+        if predicates and len(roles) == 1:
+            eligible.append(
+                {
+                    **common,
+                    "role": roles[0],
+                    "legacy_membership_predicates": predicates,
+                    "already_narrow": pair in narrow_pairs,
+                }
+            )
+        elif predicates and not roles:
+            generic_only.append({**common, "legacy_membership_predicates": predicates})
+        elif roles and not predicates:
+            role_only.append({**common, "legacy_roles": roles})
+        else:
+            conflicts.append(
+                {
+                    **common,
+                    "legacy_membership_predicates": predicates,
+                    "legacy_roles": roles,
+                    "reason_code": "conflicting_legacy_roles",
+                }
+            )
+
+    return {
+        "schema_version": AUDIT_SCHEMA_VERSION,
+        "narrow_membership_predicate": MEMBERSHIP_RELATIONSHIP_KIND,
+        "narrow_role_predicate": ROLE_PREDICATE,
+        "entailed_generic_predicate": GENERIC_MEMBERSHIP_PREDICATE,
+        "predicate_specialisation_predicate": (PREDICATE_SPECIALISATION_PREDICATE),
+        "eligible_operational_membership_count": len(eligible),
+        "already_narrow_count": sum(
+            1 for record in eligible if record["already_narrow"]
+        ),
+        "generic_only_non_authority_count": len(generic_only),
+        "role_only_count": len(role_only),
+        "conflict_count": len(conflicts),
+        "invalid_legacy_role_count": len(invalid_roles),
+        "eligible_operational_memberships": eligible[:sample_limit],
+        "generic_only_non_authority_samples": generic_only[:sample_limit],
+        "role_only_samples": role_only[:sample_limit],
+        "conflict_samples": conflicts[:sample_limit],
+        "invalid_legacy_role_samples": invalid_roles[:sample_limit],
+        "complete": True,
+    }
+
+
+def _ensure_predicate(
+    *,
+    concept_id: str,
+    name: str,
+    description: str,
+    predicate_type_id: str,
+) -> str:
+    with bypass_access_control():
+        existing = ConceptsRepository.find_one({"concept_id": concept_id})
+    if not isinstance(existing, Mapping):
+        with bypass_access_control():
+            concept_service.create_concept(
+                name=name,
+                concept_id=concept_id,
+                description=description,
+                parent_concept_ids=[predicate_type_id],
+                create_as_instance=True,
+                visibility_scope_mode="global_general",
+                maintain_relationship_inverses=False,
+            )
+        state = "created"
+    else:
+        state = "existing"
+
+    with bypass_access_control():
+        read_back = ConceptsRepository.find_one(
+            {"concept_id": concept_id},
+            {"_id": 0, "concept_id": 1, "relationships.is_an_instance_of": 1},
+        )
+    if not isinstance(read_back, Mapping):
+        raise RuntimeError(f"predicate_read_back_failed:{concept_id}")
+    relationships = read_back.get("relationships")
+    types = _normalise_values(
+        relationships.get("is_an_instance_of")
+        if isinstance(relationships, Mapping)
+        else None
+    )
+    if predicate_type_id not in types:
+        raise RuntimeError(f"predicate_type_read_back_failed:{concept_id}")
+    return state
+
+
+def ensure_von_organisation_membership_vocabulary() -> dict[str, Any]:
+    """Materialise the narrow predicates and their one-way entailment."""
+
+    states = {
+        MEMBERSHIP_RELATIONSHIP_KIND: _ensure_predicate(
+            concept_id=MEMBERSHIP_RELATIONSHIP_KIND,
+            name="Member of Von organisation",
+            description=(
+                "An explicit operational Von membership assertion. It entails "
+                "ordinary memberOf, but generic memberOf assertions do not imply "
+                "this predicate and grant no Von authority."
+            ),
+            predicate_type_id="#V#binary_predicate",
+        ),
+        ROLE_PREDICATE: _ensure_predicate(
+            concept_id=ROLE_PREDICATE,
+            name="Has Von organisation role",
+            description=(
+                "Stores the operational role for one explicit Von organisation "
+                "membership, scoped to that organisation in relation context."
+            ),
+            predicate_type_id="#V#binary_text_predicate",
+        ),
+    }
+    with bypass_access_control():
+        result = add_dynamic_relationship(
+            MEMBERSHIP_RELATIONSHIP_KIND,
+            PREDICATE_SPECIALISATION_PREDICATE,
+            GENERIC_MEMBERSHIP_PREDICATE,
+        )
+    if result.get("success") is not True:
+        raise RuntimeError(
+            "membership_predicate_specialisation_write_failed:"
+            f"{result.get('error') or 'unknown'}"
+        )
+    with bypass_access_control():
+        narrow = ConceptsRepository.find_one(
+            {"concept_id": MEMBERSHIP_RELATIONSHIP_KIND},
+            {
+                "_id": 0,
+                "concept_id": 1,
+                f"relationships.{PREDICATE_SPECIALISATION_PREDICATE}": 1,
+            },
+        )
+    relationships = narrow.get("relationships") if isinstance(narrow, Mapping) else {}
+    targets = _normalise_values(
+        relationships.get(PREDICATE_SPECIALISATION_PREDICATE)
+        if isinstance(relationships, Mapping)
+        else None
+    )
+    if GENERIC_MEMBERSHIP_PREDICATE not in targets:
+        raise RuntimeError("membership_predicate_specialisation_read_back_failed")
+    return {
+        "success": True,
+        "predicate_states": states,
+        "entailment": {
+            "specific_predicate": MEMBERSHIP_RELATIONSHIP_KIND,
+            "relation": PREDICATE_SPECIALISATION_PREDICATE,
+            "generic_predicate": GENERIC_MEMBERSHIP_PREDICATE,
+            "reverse_inference_allowed": False,
+        },
+    }
+
+
+def migrate_von_organisation_membership_predicates(
+    *,
+    dry_run: bool = True,
+    approved: bool = False,
+    sample_limit: int = 20,
+) -> dict[str, Any]:
+    """Copy only evidenced operational memberships to the narrow vocabulary."""
+
+    audit = audit_von_organisation_membership_predicates(
+        sample_limit=max(sample_limit, 100_000)
+    )
+    public_audit = {
+        **audit,
+        "eligible_operational_memberships": audit["eligible_operational_memberships"][
+            : max(0, int(sample_limit))
+        ],
+    }
+    common = {
+        "schema_version": MIGRATION_SCHEMA_VERSION,
+        "dry_run": bool(dry_run),
+        "approved": bool(approved),
+        "audit": public_audit,
+    }
+    if not dry_run and not approved:
+        return {
+            **common,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "explicit_migration_approval_required",
+        }
+    if audit["conflict_count"] or audit["invalid_legacy_role_count"]:
+        return {
+            **common,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "legacy_membership_inventory_requires_resolution",
+        }
+    if dry_run:
+        return {
+            **common,
+            "success": True,
+            "effect_status": "not_started",
+            "would_migrate_count": audit["eligible_operational_membership_count"],
+            "generic_only_relations_will_grant_authority": False,
+        }
+
+    vocabulary = ensure_von_organisation_membership_vocabulary()
+    migrated: list[dict[str, Any]] = []
+    already_current: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    eligible_records = audit["eligible_operational_memberships"]
+    for record in eligible_records:
+        user_id = record["user_concept_id"]
+        organisation_id = record["organisation_concept_id"]
+        role = record["role"]
+        try:
+            before = resolve_user_organisation_membership(user_id, organisation_id)
+            if isinstance(before, Mapping) and before.get("role") == role:
+                already_current.append(
+                    {
+                        "user_concept_id": user_id,
+                        "organisation_concept_id": organisation_id,
+                        "role": role,
+                    }
+                )
+                continue
+            with bypass_access_control():
+                create_organisation_membership(
+                    user_concept_id=user_id,
+                    organisation_concept_id=organisation_id,
+                    role=role,
+                )
+            read_back = resolve_user_organisation_membership(user_id, organisation_id)
+            if not isinstance(read_back, Mapping) or read_back.get("role") != role:
+                raise RuntimeError("narrow_membership_read_back_mismatch")
+            migrated.append(
+                {
+                    "user_concept_id": user_id,
+                    "organisation_concept_id": organisation_id,
+                    "role": role,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 - report resumable partial migration
+            failures.append(
+                {
+                    "user_concept_id": user_id,
+                    "organisation_concept_id": organisation_id,
+                    "error_class": type(exc).__name__,
+                    "error": str(exc),
+                }
+            )
+
+    final_audit = audit_von_organisation_membership_predicates(
+        sample_limit=max(sample_limit, 100_000)
+    )
+    expected_pairs = {
+        (row["user_concept_id"], row["organisation_concept_id"])
+        for row in eligible_records
+    }
+    current_pairs = {
+        (row["user_concept_id"], row["organisation_concept_id"])
+        for row in final_audit["eligible_operational_memberships"]
+        if row.get("already_narrow") is True
+    }
+    missing_pairs = sorted(expected_pairs - current_pairs)
+    success = not failures and not missing_pairs
+    return {
+        **common,
+        "success": success,
+        "effect_status": "succeeded" if success else "partial_success",
+        "vocabulary": vocabulary,
+        "migrated_count": len(migrated),
+        "already_current_count": len(already_current),
+        "failed_count": len(failures),
+        "migrated": migrated[: max(0, int(sample_limit))],
+        "already_current": already_current[: max(0, int(sample_limit))],
+        "failures": failures[: max(0, int(sample_limit))],
+        "missing_read_back_pairs": [
+            {
+                "user_concept_id": user_id,
+                "organisation_concept_id": organisation_id,
+            }
+            for user_id, organisation_id in missing_pairs[: max(0, int(sample_limit))]
+        ],
+        "generic_only_relations_grant_authority": False,
+    }
+
+
+__all__ = [
+    "AUDIT_SCHEMA_VERSION",
+    "MIGRATION_SCHEMA_VERSION",
+    "audit_von_organisation_membership_predicates",
+    "ensure_von_organisation_membership_vocabulary",
+    "migrate_von_organisation_membership_predicates",
+]

--- a/src/backend/services/organisation_membership_service.py
+++ b/src/backend/services/organisation_membership_service.py
@@ -1,7 +1,9 @@
-"""Service functions for managing organisation membership relationships in the Vontology.
+"""Service functions for managing Von organisation memberships.
 
-Handles creation, retrieval, and management of memberOf relationships between
-user concepts and organisation concepts, including role associations.
+Operational membership is represented only by the narrow
+``#V#memberOfVonOrg`` predicate.  It specialises the ordinary semantic
+``#V#memberOf`` predicate, but the converse never holds: a generic membership
+assertion must not grant Von access or an operational role.
 """
 
 from __future__ import annotations
@@ -20,10 +22,27 @@ from .ontology_authority_membership_coordination_service import (
 
 logger = logging.getLogger(__name__)
 
-# Constants for relationship kinds
-MEMBERSHIP_RELATIONSHIP_KIND = "memberOf"
-ALT_MEMBERSHIP_RELATIONSHIP = "#V#member_of_organisation"
-ROLE_PREDICATE = "#V#hasRole"
+# Authority-bearing predicates.  Keep these exact and narrow: generic
+# ``memberOf``/``member_of_organisation`` and ``hasRole`` facts are descriptive
+# ontology assertions and are deliberately not read by this service.
+MEMBERSHIP_RELATIONSHIP_KIND = "#V#memberOfVonOrg"
+ROLE_PREDICATE = "#V#hasVonOrgRole"
+
+# Represented predicate entailment used by the release migration.  The narrow
+# predicate entails the generic one for semantic reasoning; authority readers
+# only accept the narrow predicate explicitly stored on the user concept.
+GENERIC_MEMBERSHIP_PREDICATE = "#V#memberOf"
+PREDICATE_SPECIALISATION_PREDICATE = "#V#predicate_specialises_predicate"
+
+# Read only by the explicit migration service.  They remain here so the
+# authority cutover and its historical inputs have one canonical vocabulary.
+LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS = (
+    "memberOf",
+    "#V#memberOf",
+    "#V#member_of_organisation",
+    "member_of_organisation",
+)
+LEGACY_ROLE_PREDICATES = ("#V#hasRole", "hasRole")
 _ROLE_STORAGE_SEPARATOR = "::"
 
 
@@ -186,10 +205,12 @@ def is_user_member_of_organisation(
 def create_organisation_membership(
     user_concept_id: str, organisation_concept_id: str, role: str = "member"
 ) -> dict[str, Any]:
-    """Create a memberOf relationship between a user and an organisation.
+    """Create an explicit authority-bearing Von organisation membership.
 
-    Stores the relationship in the Vontology as a concept edge, with the role
-    stored as a text relation (hasRole predicate) on a context-decorated link.
+    The narrow membership edge entails ordinary semantic membership through
+    represented predicate-specialisation metadata.  This function does not
+    assert the generic edge separately.  The operational role is likewise
+    stored under a dedicated text predicate scoped to the exact organisation.
 
     Args:
         user_concept_id: The concept ID of the user (e.g., '#V#michael_witbrock')
@@ -230,7 +251,7 @@ def create_organisation_membership(
     if not org_concept:
         raise ValueError(f"Organisation concept '{organisation_concept_id}' not found")
 
-    # Create or update the memberOf relationship edge
+    # Create or update the narrow Von membership relationship edge.
     relationship_exists = _check_relationship_exists(
         user_concept_id, organisation_concept_id
     )
@@ -245,12 +266,18 @@ def create_organisation_membership(
         )
         relationship_created = True
         logger.info(
-            f"Created memberOf relationship: {user_concept_id} --memberOf--> {organisation_concept_id}"
+            "Created Von organisation membership: %s --%s--> %s",
+            user_concept_id,
+            MEMBERSHIP_RELATIONSHIP_KIND,
+            organisation_concept_id,
         )
     else:
         relationship_created = False
         logger.info(
-            f"memberOf relationship already exists: {user_concept_id} --memberOf--> {organisation_concept_id}"
+            "Von organisation membership already exists: %s --%s--> %s",
+            user_concept_id,
+            MEMBERSHIP_RELATIONSHIP_KIND,
+            organisation_concept_id,
         )
 
     if relationship_exists:
@@ -261,7 +288,7 @@ def create_organisation_membership(
             organisation_concept_id,
         )
 
-    # Store the role via text relation (hasRole predicate with context)
+    # Store the role via the narrow Von-role predicate with exact org context.
     role_result = upsert_text_for_concept(
         subject_concept_id=user_concept_id,
         predicate=ROLE_PREDICATE,
@@ -304,23 +331,19 @@ def get_user_memberships(user_concept_id: str) -> dict[str, Any]:
     if not user_concept:
         raise ValueError(f"User concept '{user_concept_id}' not found")
 
-    # Get memberOf relationships
+    # Only explicit narrow edges grant operational membership.  In particular,
+    # never merge or fall back to generic memberOf assertions here.
     memberships_dict = user_concept.get("relationships", {})
     org_ids = memberships_dict.get(MEMBERSHIP_RELATIONSHIP_KIND, [])
-    alt_org_ids = memberships_dict.get(ALT_MEMBERSHIP_RELATIONSHIP, [])
 
     if isinstance(org_ids, str):
         org_ids = [org_ids]
     if not isinstance(org_ids, list):
         org_ids = []
-    if isinstance(alt_org_ids, str):
-        alt_org_ids = [alt_org_ids]
-    if not isinstance(alt_org_ids, list):
-        alt_org_ids = []
 
     merged_org_ids = []
     seen_orgs: set[str] = set()
-    for value in [*org_ids, *alt_org_ids]:
+    for value in org_ids:
         if not isinstance(value, str):
             continue
         if not value.strip():
@@ -430,9 +453,11 @@ def get_organisation_members(
                 if tv:
                     role, stored_org = parse_organisation_role_storage_text(
                         tv.get("text"),
-                        rel.get("context")
-                        if isinstance(rel.get("context"), dict)
-                        else {},
+                        (
+                            rel.get("context")
+                            if isinstance(rel.get("context"), dict)
+                            else {}
+                        ),
                     )
                     if role and stored_org == _normalise_concept_id(
                         organisation_concept_id
@@ -447,18 +472,7 @@ def get_organisation_members(
         org_id_variants.add(organisation_concept_id[3:])
 
     membership_query = {
-        "$or": [
-            {
-                f"relationships.{MEMBERSHIP_RELATIONSHIP_KIND}": {
-                    "$in": list(org_id_variants)
-                }
-            },
-            {
-                f"relationships.{ALT_MEMBERSHIP_RELATIONSHIP}": {
-                    "$in": list(org_id_variants)
-                }
-            },
-        ]
+        f"relationships.{MEMBERSHIP_RELATIONSHIP_KIND}": {"$in": list(org_id_variants)}
     }
     with bypass_access_control():
         member_docs = list(
@@ -546,9 +560,11 @@ def update_user_role(
             if tv:
                 parsed_role, _stored_org = parse_organisation_role_storage_text(
                     tv.get("text"),
-                    current_role_rel.get("context")
-                    if isinstance(current_role_rel.get("context"), dict)
-                    else {},
+                    (
+                        current_role_rel.get("context")
+                        if isinstance(current_role_rel.get("context"), dict)
+                        else {}
+                    ),
                 )
                 if parsed_role:
                     old_role = parsed_role
@@ -645,7 +661,8 @@ def remove_organisation_membership(
     # mutation makes cross-worker revocation fail closed.
     _invalidate_user_window_authority(user_concept_id, organisation_concept_id)
 
-    # Remove the memberOf relationship
+    # Remove only the authority-bearing narrow relationship.  A separately
+    # asserted generic memberOf fact, if any, is semantic and is not authority.
     ConceptsRepository.mutate_relationship_edge(
         source_id=user_concept_id,
         kind=MEMBERSHIP_RELATIONSHIP_KIND,
@@ -682,24 +699,34 @@ def remove_organisation_membership(
 def _check_relationship_exists(
     user_concept_id: str, organisation_concept_id: str
 ) -> bool:
-    """Check if a memberOf relationship already exists between user and organisation."""
+    """Check for an explicit narrow Von organisation membership."""
     user_concept = ConceptsRepository.find_one({"concept_id": user_concept_id})
     if not user_concept:
         return False
 
     memberships_dict = user_concept.get("relationships", {})
     org_ids = memberships_dict.get(MEMBERSHIP_RELATIONSHIP_KIND, [])
+    if isinstance(org_ids, str):
+        org_ids = [org_ids]
+    if not isinstance(org_ids, list):
+        org_ids = []
     return organisation_concept_id in org_ids
 
 
 __all__ = [
     "create_organisation_membership",
+    "GENERIC_MEMBERSHIP_PREDICATE",
     "get_organisation_members",
     "get_user_memberships",
     "is_user_member_of_organisation",
+    "LEGACY_MEMBERSHIP_RELATIONSHIP_KINDS",
+    "LEGACY_ROLE_PREDICATES",
+    "MEMBERSHIP_RELATIONSHIP_KIND",
     "organisation_role_storage_text",
     "parse_organisation_role_storage_text",
+    "PREDICATE_SPECIALISATION_PREDICATE",
     "remove_organisation_membership",
     "resolve_user_organisation_membership",
+    "ROLE_PREDICATE",
     "update_user_role",
 ]

--- a/src/backend/services/predicate_family_vontology_service.py
+++ b/src/backend/services/predicate_family_vontology_service.py
@@ -16,6 +16,7 @@ FAMILY_MEMBER_PREDICATE_ID = "#V#has_member_predicate"
 FOCAL_ROLE_PREDICATE_ID = "#V#has_focal_role_predicate"
 RELATED_ROLE_PREDICATE_ID = "#V#has_related_role_predicate"
 REIFIED_RELATION_TYPE_PREDICATE_ID = "#V#has_reified_relation_type"
+PREDICATE_SPECIALISATION_PREDICATE_ID = "#V#predicate_specialises_predicate"
 _MAX_EXPANDED_PREDICATES = 100
 
 
@@ -59,6 +60,7 @@ def _empty_expansion(seeds: list[str]) -> dict[str, Any]:
         "focal_role_predicate_ids": [],
         "related_role_predicate_ids": [],
         "reified_relation_type_ids": [],
+        "entailing_specialisation_predicate_ids": [],
         "source": "vontology_predicate_schema",
     }
 
@@ -95,6 +97,8 @@ def expand_relation_predicate_family(
     reified_relation_type_ids: list[str] = []
     index_status = "available"
     family_discovery_source = "relationship_extent_index"
+    specialisation_discovery_source = "relationship_extent_index"
+    entailing_specialisations: list[str] = []
 
     try:
         predicate_projection: dict[str, int] = {
@@ -115,6 +119,58 @@ def expand_relation_predicate_family(
                     relationships.get(inverse_predicate_id),
                     limit=resolved_limit,
                 )
+
+        # Directional entailment expansion: when a query asks for a general
+        # predicate, include facts stated with predicates that specialise it.
+        # Never follow the edge from a specialisation to its generalisation,
+        # because that would make a generic fact satisfy a narrow query (and,
+        # for memberOfVonOrg, would turn description into authority).
+        frontier = list(expanded)
+        while frontier and len(expanded) < resolved_limit:
+            specialisation_rows, specialisation_count = query_relationship_extent_index(
+                predicate_id=PREDICATE_SPECIALISATION_PREDICATE_ID,
+                target_values=frontier,
+                count_total=False,
+                projection={
+                    "_id": 0,
+                    "source_concept_id": 1,
+                    "predicate_id": 1,
+                    "target_value": 1,
+                },
+                limit=resolved_limit * 4,
+            )
+            if specialisation_count < 0:
+                specialisation_discovery_source = "canonical_exact_predicate_query"
+                specialisation_documents = ConceptsRepository.find(
+                    {
+                        f"relationships.{PREDICATE_SPECIALISATION_PREDICATE_ID}": {
+                            "$in": frontier
+                        }
+                    },
+                    projection={"_id": 0, "concept_id": 1},
+                    limit=resolved_limit,
+                )
+                candidates = [
+                    document.get("concept_id")
+                    for document in specialisation_documents
+                    if isinstance(document, Mapping)
+                ]
+            else:
+                candidates = [
+                    row.get("source_concept_id")
+                    for row in specialisation_rows
+                    if isinstance(row, Mapping)
+                ]
+            next_frontier: list[str] = []
+            for candidate in _canonical_ids(candidates):
+                if candidate in expanded:
+                    continue
+                expanded.append(candidate)
+                entailing_specialisations.append(candidate)
+                next_frontier.append(candidate)
+                if len(expanded) >= resolved_limit:
+                    break
+            frontier = next_frontier
 
         family_rows, family_row_count = query_relationship_extent_index(
             predicate_id=FAMILY_MEMBER_PREDICATE_ID,
@@ -227,9 +283,11 @@ def expand_relation_predicate_family(
             "focal_role_predicate_ids": focal_role_predicate_ids,
             "related_role_predicate_ids": related_role_predicate_ids,
             "reified_relation_type_ids": reified_relation_type_ids,
+            "entailing_specialisation_predicate_ids": entailing_specialisations,
             "status": "expanded" if expanded != seeds else "unchanged",
             "relationship_extent_index_status": index_status,
             "family_discovery_source": family_discovery_source,
+            "specialisation_discovery_source": specialisation_discovery_source,
         }
     )
     return result
@@ -239,6 +297,7 @@ __all__ = [
     "FAMILY_MEMBER_PREDICATE_ID",
     "FOCAL_ROLE_PREDICATE_ID",
     "INVERSE_LINK_PREDICATE_IDS",
+    "PREDICATE_SPECIALISATION_PREDICATE_ID",
     "RELATED_ROLE_PREDICATE_ID",
     "REIFIED_RELATION_TYPE_PREDICATE_ID",
     "expand_relation_predicate_family",

--- a/src/backend/services/settings_service.py
+++ b/src/backend/services/settings_service.py
@@ -7,13 +7,8 @@ from typing import Any, Callable, Optional, Dict, List, Mapping, Sequence
 from pymongo.results import UpdateResult
 from pymongo.errors import DuplicateKeyError, OperationFailure
 from ..utils.time_utils import utc_now
-from ..db.mongo_client import (
-    APPLICATION_SETTINGS_COLLECTION_NAME,
-    get_text_values_collection,
-    get_text_relations_collection,
-)
+from ..db.mongo_client import APPLICATION_SETTINGS_COLLECTION_NAME
 from ..db.mongo_setup import get_application_settings_collection
-from .exceptions import MultipleUsersForEmailError
 from .mongo_observability_service import (
     build_mongo_operation_comment,
     observe_mongo_operation,
@@ -1700,15 +1695,15 @@ def set_current_organisation_id(org_id: str) -> bool:
 # Removed: get/set_current_organisation_concept_id functions (client localStorage authority)
 
 
-# ---------------- Identity Resolution Helpers (Deterministic, Email-Centric) ----------------
+# ---------------- Identity Resolution Helpers (Deterministic, Login-Binding-Centric) ----------------
 def _log_identity_event(**fields):
     """Emit a structured JSON log line for user identity decisions.
 
     Fields include (not exhaustive):
       event: fixed 'auth_user_resolution'
-      email: authenticated email
+      email_fingerprint: non-reversible identifier for the authenticated email
       expected_concept_id: concept id hinted by session/localStorage (if any)
-      email_relation_concept_id: concept id discovered via existing #V#has_email relation (if any)
+      login_binding_concept_id: concept id discovered via #V#hasVonLoginEmail
       action: chosen resolution path
       conflict: bool when mismatch detected
     """
@@ -1722,216 +1717,70 @@ def _log_identity_event(**fields):
 
 def _find_user_concept_by_email(
     email: str,
-) -> Optional[Dict[str, Any]]:  # Reintroduced deterministic helper
-    """Find an existing user concept via an existing #V#has_email relation.
+) -> Optional[Dict[str, Any]]:
+    """Compatibility wrapper for the narrow Von login-email resolver.
 
-    Returns the full concept document or None.
-    Safe: read-only; no mutations.
+    Despite its historical name, this function deliberately ignores ordinary
+    ``#V#has_email`` contact facts.  It is read-only and resolves only
+    ``#V#hasVonLoginEmail``.
     """
-    from ..services.concept_service import get_concept_by_id, get_concept_by_concept_id
+    from .von_user_authentication_service import find_user_concept_by_login_email
 
-    text_values_coll = get_text_values_collection()
-    text_relations_coll = get_text_relations_collection()
-
-    if text_values_coll is None or text_relations_coll is None:
-        logger.error(
-            "_find_user_concept_by_email: Missing text collections (DB unavailable)."
-        )
-        return None
-
-    tv = text_values_coll.find_one({"text": email})
-    if not tv:
-        return None
-    tv_id = str(tv.get("_id"))
-
-    # Find all relations for the given email text value
-    relations = list(
-        text_relations_coll.find({"object_text_id": tv_id, "predicate": "#V#has_email"})
-    )
-
-    if len(relations) > 1:
-        # Log a critical error if multiple users are found for the same email
-        user_ids = [rel.get("subject_concept_id") for rel in relations]
-        logger.critical(
-            f"CRITICAL: Multiple users found for email '{email}': {user_ids}. This is a data integrity issue that must be resolved manually."
-        )
-        raise MultipleUsersForEmailError(email, user_ids)
-
-    if not relations:
-        return None
-
-    rel = relations[0]  # Use the first relation found
-    subj_id = rel.get("subject_concept_id")
-    if not subj_id:
-        return None
-    try:
-        # Use get_concept_by_concept_id for Von concept IDs like #V#michael_witbrock
-        # Use get_concept_by_id for MongoDB ObjectIds
-        if subj_id.startswith("#V#"):
-            concept = get_concept_by_concept_id(subj_id)
-        else:
-            concept = get_concept_by_id(subj_id)
-        return concept
-    except Exception:
-        logger.warning(
-            f"_find_user_concept_by_email: concept retrieval failed for {subj_id}"
-        )
-        return None
+    return find_user_concept_by_login_email(email)
 
 
 def set_current_user_by_email(
     email: str, name: str, expected_user_concept_id: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
-    """Deterministically resolve (and set) the current user concept for an authenticated email.
+    """Resolve and set a user only from an explicit Von login-email binding.
 
-    Resolution algorithm (authoritative source = email relation):
-      1. If an existing #V#has_email relation maps `email` -> concept (R), adopt R.
-         - If a provided / session expected concept id (E) differs from R, log conflict (action=adopt_email_relation, conflict=true).
-      2. Else (no relation): If an expected concept id (E) is supplied and refers to a valid person concept,
-         link E to the email (create #V#has_email relation) and adopt E (action=link_expected_concept).
-      3. Else: create a new person concept, link email, adopt it (action=create_new_user).
-
-    Conflict handling: We *never* auto-merge. The email relation wins because it is durable & unique; we surface the mismatch in logs.
-    Idempotence: Repeated calls produce same adopted concept & no duplicate relations.
-
-        Identity Invariants (JVNAUTOSCI-634):
-            - Returned dict MUST contain 'concept_id'. If absent but 'id' (vontology style) is present and looks like a concept id, it is normalised.
-            - Session key 'user_concept_id' is always set to the adopted concept_id on success.
-            - A single #V#has_email relation per email is expected; multiple will log conflict (future cleanup tool will reconcile).
-            - No name-based disambiguation is performed (eliminates heuristic drift / race conditions).
+    ``name`` and ``expected_user_concept_id`` are compatibility inputs, not
+    authority.  In particular, an unbound OAuth email is never attached to a
+    concept from the existing browser session and never creates a user.  This
+    compatibility helper does not establish authentication assurance; only the
+    Google OAuth callback may record that proof after verifying the provider
+    response and the current login-email binding.
     """
-    from ..services.concept_service import (
-        get_concept_by_concept_id,
-        create_concept,
-        get_concept_by_id,
-    )
-    from ..services.text_value_service import upsert_text_for_concept
     from flask import session
+    from .von_user_authentication_service import login_email_log_fingerprint
+
+    del name
 
     if not email:
         logger.error("set_current_user_by_email: Blank email provided; aborting.")
         return None
 
-    # Allow caller override; if absent, attempt to read from existing session (pre-login hint from client localStorage)
     if expected_user_concept_id is None:
         expected_user_concept_id = session.get("user_concept_id")
 
-    try:
-        email_user = _find_user_concept_by_email(email)
-    except MultipleUsersForEmailError as e:
-        # Propagate the error to be handled by the caller (e.g., the API route)
-        raise e
-
-    adopted: Optional[Dict[str, Any]] = None
-    action = None
-    conflict = False
-
-    # Step 1: Existing relation path
-    if email_user:
-        adopted = email_user
-        action = "adopt_email_relation"
-        if (
-            expected_user_concept_id
-            and adopted.get("concept_id") != expected_user_concept_id
-        ):
-            conflict = True
-            _log_identity_event(
-                email=email,
-                expected_concept_id=expected_user_concept_id,
-                email_relation_concept_id=adopted.get("concept_id"),
-                action=action,
-                conflict=True,
-            )
-        else:
-            _log_identity_event(
-                email=email,
-                expected_concept_id=expected_user_concept_id,
-                email_relation_concept_id=adopted.get("concept_id"),
-                action=action,
-            )
-    else:
-        # Step 2: Link expected existing concept if provided & valid
-        candidate: Optional[Dict[str, Any]] = None
-        if expected_user_concept_id:
-            try:
-                candidate = get_concept_by_concept_id(expected_user_concept_id)
-            except Exception:
-                candidate = None
-        if candidate:
-            try:
-                candidate_concept_id = candidate.get("concept_id")
-                if (
-                    not isinstance(candidate_concept_id, str)
-                    or not candidate_concept_id
-                ):
-                    raise ValueError("Candidate concept missing concept_id for linking")
-                upsert_text_for_concept(
-                    subject_concept_id=candidate_concept_id,
-                    predicate="#V#has_email",
-                    text=email,
-                    provenance={"source": "login_link_existing"},
-                )
-                adopted_lookup = get_concept_by_concept_id(candidate_concept_id)
-                adopted = adopted_lookup or candidate
-                action = "link_expected_concept"
-                _log_identity_event(
-                    email=email,
-                    expected_concept_id=expected_user_concept_id,
-                    email_relation_concept_id=adopted.get("concept_id"),
-                    action=action,
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed linking expected concept {expected_user_concept_id} to email {email}: {e}"
-                )
-        # Step 3: Create new if still unresolved
-        if adopted is None:
-            try:
-                new_doc = create_concept(name=name, parent_concept_ids=["#V#person"])
-                # Fix JVNAUTOSCI-634: Use concept_id (Von format) instead of id (MongoDB ObjectId)
-                # to prevent duplicate email relations with different identifier formats
-                new_id = new_doc.get("concept_id") if new_doc else None
-                if not new_id:
-                    raise RuntimeError("create_concept returned no concept_id")
-                upsert_text_for_concept(
-                    subject_concept_id=new_id,
-                    predicate="#V#has_email",
-                    text=email,
-                    provenance={"source": "login_create_new"},
-                )
-                adopted = get_concept_by_id(new_id) or new_doc
-                action = "create_new_user"
-                _log_identity_event(
-                    email=email,
-                    expected_concept_id=expected_user_concept_id,
-                    email_relation_concept_id=adopted.get("concept_id"),
-                    action=action,
-                )
-            except Exception as e:
-                logger.error(f"Failed to create/link new user for email {email}: {e}")
-                _log_identity_event(
-                    email=email,
-                    expected_concept_id=expected_user_concept_id,
-                    action="error",
-                    error=str(e),
-                )
-                return None
-
+    adopted = _find_user_concept_by_email(email)
     if not adopted or not adopted.get("concept_id"):
-        # Attempt normalisation: some older concept docs may use 'id' or only have a legacy structure.
-        fallback_id = adopted.get("id") or adopted.get("_id")
-        if isinstance(fallback_id, str) and fallback_id.startswith("#V#"):
-            adopted["concept_id"] = fallback_id
-        else:
-            logger.error(
-                f"set_current_user_by_email: Adopted concept invalid for email {email} (action={action})."
-            )
-            return None
+        _log_identity_event(
+            email_fingerprint=login_email_log_fingerprint(email),
+            expected_concept_id=expected_user_concept_id,
+            action="reject_unbound_login_email",
+        )
+        return None
+
+    conflict = bool(
+        expected_user_concept_id
+        and adopted.get("concept_id") != expected_user_concept_id
+    )
+    _log_identity_event(
+        email_fingerprint=login_email_log_fingerprint(email),
+        expected_concept_id=expected_user_concept_id,
+        login_binding_concept_id=adopted.get("concept_id"),
+        action="adopt_explicit_login_binding",
+        conflict=conflict,
+    )
 
     # Set session binding (authoritative for remainder of request flow)
     session["user_concept_id"] = adopted.get("concept_id")
     logger.info(
-        f"set_current_user_by_email: Adopted concept {adopted.get('concept_id')} (action={action}, conflict={conflict})."
+        "set_current_user_by_email: Adopted explicit login binding concept=%s "
+        "conflict=%s.",
+        adopted.get("concept_id"),
+        conflict,
     )
     return adopted
 

--- a/src/backend/services/von_login_email_migration_service.py
+++ b/src/backend/services/von_login_email_migration_service.py
@@ -1,0 +1,279 @@
+"""Create and populate the narrow Von login-email authority predicate.
+
+Unlike organisation membership, there is intentionally no data-driven legacy
+migration here.  Ordinary ``#V#has_email`` values may be contact addresses and
+are never copied into authentication authority.  An operator must provide the
+exact reviewed ``(user, email)`` allow-list.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.access_control import bypass_access_control
+from . import concept_service
+from .relationship_write_service import add_dynamic_relationship
+from .von_user_authentication_service import (
+    GENERIC_EMAIL_PREDICATE,
+    LOGIN_EMAIL_PREDICATE,
+    PREDICATE_SPECIALISATION_PREDICATE,
+    bind_von_login_email,
+    list_von_login_email_user_ids,
+    normalise_von_login_email,
+)
+
+MIGRATION_SCHEMA_VERSION = "von_login_email_predicate_migration.v1"
+
+
+def _normalise_concept_id(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("user_concept_id_required")
+    concept_id = value.strip()
+    return concept_id if concept_id.startswith("#V#") else f"#V#{concept_id}"
+
+
+def _normalise_values(value: object) -> list[str]:
+    values = value if isinstance(value, list) else [value]
+    output: list[str] = []
+    for item in values:
+        if not isinstance(item, str) or not item.strip():
+            continue
+        concept_id = item.strip()
+        if not concept_id.startswith("#V#"):
+            concept_id = f"#V#{concept_id}"
+        if concept_id not in output:
+            output.append(concept_id)
+    return output
+
+
+def ensure_von_login_email_vocabulary() -> dict[str, Any]:
+    """Materialise hasVonLoginEmail and its one-way email entailment."""
+
+    with bypass_access_control():
+        existing = ConceptsRepository.find_one({"concept_id": LOGIN_EMAIL_PREDICATE})
+    if not isinstance(existing, Mapping):
+        with bypass_access_control():
+            concept_service.create_concept(
+                name="Has Von login email",
+                concept_id=LOGIN_EMAIL_PREDICATE,
+                description=(
+                    "An explicit server-authoritative email permitted to "
+                    "authenticate as this Von user. It entails ordinary "
+                    "has_email, but an ordinary has_email assertion never "
+                    "implies this predicate or grants login authority."
+                ),
+                parent_concept_ids=["#V#binary_text_predicate"],
+                create_as_instance=True,
+                visibility_scope_mode="global_general",
+                maintain_relationship_inverses=False,
+            )
+        state = "created"
+    else:
+        state = "existing"
+
+    with bypass_access_control():
+        predicate = ConceptsRepository.find_one(
+            {"concept_id": LOGIN_EMAIL_PREDICATE},
+            {
+                "_id": 0,
+                "concept_id": 1,
+                "relationships.is_an_instance_of": 1,
+            },
+        )
+    relationships = (
+        predicate.get("relationships") if isinstance(predicate, Mapping) else {}
+    )
+    types = _normalise_values(
+        relationships.get("is_an_instance_of")
+        if isinstance(relationships, Mapping)
+        else None
+    )
+    if "#V#binary_text_predicate" not in types:
+        raise RuntimeError("login_email_predicate_type_read_back_failed")
+
+    with bypass_access_control():
+        result = add_dynamic_relationship(
+            LOGIN_EMAIL_PREDICATE,
+            PREDICATE_SPECIALISATION_PREDICATE,
+            GENERIC_EMAIL_PREDICATE,
+        )
+    if result.get("success") is not True:
+        raise RuntimeError(
+            "login_email_predicate_specialisation_write_failed:"
+            f"{result.get('error') or 'unknown'}"
+        )
+
+    with bypass_access_control():
+        read_back = ConceptsRepository.find_one(
+            {"concept_id": LOGIN_EMAIL_PREDICATE},
+            {
+                "_id": 0,
+                "concept_id": 1,
+                f"relationships.{PREDICATE_SPECIALISATION_PREDICATE}": 1,
+            },
+        )
+    read_back_relationships = (
+        read_back.get("relationships") if isinstance(read_back, Mapping) else {}
+    )
+    targets = _normalise_values(
+        read_back_relationships.get(PREDICATE_SPECIALISATION_PREDICATE)
+        if isinstance(read_back_relationships, Mapping)
+        else None
+    )
+    if GENERIC_EMAIL_PREDICATE not in targets:
+        raise RuntimeError("login_email_predicate_specialisation_read_back_failed")
+
+    return {
+        "success": True,
+        "predicate_state": state,
+        "entailment": {
+            "specific_predicate": LOGIN_EMAIL_PREDICATE,
+            "relation": PREDICATE_SPECIALISATION_PREDICATE,
+            "generic_predicate": GENERIC_EMAIL_PREDICATE,
+            "reverse_inference_allowed": False,
+        },
+    }
+
+
+def _normalise_explicit_bindings(
+    bindings: Iterable[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    normalised: list[dict[str, str]] = []
+    seen_pairs: set[tuple[str, str]] = set()
+    requested_owners: dict[str, str] = {}
+    for binding in bindings:
+        if not isinstance(binding, Mapping):
+            raise ValueError("login_email_binding_not_mapping")
+        user_id = _normalise_concept_id(binding.get("user_concept_id"))
+        email = normalise_von_login_email(binding.get("email"))
+        prior_owner = requested_owners.get(email)
+        if prior_owner is not None and prior_owner != user_id:
+            raise ValueError("login_email_requested_for_multiple_users")
+        requested_owners[email] = user_id
+        pair = (user_id, email)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        normalised.append({"user_concept_id": user_id, "email": email})
+    return normalised
+
+
+def migrate_explicit_von_login_email_bindings(
+    *,
+    bindings: Iterable[Mapping[str, Any]],
+    dry_run: bool = True,
+    approved: bool = False,
+) -> dict[str, Any]:
+    """Validate or apply only the exact operator-supplied login allow-list."""
+
+    try:
+        requested = _normalise_explicit_bindings(bindings)
+    except ValueError as exc:
+        return {
+            "schema_version": MIGRATION_SCHEMA_VERSION,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": str(exc),
+            "generic_contact_emails_scanned": False,
+            "generic_contact_emails_migrated": False,
+        }
+
+    if not dry_run and not approved:
+        return {
+            "schema_version": MIGRATION_SCHEMA_VERSION,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "explicit_migration_approval_required",
+            "requested_binding_count": len(requested),
+            "generic_contact_emails_scanned": False,
+            "generic_contact_emails_migrated": False,
+        }
+
+    conflicts: list[dict[str, Any]] = []
+    ready: list[dict[str, Any]] = []
+    for binding in requested:
+        user_id = binding["user_concept_id"]
+        email = binding["email"]
+        with bypass_access_control():
+            user = ConceptsRepository.find_one(
+                {"concept_id": user_id},
+                projection={"_id": 1, "concept_id": 1},
+            )
+        if not isinstance(user, Mapping):
+            conflicts.append(
+                {
+                    **binding,
+                    "reason_code": "user_concept_not_found",
+                }
+            )
+            continue
+        existing_user_ids = list_von_login_email_user_ids(email)
+        other_user_ids = [item for item in existing_user_ids if item != user_id]
+        if other_user_ids:
+            conflicts.append(
+                {
+                    **binding,
+                    "reason_code": "login_email_bound_to_other_user",
+                    "existing_user_concept_ids": other_user_ids,
+                }
+            )
+            continue
+        ready.append(
+            {
+                **binding,
+                "already_bound": existing_user_ids == [user_id],
+            }
+        )
+
+    report: dict[str, Any] = {
+        "schema_version": MIGRATION_SCHEMA_VERSION,
+        "success": not conflicts,
+        "effect_status": "dry_run" if dry_run else "not_started",
+        "requested_binding_count": len(requested),
+        "ready_binding_count": len(ready),
+        "conflict_count": len(conflicts),
+        "ready_bindings": ready,
+        "conflicts": conflicts,
+        "login_email_predicate": LOGIN_EMAIL_PREDICATE,
+        "entailed_generic_predicate": GENERIC_EMAIL_PREDICATE,
+        "generic_contact_emails_scanned": False,
+        "generic_contact_emails_migrated": False,
+    }
+    if conflicts or dry_run:
+        return report
+
+    vocabulary = ensure_von_login_email_vocabulary()
+    results: list[dict[str, Any]] = []
+    for binding in ready:
+        result = bind_von_login_email(
+            user_concept_id=binding["user_concept_id"],
+            email=binding["email"],
+            provenance={
+                "migration_schema_version": MIGRATION_SCHEMA_VERSION,
+                "approved": True,
+            },
+        )
+        results.append(result)
+
+    report.update(
+        {
+            "success": True,
+            "effect_status": "completed",
+            "vocabulary": vocabulary,
+            "binding_results": results,
+            "created_binding_count": sum(
+                1 for result in results if result["relation_created"]
+            ),
+            "verified_binding_count": len(results),
+        }
+    )
+    return report
+
+
+__all__ = [
+    "MIGRATION_SCHEMA_VERSION",
+    "ensure_von_login_email_vocabulary",
+    "migrate_explicit_von_login_email_bindings",
+]

--- a/src/backend/services/von_user_authentication_service.py
+++ b/src/backend/services/von_user_authentication_service.py
@@ -1,0 +1,252 @@
+"""Server-authoritative Von login-email bindings.
+
+``#V#has_email`` is ordinary descriptive contact information.  It must never
+select an authenticated actor.  Google OAuth resolves only the deliberately
+narrow ``#V#hasVonLoginEmail`` predicate, whose mutation is reserved to this
+operator-controlled lifecycle.
+
+One user may have several login emails.  One normalised email may identify at
+most one user; ambiguous or stale bindings fail closed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from hashlib import sha256
+import logging
+import re
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from ..security.access_control import bypass_access_control
+from .exceptions import MultipleUsersForEmailError
+from .text_value_service import (
+    delete_text_relation_by_predicate_and_text,
+    upsert_text_for_concept,
+)
+
+logger = logging.getLogger(__name__)
+
+LOGIN_EMAIL_PREDICATE = "#V#hasVonLoginEmail"
+GENERIC_EMAIL_PREDICATE = "#V#has_email"
+PREDICATE_SPECIALISATION_PREDICATE = "#V#predicate_specialises_predicate"
+
+_LOGIN_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+$")
+
+
+class LoginEmailBindingConflictError(RuntimeError):
+    """The requested email is already bound to a different Von user."""
+
+    def __init__(self, email: str, existing_user_ids: list[str]):
+        self.email = email
+        self.existing_user_ids = list(existing_user_ids)
+        super().__init__("Login email is already bound to another Von user")
+
+
+def normalise_von_login_email(value: object) -> str:
+    """Return the canonical form used for exact OAuth identity lookup."""
+
+    email = str(value or "").strip().casefold()
+    if not email or not _LOGIN_EMAIL_PATTERN.fullmatch(email):
+        raise ValueError("login_email_invalid")
+    return email
+
+
+def login_email_log_fingerprint(value: object) -> str:
+    """Return a non-reversible short identifier suitable for auth logs."""
+
+    try:
+        normalised = normalise_von_login_email(value)
+    except ValueError:
+        normalised = str(value or "").strip().casefold()
+    return sha256(normalised.encode("utf-8")).hexdigest()[:12]
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    concept_id = value.strip()
+    return concept_id if concept_id.startswith("#V#") else f"#V#{concept_id}"
+
+
+def _login_email_text_value_ids(email: str) -> list[Any]:
+    rows = TextValuesRepository.find(
+        {"text": email},
+        projection={"_id": 1},
+    )
+    identifiers: list[Any] = []
+    for row in rows:
+        if not isinstance(row, Mapping) or row.get("_id") is None:
+            continue
+        raw_id = row["_id"]
+        for candidate in (raw_id, str(raw_id)):
+            if candidate not in identifiers:
+                identifiers.append(candidate)
+    return identifiers
+
+
+def list_von_login_email_user_ids(email: object) -> list[str]:
+    """Return every subject explicitly bound to the normalised login email."""
+
+    normalised_email = normalise_von_login_email(email)
+    text_value_ids = _login_email_text_value_ids(normalised_email)
+    if not text_value_ids:
+        return []
+    relations = TextRelationsRepository.find(
+        {
+            "predicate": LOGIN_EMAIL_PREDICATE,
+            "object_text_id": {"$in": text_value_ids},
+        },
+        projection={"_id": 0, "subject_concept_id": 1},
+    )
+    user_ids = {
+        concept_id
+        for relation in relations
+        if isinstance(relation, Mapping)
+        and (concept_id := _normalise_concept_id(relation.get("subject_concept_id")))
+        is not None
+    }
+    return sorted(user_ids)
+
+
+def find_user_concept_by_login_email(email: object) -> dict[str, Any] | None:
+    """Resolve one explicit login binding without consulting contact email.
+
+    This is a trusted pre-authentication read and therefore deliberately does
+    not depend on the as-yet-unresolved actor's visibility context.
+    """
+
+    normalised_email = normalise_von_login_email(email)
+    user_ids = list_von_login_email_user_ids(normalised_email)
+    if len(user_ids) > 1:
+        logger.critical(
+            "Ambiguous Von login-email binding fingerprint=%s count=%d",
+            login_email_log_fingerprint(normalised_email),
+            len(user_ids),
+        )
+        raise MultipleUsersForEmailError(normalised_email, user_ids)
+    if not user_ids:
+        return None
+
+    with bypass_access_control():
+        user = ConceptsRepository.find_one({"concept_id": user_ids[0]})
+    if not isinstance(user, Mapping):
+        logger.error(
+            "Stale Von login-email binding fingerprint=%s",
+            login_email_log_fingerprint(normalised_email),
+        )
+        return None
+    result = dict(user)
+    result["concept_id"] = user_ids[0]
+    return result
+
+
+def bind_von_login_email(
+    *,
+    user_concept_id: str,
+    email: object,
+    provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Add one explicit operator-authorised login binding and read it back."""
+
+    normalised_user_id = _normalise_concept_id(user_concept_id)
+    if normalised_user_id is None:
+        raise ValueError("user_concept_id_required")
+    normalised_email = normalise_von_login_email(email)
+
+    with bypass_access_control():
+        user = ConceptsRepository.find_one(
+            {"concept_id": normalised_user_id},
+            projection={"_id": 1, "concept_id": 1},
+        )
+    if not isinstance(user, Mapping):
+        raise ValueError(f"user_concept_not_found:{normalised_user_id}")
+
+    existing_user_ids = list_von_login_email_user_ids(normalised_email)
+    conflicting_user_ids = [
+        concept_id
+        for concept_id in existing_user_ids
+        if concept_id != normalised_user_id
+    ]
+    if conflicting_user_ids:
+        raise LoginEmailBindingConflictError(
+            normalised_email,
+            conflicting_user_ids,
+        )
+
+    with bypass_access_control():
+        write_result = upsert_text_for_concept(
+            subject_concept_id=normalised_user_id,
+            predicate=LOGIN_EMAIL_PREDICATE,
+            text=normalised_email,
+            provenance={
+                "source": "von_login_email_binding",
+                **dict(provenance or {}),
+            },
+        )
+
+    read_back_user_ids = list_von_login_email_user_ids(normalised_email)
+    if read_back_user_ids != [normalised_user_id]:
+        raise RuntimeError("von_login_email_binding_read_back_failed")
+    return {
+        "success": True,
+        "user_concept_id": normalised_user_id,
+        "email": normalised_email,
+        "relation_created": bool(write_result.get("relation_created")),
+        "read_back_user_concept_id": read_back_user_ids[0],
+    }
+
+
+def remove_von_login_email(
+    *,
+    user_concept_id: str,
+    email: object,
+) -> dict[str, Any]:
+    """Revoke one exact login binding without deleting contact information."""
+
+    normalised_user_id = _normalise_concept_id(user_concept_id)
+    if normalised_user_id is None:
+        raise ValueError("user_concept_id_required")
+    normalised_email = normalise_von_login_email(email)
+    existing_user_ids = list_von_login_email_user_ids(normalised_email)
+    if normalised_user_id not in existing_user_ids:
+        return {
+            "success": True,
+            "user_concept_id": normalised_user_id,
+            "email": normalised_email,
+            "removed": False,
+        }
+
+    with bypass_access_control():
+        delete_text_relation_by_predicate_and_text(
+            normalised_user_id,
+            LOGIN_EMAIL_PREDICATE,
+            normalised_email,
+            garbage_collect=False,
+        )
+    if normalised_user_id in list_von_login_email_user_ids(normalised_email):
+        raise RuntimeError("von_login_email_revocation_read_back_failed")
+    return {
+        "success": True,
+        "user_concept_id": normalised_user_id,
+        "email": normalised_email,
+        "removed": True,
+    }
+
+
+__all__ = [
+    "GENERIC_EMAIL_PREDICATE",
+    "LOGIN_EMAIL_PREDICATE",
+    "LoginEmailBindingConflictError",
+    "PREDICATE_SPECIALISATION_PREDICATE",
+    "bind_von_login_email",
+    "find_user_concept_by_login_email",
+    "list_von_login_email_user_ids",
+    "login_email_log_fingerprint",
+    "normalise_von_login_email",
+    "remove_von_login_email",
+]

--- a/src/backend/utilities/migrate_von_login_email_bindings.py
+++ b/src/backend/utilities/migrate_von_login_email_bindings.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Validate or apply an explicit Von login-email allow-list.
+
+Examples:
+    python -m src.backend.utilities.migrate_von_login_email_bindings \
+      --binding '#V#alice=alice@example.org'
+
+    python -m src.backend.utilities.migrate_von_login_email_bindings \
+      --binding '#V#alice=alice@example.org' --apply --approved
+
+The command never discovers or copies ``#V#has_email`` contact values.  Every
+authority-bearing login address must appear explicitly as ``USER=EMAIL``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.backend.services.von_login_email_migration_service import (
+    migrate_explicit_von_login_email_bindings,
+)
+
+
+def _parse_binding(raw: str) -> dict[str, str]:
+    user_concept_id, separator, email = str(raw or "").partition("=")
+    if not separator or not user_concept_id.strip() or not email.strip():
+        raise argparse.ArgumentTypeError(
+            "binding must have the exact form USER_CONCEPT_ID=EMAIL"
+        )
+    return {
+        "user_concept_id": user_concept_id.strip(),
+        "email": email.strip(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Populate hasVonLoginEmail only from an explicit reviewed allow-list."
+        )
+    )
+    parser.add_argument(
+        "--binding",
+        action="append",
+        type=_parse_binding,
+        required=True,
+        metavar="USER_CONCEPT_ID=EMAIL",
+        help=(
+            "Exact user/email login binding. Repeat for every permitted address; "
+            "ordinary has_email values are never copied."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the bindings; omission performs a read-only dry run.",
+    )
+    parser.add_argument(
+        "--approved",
+        action="store_true",
+        help="Explicitly approve this authority-bearing allow-list.",
+    )
+    args = parser.parse_args()
+
+    report = migrate_explicit_von_login_email_bindings(
+        bindings=args.binding,
+        dry_run=not args.apply,
+        approved=args.approved,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, default=str))
+    return 0 if report.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/utilities/migrate_von_organisation_membership_predicates.py
+++ b/src/backend/utilities/migrate_von_organisation_membership_predicates.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Audit or apply the narrow Von organisation membership migration.
+
+Examples:
+    python -m src.backend.utilities.migrate_von_organisation_membership_predicates
+    python -m src.backend.utilities.migrate_von_organisation_membership_predicates --apply --approved
+
+The default is a read-only dry run.  Applying requires both flags so an
+operator cannot turn generic ontology membership facts into authority by
+accident.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.backend.services.organisation_membership_predicate_migration_service import (
+    migrate_von_organisation_membership_predicates,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate evidenced Von memberships to narrow predicates."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the migration; omission performs a read-only dry run.",
+    )
+    parser.add_argument(
+        "--approved",
+        action="store_true",
+        help="Explicitly approve the authority-bearing migration.",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=20,
+        help="Maximum detailed records to include in the JSON report.",
+    )
+    args = parser.parse_args()
+
+    report = migrate_von_organisation_membership_predicates(
+        dry_run=not args.apply,
+        approved=args.approved,
+        sample_limit=args.sample_limit,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, default=str))
+    return 0 if report.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/vontology/code_concepts_registry.py
+++ b/src/backend/vontology/code_concepts_registry.py
@@ -57,6 +57,8 @@ _TEXT_PREDICATE_IDS = [
     "#V#hasDefinition",
     "#V#has_renderer_profile_json",
     "#V#has_constitutive_relation_requirements_json",
+    "#V#hasVonOrgRole",
+    "#V#hasVonLoginEmail",
 ]
 
 _FILE_METADATA_PREDICATE_IDS = [
@@ -262,6 +264,7 @@ _OTHER_PREDICATE_IDS = [
     "#V#has_email",
     "#V#hasRole",
     "#V#memberOf",
+    "#V#memberOfVonOrg",
     "#V#member_of_organisation",
     "#V#has_birthplace",
     "#V#has_occupation",

--- a/src/backend/vontology/seed_bundles/constitutive_relation_requirements_seed_bundle.json
+++ b/src/backend/vontology/seed_bundles/constitutive_relation_requirements_seed_bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "constitutive_relation_requirement_seed_bundle.v1",
-  "seed_version": "1",
+  "seed_version": "2",
   "source_tag": "JVNAUTOSCI-1035",
   "managed_by": "constitutive_relation_requirement_service",
   "profiles": [
@@ -11,8 +11,8 @@
         "requirements": [
           {
             "requirement_id": "von_user_organisation_has_von_user_member",
-            "predicate_concept_id": "#V#memberOf",
-            "predicate_label": "member of",
+            "predicate_concept_id": "#V#memberOfVonOrg",
+            "predicate_label": "member of Von organisation",
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
             "other_argument_type_label": "Von user",

--- a/tests/backend/test_access_control_identity_resolution.py
+++ b/tests/backend/test_access_control_identity_resolution.py
@@ -124,6 +124,45 @@ def test_header_identity_cache_is_request_local(monkeypatch) -> None:
         assert access_control.get_effective_user_concept_id() == "#V#actor_b"
 
 
+def test_pre_cutover_google_session_without_assurance_has_no_actor_or_org() -> None:
+    from flask import session
+
+    import src.backend.security.access_control as access_control
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    with app.test_request_context("/von/generate"):
+        session["user_concept_id"] = "#V#victim"
+        session["user_email"] = "attacker@example.org"
+        session["auth_provider"] = "google_oauth"
+        session["organisation_concept_id"] = "#V#private_org"
+
+        assert access_control.get_effective_user_concept_id() is None
+        assert access_control.get_effective_organisation_concept_id() is None
+
+
+def test_google_session_with_login_email_assurance_has_its_bound_actor() -> None:
+    from flask import session
+
+    import src.backend.security.access_control as access_control
+    from src.backend.security.authentication_assurance import (
+        AUTHENTICATION_ASSURANCE_SESSION_KEY,
+        GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE,
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    with app.test_request_context("/von/generate"):
+        session["user_concept_id"] = "#V#alice"
+        session["user_email"] = "alice@example.org"
+        session["auth_provider"] = "google_oauth"
+        session[AUTHENTICATION_ASSURANCE_SESSION_KEY] = (
+            GOOGLE_OAUTH_LOGIN_EMAIL_ASSURANCE
+        )
+
+        assert access_control.get_effective_user_concept_id() == "#V#alice"
+
+
 def test_explicit_anonymous_actor_suppresses_ambient_identity_without_a_source(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_browser_test_auth_routes.py
+++ b/tests/backend/test_browser_test_auth_routes.py
@@ -47,7 +47,10 @@ def test_auth_status_includes_browser_test_mode_descriptor(monkeypatch, app_clie
     assert payload["authenticated"] is False
     assert payload["browser_test_mode"]["available"] is True
     assert payload["browser_test_mode"]["status"] == "available"
-    assert payload["browser_test_mode"]["identity_label"] == "Zhan von Witbrock <zhanvonwitbrock@gmail.com>"
+    assert (
+        payload["browser_test_mode"]["identity_label"]
+        == "Zhan von Witbrock <zhanvonwitbrock@gmail.com>"
+    )
     assert payload["browser_test_mode"]["fixture_id"] == "browser_user_view.v1"
 
 
@@ -145,7 +148,10 @@ def test_browser_test_login_sets_browser_test_session(monkeypatch, app_client):
     assert payload["authenticated"] is True
     assert payload["auth_provider"] == "browser_test_fixture"
     assert payload["user_concept_id"] == "#V#zhan_von_witbrock"
-    assert payload["organisation"]["concept_id"] == "#V#university_of_auckland_strong_ai_lab"
+    assert (
+        payload["organisation"]["concept_id"]
+        == "#V#university_of_auckland_strong_ai_lab"
+    )
     assert payload["window_session_id"] == "ws_browser_test"
     assert payload["fixture"]["messages"]["total"] == 3
     assert login_calls == [
@@ -156,7 +162,10 @@ def test_browser_test_login_sets_browser_test_session(monkeypatch, app_client):
     ]
 
 
-def test_exchange_token_clears_scope_when_authenticated_user_changes(app_client):
+def test_exchange_token_clears_scope_when_authenticated_user_changes(
+    monkeypatch,
+    app_client,
+):
     _, client = app_client
     token = "cross-account-token"
     auth_routes._oauth_states[token] = {
@@ -167,6 +176,13 @@ def test_exchange_token_clears_scope_when_authenticated_user_changes(app_client)
             "name": "User B",
         },
     }
+    monkeypatch.setattr(
+        auth_routes,
+        "find_user_concept_by_login_email",
+        lambda email: (
+            {"concept_id": "#V#user_b"} if email == "user-b@example.test" else None
+        ),
+    )
     with client.session_transaction() as sess:
         sess["user_concept_id"] = "#V#user_a"
         sess["user_email"] = "user-a@example.test"
@@ -188,6 +204,56 @@ def test_exchange_token_clears_scope_when_authenticated_user_changes(app_client)
         assert "role_in_org" not in sess
         assert "namespace" not in sess
         assert "session_id" not in sess
+
+
+def test_auth_status_does_not_treat_email_without_user_binding_as_authenticated(
+    app_client,
+):
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess["user_email"] = "unbound@example.test"
+        sess["auth_provider"] = "google_oauth"
+
+    response = client.get("/von/api/auth/status")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["authenticated"] is False
+    assert payload["email"] is None
+    assert payload["user_concept_id"] is None
+    assert payload["auth_provider"] is None
+
+
+def test_exchange_token_rechecks_login_binding_and_fails_closed(
+    monkeypatch,
+    app_client,
+):
+    _, client = app_client
+    token = "revoked-binding-token"
+    auth_routes._oauth_states[token] = {
+        "timestamp": time.time(),
+        "user": {
+            "concept_id": "#V#user_b",
+            "email": "user-b@example.test",
+            "name": "User B",
+        },
+    }
+    monkeypatch.setattr(
+        auth_routes,
+        "find_user_concept_by_login_email",
+        lambda _email: None,
+    )
+
+    response = client.post(
+        "/von/api/auth/exchange-token",
+        json={"token": token},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["error_code"] == "von_login_email_binding_invalid"
+    with client.session_transaction() as sess:
+        assert "user_concept_id" not in sess
+        assert "user_email" not in sess
 
 
 def test_logout_invalidates_owned_window_context(monkeypatch, app_client):

--- a/tests/backend/test_concept_qa_conversation_service.py
+++ b/tests/backend/test_concept_qa_conversation_service.py
@@ -120,7 +120,7 @@ def test_representation_status_question_is_answered_from_receipt_without_model(
             "status": "tentative",
             "effect_status": "succeeded",
             "assertion_id": "ska_member",
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "activation_effect": "organisation_membership",
             "canonical_publication": False,
         },
@@ -194,7 +194,7 @@ def test_autoformalisation_requires_declared_tentative_permission(monkeypatch):
         exact_input=exact,
         answer="Michael Witbrock",
         proposed_predicate={
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
             "auto_formalisation_allowed": False,
@@ -240,7 +240,7 @@ def test_safe_short_answer_is_stored_as_tentative_direction_aware_relation(
             "canonical_read_back": {
                 "assertion_id": "ska_tentative_member",
                 "subject_concept_id": "#V#michael_witbrock",
-                "predicate": "#V#memberOf",
+                "predicate": "#V#memberOfVonOrg",
                 "object_concept_id": CONCEPT_ID,
                 "epistemic_status": "tentative",
             },
@@ -263,7 +263,7 @@ def test_safe_short_answer_is_stored_as_tentative_direction_aware_relation(
         answer="Michael Witbrock",
         proposed_predicate={
             "requirement_id": "organisation_has_von_user",
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
             "declared_on_type_concept_id": "#V#von_user_organisation",
@@ -343,7 +343,7 @@ def test_code_string_answer_cannot_bypass_counterpart_type_resolution(monkeypatc
         },
         answer="#V#some_organisation",
         proposed_predicate={
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
             "auto_formalisation_allowed": True,
@@ -484,7 +484,7 @@ def test_membership_activation_success_is_retained_when_promotion_needs_retry(
     assertion = {
         "assertion_id": "ska_member",
         "subject_concept_id": "#V#michael_witbrock",
-        "predicate": "#V#memberOf",
+        "predicate": "#V#memberOfVonOrg",
         "object_concept_id": CONCEPT_ID,
         "epistemic_status": "tentative",
     }
@@ -520,7 +520,7 @@ def test_membership_activation_success_is_retained_when_promotion_needs_retry(
     formalisation = {
         "assertion_id": "ska_member",
         "subject_concept_id": "#V#michael_witbrock",
-        "predicate_concept_id": "#V#memberOf",
+        "predicate_concept_id": "#V#memberOfVonOrg",
         "object_concept_id": CONCEPT_ID,
         "focal_argument": "object",
         "other_argument_type_concept_id": "#V#von_user",
@@ -771,7 +771,7 @@ def test_member_confirmation_authority_denial_preserves_tentative_candidate(
     assertion = {
         "assertion_id": "ska_member_denied",
         "subject_concept_id": "#V#person",
-        "predicate": "#V#memberOf",
+        "predicate": "#V#memberOfVonOrg",
         "object_concept_id": CONCEPT_ID,
         "epistemic_status": "tentative",
     }
@@ -811,7 +811,7 @@ def test_member_confirmation_authority_denial_preserves_tentative_candidate(
         formalisation={
             "assertion_id": "ska_member_denied",
             "subject_concept_id": "#V#person",
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "object_concept_id": CONCEPT_ID,
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
@@ -851,7 +851,7 @@ def test_preexisting_membership_lets_original_actor_confirm_without_self_grant(
     assertion = {
         "assertion_id": "ska_member_preexisting",
         "subject_concept_id": "#V#person",
-        "predicate": "#V#memberOf",
+        "predicate": "#V#memberOfVonOrg",
         "object_concept_id": CONCEPT_ID,
         "epistemic_status": "tentative",
     }
@@ -894,7 +894,7 @@ def test_preexisting_membership_lets_original_actor_confirm_without_self_grant(
         formalisation={
             "assertion_id": "ska_member_preexisting",
             "subject_concept_id": "#V#person",
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "object_concept_id": CONCEPT_ID,
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",

--- a/tests/backend/test_concept_service_question_prompting.py
+++ b/tests/backend/test_concept_service_question_prompting.py
@@ -120,7 +120,7 @@ def test_emitted_question_binds_only_the_matching_plan_item():
 
     first = {
         "requirement_id": "organisation_has_member",
-        "predicate_concept_id": "#V#memberOf",
+        "predicate_concept_id": "#V#memberOfVonOrg",
         "focal_argument": "object",
         "other_argument_type_concept_id": "#V#von_user",
         "declared_on_type_concept_id": "#V#von_user_organisation",
@@ -151,7 +151,7 @@ def test_paraphrased_or_ambiguous_question_is_not_bound_to_formalisation():
     plan = [
         {
             "requirement_id": "organisation_has_member",
-            "predicate_concept_id": "#V#memberOf",
+            "predicate_concept_id": "#V#memberOfVonOrg",
             "focal_argument": "object",
             "other_argument_type_concept_id": "#V#von_user",
             "declared_on_type_concept_id": "#V#von_user_organisation",

--- a/tests/backend/test_google_auth_proxy_routes.py
+++ b/tests/backend/test_google_auth_proxy_routes.py
@@ -55,11 +55,9 @@ def app_client(monkeypatch: pytest.MonkeyPatch):
     auth_routes._oauth_states.clear()
     monkeypatch.setattr(
         auth_routes,
-        "set_current_user_by_email",
-        lambda email, name: {
+        "find_user_concept_by_login_email",
+        lambda email: {
             "concept_id": "#V#example_user",
-            "email": email,
-            "name": name,
         },
     )
 
@@ -113,3 +111,30 @@ def test_callback_exchanges_using_configured_external_https_url(app_client) -> N
         "https://spark.example.test/von/api/auth/google/callback"
         "?code=abc&state=proxy-state"
     )
+
+
+def test_callback_rejects_an_email_without_explicit_login_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    app_client,
+) -> None:
+    client, _ = app_client
+    monkeypatch.setattr(
+        auth_routes,
+        "find_user_concept_by_login_email",
+        lambda _email: None,
+    )
+    auth_routes._oauth_states["proxy-state"] = {
+        "timestamp": time.time(),
+        "used": False,
+    }
+
+    response = client.get(
+        "/von/api/auth/google/callback?code=abc&state=proxy-state",
+        base_url="http://spark.example.test",
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["error_code"] == "von_login_email_not_authorised"
+    with client.session_transaction() as flask_session:
+        assert "user_concept_id" not in flask_session
+        assert "user_email" not in flask_session

--- a/tests/backend/test_ontology_http_text_relation_containment.py
+++ b/tests/backend/test_ontology_http_text_relation_containment.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from bson import ObjectId
 from flask import Flask
+import pytest
 
 from src.backend.server.routes import concept_routes
 from src.backend.services import ontology_mutation_command_service as command
@@ -158,14 +159,25 @@ def test_http_text_delete_by_predicate_and_text_fails_closed(monkeypatch) -> Non
     )
 
 
-def test_http_relation_id_cannot_patch_an_ontology_role_relation(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "reserved_predicate",
+    [
+        "#V#has_ontology_authority_role",
+        "#V#hasVonOrgRole",
+        "#V#hasVonLoginEmail",
+    ],
+)
+def test_http_relation_id_cannot_patch_a_reserved_authority_relation(
+    monkeypatch,
+    reserved_predicate: str,
+) -> None:
     mutation_called = False
 
     def relation_find_one(_query: dict[str, Any]) -> dict[str, Any]:
         return {
             "_id": "role-relation",
             "subject_concept_id": "#V#administrator",
-            "predicate": "#V#has_ontology_authority_role",
+            "predicate": reserved_predicate,
             "object_text_id": "role-text",
             "context": {},
         }
@@ -187,6 +199,55 @@ def test_http_relation_id_cannot_patch_an_ontology_role_relation(monkeypatch) ->
     response = _client().patch(
         "/api/concepts/%23V%23administrator/texts/role-relation",
         json={"text": "no longer an administrator", "lang": "en"},
+    )
+
+    assert response.status_code == 403
+    payload = response.get_json()
+    assert payload["error_code"] == ("dedicated_ontology_governance_operation_required")
+    assert payload["effect_status"] == "not_started"
+    assert mutation_called is False
+
+
+@pytest.mark.parametrize(
+    "reserved_predicate",
+    [
+        "#V#has_ontology_authority_role",
+        "#V#hasVonOrgRole",
+        "#V#hasVonLoginEmail",
+    ],
+)
+def test_http_relation_id_cannot_delete_a_reserved_authority_relation(
+    monkeypatch,
+    reserved_predicate: str,
+) -> None:
+    mutation_called = False
+
+    def relation_find_one(_query: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "_id": "role-relation",
+            "subject_concept_id": "#V#administrator",
+            "predicate": reserved_predicate,
+            "object_text_id": "role-text",
+            "context": {},
+        }
+
+    def delete(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal mutation_called
+        mutation_called = True
+        return {"deleted": True}
+
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(command.TextRelationsRepository, "find_one", relation_find_one)
+    monkeypatch.setattr(
+        command.TextValuesRepository,
+        "find_one",
+        lambda _query: {"_id": "role-text", "text": "reserved value", "lang": "en"},
+    )
+    monkeypatch.setattr(concept_routes, "delete_text_relation", delete)
+
+    response = _client().delete(
+        "/api/concepts/%23V%23administrator/texts/role-relation",
+        json={},
     )
 
     assert response.status_code == 403

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -408,9 +408,19 @@ def test_ordinary_actor_keeps_exact_private_creation_and_edit_authority(
     assert edit_decision.reason_code == "semantic_ontology_authority_verified"
 
 
+@pytest.mark.parametrize(
+    "reserved_predicate",
+    [
+        "#V#has_ontology_authority_role",
+        "#V#hasVonOrgRole",
+        "#V#memberOfVonOrg",
+        "#V#hasVonLoginEmail",
+    ],
+)
 def test_reserved_predicates_cannot_be_changed_by_generic_write(
     authority_stores,
     monkeypatch,
+    reserved_predicate,
 ):
     service, _delegations, _receipts = authority_stores
     global_role = _evidence(
@@ -422,7 +432,7 @@ def test_reserved_predicates_cannot_be_changed_by_generic_write(
     )
     with service.override_current_actor("#V#admin", None):
         decision = service.authorise_ontology_mutation(
-            _intent(service, predicate=service.AUTHORITY_ROLE_PREDICATE)
+            _intent(service, predicate=reserved_predicate)
         )
     assert decision.allowed is False
     assert decision.reason_code == ("dedicated_ontology_governance_operation_required")
@@ -941,3 +951,16 @@ def test_actor_bound_private_workflow_does_not_bypass_governance_predicates(
 
     assert decision.allowed is False
     assert decision.reason_code == "dedicated_ontology_governance_operation_required"
+
+
+def test_only_narrow_von_membership_and_login_predicates_are_reserved():
+    from src.backend.services import ontology_publication_authority_service as service
+
+    assert "#V#memberOfVonOrg" in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#hasVonOrgRole" in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#hasVonLoginEmail" in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#memberOf" not in service.RESERVED_AUTHORITY_PREDICATES
+    assert "memberOf" not in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#member_of_organisation" not in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#hasRole" not in service.RESERVED_AUTHORITY_PREDICATES
+    assert "#V#has_email" not in service.RESERVED_AUTHORITY_PREDICATES

--- a/tests/backend/test_organisation_membership_predicate_migration_service.py
+++ b/tests/backend/test_organisation_membership_predicate_migration_service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from src.backend.services import (
+    organisation_membership_predicate_migration_service as migration,
+)
+
+
+def test_audit_separates_governed_legacy_records_from_generic_membership(
+    monkeypatch,
+):
+    governed = ("#V#governed_user", "#V#von_org")
+    descriptive = ("#V#researcher", "#V#ordinary_org")
+    monkeypatch.setattr(
+        migration,
+        "_legacy_edge_pairs",
+        lambda: {
+            governed: {"memberOf"},
+            descriptive: {"#V#member_of_organisation"},
+        },
+    )
+    monkeypatch.setattr(
+        migration,
+        "_legacy_role_pairs",
+        lambda: ({governed: {"owner"}}, []),
+    )
+    monkeypatch.setattr(migration, "_narrow_membership_pairs", set)
+
+    report = migration.audit_von_organisation_membership_predicates()
+
+    assert report["eligible_operational_membership_count"] == 1
+    assert report["eligible_operational_memberships"] == [
+        {
+            "user_concept_id": governed[0],
+            "organisation_concept_id": governed[1],
+            "role": "owner",
+            "legacy_membership_predicates": ["memberOf"],
+            "already_narrow": False,
+        }
+    ]
+    assert report["generic_only_non_authority_count"] == 1
+    assert (
+        report["generic_only_non_authority_samples"][0]["user_concept_id"]
+        == descriptive[0]
+    )
+
+
+def test_apply_migrates_only_role_backed_operational_membership(monkeypatch):
+    governed = ("#V#governed_user", "#V#von_org")
+    descriptive = ("#V#researcher", "#V#ordinary_org")
+    narrow_pairs: set[tuple[str, str]] = set()
+    roles: dict[tuple[str, str], str] = {}
+    create_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        migration,
+        "_legacy_edge_pairs",
+        lambda: {
+            governed: {"memberOf"},
+            descriptive: {"#V#member_of_organisation"},
+        },
+    )
+    monkeypatch.setattr(
+        migration,
+        "_legacy_role_pairs",
+        lambda: ({governed: {"owner"}}, []),
+    )
+    monkeypatch.setattr(
+        migration, "_narrow_membership_pairs", lambda: set(narrow_pairs)
+    )
+    monkeypatch.setattr(
+        migration,
+        "ensure_von_organisation_membership_vocabulary",
+        lambda: {"success": True},
+    )
+
+    def resolve(user_id, organisation_id):
+        role = roles.get((user_id, organisation_id))
+        if role is None:
+            return None
+        return {
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+            "role": role,
+        }
+
+    def create(*, user_concept_id, organisation_concept_id, role):
+        pair = (user_concept_id, organisation_concept_id)
+        create_calls.append((user_concept_id, organisation_concept_id, role))
+        narrow_pairs.add(pair)
+        roles[pair] = role
+        return {"relationship_created": True}
+
+    monkeypatch.setattr(migration, "resolve_user_organisation_membership", resolve)
+    monkeypatch.setattr(migration, "create_organisation_membership", create)
+
+    report = migration.migrate_von_organisation_membership_predicates(
+        dry_run=False,
+        approved=True,
+    )
+
+    assert report["success"] is True
+    assert report["migrated_count"] == 1
+    assert create_calls == [(governed[0], governed[1], "owner")]
+    assert descriptive not in narrow_pairs
+    assert report["generic_only_relations_grant_authority"] is False
+
+
+def test_apply_requires_explicit_approval(monkeypatch):
+    monkeypatch.setattr(migration, "_legacy_edge_pairs", dict)
+    monkeypatch.setattr(migration, "_legacy_role_pairs", lambda: ({}, []))
+    monkeypatch.setattr(migration, "_narrow_membership_pairs", set)
+
+    report = migration.migrate_von_organisation_membership_predicates(
+        dry_run=False,
+        approved=False,
+    )
+
+    assert report["success"] is False
+    assert report["effect_status"] == "not_started"
+    assert report["error_code"] == "explicit_migration_approval_required"
+
+
+def test_vocabulary_represents_one_way_memberof_entailment(monkeypatch):
+    documents: dict[str, dict] = {
+        migration.GENERIC_MEMBERSHIP_PREDICATE: {
+            "concept_id": migration.GENERIC_MEMBERSHIP_PREDICATE,
+            "relationships": {"is_an_instance_of": ["#V#predicate"]},
+        },
+        migration.PREDICATE_SPECIALISATION_PREDICATE: {
+            "concept_id": migration.PREDICATE_SPECIALISATION_PREDICATE,
+            "relationships": {"is_an_instance_of": ["#V#predicate"]},
+        },
+    }
+
+    def find_one(query, projection=None):
+        return documents.get(query.get("concept_id"))
+
+    def create_concept(**kwargs):
+        documents[kwargs["concept_id"]] = {
+            "concept_id": kwargs["concept_id"],
+            "relationships": {"is_an_instance_of": list(kwargs["parent_concept_ids"])},
+        }
+        return documents[kwargs["concept_id"]]
+
+    def add_relationship(source_id, predicate, target_id):
+        relationships = documents[source_id].setdefault("relationships", {})
+        relationships.setdefault(predicate, []).append(target_id)
+        return {"success": True, "modified": True}
+
+    monkeypatch.setattr(migration.ConceptsRepository, "find_one", find_one)
+    monkeypatch.setattr(migration.concept_service, "create_concept", create_concept)
+    monkeypatch.setattr(migration, "add_dynamic_relationship", add_relationship)
+
+    report = migration.ensure_von_organisation_membership_vocabulary()
+
+    assert report["success"] is True
+    assert report["entailment"] == {
+        "specific_predicate": "#V#memberOfVonOrg",
+        "relation": "#V#predicate_specialises_predicate",
+        "generic_predicate": "#V#memberOf",
+        "reverse_inference_allowed": False,
+    }
+    assert documents["#V#memberOfVonOrg"]["relationships"][
+        "#V#predicate_specialises_predicate"
+    ] == ["#V#memberOf"]
+    assert (
+        "#V#predicate_specialises_predicate"
+        not in documents["#V#memberOf"]["relationships"]
+    )

--- a/tests/backend/test_organisation_membership_service.py
+++ b/tests/backend/test_organisation_membership_service.py
@@ -1,7 +1,7 @@
 """Tests for organisation_membership_service.py
 
-Tests the Vontology-based membership model that stores user-organisation
-relationships and roles using the memberOf predicate and hasRole text relations.
+Tests the Vontology-based membership model that stores authority-bearing
+user-organisation relationships and roles under narrow Von predicates.
 """
 
 import sys
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from src.backend.services.organisation_membership_service import (
     MEMBERSHIP_RELATIONSHIP_KIND,
+    ROLE_PREDICATE,
     create_organisation_membership,
     get_organisation_members,
     get_user_memberships,
@@ -94,6 +95,7 @@ def mock_text_repos():
             "src.backend.db.repositories.text_value_repository.TextValuesRepository"
         ) as text_vals,
     ):
+
         def find_text_value_by_id(value, projection=None):
             query = {"_id": value}
             if projection is None:
@@ -164,7 +166,7 @@ class TestCreateOrganisationMembership:
         call_args = mock_text_value_service.call_args
         assert call_args[1]["subject_concept_id"] == user_id
         # Predicate is stored as namespaced concept identifier
-        assert call_args[1]["predicate"] == "#V#hasRole"
+        assert call_args[1]["predicate"] == ROLE_PREDICATE
         assert call_args[1]["text"] == f"{role}::{org_id}"
         assert mock_window_authority_invalidation == []
 
@@ -184,12 +186,12 @@ class TestCreateOrganisationMembership:
         mock_concepts_repo.find_one.side_effect = [
             {
                 "concept_id": user_id,
-                "relationships": {"memberOf": [org_id]},
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
             },  # user lookup in create
             {"concept_id": org_id, "relationships": {}},  # org lookup in create
             {
                 "concept_id": user_id,
-                "relationships": {"memberOf": [org_id]},
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
             },  # user lookup in _check
         ]
         mock_text_value_service.return_value = {
@@ -275,20 +277,20 @@ class TestGetUserMemberships:
         # Setup
         mock_concepts_repo.find_one.return_value = {
             "concept_id": user_id,
-            "relationships": {"memberOf": orgs},
+            "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: orgs},
         }
 
         text_rels, text_vals = mock_text_repos
         text_rels.find.return_value = [
             {
                 "subject_concept_id": user_id,
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_1",
                 "context": {"organisation_id": "#V#sail"},
             },
             {
                 "subject_concept_id": user_id,
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_2",
                 "context": {"organisation_id": "#V#other_org"},
             },
@@ -333,10 +335,10 @@ class TestGetUserMemberships:
         assert result["total_memberships"] == 0
         assert result["memberships"] == []
 
-    def test_get_memberships_merges_canonical_and_legacy_relationships(
+    def test_generic_membership_relations_do_not_grant_von_authority(
         self, mock_concepts_repo, mock_access_control, mock_text_repos
     ):
-        """Both stored membership predicates remain visible and deduplicated."""
+        """Descriptive membership is not an operational access grant."""
         user_id = "#V#michael_witbrock"
         mock_concepts_repo.find_one.return_value = {
             "concept_id": user_id,
@@ -353,18 +355,33 @@ class TestGetUserMemberships:
 
         result = get_user_memberships(user_id)
 
-        assert result["memberships"] == [
+        assert result["memberships"] == []
+        assert result["total_memberships"] == 0
+
+    def test_generic_membership_with_role_still_does_not_grant_von_authority(
+        self, mock_concepts_repo, mock_access_control, mock_text_repos
+    ):
+        user_id = "#V#michael_witbrock"
+        org_id = "#V#semantic_affiliation"
+        mock_concepts_repo.find_one.return_value = {
+            "concept_id": user_id,
+            "relationships": {"memberOf": [org_id]},
+        }
+        text_rels, text_vals = mock_text_repos
+        text_rels.find.return_value = [
             {
-                "organisation_concept_id": (
-                    "#V#university_of_auckland_strong_ai_lab"
-                ),
-                "role": "member",
-            },
-            {
-                "organisation_concept_id": "#V#the_lu_witbrock_household",
-                "role": "member",
-            },
+                "subject_concept_id": user_id,
+                "predicate": ROLE_PREDICATE,
+                "object_text_id": "misleading-role",
+                "context": {"organisation_id": org_id},
+            }
         ]
+        text_vals.find_one.side_effect = [{"text": f"owner::{org_id}"}]
+
+        result = get_user_memberships(user_id)
+
+        assert result["memberships"] == []
+        assert result["total_memberships"] == 0
 
     def test_get_memberships_decodes_scope_distinct_equal_roles(
         self, mock_concepts_repo, mock_access_control, mock_text_repos
@@ -373,7 +390,7 @@ class TestGetUserMemberships:
         orgs = ["#V#org_a", "#V#org_b"]
         mock_concepts_repo.find_one.return_value = {
             "concept_id": user_id,
-            "relationships": {"memberOf": orgs},
+            "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: orgs},
         }
         text_rels, text_vals = mock_text_repos
         text_rels.find.return_value = [
@@ -423,6 +440,7 @@ def test_organisation_role_storage_is_scope_distinct_and_legacy_readable():
         first, {"organisation_id": "#V#org_b"}
     ) == (None, None)
 
+
 # --- Tests for get_organisation_members ---
 
 
@@ -445,13 +463,13 @@ class TestGetOrganisationMembers:
         text_rels.find.return_value = [
             {
                 "subject_concept_id": "#V#michael_witbrock",
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_1",
                 "context": {"organisation_id": org_id},
             },
             {
                 "subject_concept_id": "#V#john_smith",
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_2",
                 "context": {"organisation_id": org_id},
             },
@@ -484,13 +502,13 @@ class TestGetOrganisationMembers:
         text_rels.find.return_value = [
             {
                 "subject_concept_id": "#V#michael_witbrock",
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_1",
                 "context": {"organisation_id": org_id},
             },
             {
                 "subject_concept_id": "#V#john_smith",
-                "predicate": "hasRole",
+                "predicate": ROLE_PREDICATE,
                 "object_text_id": "tv_2",
                 "context": {"organisation_id": org_id},
             },
@@ -534,8 +552,14 @@ class TestUpdateUserRole:
 
         # Setup: user has membership
         mock_concepts_repo.find_one.side_effect = [
-            {"concept_id": user_id, "relationships": {"memberOf": [org_id]}},
-            {"concept_id": user_id, "relationships": {"memberOf": [org_id]}},
+            {
+                "concept_id": user_id,
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
+            },
+            {
+                "concept_id": user_id,
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
+            },
         ]
 
         text_rels, text_vals = mock_text_repos
@@ -593,8 +617,14 @@ class TestUpdateUserRole:
         org_id = "#V#sail"
 
         mock_concepts_repo.find_one.side_effect = [
-            {"concept_id": user_id, "relationships": {"memberOf": [org_id]}},
-            {"concept_id": user_id, "relationships": {"memberOf": [org_id]}},
+            {
+                "concept_id": user_id,
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
+            },
+            {
+                "concept_id": user_id,
+                "relationships": {MEMBERSHIP_RELATIONSHIP_KIND: [org_id]},
+            },
         ]
 
         text_rels, text_vals = mock_text_repos
@@ -637,7 +667,7 @@ class TestRemoveOrganisationMembership:
         text_rels.find_one.return_value = {
             "_id": "rel_id",
             "subject_concept_id": user_id,
-            "predicate": "hasRole",
+            "predicate": ROLE_PREDICATE,
             "context": {"organisation_id": org_id},
         }
         monkeypatch.setattr(

--- a/tests/backend/test_predicate_family_vontology_service.py
+++ b/tests/backend/test_predicate_family_vontology_service.py
@@ -46,6 +46,8 @@ def test_expand_relation_predicate_family_uses_inverse_and_indexed_family_schema
         captured = dict(kwargs)
         captured["target_values"] = list(kwargs.get("target_values") or [])
         index_queries.append(captured)
+        if kwargs["predicate_id"] == service.PREDICATE_SPECIALISATION_PREDICATE_ID:
+            return [], 0
         return (
             [
                 {
@@ -81,6 +83,18 @@ def test_expand_relation_predicate_family_uses_inverse_and_indexed_family_schema
     assert result["family_discovery_source"] == "relationship_extent_index"
     assert index_queries == [
         {
+            "predicate_id": "#V#predicate_specialises_predicate",
+            "target_values": ["#V#direct_relation", "#V#inverse_relation"],
+            "count_total": False,
+            "projection": {
+                "_id": 0,
+                "source_concept_id": 1,
+                "predicate_id": 1,
+                "target_value": 1,
+            },
+            "limit": 128,
+        },
+        {
             "predicate_id": "#V#has_member_predicate",
             "target_values": ["#V#direct_relation", "#V#inverse_relation"],
             "count_total": False,
@@ -91,7 +105,7 @@ def test_expand_relation_predicate_family_uses_inverse_and_indexed_family_schema
                 "target_value": 1,
             },
             "limit": 128,
-        }
+        },
     ]
     assert len(queries) == 2
 
@@ -120,11 +134,11 @@ def test_expand_relation_predicate_family_uses_exact_fallback_when_index_unavail
             return [
                 {
                     "concept_id": "#V#direct_relation",
-                    "relationships": {
-                        "#V#inverse_predicates": ["#V#inverse_relation"]
-                    },
+                    "relationships": {"#V#inverse_predicates": ["#V#inverse_relation"]},
                 }
             ]
+        if f"relationships.{service.PREDICATE_SPECIALISATION_PREDICATE_ID}" in query:
+            return []
         return [
             {
                 "concept_id": "#V#represented_relation_family",
@@ -158,20 +172,58 @@ def test_expand_relation_predicate_family_uses_exact_fallback_when_index_unavail
         "#V#inverse_relation",
         "#V#role_relation",
     ]
-    assert result["family_concept_ids"] == [
-        "#V#represented_relation_family"
-    ]
+    assert result["family_concept_ids"] == ["#V#represented_relation_family"]
     assert result["relationship_extent_index_status"] == "unavailable"
-    assert result["family_discovery_source"] == (
-        "canonical_exact_predicate_query"
-    )
-    assert queries[1]["query"] == {
+    assert result["family_discovery_source"] == ("canonical_exact_predicate_query")
+    assert queries[2]["query"] == {
         "relationships.#V#has_member_predicate": {
             "$in": ["#V#direct_relation", "#V#inverse_relation"]
         }
     }
-    assert queries[1]["limit"] == 32
-    assert queries[1]["max_time_ms"] is None
+    assert queries[2]["limit"] == 32
+    assert queries[2]["max_time_ms"] is None
+
+
+def test_general_predicate_query_expands_to_specialisations_but_not_reverse(
+    monkeypatch,
+) -> None:
+    def fake_find(query, projection=None, *, limit=0):
+        concept_ids = query.get("concept_id", {}).get("$in", [])
+        if concept_ids:
+            return [
+                {"concept_id": concept_id, "relationships": {}}
+                for concept_id in concept_ids
+            ]
+        return []
+
+    def fake_index(**kwargs):
+        predicate = kwargs["predicate_id"]
+        targets = list(kwargs.get("target_values") or [])
+        if predicate == service.PREDICATE_SPECIALISATION_PREDICATE_ID and targets == [
+            "#V#memberOf"
+        ]:
+            return (
+                [
+                    {
+                        "source_concept_id": "#V#memberOfVonOrg",
+                        "predicate_id": predicate,
+                        "target_value": "#V#memberOf",
+                    }
+                ],
+                1,
+            )
+        return [], 0
+
+    monkeypatch.setattr(service.ConceptsRepository, "find", staticmethod(fake_find))
+    monkeypatch.setattr(service, "query_relationship_extent_index", fake_index)
+
+    general = service.expand_relation_predicate_family(["#V#memberOf"])
+    narrow = service.expand_relation_predicate_family(["#V#memberOfVonOrg"])
+
+    assert general["predicate_ids"] == ["#V#memberOf", "#V#memberOfVonOrg"]
+    assert general["entailing_specialisation_predicate_ids"] == ["#V#memberOfVonOrg"]
+    assert narrow["predicate_ids"] == ["#V#memberOfVonOrg"]
+    assert narrow["entailing_specialisation_predicate_ids"] == []
 
 
 def test_expand_relation_predicate_family_fails_soft(monkeypatch) -> None:

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -373,6 +373,8 @@ def test_set_user_concept_updates_session_context_and_org_listing(
     orgs_data = orgs.get_json()
     assert orgs_data["total_count"] == 1
     assert orgs_data["organisations"][0]["concept_id"] == "#V#the_lu_witbrock_household"
+    with client.session_transaction() as sess:
+        assert sess["von_authentication_assurance"] == "hasVonLoginEmail.v1"
 
 
 def test_set_user_concept_rejects_bare_legacy_header_without_seeding_session(
@@ -546,6 +548,8 @@ def test_get_my_organisations_uses_authenticated_user_not_email(app_client):
         sess["user_id"] = "opaque-oauth-subject"
         sess["user_email"] = "lu.yunli@example.com"
         sess["user_concept_id"] = "#V#michael_witbrock"
+        sess["auth_provider"] = "google_oauth"
+        sess["von_authentication_assurance"] = "hasVonLoginEmail.v1"
 
     resp = client.get("/von/api/organisations/my_organisations")
 

--- a/tests/backend/test_von_login_email_migration_service.py
+++ b/tests/backend/test_von_login_email_migration_service.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from src.backend.services import von_login_email_migration_service as migration
+
+
+def test_dry_run_uses_only_explicit_bindings_and_never_scans_contact_email(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        migration.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {"concept_id": "#V#alice"},
+    )
+    monkeypatch.setattr(
+        migration,
+        "list_von_login_email_user_ids",
+        lambda _email: [],
+    )
+
+    report = migration.migrate_explicit_von_login_email_bindings(
+        bindings=[
+            {
+                "user_concept_id": "#V#alice",
+                "email": "Alice@Example.ORG",
+            }
+        ]
+    )
+
+    assert report["success"] is True
+    assert report["effect_status"] == "dry_run"
+    assert report["ready_bindings"] == [
+        {
+            "user_concept_id": "#V#alice",
+            "email": "alice@example.org",
+            "already_bound": False,
+        }
+    ]
+    assert report["generic_contact_emails_scanned"] is False
+    assert report["generic_contact_emails_migrated"] is False
+
+
+def test_apply_requires_explicit_approval():
+    report = migration.migrate_explicit_von_login_email_bindings(
+        bindings=[
+            {
+                "user_concept_id": "#V#alice",
+                "email": "alice@example.org",
+            }
+        ],
+        dry_run=False,
+        approved=False,
+    )
+
+    assert report["success"] is False
+    assert report["error_code"] == "explicit_migration_approval_required"
+
+
+def test_apply_binds_only_the_reviewed_allow_list(monkeypatch):
+    monkeypatch.setattr(
+        migration.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {"concept_id": "#V#alice"},
+    )
+    monkeypatch.setattr(
+        migration,
+        "list_von_login_email_user_ids",
+        lambda _email: [],
+    )
+    monkeypatch.setattr(
+        migration,
+        "ensure_von_login_email_vocabulary",
+        lambda: {"success": True},
+    )
+    calls: list[dict] = []
+
+    def bind(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "relation_created": True,
+            "user_concept_id": kwargs["user_concept_id"],
+            "email": kwargs["email"],
+        }
+
+    monkeypatch.setattr(migration, "bind_von_login_email", bind)
+
+    report = migration.migrate_explicit_von_login_email_bindings(
+        bindings=[
+            {
+                "user_concept_id": "#V#alice",
+                "email": "alice@example.org",
+            }
+        ],
+        dry_run=False,
+        approved=True,
+    )
+
+    assert report["success"] is True
+    assert report["created_binding_count"] == 1
+    assert calls[0]["user_concept_id"] == "#V#alice"
+    assert calls[0]["email"] == "alice@example.org"
+    assert report["generic_contact_emails_migrated"] is False
+
+
+def test_vocabulary_represents_one_way_email_entailment(monkeypatch):
+    documents: dict[str, dict] = {
+        migration.GENERIC_EMAIL_PREDICATE: {
+            "concept_id": migration.GENERIC_EMAIL_PREDICATE,
+            "relationships": {"is_an_instance_of": ["#V#binary_text_predicate"]},
+        },
+        migration.PREDICATE_SPECIALISATION_PREDICATE: {
+            "concept_id": migration.PREDICATE_SPECIALISATION_PREDICATE,
+            "relationships": {"is_an_instance_of": ["#V#predicate"]},
+        },
+    }
+
+    def find_one(query, projection=None):
+        return documents.get(query.get("concept_id"))
+
+    def create_concept(**kwargs):
+        documents[kwargs["concept_id"]] = {
+            "concept_id": kwargs["concept_id"],
+            "relationships": {"is_an_instance_of": list(kwargs["parent_concept_ids"])},
+        }
+        return documents[kwargs["concept_id"]]
+
+    def add_relationship(source_id, predicate, target_id):
+        relationships = documents[source_id].setdefault("relationships", {})
+        relationships.setdefault(predicate, []).append(target_id)
+        return {"success": True, "modified": True}
+
+    monkeypatch.setattr(migration.ConceptsRepository, "find_one", find_one)
+    monkeypatch.setattr(migration.concept_service, "create_concept", create_concept)
+    monkeypatch.setattr(migration, "add_dynamic_relationship", add_relationship)
+
+    report = migration.ensure_von_login_email_vocabulary()
+
+    assert report["entailment"] == {
+        "specific_predicate": "#V#hasVonLoginEmail",
+        "relation": "#V#predicate_specialises_predicate",
+        "generic_predicate": "#V#has_email",
+        "reverse_inference_allowed": False,
+    }
+    assert documents["#V#hasVonLoginEmail"]["relationships"][
+        "#V#predicate_specialises_predicate"
+    ] == ["#V#has_email"]
+    assert (
+        "#V#predicate_specialises_predicate"
+        not in documents["#V#has_email"]["relationships"]
+    )

--- a/tests/backend/test_von_user_authentication_service.py
+++ b/tests/backend/test_von_user_authentication_service.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from src.backend.services import settings_service
+from src.backend.services import von_user_authentication_service as service
+from src.backend.services.exceptions import MultipleUsersForEmailError
+
+
+def test_login_lookup_uses_only_narrow_predicate_and_normalised_email(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def find_text_values(query, **_kwargs):
+        captured["text_query"] = query
+        return [{"_id": "email-text-id"}]
+
+    def find_text_relations(query, **_kwargs):
+        captured["relation_query"] = query
+        return [{"subject_concept_id": "#V#alice"}]
+
+    monkeypatch.setattr(service.TextValuesRepository, "find", find_text_values)
+    monkeypatch.setattr(service.TextRelationsRepository, "find", find_text_relations)
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda query, projection=None: (
+            {"concept_id": "#V#alice", "direct_concept_name": "Alice"}
+            if query == {"concept_id": "#V#alice"}
+            else None
+        ),
+    )
+
+    user = service.find_user_concept_by_login_email(" Alice@Example.ORG ")
+
+    assert user["concept_id"] == "#V#alice"
+    assert captured["text_query"] == {"text": "alice@example.org"}
+    assert captured["relation_query"] == {
+        "predicate": "#V#hasVonLoginEmail",
+        "object_text_id": {"$in": ["email-text-id"]},
+    }
+
+
+def test_generic_has_email_relation_cannot_select_authenticated_actor(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find",
+        lambda *_args, **_kwargs: [{"_id": "email-text-id"}],
+    )
+
+    def find_relations(query, **_kwargs):
+        if query.get("predicate") == "#V#has_email":
+            return [{"subject_concept_id": "#V#victim"}]
+        return []
+
+    monkeypatch.setattr(service.TextRelationsRepository, "find", find_relations)
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {"concept_id": "#V#victim"},
+    )
+
+    assert service.find_user_concept_by_login_email("attacker@example.org") is None
+
+
+def test_ambiguous_narrow_login_binding_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find",
+        lambda *_args, **_kwargs: [{"_id": "email-text-id"}],
+    )
+    monkeypatch.setattr(
+        service.TextRelationsRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"subject_concept_id": "#V#alice"},
+            {"subject_concept_id": "#V#mallory"},
+        ],
+    )
+
+    with pytest.raises(MultipleUsersForEmailError):
+        service.find_user_concept_by_login_email("shared@example.org")
+
+
+def test_binding_rejects_email_owned_by_another_user(monkeypatch):
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {"concept_id": "#V#alice"},
+    )
+    monkeypatch.setattr(
+        service,
+        "list_von_login_email_user_ids",
+        lambda _email: ["#V#mallory"],
+    )
+    monkeypatch.setattr(
+        service,
+        "upsert_text_for_concept",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("conflicting binding must not write")
+        ),
+    )
+
+    with pytest.raises(service.LoginEmailBindingConflictError):
+        service.bind_von_login_email(
+            user_concept_id="#V#alice",
+            email="shared@example.org",
+        )
+
+
+def test_binding_writes_only_narrow_predicate_and_reads_back(monkeypatch):
+    lookup_count = 0
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        service.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {"concept_id": "#V#alice"},
+    )
+
+    def list_bindings(_email):
+        nonlocal lookup_count
+        lookup_count += 1
+        return [] if lookup_count == 1 else ["#V#alice"]
+
+    def upsert(**kwargs):
+        captured.update(kwargs)
+        return {"relation_created": True}
+
+    monkeypatch.setattr(service, "list_von_login_email_user_ids", list_bindings)
+    monkeypatch.setattr(service, "upsert_text_for_concept", upsert)
+
+    result = service.bind_von_login_email(
+        user_concept_id="#V#alice",
+        email="Alice@Example.ORG",
+    )
+
+    assert result["success"] is True
+    assert captured["predicate"] == "#V#hasVonLoginEmail"
+    assert captured["text"] == "alice@example.org"
+
+
+def test_settings_login_does_not_link_or_create_from_session_hint(monkeypatch):
+    app = Flask(__name__)
+    app.secret_key = "login-email-test"
+    monkeypatch.setattr(
+        settings_service,
+        "_find_user_concept_by_email",
+        lambda _email: None,
+    )
+
+    with app.test_request_context("/"):
+        from flask import session
+
+        session["user_concept_id"] = "#V#victim"
+        result = settings_service.set_current_user_by_email(
+            "attacker@example.org",
+            "Attacker",
+        )
+
+        assert result is None
+        assert session["user_concept_id"] == "#V#victim"

--- a/tests/frontend/chatTabConceptQa.test.js
+++ b/tests/frontend/chatTabConceptQa.test.js
@@ -97,7 +97,7 @@ describe('chat workspace concept Q&A mode', () => {
                 content: 'Which organisation is it a member of?',
                 concept_q_and_a: {
                     elicitation_predicate: {
-                        predicate_concept_id: '#V#memberOf',
+                        predicate_concept_id: '#V#memberOfVonOrg',
                         predicate_label: 'member of',
                         status: 'missing',
                         gap_status: 'asserted_relation_missing',
@@ -152,7 +152,7 @@ describe('chat workspace concept Q&A mode', () => {
                     formalisation: {
                         status: 'tentative',
                         assertion_id: 'tentative-7',
-                        predicate_id: '#V#memberOf',
+                        predicate_id: '#V#memberOfVonOrg',
                         confirmation: {
                             available: true,
                             method: 'POST',

--- a/tests/frontend/conceptInteractionQandAReframe.test.js
+++ b/tests/frontend/conceptInteractionQandAReframe.test.js
@@ -115,7 +115,7 @@ describe('concept-improvement Q&A entry point', () => {
                         content: 'Which organisation is it a member of?',
                         concept_q_and_a: {
                             elicitation_predicate: {
-                                predicate_concept_id: '#V#memberOf',
+                                predicate_concept_id: '#V#memberOfVonOrg',
                                 predicate_label: 'member of',
                                 status: 'missing',
                                 gap_status: 'asserted_relation_missing',

--- a/tests/frontend/conceptQaReceipt.test.js
+++ b/tests/frontend/conceptQaReceipt.test.js
@@ -47,7 +47,7 @@ describe('concept Q&A representation receipt', () => {
                 formalisation: {
                     status: 'tentative',
                     assertion_id: 'tentative-member-1',
-                    predicate_concept_id: '#V#memberOf',
+                    predicate_concept_id: '#V#memberOfVonOrg',
                     confirmation: {
                         available: true,
                         method: 'POST',

--- a/tests/frontend/conceptQaSession.test.js
+++ b/tests/frontend/conceptQaSession.test.js
@@ -86,7 +86,7 @@ describe('concept Q&A frontend contract', () => {
                 content: 'Who is it a member of?',
                 concept_q_and_a: {
                     elicitation_predicate: {
-                        predicate_concept_id: '#V#memberOf',
+                        predicate_concept_id: '#V#memberOfVonOrg',
                         predicate_label: 'member of',
                         status: 'missing',
                         gap_status: 'asserted_relation_missing',


### PR DESCRIPTION
## Outcome

- add `hasVonLoginEmail` as the only Google OAuth-to-user binding predicate; ordinary `has_email` remains descriptive
- replace operational `memberOf`/`hasRole` reads with `memberOfVonOrg`/`hasVonOrgRole`
- represent one-way specialisation so `memberOfVonOrg` entails `memberOf`, never the reverse
- add explicit, fail-closed migration CLIs for reviewed login-email bindings and role-backed legacy memberships
- invalidate pre-cutover Google sessions that lack the new binding assurance

## Security boundary

Generic ontology mutation surfaces reserve the three narrow authority predicates. OAuth login fails closed for absent, stale, or ambiguous bindings, and popup token exchange revalidates the current binding. The login migration never scans or copies ordinary contact-email facts.

## Validation

- 124 affected backend tests passed after rebasing on current `main`; one unchanged window-session test could not run because local Mongo was unavailable
- broader near-neighbour run: 132 passed; 11 unchanged durable-window tests failed on the same local Mongo connection refusal
- 24 affected frontend tests passed
- compileall, migration CLI help, Black checks, and `git diff --check` passed
