### PR TITLE
Preserve exact registered predicate IDs

### DIFF
--- a/src/backend/services/concept_service.py
+++ b/src/backend/services/concept_service.py
@@ -496,6 +496,25 @@ def enforce_preserved_fields_write(payload: Dict[str, Any]):
 # REFACTORING_NOTE: Functions for 'concepts' collection will go here.
 
 
+def _normalise_concept_id_for_persistence(value: object) -> Optional[str]:
+    """Preserve exact built-in IDs; canonicalise ordinary concept IDs.
+
+    The code-concept registry is the authority for built-in predicate IDs and
+    includes established camel-case IDs such as ``#V#memberOf``.  Persisting a
+    registered built-in under a lower-cased alias would split its represented
+    identity from the ID used by runtime code.  Inputs outside that exact,
+    finite registry continue through the ordinary lower-case canonicalisation.
+    """
+
+    from ..utils.concept_id_utils import canonicalise_vontology_concept_id
+    from ..vontology.code_concepts_registry import is_code_concept_id
+
+    exact_id = value.strip() if isinstance(value, str) else None
+    if exact_id and is_code_concept_id(exact_id):
+        return exact_id
+    return canonicalise_vontology_concept_id(value)
+
+
 # ---------- Context helpers ----------
 def gather_descriptive_material(
     concept: Dict[str, Any],
@@ -607,9 +626,7 @@ def create_concept(
 
     if concept_id:
         try:
-            from ..utils.concept_id_utils import canonicalise_vontology_concept_id
-
-            canonical_id = canonicalise_vontology_concept_id(concept_id)
+            canonical_id = _normalise_concept_id_for_persistence(concept_id)
         except Exception:
             canonical_id = None
 

--- a/tests/backend/test_concept_service_code_predicate_ids.py
+++ b/tests/backend/test_concept_service_code_predicate_ids.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from src.backend.services import concept_service
+
+
+class _InsertResult:
+    inserted_id = "created-id"
+
+
+class _Collection:
+    def __init__(self) -> None:
+        self.document: dict | None = None
+
+    def insert_one(self, document: dict) -> _InsertResult:
+        self.document = deepcopy(document)
+        self.document["_id"] = _InsertResult.inserted_id
+        return _InsertResult()
+
+    def find_one(self, query: dict) -> dict | None:
+        if self.document is None or query.get("_id") != _InsertResult.inserted_id:
+            return None
+        return deepcopy(self.document)
+
+
+def test_create_concept_preserves_exact_registered_code_predicate_id(
+    monkeypatch,
+) -> None:
+    collection = _Collection()
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository, "collection", lambda: collection
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_event_workflow_integration_enabled",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        concept_service, "_invalidate_concept_mutation_caches", lambda: None
+    )
+
+    created = concept_service.create_concept(
+        name="Has Von login email",
+        concept_id="#V#hasVonLoginEmail",
+        parent_concept_ids=["#V#binary_text_predicate"],
+        create_as_instance=True,
+        visibility_scope_mode="global_general",
+        defer_text_relations=True,
+        maintain_relationship_inverses=False,
+    )
+
+    assert created["concept_id"] == "#V#hasVonLoginEmail"
+    assert collection.document is not None
+    assert collection.document["concept_id"] == "#V#hasVonLoginEmail"
+
+
+def test_create_concept_still_canonicalises_unregistered_mixed_case_id(
+    monkeypatch,
+) -> None:
+    collection = _Collection()
+    monkeypatch.setattr(
+        concept_service.ConceptsRepository, "collection", lambda: collection
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "get_event_workflow_integration_enabled",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        concept_service, "_invalidate_concept_mutation_caches", lambda: None
+    )
+
+    created = concept_service.create_concept(
+        name="Ordinary mixed case concept",
+        concept_id="#V#OrdinaryMixedCaseConcept",
+        parent_concept_ids=["#V#person"],
+        create_as_instance=True,
+        visibility_scope_mode="global_general",
+        defer_text_relations=True,
+        maintain_relationship_inverses=False,
+    )
+
+    assert created["concept_id"] == "#V#ordinarymixedcaseconcept"
+    assert collection.document is not None
+    assert collection.document["concept_id"] == "#V#ordinarymixedcaseconcept"


### PR DESCRIPTION
## Outcome\nUnblock the explicit Von login-email and organisation-membership vocabulary migrations by preserving exact IDs from the finite built-in code-concept registry.\n\n## Security boundary\nOnly an exact ID already present in the code-concept registry bypasses ordinary lowercase canonicalisation. Unregistered/user-created IDs retain existing canonicalisation. No authentication or membership authority is broadened.\n\n## Validation\n- 85 focused backend tests passed across concept creation, code predicate sync, Google OAuth, login identity, organisation membership, predicate entailment, and both migrations\n- Python compileall passed\n- git diff --check passed\n\n## Live observation addressed\nThe DGX migration stopped before creating login bindings because  was persisted as ; this change makes canonical read-back use the exact registered predicate ID.