### PR TITLE
Make model quota exhaustion actionable

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -14268,7 +14268,11 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         # falling back to reading the screen/markdown verbatim.
         needs_spoken_backfill = False
         spoken_from_screen_text = False
-        if presenter_mode_requested:
+        if presenter_mode_requested and not adaptive_delivery_success:
+            # A failed primary model call must not trigger another call to the
+            # same unavailable provider merely to narrate the failure.
+            spoken_backfill_second_pass_reason = "turn_not_deliverable"
+        elif presenter_mode_requested:
             if presenter_channels_missing:
                 needs_spoken_backfill = True
                 if has_tool_messages:
@@ -14479,7 +14483,9 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             spoken_backfill_suppression_reason = "presenter_mode_disabled"
         elif not needs_spoken_backfill:
             spoken_backfill_status = "skipped"
-            spoken_backfill_suppression_reason = "not_required"
+            spoken_backfill_suppression_reason = (
+                spoken_backfill_second_pass_reason or "not_required"
+            )
         elif spoken_backfill_applied:
             spoken_backfill_status = (
                 "fallback_success"
@@ -14782,7 +14788,10 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             canonical_outcome=canonical_outcome_response,
         )
 
-        if not buttonify_setting_enabled:
+        if not adaptive_delivery_success:
+            # Avoid a second request to a provider that just failed the turn.
+            buttonify_suppression_reason = "turn_not_deliverable"
+        elif not buttonify_setting_enabled:
             buttonify_suppression_reason = "buttonify_disabled"
         elif not buttonify_requested and raw_skip_buttonify is None:
             buttonify_suppression_reason = "foreground_delivery_priority"

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -1440,6 +1440,35 @@ def _is_transient_model_request_liveness_failure(exc: BaseException) -> bool:
     return False
 
 
+def _provider_quota_exhaustion_message(
+    exc: BaseException,
+    *,
+    configured_provider: str | None,
+) -> str | None:
+    """Return an actionable, credential-free message for exhausted quota."""
+
+    lowered = str(exc).lower()
+    if not any(
+        marker in lowered
+        for marker in (
+            "insufficient_quota",
+            "credit_balance_exhausted",
+            "quota_exhausted",
+        )
+    ):
+        return None
+
+    provider = str(configured_provider or "model provider").strip().lower()
+    provider_label = "OpenAI" if provider == "openai" else "The model provider"
+    return (
+        f"{provider_label} rejected the model call because the configured API "
+        "project has no credits or quota remaining "
+        "(credit_balance_exhausted / insufficient_quota). Add credits to that "
+        "provider project, or choose another enabled model in Settings, then "
+        "retry."
+    )
+
+
 def _structured_transport_failure_telemetry(
     exc: StructuredToolTransportError,
 ) -> dict[str, Any]:
@@ -9013,6 +9042,10 @@ def execute_adaptive_turn(
                 if isinstance(exc, StructuredToolTransportError)
                 else {}
             )
+            quota_message = _provider_quota_exhaustion_message(
+                exc,
+                configured_provider=configured_provider or None,
+            )
             if "provider_request_sent" in transport_failure_telemetry:
                 provider_request_sent = transport_failure_telemetry[
                     "provider_request_sent"
@@ -9069,6 +9102,12 @@ def execute_adaptive_turn(
                     "partial_response_retained": bool(partial_response_text),
                     "error": str(exc),
                     "error_class": type(exc).__name__,
+                    **(
+                        {"failure_kind": "quota_exhausted"}
+                        if quota_message
+                        and "failure_kind" not in transport_failure_telemetry
+                        else {}
+                    ),
                     **transport_failure_telemetry,
                 }
             )
@@ -9286,6 +9325,11 @@ def execute_adaptive_turn(
                         continue
             terminal_status = "model_error"
             failure_kind = transport_failure_telemetry.get("failure_kind")
+            if quota_message:
+                return finish(
+                    last_partial_text.strip() or quota_message,
+                    status=terminal_status,
+                )
             if failure_kind == "provider_rate_limited":
                 text = last_partial_text.strip() or (
                     "I could not complete the request because the model provider "

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -9989,6 +9989,39 @@ def test_non_liveness_model_failure_is_not_retried_after_compaction(
     )
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        ToolCallError(
+            "OpenAI call failed: Error code: 429 - "
+            "{'error': {'code': 'credit_balance_exhausted', "
+            "'type': 'insufficient_quota'}}"
+        ),
+        ToolCallError("OpenAI call failed: quota_exhausted"),
+    ],
+)
+def test_quota_exhaustion_returns_actionable_provider_message(
+    error: Exception,
+) -> None:
+    result = execute_adaptive_turn(
+        gateway=None,
+        prompt="Represent this organisation.",
+        context=[],
+        llm_client=_SequenceClient(error),
+        model="gpt-test",
+        turn_id="turn-quota-exhausted",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "model_error"
+    assert "credit_balance_exhausted / insufficient_quota" in result.response_text
+    assert "Add credits" in result.response_text
+    assert "choose another enabled model in Settings" in result.response_text
+    assert "ToolCallError" not in result.response_text
+    assert result.llm_calls[0]["failure_kind"] == "quota_exhausted"
+
+
 def test_elapsed_thresholds_are_one_time_model_advisories_without_removing_tools() -> (
     None
 ):

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -243,6 +243,67 @@ def test_partial_answer_terminal_status_is_delivered_as_honest_success(
     ] == "answer_partially_completed"
 
 
+def test_failed_turn_does_not_retry_provider_for_optional_response_transforms(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.backend.server.routes import von_routes
+
+    adaptive_state = app.config["_ADAPTIVE_TURN_STATE"]
+    adaptive_state["response_text"] = (
+        "OpenAI rejected the model call because the configured API project has "
+        "no credits remaining. Add credits or choose another enabled model in "
+        "Settings, then retry."
+    )
+    adaptive_state["terminal_status"] = "model_error"
+    app.config["TESTING"] = False
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(von_routes, "get_buttonify_model_enabled", lambda: True)
+
+    def _unexpected_transform_call(*_args: Any, **_kwargs: Any) -> str:
+        raise AssertionError("failed turns must not call the unavailable model again")
+
+    monkeypatch.setattr(
+        von_routes,
+        "_llm_generate_spoken_backfill",
+        _unexpected_transform_call,
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_llm_generate_buttonify",
+        _unexpected_transform_call,
+    )
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={
+            "prompt": "Represent this organisation.",
+            "presenter_mode": True,
+            "skip_buttonify": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["terminal_status"] == "model_error"
+    assert payload["llm_debug"]["spoken_backfill_second_pass_attempted"] is False
+    transforms = {
+        item["transform_name"]: item
+        for item in payload["llm_debug"]["response_transformations"][
+            "transformations"
+        ]
+    }
+    assert transforms["spoken_backfill"]["status"] == "skipped"
+    assert (
+        transforms["spoken_backfill"]["suppression_reason"]
+        == "turn_not_deliverable"
+    )
+    assert transforms["buttonify"]["status"] == "skipped"
+    assert transforms["buttonify"]["suppression_reason"] == "turn_not_deliverable"
+    assert payload["llm_debug"]["llm_usage_cost_summary"]["call_count"] == 1
+
+
 def test_ordinary_generate_does_not_run_disabled_buttonify_model(
     app: Flask,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Merge decision: ready — quota exhaustion is now actionable in the actual turn result, and a failed primary turn no longer repeats calls to the same failed provider for optional response decoration.

## User outcome

When a model provider has no quota or credits, Von tells the user exactly how to recover instead of reporting the wrapper class ToolCallError. The failed turn also stops before optional narration and quick-reply model calls.

## Material changes

- Detect provider quota and credit exhaustion in the adaptive turn boundary.
- Return a credential-free message directing the user to add provider credits or choose another enabled model in Settings and retry.
- Record failure_kind quota_exhausted in turn telemetry.
- Suppress narration and buttonify model calls when the primary turn is not deliverable.
- Jira: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2705

## Evidence

- DGX turn 5eedc3ce-e4fc-4955-a63c-23f1bc29e496: terminal model_error, zero tool calls, OpenAI 429 insufficient_quota and credit_balance_exhausted; the old UI exposed only ToolCallError and subsequently attempted narration and buttonify.
- Focused adaptive-turn regression: 6 passed.
- Focused route and neighbouring successful-transform regressions: 3 passed.
- A wider affected-file run reached 79 passes before an unrelated mock-isolation test attempted unavailable localhost Mongo; that same test passed alone on both candidate and unchanged main.
- Candidate served successfully at localhost:5001 and the authenticated browser identified the experimental task branch build.
- DGX Ollama qwen3.5:27b completed a live probe and is selected and allowed for the requesting user's Primary Labs browser scope.

## Ship boundary

- **Minimum ship criteria:** Correct quota diagnosis, actionable recovery text, quota telemetry, and no optional repeat calls after terminal primary failure, covered by targeted tests.
- **Stop-ship conditions:** The message still exposes only an exception class, suggests an inapplicable remedy, or the failed turn makes narration/buttonify provider calls.
- **Non-blocking observations:** The broad test run's isolated Mongo mock leak reproduced as green when run alone on both candidate and main. Final DGX browser acceptance follows merge and restart.
- **Non-goals:** Automatic provider billing changes, silent model fallback, changes to model eligibility policy, and repair of the independently unavailable workflow capability index.
