### PR TITLE
Make membership migration conflicts explicitly resolvable

### DIFF
--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -79,6 +79,23 @@ Run the first command before applying. If it reports a missing user or an
 address already bound to another user, correct that exact conflict and rerun
 the dry run; do not work around it by adding a generic email relation.
 
+The organisation-membership migration likewise performs a dry run by default.
+It copies only legacy membership pairs backed by exactly one scoped operational
+role. If it reports conflicting legacy roles, resolve each pair explicitly
+with the exact `--role-override` form shown by `--help`, for example:
+
+```sh
+python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+  --role-override '#V#person_id=#V#organisation_id=owner'
+
+python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+  --role-override '#V#person_id=#V#organisation_id=owner' \
+  --apply --approved
+```
+
+The selected role must already occur in the legacy evidence for that exact
+user/organisation pair. Unrelated overrides and invented roles fail closed.
+
 ## 2) Vontology access control (concepts + relationships)
 
 ### Visibility model

--- a/src/backend/services/organisation_membership_predicate_migration_service.py
+++ b/src/backend/services/organisation_membership_predicate_migration_service.py
@@ -15,7 +15,7 @@ historical semantic data but are no longer read for authority after cutover.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
@@ -58,6 +58,30 @@ def _normalise_values(value: object) -> list[str]:
         if normalised and normalised not in output:
             output.append(normalised)
     return output
+
+
+def _normalise_role_overrides(
+    overrides: Iterable[Mapping[str, Any]] | None,
+) -> dict[tuple[str, str], str]:
+    """Validate exact operator choices for otherwise ambiguous legacy pairs."""
+
+    normalised: dict[tuple[str, str], str] = {}
+    for override in overrides or ():
+        if not isinstance(override, Mapping):
+            raise ValueError("membership_role_override_not_mapping")
+        user_id = _normalise_concept_id(override.get("user_concept_id"))
+        organisation_id = _normalise_concept_id(override.get("organisation_concept_id"))
+        role = str(override.get("role") or "").strip()
+        if user_id is None or organisation_id is None:
+            raise ValueError("membership_role_override_pair_required")
+        if role not in AVAILABLE_ROLES:
+            raise ValueError("membership_role_override_invalid_role")
+        pair = (user_id, organisation_id)
+        previous = normalised.get(pair)
+        if previous is not None and previous != role:
+            raise ValueError("membership_role_override_conflicts_with_itself")
+        normalised[pair] = role
+    return normalised
 
 
 def _legacy_edge_pairs() -> dict[tuple[str, str], set[str]]:
@@ -206,6 +230,7 @@ def audit_von_organisation_membership_predicates(
                     **common,
                     "legacy_membership_predicates": predicates,
                     "legacy_roles": roles,
+                    "already_narrow": pair in narrow_pairs,
                     "reason_code": "conflicting_legacy_roles",
                 }
             )
@@ -344,23 +369,97 @@ def migrate_von_organisation_membership_predicates(
     dry_run: bool = True,
     approved: bool = False,
     sample_limit: int = 20,
+    role_overrides: Iterable[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Copy only evidenced operational memberships to the narrow vocabulary."""
+
+    try:
+        normalised_overrides = _normalise_role_overrides(role_overrides)
+    except ValueError as exc:
+        return {
+            "schema_version": MIGRATION_SCHEMA_VERSION,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": str(exc),
+        }
 
     audit = audit_von_organisation_membership_predicates(
         sample_limit=max(sample_limit, 100_000)
     )
+    sample_count = max(0, int(sample_limit))
     public_audit = {
         **audit,
         "eligible_operational_memberships": audit["eligible_operational_memberships"][
-            : max(0, int(sample_limit))
+            :sample_count
+        ],
+        "generic_only_non_authority_samples": audit[
+            "generic_only_non_authority_samples"
+        ][:sample_count],
+        "role_only_samples": audit["role_only_samples"][:sample_count],
+        "conflict_samples": audit["conflict_samples"][:sample_count],
+        "invalid_legacy_role_samples": audit["invalid_legacy_role_samples"][
+            :sample_count
         ],
     }
+    eligible_records = list(audit["eligible_operational_memberships"])
+    resolved_conflicts: list[dict[str, Any]] = []
+    unresolved_conflicts: list[dict[str, Any]] = []
+    override_errors: list[dict[str, Any]] = []
+    unused_override_pairs = set(normalised_overrides)
+    for conflict in audit["conflict_samples"]:
+        pair = (
+            conflict["user_concept_id"],
+            conflict["organisation_concept_id"],
+        )
+        selected_role = normalised_overrides.get(pair)
+        if selected_role is None:
+            unresolved_conflicts.append(conflict)
+            continue
+        unused_override_pairs.discard(pair)
+        if selected_role not in conflict.get("legacy_roles", []):
+            override_errors.append(
+                {
+                    "user_concept_id": pair[0],
+                    "organisation_concept_id": pair[1],
+                    "requested_role": selected_role,
+                    "legacy_roles": list(conflict.get("legacy_roles", [])),
+                    "reason_code": "role_override_not_present_in_legacy_evidence",
+                }
+            )
+            continue
+        resolved = {
+            "user_concept_id": pair[0],
+            "organisation_concept_id": pair[1],
+            "role": selected_role,
+            "legacy_membership_predicates": list(
+                conflict.get("legacy_membership_predicates", [])
+            ),
+            "legacy_roles": list(conflict.get("legacy_roles", [])),
+            "already_narrow": bool(conflict.get("already_narrow")),
+            "role_override_applied": True,
+        }
+        resolved_conflicts.append(resolved)
+        eligible_records.append(resolved)
+    for pair in sorted(unused_override_pairs):
+        override_errors.append(
+            {
+                "user_concept_id": pair[0],
+                "organisation_concept_id": pair[1],
+                "requested_role": normalised_overrides[pair],
+                "reason_code": "role_override_does_not_match_a_conflicted_pair",
+            }
+        )
     common = {
         "schema_version": MIGRATION_SCHEMA_VERSION,
         "dry_run": bool(dry_run),
         "approved": bool(approved),
         "audit": public_audit,
+        "resolved_conflict_count": len(resolved_conflicts),
+        "resolved_conflicts": resolved_conflicts[:sample_count],
+        "unresolved_conflict_count": len(unresolved_conflicts),
+        "unresolved_conflicts": unresolved_conflicts[:sample_count],
+        "role_override_error_count": len(override_errors),
+        "role_override_errors": override_errors[:sample_count],
     }
     if not dry_run and not approved:
         return {
@@ -369,7 +468,7 @@ def migrate_von_organisation_membership_predicates(
             "effect_status": "not_started",
             "error_code": "explicit_migration_approval_required",
         }
-    if audit["conflict_count"] or audit["invalid_legacy_role_count"]:
+    if unresolved_conflicts or override_errors or audit["invalid_legacy_role_count"]:
         return {
             **common,
             "success": False,
@@ -381,7 +480,7 @@ def migrate_von_organisation_membership_predicates(
             **common,
             "success": True,
             "effect_status": "not_started",
-            "would_migrate_count": audit["eligible_operational_membership_count"],
+            "would_migrate_count": len(eligible_records),
             "generic_only_relations_will_grant_authority": False,
         }
 
@@ -389,7 +488,6 @@ def migrate_von_organisation_membership_predicates(
     migrated: list[dict[str, Any]] = []
     already_current: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
-    eligible_records = audit["eligible_operational_memberships"]
     for record in eligible_records:
         user_id = record["user_concept_id"]
         organisation_id = record["organisation_concept_id"]
@@ -431,20 +529,29 @@ def migrate_von_organisation_membership_predicates(
                 }
             )
 
-    final_audit = audit_von_organisation_membership_predicates(
-        sample_limit=max(sample_limit, 100_000)
-    )
-    expected_pairs = {
-        (row["user_concept_id"], row["organisation_concept_id"])
-        for row in eligible_records
-    }
-    current_pairs = {
-        (row["user_concept_id"], row["organisation_concept_id"])
-        for row in final_audit["eligible_operational_memberships"]
-        if row.get("already_narrow") is True
-    }
-    missing_pairs = sorted(expected_pairs - current_pairs)
-    success = not failures and not missing_pairs
+    missing_read_back: list[dict[str, Any]] = []
+    for record in eligible_records:
+        read_back = resolve_user_organisation_membership(
+            record["user_concept_id"],
+            record["organisation_concept_id"],
+        )
+        if (
+            not isinstance(read_back, Mapping)
+            or read_back.get("role") != record["role"]
+        ):
+            missing_read_back.append(
+                {
+                    "user_concept_id": record["user_concept_id"],
+                    "organisation_concept_id": record["organisation_concept_id"],
+                    "expected_role": record["role"],
+                    "actual_role": (
+                        read_back.get("role")
+                        if isinstance(read_back, Mapping)
+                        else None
+                    ),
+                }
+            )
+    success = not failures and not missing_read_back
     return {
         **common,
         "success": success,
@@ -456,13 +563,7 @@ def migrate_von_organisation_membership_predicates(
         "migrated": migrated[: max(0, int(sample_limit))],
         "already_current": already_current[: max(0, int(sample_limit))],
         "failures": failures[: max(0, int(sample_limit))],
-        "missing_read_back_pairs": [
-            {
-                "user_concept_id": user_id,
-                "organisation_concept_id": organisation_id,
-            }
-            for user_id, organisation_id in missing_pairs[: max(0, int(sample_limit))]
-        ],
+        "missing_read_back_pairs": missing_read_back[:sample_count],
         "generic_only_relations_grant_authority": False,
     }
 

--- a/src/backend/utilities/migrate_von_organisation_membership_predicates.py
+++ b/src/backend/utilities/migrate_von_organisation_membership_predicates.py
@@ -3,6 +3,8 @@
 
 Examples:
     python -m src.backend.utilities.migrate_von_organisation_membership_predicates
+    python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+      --role-override '#V#user=#V#organisation=owner'
     python -m src.backend.utilities.migrate_von_organisation_membership_predicates --apply --approved
 
 The default is a read-only dry run.  Applying requires both flags so an
@@ -18,6 +20,19 @@ import json
 from src.backend.services.organisation_membership_predicate_migration_service import (
     migrate_von_organisation_membership_predicates,
 )
+
+
+def _parse_role_override(raw: str) -> dict[str, str]:
+    parts = [part.strip() for part in str(raw or "").split("=")]
+    if len(parts) != 3 or not all(parts):
+        raise argparse.ArgumentTypeError(
+            "role override must have the exact form USER_CONCEPT_ID=ORGANISATION_CONCEPT_ID=ROLE"
+        )
+    return {
+        "user_concept_id": parts[0],
+        "organisation_concept_id": parts[1],
+        "role": parts[2],
+    }
 
 
 def main() -> int:
@@ -40,12 +55,25 @@ def main() -> int:
         default=20,
         help="Maximum detailed records to include in the JSON report.",
     )
+    parser.add_argument(
+        "--role-override",
+        action="append",
+        type=_parse_role_override,
+        default=[],
+        metavar="USER_CONCEPT_ID=ORGANISATION_CONCEPT_ID=ROLE",
+        help=(
+            "Resolve one reported conflicting legacy role pair explicitly. "
+            "The role must be one of the roles already evidenced for that exact pair. "
+            "Repeat for every conflict; unrelated or invented overrides fail closed."
+        ),
+    )
     args = parser.parse_args()
 
     report = migrate_von_organisation_membership_predicates(
         dry_run=not args.apply,
         approved=args.approved,
         sample_limit=args.sample_limit,
+        role_overrides=args.role_override,
     )
     print(json.dumps(report, indent=2, sort_keys=True, default=str))
     return 0 if report.get("success") is True else 1

--- a/tests/backend/test_organisation_membership_predicate_migration_service.py
+++ b/tests/backend/test_organisation_membership_predicate_migration_service.py
@@ -120,6 +120,77 @@ def test_apply_requires_explicit_approval(monkeypatch):
     assert report["error_code"] == "explicit_migration_approval_required"
 
 
+def test_conflicting_roles_require_an_exact_evidenced_override(monkeypatch):
+    pair = ("#V#alice", "#V#von_org")
+    monkeypatch.setattr(migration, "_legacy_edge_pairs", lambda: {pair: {"memberOf"}})
+    monkeypatch.setattr(
+        migration,
+        "_legacy_role_pairs",
+        lambda: ({pair: {"member", "owner"}}, []),
+    )
+    monkeypatch.setattr(migration, "_narrow_membership_pairs", set)
+
+    blocked = migration.migrate_von_organisation_membership_predicates()
+    assert blocked["success"] is False
+    assert blocked["unresolved_conflict_count"] == 1
+    assert blocked["error_code"] == "legacy_membership_inventory_requires_resolution"
+
+    resolved = migration.migrate_von_organisation_membership_predicates(
+        role_overrides=[
+            {
+                "user_concept_id": pair[0],
+                "organisation_concept_id": pair[1],
+                "role": "owner",
+            }
+        ]
+    )
+    assert resolved["success"] is True
+    assert resolved["resolved_conflict_count"] == 1
+    assert resolved["would_migrate_count"] == 1
+    assert resolved["resolved_conflicts"][0]["role"] == "owner"
+
+
+def test_role_override_cannot_invent_a_role_or_target_an_unconflicted_pair(
+    monkeypatch,
+):
+    pair = ("#V#alice", "#V#von_org")
+    monkeypatch.setattr(migration, "_legacy_edge_pairs", lambda: {pair: {"memberOf"}})
+    monkeypatch.setattr(
+        migration,
+        "_legacy_role_pairs",
+        lambda: ({pair: {"member", "owner"}}, []),
+    )
+    monkeypatch.setattr(migration, "_narrow_membership_pairs", set)
+
+    invented = migration.migrate_von_organisation_membership_predicates(
+        role_overrides=[
+            {
+                "user_concept_id": pair[0],
+                "organisation_concept_id": pair[1],
+                "role": "admin",
+            }
+        ]
+    )
+    assert invented["success"] is False
+    assert invented["role_override_errors"][0]["reason_code"] == (
+        "role_override_not_present_in_legacy_evidence"
+    )
+
+    unrelated = migration.migrate_von_organisation_membership_predicates(
+        role_overrides=[
+            {
+                "user_concept_id": "#V#bob",
+                "organisation_concept_id": pair[1],
+                "role": "member",
+            }
+        ]
+    )
+    assert unrelated["success"] is False
+    assert unrelated["role_override_errors"][0]["reason_code"] == (
+        "role_override_does_not_match_a_conflicted_pair"
+    )
+
+
 def test_vocabulary_represents_one_way_memberof_entailment(monkeypatch):
     documents: dict[str, dict] = {
         migration.GENERIC_MEMBERSHIP_PREDICATE: {


### PR DESCRIPTION
## Outcome

The live DGX dry run found one legacy user/organisation pair with two historical role values. This adds an exact `--role-override USER=ORGANISATION=ROLE` escape hatch instead of choosing silently.

The override is accepted only when:
- it targets a pair actually reported as conflicted
- its selected role already appears in that pair's legacy evidence
- every conflict is explicitly resolved

Final migration verification now reads every expected narrow membership and exact role back through the authority reader, including overridden pairs.

## Validation

- 30 migration and membership service tests passed
- Black check and `git diff --check` passed
- DGX dry run remained non-mutating and stopped on the unresolved conflict as designed
