### PR TITLE
Fix shared history and Concept Q&A recovery

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -18438,6 +18438,7 @@ def set_chat_session():
             "concept_q_and_a.schema_version": 1,
             "concept_q_and_a.concept": 1,
             "concept_q_and_a.lifecycle": 1,
+            "concept_q_and_a.initial_question": 1,
         }
         if include_history:
             projection["history"] = 1
@@ -20142,6 +20143,28 @@ def _normalise_history_timestamp(value: Any) -> datetime | None:
     return None
 
 
+def _history_merge_content_key(content: Any) -> tuple[str, Any]:
+    """Return a hashable, stable identity component for history content."""
+
+    try:
+        hash(content)
+    except TypeError:
+        try:
+            return (
+                "structured",
+                json.dumps(
+                    content,
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            )
+        except (TypeError, ValueError):
+            return ("structured_repr", repr(content))
+    return ("scalar", content)
+
+
 def _history_merge_key(message: dict) -> tuple | None:
     if not isinstance(message, dict):
         return None
@@ -20155,7 +20178,7 @@ def _history_merge_key(message: dict) -> tuple | None:
         ts_key = ts
     else:
         ts_key = None
-    return (role, content, author, ts_key)
+    return (role, _history_merge_content_key(content), author, ts_key)
 
 
 def _merge_shared_histories(

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -799,11 +799,47 @@ def project_concept_q_and_a_session_metadata(
                 lifecycle[key] = timestamp.isoformat()
             elif isinstance(value, str) and value.strip():
                 lifecycle[key] = value.strip()
-    return {
+    raw_initial_question = raw_state.get("initial_question")
+    initial_question: Dict[str, Any] = {}
+    if isinstance(raw_initial_question, Mapping):
+        status = raw_initial_question.get("status")
+        if isinstance(status, str) and status.strip():
+            initial_question["status"] = status.strip()
+        retryable = raw_initial_question.get("retryable")
+        if isinstance(retryable, bool):
+            initial_question["retryable"] = retryable
+        attempt_count = raw_initial_question.get("attempt_count")
+        if (
+            isinstance(attempt_count, int)
+            and not isinstance(attempt_count, bool)
+            and attempt_count >= 0
+        ):
+            initial_question["attempt_count"] = attempt_count
+        last_attempt_at = raw_initial_question.get("last_attempt_at")
+        timestamp = _coerce_datetime(last_attempt_at)
+        if timestamp is not None:
+            initial_question["last_attempt_at"] = timestamp.isoformat()
+        elif isinstance(last_attempt_at, str) and last_attempt_at.strip():
+            initial_question["last_attempt_at"] = last_attempt_at.strip()
+        raw_failure = raw_initial_question.get("failure")
+        if isinstance(raw_failure, Mapping):
+            failure: Dict[str, Any] = {}
+            error_code = raw_failure.get("error_code")
+            if isinstance(error_code, str) and error_code.strip():
+                failure["error_code"] = error_code.strip()
+            message = raw_failure.get("message")
+            if isinstance(message, str) and message.strip():
+                failure["message"] = message.strip()
+            if failure:
+                initial_question["failure"] = failure
+    projection = {
         "schema_version": raw_state.get("schema_version"),
         "concept": concept,
         "lifecycle": lifecycle or None,
     }
+    if initial_question:
+        projection["initial_question"] = initial_question
+    return projection
 
 
 def _concept_q_and_a_metadata_field(doc: Mapping[str, Any]) -> Dict[str, Any]:
@@ -842,6 +878,7 @@ def project_chat_session_mode_state(doc: Mapping[str, Any]) -> Dict[str, Any]:
         projection["concept_q_and_a"] = concept_q_and_a
         projection["concept"] = concept_q_and_a.get("concept")
         projection["lifecycle"] = concept_q_and_a.get("lifecycle")
+        projection["initial_question"] = concept_q_and_a.get("initial_question")
     return projection
 
 
@@ -1112,6 +1149,7 @@ def _add_chat_session_provenance_projection(
     projection["concept_q_and_a.schema_version"] = 1
     projection["concept_q_and_a.concept"] = 1
     projection["concept_q_and_a.lifecycle"] = 1
+    projection["concept_q_and_a.initial_question"] = 1
     return projection
 
 
@@ -1911,6 +1949,7 @@ def get_chat_history_session_state(
                             "concept_q_and_a.schema_version": 1,
                             "concept_q_and_a.concept": 1,
                             "concept_q_and_a.lifecycle": 1,
+                            "concept_q_and_a.initial_question": 1,
                         }
                     },
                 ]
@@ -1944,6 +1983,7 @@ def get_chat_history_session_state(
                     "concept_q_and_a.schema_version": 1,
                     "concept_q_and_a.concept": 1,
                     "concept_q_and_a.lifecycle": 1,
+                    "concept_q_and_a.initial_question": 1,
                 }
                 if include_history:
                     projection["history"] = 1

--- a/src/backend/services/concept_qa_conversation_service.py
+++ b/src/backend/services/concept_qa_conversation_service.py
@@ -9,6 +9,7 @@ per-turn representation receipts.
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 import uuid
 from collections.abc import Mapping
@@ -40,6 +41,7 @@ FINISHED = "finished"
 CANCELLED = "cancelled"
 TERMINAL_STATUSES = frozenset({FINISHED, CANCELLED})
 _MAX_SESSIONS = 20
+logger = logging.getLogger(__name__)
 
 
 class ConceptQAConversationError(RuntimeError):
@@ -267,6 +269,43 @@ def _structured_turns(doc: Mapping[str, Any]) -> list[dict[str, Any]]:
     return turns
 
 
+def _initial_question_state(doc: Mapping[str, Any]) -> dict[str, Any]:
+    """Project explicit state or recover a pre-state-machine active carrier."""
+
+    qa_state = doc.get("concept_q_and_a")
+    explicit = (
+        qa_state.get("initial_question") if isinstance(qa_state, Mapping) else None
+    )
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    if any(
+        isinstance(item, Mapping) and item.get("role") == "assistant"
+        for item in history
+    ):
+        # The durable turn is stronger evidence than a stale failure marker from
+        # a concurrent attempt. Preserve attempt telemetry, but project truth.
+        ready = dict(explicit) if isinstance(explicit, Mapping) else {}
+        ready.update({"status": "ready", "retryable": False})
+        ready.setdefault("attempt_count", 0)
+        ready.pop("failure", None)
+        return _iso(ready)
+
+    if isinstance(explicit, Mapping):
+        return _iso(dict(explicit))
+
+    if _session_lifecycle(doc).get("status") == ACTIVE:
+        return {
+            "status": "retryable_failure",
+            "retryable": True,
+            "attempt_count": 0,
+            "failure": {
+                "error_code": "initial_question_missing",
+                "message": "The active Q&A conversation has no initial question.",
+            },
+        }
+
+    return {"status": "not_available", "retryable": False, "attempt_count": 0}
+
+
 def _project_session(doc: Mapping[str, Any]) -> dict[str, Any]:
     user_id = str(doc.get("user_id") or "")
     session_id = str(doc.get("session_id") or "")
@@ -294,6 +333,7 @@ def _project_session(doc: Mapping[str, Any]) -> dict[str, Any]:
         "focal_concept_ids": list(doc.get("focal_concept_ids") or []),
         "concept": _session_concept(doc),
         "lifecycle": _session_lifecycle(doc),
+        "initial_question": _initial_question_state(doc),
         "llm_selection": _iso(qa_state.get("llm_selection"))
         if isinstance(qa_state, Mapping)
         else None,
@@ -1029,6 +1069,54 @@ def _record_turn_receipt(
         raise ConceptQAConversationError(
             "Could not persist the Q&A representation receipt",
             error_code="turn_receipt_write_failed",
+        ) from exc
+    if getattr(result, "matched_count", 0) != 1:
+        raise ConceptQAConversationNotFound(
+            "Q&A conversation was not found", error_code="conversation_not_found"
+        )
+
+
+def _record_initial_question_state(
+    *,
+    user_id: str,
+    namespace: str,
+    session_id: str,
+    status: str,
+    retryable: bool,
+    failure_code: str | None = None,
+) -> None:
+    """Record a bounded, retryable initial-question outcome on its carrier."""
+
+    query = _actor_query(
+        user_id=user_id,
+        namespace=namespace,
+        session_id=session_id,
+    )
+    now = _now()
+    fields: dict[str, Any] = {
+        "concept_q_and_a.initial_question.status": status,
+        "concept_q_and_a.initial_question.retryable": retryable,
+        "concept_q_and_a.initial_question.last_attempt_at": now,
+        "updated_at": now,
+    }
+    if failure_code:
+        # Do not persist a provider exception or response body in the carrier.
+        fields["concept_q_and_a.initial_question.failure"] = {
+            "error_code": failure_code,
+            "message": "The initial Q&A question could not be generated.",
+        }
+    try:
+        update: dict[str, Any] = {
+            "$set": fields,
+            "$inc": {"concept_q_and_a.initial_question.attempt_count": 1},
+        }
+        if not failure_code:
+            update["$unset"] = {"concept_q_and_a.initial_question.failure": ""}
+        result = _collection().update_one(query, update)
+    except PyMongoError as exc:
+        raise ConceptQAConversationError(
+            "Could not record the initial Q&A question state",
+            error_code="initial_question_state_write_failed",
         ) from exc
     if getattr(result, "matched_count", 0) != 1:
         raise ConceptQAConversationNotFound(
@@ -1795,7 +1883,7 @@ def _ensure_initial_assistant_turn(
     session_id: str,
     concept: Mapping[str, Any],
     session_doc: Mapping[str, Any],
-) -> None:
+) -> bool:
     history = (
         session_doc.get("history")
         if isinstance(session_doc.get("history"), list)
@@ -1805,7 +1893,7 @@ def _ensure_initial_assistant_turn(
         isinstance(item, Mapping) and item.get("role") == "assistant"
         for item in history
     ):
-        return
+        return True
     qa_state = session_doc.get("concept_q_and_a")
     initial_notes = (
         qa_state.get("initial_notes") if isinstance(qa_state, Mapping) else None
@@ -1818,26 +1906,54 @@ def _ensure_initial_assistant_turn(
         if isinstance(qa_state, Mapping)
         else None,
     }
-    result = concept_service.generate_initial_question(
-        str(concept.get("concept_id")),
-        initial_notes=str(initial_notes or ""),
-        interaction_session=runtime_session,
-        persist_interaction_question=False,
-    )
-    if not isinstance(result, Mapping) or result.get("status") != "success":
-        raise ConceptQAConversationError(
-            "Could not generate the initial Q&A turn",
-            error_code=str(
-                (result or {}).get("status")
-                if isinstance(result, Mapping)
-                else "initial_question_failed"
-            ),
+    try:
+        result = concept_service.generate_initial_question(
+            str(concept.get("concept_id")),
+            initial_notes=str(initial_notes or ""),
+            interaction_session=runtime_session,
+            persist_interaction_question=False,
         )
+    except Exception:
+        # This intentionally covers any ordinary provider/transport exception:
+        # the active carrier was committed before generation, so returning it
+        # with bounded recovery state is safer than losing its only reference.
+        # Preserve the traceback in operational logs, never in the carrier.
+        logger.exception(
+            "Initial concept Q&A question generation failed; preserving carrier for retry "
+            "session_id=%s concept_id=%s",
+            session_id,
+            concept.get("concept_id"),
+        )
+        _record_initial_question_state(
+            user_id=user_id,
+            namespace=namespace,
+            session_id=session_id,
+            status="retryable_failure",
+            retryable=True,
+            failure_code="initial_question_generation_failed",
+        )
+        return False
+    if not isinstance(result, Mapping) or result.get("status") != "success":
+        _record_initial_question_state(
+            user_id=user_id,
+            namespace=namespace,
+            session_id=session_id,
+            status="retryable_failure",
+            retryable=True,
+            failure_code="initial_question_generation_failed",
+        )
+        return False
     question = str(result.get("question") or "").strip()
     if not question:
-        raise ConceptQAConversationError(
-            "Initial Q&A turn was empty", error_code="initial_question_empty"
+        _record_initial_question_state(
+            user_id=user_id,
+            namespace=namespace,
+            session_id=session_id,
+            status="retryable_failure",
+            retryable=True,
+            failure_code="initial_question_empty",
         )
+        return False
     emitted_predicate = result.get("elicitation_predicate")
     elicitation_predicate = (
         concept_service._project_elicitation_metadata(emitted_predicate)
@@ -1866,6 +1982,14 @@ def _ensure_initial_assistant_turn(
         message=assistant_message,
         require_active=True,
     )
+    _record_initial_question_state(
+        user_id=user_id,
+        namespace=namespace,
+        session_id=session_id,
+        status="ready",
+        retryable=False,
+    )
+    return True
 
 
 def start_concept_qa_conversation(
@@ -1935,6 +2059,11 @@ def start_concept_qa_conversation(
             },
             "turn_receipts": {},
             "initial_notes": str(initial_notes or "").strip() or None,
+            "initial_question": {
+                "status": "pending",
+                "retryable": False,
+                "attempt_count": 0,
+            },
         }
         if llm_selection:
             qa_state["llm_selection"] = llm_selection
@@ -2227,6 +2356,11 @@ def submit_concept_qa_turn(
         raise ConceptQAConversationConflict(
             f"Q&A conversation is {lifecycle.get('status') or 'not active'}",
             error_code="conversation_terminal",
+        )
+    if _initial_question_state(doc).get("status") != "ready":
+        raise ConceptQAConversationConflict(
+            "Retry the initial Q&A question before submitting an answer",
+            error_code="initial_question_not_ready",
         )
     effective_org_id = _normalise_org_id(doc.get("organisation_concept_id")) or org_id
     prior_doc = doc

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1926,14 +1926,18 @@ function updateConceptQaComposerUi() {
     const busy = conceptQaSubmitInFlight.has(session.session_id)
         || conceptQaTransitionInFlight.has(session.session_id);
     const terminal = session.lifecycle !== 'active';
+    const awaitingInitialQuestion = session.lifecycle === 'active'
+        && !conceptQaActionAllowed(session, 'submit_turn');
     const readOnly = isExternalConversationReadOnly();
-    promptInput.disabled = readOnly || terminal || busy;
+    promptInput.disabled = readOnly || terminal || awaitingInitialQuestion || busy;
     promptInput.setAttribute(
         'placeholder',
         readOnly
             ? 'Imported snapshot — choose Continue to add new turns.'
             : terminal
             ? `Concept Q&A ${session.lifecycle}; the transcript remains available.`
+            : awaitingInitialQuestion
+            ? 'Retry the initial question from the concept card before answering.'
             : (busy ? 'Saving this Q&A turn…' : 'Answer the current concept question…'),
     );
 }
@@ -1958,7 +1962,11 @@ function renderConceptQaConversationControls() {
     title.textContent = 'Concept Q&A';
     const status = document.createElement('span');
     status.className = 'concept-qa-conversation-status';
-    status.textContent = session.lifecycle === 'active'
+    const awaitingInitialQuestion = session.lifecycle === 'active'
+        && !conceptQaActionAllowed(session, 'submit_turn');
+    status.textContent = session.lifecycle === 'active' && awaitingInitialQuestion
+        ? 'Needs retry · return to the concept card to generate the initial question.'
+        : session.lifecycle === 'active'
         ? 'Active · answers and representation outcomes are saved in this conversation.'
         : `${session.lifecycle === 'finished' ? 'Finished' : 'Cancelled'} · transcript and prior knowledge are retained.`;
     header.append(title, status);
@@ -2108,6 +2116,11 @@ async function submitActiveConceptQaPrompt({ session, promptInput, promptRaw }) 
     if (!session?.concept_id || !session?.session_id) return false;
     if (session.lifecycle !== 'active') {
         showToast(`This concept Q&A is ${session.lifecycle}; its transcript remains available.`, 'info');
+        renderConceptQaConversationControls();
+        return false;
+    }
+    if (!conceptQaActionAllowed(session, 'submit_turn')) {
+        showToast('Retry the initial concept question before submitting an answer.', 'info');
         renderConceptQaConversationControls();
         return false;
     }
@@ -6559,11 +6572,17 @@ function updateSendButtonForCurrentChatState() {
         )
     );
     const conceptQaTerminal = Boolean(conceptQaSession && conceptQaSession.lifecycle !== 'active');
+    const conceptQaAwaitingInitialQuestion = Boolean(
+        conceptQaSession
+        && conceptQaSession.lifecycle === 'active'
+        && !conceptQaActionAllowed(conceptQaSession, 'submit_turn')
+    );
     sendButton.disabled = uploadInFlight
         || queueSubmissionInFlight
         || readOnly
         || conceptQaBusy
-        || conceptQaTerminal;
+        || conceptQaTerminal
+        || conceptQaAwaitingInitialQuestion;
     sendButton.setAttribute('aria-busy', queueSubmissionInFlight || conceptQaBusy ? 'true' : 'false');
     if (readOnly) {
         sendButton.textContent = 'Read-only import';
@@ -6571,9 +6590,17 @@ function updateSendButtonForCurrentChatState() {
         return;
     }
     if (conceptQaSession) {
-        sendButton.textContent = conceptQaTerminal
-            ? `Q&A ${conceptQaSession.lifecycle}`
-            : (conceptQaBusy ? 'Saving Q&A…' : 'Submit answer');
+        if (conceptQaTerminal) {
+            sendButton.textContent = `Q&A ${conceptQaSession.lifecycle}`;
+        } else if (conceptQaAwaitingInitialQuestion) {
+            sendButton.textContent = 'Retry question first';
+        } else {
+            sendButton.textContent = conceptQaBusy ? 'Saving Q&A…' : 'Submit answer';
+        }
+        if (conceptQaAwaitingInitialQuestion) {
+            sendButton.title = 'Return to the concept card and retry the initial question before answering.';
+            return;
+        }
         sendButton.title = conceptQaTerminal
             ? 'The transcript remains available, but this concept Q&A no longer accepts turns.'
             : (conceptQaBusy ? 'Saving this turn and its representation receipts.' : 'Submit this answer to concept Q&A.');

--- a/src/frontend/web/von_interface/static/js/conceptTab.js
+++ b/src/frontend/web/von_interface/static/js/conceptTab.js
@@ -1614,20 +1614,27 @@ function renderConceptQaSessionCard({ suffix = '', session = null, error = null,
   const controls = getConceptQaCardElements(suffix);
   if (!controls.card) return false;
 
-  const state = error ? 'error' : (session?.lifecycle || 'ready');
+  const initialQuestionRetryable = session?.initial_question?.retryable === true;
+  const state = error
+    ? 'error'
+    : (initialQuestionRetryable ? 'retryable' : (session?.lifecycle || 'ready'));
   controls.card.dataset.state = state;
   if (controls.badge) {
     controls.badge.textContent = error
       ? 'Unavailable'
+      : (initialQuestionRetryable
+        ? 'Needs retry'
       : (session?.lifecycle === 'active'
         ? 'Active'
         : (session?.lifecycle === 'finished'
           ? 'Finished'
-          : (session?.lifecycle === 'cancelled' ? 'Cancelled' : 'Ready')));
+          : (session?.lifecycle === 'cancelled' ? 'Cancelled' : 'Ready'))));
   }
   if (controls.summary) {
     if (error) {
       controls.summary.textContent = 'Q&A status could not be checked. You can retry without losing an existing transcript.';
+    } else if (initialQuestionRetryable) {
+      controls.summary.textContent = 'The first Q&A question could not be generated. Retry to continue this same recoverable conversation.';
     } else if (session?.lifecycle === 'active') {
       controls.summary.textContent = 'A recoverable Q&A conversation is active for this concept.';
     } else if (session?.lifecycle === 'finished') {
@@ -1649,13 +1656,19 @@ function renderConceptQaSessionCard({ suffix = '', session = null, error = null,
   const hasSession = Boolean(session?.session_id);
   const isActive = session?.lifecycle === 'active';
   if (controls.start) {
-    controls.start.classList.toggle('hidden', isActive);
-    controls.start.textContent = hasSession ? 'Start new Q&A' : 'Improve concept by Q&A';
-    controls.start.title = 'Answer guided questions in a recoverable conversation; admitted exact claims retain provenance.';
+    controls.start.classList.toggle('hidden', isActive && !initialQuestionRetryable);
+    controls.start.textContent = initialQuestionRetryable
+      ? 'Retry initial question'
+      : (hasSession ? 'Start new Q&A' : 'Improve concept by Q&A');
+    controls.start.title = initialQuestionRetryable
+      ? 'Retry the first question in this existing recoverable Q&A conversation.'
+      : 'Answer guided questions in a recoverable conversation; admitted exact claims retain provenance.';
   }
   if (controls.resume) {
-    controls.resume.classList.toggle('hidden', !isActive);
-    controls.resume.onclick = isActive ? () => void openConceptQaSessionInChat(session) : null;
+    controls.resume.classList.toggle('hidden', !isActive || initialQuestionRetryable);
+    controls.resume.onclick = isActive && !initialQuestionRetryable
+      ? () => void openConceptQaSessionInChat(session)
+      : null;
   }
   if (controls.open) {
     controls.open.classList.toggle('hidden', !hasSession);
@@ -1725,6 +1738,9 @@ export async function handleStartInteraction() {
     const session = await startConceptQaSession(conceptId, buildLocalModelRequestFields());
     conceptQaSessionByConcept.set(conceptId, session);
     renderConceptQaSessionCard({ suffix, session });
+    if (session.initial_question?.retryable === true) {
+      return false;
+    }
     await openConceptQaSessionInChat(session);
     return true;
   } catch (error) {

--- a/src/frontend/web/von_interface/static/js/utils/conceptQaSession.js
+++ b/src/frontend/web/von_interface/static/js/utils/conceptQaSession.js
@@ -33,6 +33,21 @@ function normaliseActionList(value, lifecycle) {
   return ['open_transcript', 'copy_reference'];
 }
 
+function normaliseInitialQuestion(value) {
+  const source = firstObject(value) || {};
+  const status = cleanText(source.status).toLowerCase().replace(/[\s-]+/g, '_');
+  const failure = firstObject(source.failure);
+  return {
+    status: status || 'ready',
+    retryable: source.retryable === true || status === 'retryable_failure',
+    attempt_count: Number.isInteger(source.attempt_count) ? source.attempt_count : 0,
+    failure: failure ? {
+      error_code: cleanText(failure.error_code) || null,
+      message: cleanText(failure.message) || null,
+    } : null,
+  };
+}
+
 export function normaliseConceptQaReceipts(value) {
   const source = firstObject(value?.receipts, value?.representation, value) || {};
   return {
@@ -80,6 +95,11 @@ export function normaliseConceptQaSession(value, defaults = {}) {
     ? source.turns
     : (Array.isArray(root.turns) ? root.turns : []);
   const receipts = normaliseConceptQaReceipts(root.receipts || source.receipts || source.latest_receipts);
+  const initialQuestion = normaliseInitialQuestion(source.initial_question);
+  const availableActions = normaliseActionList(
+    source.available_actions || source.allowed_actions,
+    lifecycle,
+  ).filter((action) => !(initialQuestion.retryable && action === 'submit_turn'));
 
   return {
     ...source,
@@ -92,13 +112,11 @@ export function normaliseConceptQaSession(value, defaults = {}) {
     origin_kind: CONCEPT_QA_ORIGIN_KIND,
     lifecycle,
     status: lifecycle,
-    available_actions: normaliseActionList(
-      source.available_actions || source.allowed_actions,
-      lifecycle,
-    ),
+    available_actions: availableActions,
     conversation_reference: canonicalRef || null,
     turns,
     receipts,
+    initial_question: initialQuestion,
     created: root.created === true || source.created === true,
     resumed: root.resumed === true || source.resumed === true,
     updated_at: cleanText(source.updated_at) || cleanText(root.updated_at) || null,
@@ -186,7 +204,10 @@ export function conceptQaActionAllowed(session, action) {
   if (!projection) return false;
   const actions = new Set(projection.available_actions);
   if (actions.has(action)) return true;
-  if (action === 'submit_turn') return projection.lifecycle === 'active';
+  if (action === 'submit_turn') {
+    return projection.lifecycle === 'active'
+      && projection.initial_question?.retryable !== true;
+  }
   return ['open_transcript', 'copy_reference'].includes(action);
 }
 

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -2111,6 +2111,17 @@ body.von-signed-out {
     color: #b91c1c;
 }
 
+.concept-qa-session-card[data-state="retryable"] {
+    border-color: #fcd34d;
+    border-left-color: #d97706;
+    background: #fffbeb;
+}
+
+.concept-qa-session-card[data-state="retryable"] .concept-qa-session-badge {
+    background: #fef3c7;
+    color: #92400e;
+}
+
 .concept-qa-session-summary {
     margin: 0;
     color: #334155;

--- a/tests/backend/test_concept_qa_conversation_service.py
+++ b/tests/backend/test_concept_qa_conversation_service.py
@@ -1246,6 +1246,53 @@ def test_generic_chat_state_preserves_terminal_q_and_a_mode_and_focal_state(
     assert summary["completed_at"] == "2026-09-02T12:00:00+00:00"
 
 
+@pytest.mark.parametrize("history_tail_limit", [None, 1])
+def test_generic_chat_state_preserves_retryable_initial_question_state(
+    monkeypatch,
+    history_tail_limit,
+):
+    from src.backend.services import chat_history_service
+
+    collection = _chat_collection()
+    doc = _session_doc()
+    doc["concept_q_and_a"]["initial_question"] = {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 1,
+        "last_attempt_at": "2026-09-02T12:00:00+00:00",
+        "failure": {
+            "error_code": "initial_question_generation_failed",
+            "message": "The initial Q&A question could not be generated.",
+        },
+    }
+    collection.insert_one(doc)
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_collection_service",
+        lambda **_kwargs: collection,
+    )
+
+    state = chat_history_service.get_chat_history_session_state(
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        namespace=NAMESPACE,
+        history_tail_limit=history_tail_limit,
+    )
+
+    expected = {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 1,
+        "last_attempt_at": "2026-09-02T12:00:00+00:00",
+        "failure": {
+            "error_code": "initial_question_generation_failed",
+            "message": "The initial Q&A question could not be generated.",
+        },
+    }
+    assert state["concept_q_and_a"]["initial_question"] == expected
+    assert state["initial_question"] == expected
+
+
 def test_start_resumes_same_active_carrier_and_initial_assistant_is_once(monkeypatch):
     from src.backend.services import concept_qa_conversation_service as service
 
@@ -1310,6 +1357,149 @@ def test_start_resumes_same_active_carrier_and_initial_assistant_is_once(monkeyp
     assert (
         collection.count_documents({"concept_q_and_a.lifecycle.status": "active"}) == 1
     )
+
+
+def test_initial_question_failure_is_typed_and_retries_same_active_carrier(
+    monkeypatch, caplog
+):
+    from src.backend.services import concept_qa_conversation_service as service
+
+    collection = _chat_collection()
+    collection.create_index(
+        [("concept_q_and_a.active_key", 1)],
+        name="concept_q_and_a_active_key_unique_v1",
+        unique=True,
+        partialFilterExpression={
+            "mode": "concept_q_and_a",
+            "origin_kind": "concept_q_and_a",
+            "concept_q_and_a.lifecycle.status": "active",
+            "concept_q_and_a.active_key": {"$type": "string"},
+        },
+    )
+    _patch_chat_store(monkeypatch, service, collection)
+    monkeypatch.setattr(service.chat_history_service, "get_session_context", dict)
+    monkeypatch.setattr(
+        service.concept_service,
+        "_normalise_interaction_llm_selection",
+        lambda **_kwargs: None,
+    )
+    attempts = {"count": 0}
+
+    def generate_initial_question(*_args, **_kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("simulated provider transport failure")
+        return {
+            "status": "success",
+            "question": "Which organisation is Primary Labs a member of?",
+        }
+
+    monkeypatch.setattr(
+        service.concept_service,
+        "generate_initial_question",
+        generate_initial_question,
+    )
+
+    with caplog.at_level("ERROR", logger=service.__name__):
+        failed_start = service.start_concept_qa_conversation(
+            concept_id=CONCEPT_ID,
+            user_id=USER_ID,
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+        )
+
+    assert failed_start["created"] is True
+    assert failed_start["resumed"] is False
+    assert failed_start["lifecycle"]["status"] == "active"
+    assert failed_start["initial_question"] == {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 1,
+        "last_attempt_at": failed_start["initial_question"]["last_attempt_at"],
+        "failure": {
+            "error_code": "initial_question_generation_failed",
+            "message": "The initial Q&A question could not be generated.",
+        },
+    }
+    assert failed_start["turns"] == []
+    assert any(
+        record.exc_info
+        and "Initial concept Q&A question generation failed" in record.getMessage()
+        for record in caplog.records
+    )
+    assert collection.count_documents({"concept_q_and_a.lifecycle.status": "active"}) == 1
+
+    with pytest.raises(service.ConceptQAConversationConflict) as exc_info:
+        service.submit_concept_qa_turn(
+            concept_id=CONCEPT_ID,
+            session_id=failed_start["session_id"],
+            turn_id="premature-answer",
+            user_id=USER_ID,
+            answer="An answer without a question",
+            namespace=NAMESPACE,
+            organisation_concept_id=ORG_ID,
+        )
+    assert exc_info.value.error_code == "initial_question_not_ready"
+    assert failed_start["turns"] == []
+
+    retried = service.start_concept_qa_conversation(
+        concept_id=CONCEPT_ID,
+        user_id=USER_ID,
+        namespace=NAMESPACE,
+        organisation_concept_id=ORG_ID,
+    )
+
+    assert retried["created"] is False
+    assert retried["resumed"] is True
+    assert retried["session_id"] == failed_start["session_id"]
+    assert retried["initial_question"]["status"] == "ready"
+    assert retried["initial_question"]["retryable"] is False
+    assert retried["initial_question"]["attempt_count"] == 2
+    assert retried["initial_question"].get("failure") is None
+    assert [turn["content"] for turn in retried["turns"]] == [
+        "Which organisation is Primary Labs a member of?"
+    ]
+    assert collection.count_documents({"concept_q_and_a.lifecycle.status": "active"}) == 1
+
+
+def test_pre_state_machine_active_carrier_without_question_is_retryable():
+    from src.backend.services import concept_qa_conversation_service as service
+
+    doc = _session_doc()
+    doc["history"] = []
+
+    projected = service._project_session(doc)
+
+    assert projected["lifecycle"]["status"] == "active"
+    assert projected["initial_question"] == {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 0,
+        "failure": {
+            "error_code": "initial_question_missing",
+            "message": "The active Q&A conversation has no initial question.",
+        },
+    }
+
+
+def test_projection_prefers_durable_question_over_stale_retry_marker():
+    from src.backend.services import concept_qa_conversation_service as service
+
+    doc = _session_doc()
+    doc["concept_q_and_a"]["initial_question"] = {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 2,
+        "failure": {"error_code": "initial_question_generation_failed"},
+    }
+
+    projected = service._project_session(doc)
+
+    assert projected["initial_question"] == {
+        "status": "ready",
+        "retryable": False,
+        "attempt_count": 2,
+    }
 
 
 def test_initial_assistant_omits_model_debug_when_legacy_generator_has_none(

--- a/tests/backend/test_set_chat_session_endpoint.py
+++ b/tests/backend/test_set_chat_session_endpoint.py
@@ -203,7 +203,11 @@ def test_set_chat_session_projects_terminal_concept_q_and_a_state(
     _, client = app_client
 
     class _FakeColl:
+        def __init__(self):
+            self.projections = []
+
         def find_one(self, query, projection=None):
+            self.projections.append(projection)
             if query.get("user_id") != "#V#u" or query.get("session_id") != "qa-1":
                 return None
             return {
@@ -219,15 +223,21 @@ def test_set_chat_session_projects_terminal_concept_q_and_a_state(
                         "name": "Primary Labs",
                     },
                     "lifecycle": {"status": "finished", "revision": 1},
+                    "initial_question": {
+                        "status": "ready",
+                        "retryable": False,
+                        "attempt_count": 1,
+                    },
                 },
             }
 
     import src.backend.services.chat_history_service as chat_history_service
 
+    coll = _FakeColl()
     monkeypatch.setattr(
         chat_history_service,
         "get_chat_history_collection_service",
-        lambda **_kwargs: _FakeColl(),
+        lambda **_kwargs: coll,
     )
     with client.session_transaction() as sess:
         sess["user_concept_id"] = "#V#u"
@@ -243,6 +253,13 @@ def test_set_chat_session_projects_terminal_concept_q_and_a_state(
     assert body["origin_kind"] == "concept_q_and_a"
     assert body["focal_concept_ids"] == ["#V#primary_labs"]
     assert body["qa_session"]["lifecycle"]["status"] == "finished"
+    assert body["qa_session"]["initial_question"] == {
+        "status": "ready",
+        "retryable": False,
+        "attempt_count": 1,
+    }
+    assert coll.projections
+    assert coll.projections[-1]["concept_q_and_a.initial_question"] == 1
 
 
 def test_set_chat_session_allows_shared_invite(monkeypatch, app_client):
@@ -359,6 +376,144 @@ def test_history_uses_query_session_id(monkeypatch, app_client):
 
     with client.session_transaction() as sess:
         assert sess.get("session_id") == "session-from-cookie"
+
+
+def test_merge_shared_histories_deduplicates_equivalent_structured_content():
+    blob_ref = {
+        "schema_version": "debug_payload_blob_ref.v1",
+        "blob_ref": {"backend": "local", "key": "debug/shared.json.gz"},
+    }
+
+    merged = von_routes._merge_shared_histories(
+        [
+            {
+                "role": "assistant",
+                "content": blob_ref,
+                "author_user_id": "#V#owner",
+                "timestamp": "2026-09-02T12:00:00Z",
+            }
+        ],
+        [
+            {
+                "role": "assistant",
+                "content": {
+                    "blob_ref": {
+                        "key": "debug/shared.json.gz",
+                        "backend": "local",
+                    },
+                    "schema_version": "debug_payload_blob_ref.v1",
+                },
+                "author_user_id": "#V#owner",
+                "timestamp": "2026-09-02T12:00:00Z",
+            }
+        ],
+    )
+
+    assert merged == [
+        {
+            "role": "assistant",
+            "content": blob_ref,
+            "author_user_id": "#V#owner",
+            "timestamp": "2026-09-02T12:00:00Z",
+        }
+    ]
+
+
+def test_shared_history_paging_keeps_structured_blob_content(monkeypatch, app_client):
+    _, client = app_client
+    import src.backend.services.chat_history_service as chat_history_service
+
+    blob_ref = {
+        "schema_version": "debug_payload_blob_ref.v1",
+        "blob_ref": {"backend": "local", "key": "debug/shared.json.gz"},
+    }
+    owner_history = [
+        {
+            "role": "assistant",
+            "content": "Earlier owner response",
+            "author_user_id": "#V#owner",
+            "timestamp": "2026-09-02T12:00:00Z",
+        },
+        {
+            "role": "assistant",
+            "content": blob_ref,
+            "author_user_id": "#V#owner",
+            "timestamp": "2026-09-02T12:00:01Z",
+        },
+    ]
+    invitee_history = [
+        {
+            "role": "assistant",
+            "content": {
+                "blob_ref": {
+                    "key": "debug/shared.json.gz",
+                    "backend": "local",
+                },
+                "schema_version": "debug_payload_blob_ref.v1",
+            },
+            "author_user_id": "#V#owner",
+            "timestamp": "2026-09-02T12:00:01Z",
+        }
+    ]
+
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *args, **kwargs: {"namespace": "#V#invitee@org"},
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_resolve_shared_conversation_owner",
+        lambda **_kwargs: (
+            "#V#owner",
+            {
+                "conversation_owner_user_id": "#V#owner",
+                "organisation_concept_id": "#V#org",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_load_conversation_session_state_fail_soft",
+        lambda **kwargs: (
+            owner_history,
+            None,
+            None,
+            None,
+            [],
+            {"history_offset": 0, "history_truncated": False},
+        ),
+    )
+    monkeypatch.setattr(
+        chat_history_service,
+        "get_chat_history_session_state",
+        lambda **kwargs: {"history": invitee_history, "history_truncated": False},
+    )
+    monkeypatch.setattr(von_routes, "chat_history_service", chat_history_service)
+
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#invitee"
+
+    response = client.get(
+        "/von/history?session_id=shared-session&segments=1&segment_size=1"
+        "&include_debug=0"
+    )
+
+    assert response.status_code == 200, response.get_json()
+    payload = response.get_json()
+    assert payload["history"] == [
+        {
+            "role": "assistant",
+            "content": blob_ref,
+            "author_user_id": "#V#owner",
+            "timestamp": "2026-09-02T12:00:01Z",
+            "history_location": {
+                "session_id": "shared-session",
+                "history_index": 1,
+            },
+        }
+    ]
+    assert payload["has_more_history"] is True
 
 
 def test_set_chat_session_returns_retryable_on_transient_mongo_failure(

--- a/tests/backend/test_von_history_debug_endpoint.py
+++ b/tests/backend/test_von_history_debug_endpoint.py
@@ -127,6 +127,72 @@ def test_history_projects_terminal_concept_q_and_a_carrier_state(monkeypatch):
     assert body["qa_session"]["lifecycle"]["status"] == "cancelled"
 
 
+def test_history_projects_retryable_initial_concept_q_and_a_question(monkeypatch):
+    from src.backend.server.routes import von_routes
+
+    initial_question = {
+        "status": "retryable_failure",
+        "retryable": True,
+        "attempt_count": 1,
+        "failure": {
+            "error_code": "initial_question_generation_failed",
+            "message": "The initial question could not be generated.",
+        },
+    }
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#test_user"},
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_resolve_shared_conversation_owner",
+        lambda **_kwargs: ("#V#test_user", None),
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "get_chat_history_session_state",
+        lambda **kwargs: {
+            "session_id": kwargs["session_id"],
+            "history": [],
+            "mode": "concept_q_and_a",
+            "origin_kind": "concept_q_and_a",
+            "focal_concept_ids": ["#V#primary_labs"],
+            "concept_q_and_a": {
+                "schema_version": "concept_q_and_a_session.v1",
+                "concept": {
+                    "concept_id": "#V#primary_labs",
+                    "name": "Primary Labs",
+                },
+                "lifecycle": {"status": "active", "revision": 0},
+                "initial_question": initial_question,
+            },
+        },
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+    response = app.test_client().get(
+        "/von/history",
+        query_string={"session_id": "qa-retryable"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["session"]["initial_question"] == initial_question
+    assert body["qa_session"]["initial_question"] == initial_question
+
+
 def test_history_endpoint_returns_compact_debug_refs_without_hydration(monkeypatch):
     from src.backend.server.routes.von_routes import von_bp
 

--- a/tests/frontend/chatTabConceptQa.test.js
+++ b/tests/frontend/chatTabConceptQa.test.js
@@ -137,6 +137,31 @@ describe('chat workspace concept Q&A mode', () => {
         expect(document.getElementById('promptInput').disabled).toBe(true);
     });
 
+    test('keeps an incomplete Q&A transcript inspectable but blocks answers until retry', async () => {
+        const qa = require(qaModulePath);
+        const chat = require(chatTabModulePath);
+        chat.__testOnly_setConceptQaSession(activeSession({
+            initial_question: {
+                status: 'retryable_failure',
+                retryable: true,
+                attempt_count: 1,
+            },
+            turns: [],
+        }));
+
+        expect(document.getElementById('conceptQaConversationControls').textContent)
+            .toContain('Needs retry');
+        expect(document.getElementById('promptInput').disabled).toBe(true);
+        expect(document.getElementById('promptInput').placeholder)
+            .toContain('Retry the initial question from the concept card');
+        expect(document.getElementById('sendButton').disabled).toBe(true);
+        expect(document.getElementById('sendButton').textContent).toBe('Retry question first');
+
+        document.getElementById('promptInput').value = 'An answer without a question';
+        await chat.__testOnly_sendChatPrompt();
+        expect(qa.submitConceptQaTurn).not.toHaveBeenCalled();
+    });
+
     test('rehydrates stable turn IDs, LLM access and separate receipts in the normal transcript', () => {
         const chat = require(chatTabModulePath);
         chat.__testOnly_setConceptQaSession(activeSession());

--- a/tests/frontend/conceptInteractionQandAReframe.test.js
+++ b/tests/frontend/conceptInteractionQandAReframe.test.js
@@ -3,9 +3,13 @@ const path = require('path');
 
 const {
     describeConceptQaRepresentation,
+    handleStartInteraction,
     isUnmistakableMissingConceptQaRoute,
     refreshConceptQaSessionCard,
 } = require('../../src/frontend/web/von_interface/static/js/conceptTab.js');
+const {
+    setCurrentlySelectedConceptId,
+} = require('../../src/frontend/web/von_interface/static/js/state.js');
 
 const conceptTemplate = fs.readFileSync(
     path.resolve(__dirname, '../../src/frontend/web/von_interface/templates/concept_tab.html'),
@@ -145,5 +149,94 @@ describe('concept-improvement Q&A entry point', () => {
         expect(document.getElementById('conceptQaGapStatus').textContent).toContain(
             'not an assertion or a creation block'
         );
+    });
+
+    test('renders a retryable initial-question failure as an existing recoverable Q&A', async () => {
+        document.body.innerHTML = conceptTemplate;
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                sessions: [{
+                    session_id: 'qa-primary-labs-retry',
+                    focal_concept_ids: ['#V#primary_labs'],
+                    lifecycle: { status: 'active', revision: 0 },
+                    mode: 'concept_q_and_a',
+                    origin_kind: 'concept_q_and_a',
+                    initial_question: {
+                        status: 'retryable_failure',
+                        retryable: true,
+                        attempt_count: 1,
+                        failure: {
+                            error_code: 'initial_question_generation_failed',
+                            message: 'The initial Q&A question could not be generated.',
+                        },
+                    },
+                    conversation_reference: {
+                        schema_version: 'conversation_reference.v1',
+                        binding_kind: 'explicit_session_id',
+                        session_id: 'qa-primary-labs-retry',
+                    },
+                    turns: [],
+                }],
+            }),
+        }));
+        try {
+            await refreshConceptQaSessionCard('#V#primary_labs');
+        } finally {
+            global.fetch = originalFetch;
+        }
+
+        expect(document.getElementById('conceptQaSessionBadge').textContent).toBe('Needs retry');
+        expect(document.getElementById('conceptQaSessionSummary').textContent)
+            .toContain('Retry to continue this same recoverable conversation');
+        expect(document.getElementById('startInteractionButton').textContent)
+            .toBe('Retry initial question');
+        expect(document.getElementById('startInteractionButton').classList)
+            .not.toContain('hidden');
+        expect(document.getElementById('resumeConceptQaButton').classList).toContain('hidden');
+        expect(document.getElementById('openConceptQaTranscriptButton').classList)
+            .not.toContain('hidden');
+    });
+
+    test('keeps a partial start on the concept card instead of opening an empty transcript', async () => {
+        document.body.innerHTML = conceptTemplate;
+        setCurrentlySelectedConceptId('#V#primary_labs');
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn(async (url) => {
+            expect(String(url)).toContain('/q_and_a/start');
+            return {
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    session_id: 'qa-primary-labs-partial-start',
+                    focal_concept_ids: ['#V#primary_labs'],
+                    lifecycle: { status: 'active', revision: 0 },
+                    mode: 'concept_q_and_a',
+                    origin_kind: 'concept_q_and_a',
+                    initial_question: {
+                        status: 'retryable_failure',
+                        retryable: true,
+                        attempt_count: 1,
+                    },
+                    turns: [],
+                }),
+            };
+        });
+        let started;
+        try {
+            started = await handleStartInteraction();
+        } finally {
+            global.fetch = originalFetch;
+        }
+
+        expect(started).toBe(false);
+        expect(global.fetch).toBe(originalFetch);
+        expect(document.getElementById('conceptQaSessionCard').dataset.state).toBe('retryable');
+        expect(document.getElementById('startInteractionButton').textContent)
+            .toBe('Retry initial question');
+        expect(document.getElementById('conceptQaSessionSummary').textContent)
+            .toContain('same recoverable conversation');
     });
 });


### PR DESCRIPTION
Merge decision: ready — shared conversation history accepts structured message content, and a failed initial Concept Q&A question remains visibly retryable across reload instead of producing an HTTP 500 or enabling an invalid answer.

## User outcome

Opening shared history no longer fails when a message contains structured content. Starting Concept Q&A now preserves the durable conversation carrier when initial question generation fails, reports a recoverable state, and lets the user retry safely.

## Material changes

- Canonicalise structured history content before duplicate detection.
- Persist and project bounded initial-question attempt state on Concept Q&A carriers.
- Preserve that state through normal history, tail aggregation, and session-switch reads.
- Show a Needs retry state and disable answering until an initial question exists.
- Add backend paging, recovery, reload, session-switch, and frontend interaction regressions.

## Evidence

- Rebased onto current origin/main without conflicts.
- Affected backend/history acceptance: 105 passed, 1 third-party deprecation warning.
- Post-correction Concept Q&A service suite: 31 passed.
- Post-correction history and session route suites: 18 passed, 1 third-party deprecation warning.
- Affected frontend suites: 34 passed.
- Ruff fatal-error selection and git diff whitespace checks passed.
- Independent static review found no remaining merge blocker.

## Ship boundary

- **Minimum ship criteria:** Structured history content loads and deduplicates without a hash error; failed initial Q&A generation returns a durable retryable state; reload retains that state; answering is blocked until ready; affected tests and required CI pass.
- **Stop-ship conditions:** Either reported error remains reproducible, retry state is lost on a supported reload path, premature answers can be submitted, or required CI fails because of this candidate.
- **Non-blocking observations:** Full-repository Ruff contains pre-existing legacy violations. Exact signed-in Primary Labs data was unavailable in the isolated browser fixture, while the candidate server and automated user-path coverage were healthy.
- **Non-goals:** Deployment or live-runtime activation, redesigning provider generation, and unrelated lockfile or workspace changes.
