### PR TITLE
Bound Ollama auxiliary generation

### DIFF
--- a/src/backend/languagemodels/llm_interface.py
+++ b/src/backend/languagemodels/llm_interface.py
@@ -1347,6 +1347,19 @@ class OllamaClient(LLMInterface):
         messages = to_ollama_messages(conv)
 
         ollama_options = {}
+        ollama_think = ollama_params.pop("think", None)
+        if not (
+            isinstance(ollama_think, bool)
+            or (
+                isinstance(ollama_think, str)
+                and ollama_think in {"low", "medium", "high"}
+            )
+        ):
+            if ollama_think is not None:
+                logger.warning(
+                    "Ignoring invalid llm_param: think for Ollama client"
+                )
+            ollama_think = None
         if ollama_params:
             # Only pass parameters that are valid for ollama.Client.chat options
             valid_ollama_options = [
@@ -1385,12 +1398,15 @@ class OllamaClient(LLMInterface):
 
                 _generate_started = time.perf_counter()
                 request_client = self.client
+                chat_kwargs = {
+                    "model": target_model,
+                    "messages": messages,
+                    "options": ollama_options if ollama_options else None,
+                }
+                if ollama_think is not None:
+                    chat_kwargs["think"] = ollama_think
                 response = request_client.chat(
-                    model=target_model,
-                    messages=messages,
-                    options=(
-                        ollama_options if ollama_options else None
-                    ),  # Pass options if any
+                    **chat_kwargs,
                 )
                 if _should_log_llm_io():
                     logger.debug("Ollama raw response: %s", response)

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -40,6 +40,7 @@ from ...workflows.durable.turn_execution_runtime_support import (
 )
 from ...languagemodels.llm_interface import (
     ModelExecutionEligibilityError,
+    OllamaClient,
     _extract_ollama_model_id,
     _extract_openai_model_id,
     _looks_like_browser_object_model_reference,
@@ -20995,8 +20996,13 @@ def _llm_generate_spoken_backfill(
         ],
         "model": model,
     }
-    if isinstance(model_parameters, Mapping) and model_parameters:
-        kwargs["llm_params"] = dict(model_parameters)
+    bounded_parameters = _bounded_ollama_auxiliary_model_parameters(
+        llm_client,
+        model_parameters,
+        num_predict_limit=_OLLAMA_SPOKEN_BACKFILL_NUM_PREDICT_LIMIT,
+    )
+    if bounded_parameters:
+        kwargs["llm_params"] = bounded_parameters
     return llm_client.generate(**kwargs)
 
 
@@ -21006,9 +21012,46 @@ def _llm_generate_buttonify(llm_client, prompt, model, model_parameters=None):
         "context": [],
         "model": model,
     }
-    if isinstance(model_parameters, Mapping) and model_parameters:
-        kwargs["llm_params"] = dict(model_parameters)
+    bounded_parameters = _bounded_ollama_auxiliary_model_parameters(
+        llm_client,
+        model_parameters,
+        num_predict_limit=_OLLAMA_BUTTONIFY_NUM_PREDICT_LIMIT,
+    )
+    if bounded_parameters:
+        kwargs["llm_params"] = bounded_parameters
     return llm_client.generate(**kwargs)
+
+
+_OLLAMA_SPOKEN_BACKFILL_NUM_PREDICT_LIMIT = 512
+_OLLAMA_BUTTONIFY_NUM_PREDICT_LIMIT = 128
+
+
+def _bounded_ollama_auxiliary_model_parameters(
+    llm_client,
+    model_parameters,
+    *,
+    num_predict_limit: int,
+) -> dict[str, Any]:
+    parameters = (
+        dict(model_parameters) if isinstance(model_parameters, Mapping) else {}
+    )
+    if not isinstance(llm_client, OllamaClient):
+        return parameters
+
+    # These are mechanical presentation transforms. Local reasoning models can
+    # otherwise spend the entire small output budget in hidden thinking and
+    # return no usable narration or JSON options.
+    parameters["think"] = False
+    requested_limit = parameters.get("num_predict")
+    if (
+        not isinstance(requested_limit, int)
+        or isinstance(requested_limit, bool)
+        or requested_limit <= 0
+    ):
+        parameters["num_predict"] = num_predict_limit
+    else:
+        parameters["num_predict"] = min(requested_limit, num_predict_limit)
+    return parameters
 
 
 def _contains_openai_quota_error(message: object) -> bool:

--- a/tests/backend/test_llm_response_cache_service.py
+++ b/tests/backend/test_llm_response_cache_service.py
@@ -170,3 +170,33 @@ def test_ollama_generate_uses_cache(monkeypatch):
     stats = cache.get_llm_response_cache_stats()
     assert stats["hits"] == 1
     assert stats["stores"] == 1
+
+
+def test_ollama_generate_maps_thinking_control_to_chat_transport(monkeypatch):
+    from src.backend.languagemodels.llm_interface import OllamaClient
+
+    client = OllamaClient.__new__(OllamaClient)
+    client.host = "http://127.0.0.1:11434"
+    client.default_model = "qwen3:8b"
+    captured: dict[str, Any] = {}
+
+    class _FakeOllama:
+        def chat(self, **kwargs: Any) -> dict[str, dict[str, str]]:
+            captured.update(kwargs)
+            return {"message": {"content": '["Continue", "Stop"]'}}
+
+    client.client = _FakeOllama()
+
+    with patch(
+        "src.backend.languagemodels.local_model_preflight.enforce_local_model_preflight",
+        lambda *args, **kwargs: None,
+    ):
+        response = client.generate(
+            "Return two options.",
+            model="qwen3:8b",
+            llm_params={"think": False, "num_predict": 128},
+        )
+
+    assert response == '["Continue", "Stop"]'
+    assert captured["think"] is False
+    assert captured["options"] == {"num_predict": 128}

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -12,6 +12,113 @@ from src.backend.services.adaptive_turn_service import AdaptiveTurnResult
 _ADAPTIVE_RESPONSE = "A useful answer chosen by the adaptive turn."
 
 
+def test_ollama_auxiliary_generations_have_provider_request_token_bounds() -> None:
+    from src.backend.languagemodels.llm_interface import OllamaClient
+    from src.backend.server.routes import von_routes
+
+    class _RecordingOllamaClient(OllamaClient):
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def generate(self, **kwargs: Any) -> str:
+            self.calls.append(dict(kwargs))
+            return "ok"
+
+    client = _RecordingOllamaClient()
+
+    von_routes._llm_generate_spoken_backfill(
+        client,
+        "system",
+        "user",
+        "qwen3.5:27b",
+    )
+    von_routes._llm_generate_buttonify(
+        client,
+        "prompt",
+        "qwen3.5:27b",
+    )
+
+    assert client.calls[0]["llm_params"] == {
+        "think": False,
+        "num_predict": 512,
+    }
+    assert client.calls[1]["llm_params"] == {
+        "think": False,
+        "num_predict": 128,
+    }
+
+
+def test_ollama_auxiliary_bounds_preserve_lower_caller_limit_without_mutation() -> None:
+    from src.backend.languagemodels.llm_interface import OllamaClient
+    from src.backend.server.routes import von_routes
+
+    class _RecordingOllamaClient(OllamaClient):
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def generate(self, **kwargs: Any) -> str:
+            self.calls.append(dict(kwargs))
+            return "ok"
+
+    client = _RecordingOllamaClient()
+    requested_parameters = {"temperature": 0.2, "num_predict": 64}
+
+    von_routes._llm_generate_spoken_backfill(
+        client,
+        "system",
+        "user",
+        "qwen3.5:27b",
+        requested_parameters,
+    )
+    von_routes._llm_generate_buttonify(
+        client,
+        "prompt",
+        "qwen3.5:27b",
+        {"temperature": 0.2, "num_predict": 2048},
+    )
+
+    assert client.calls[0]["llm_params"] == {
+        "temperature": 0.2,
+        "think": False,
+        "num_predict": 64,
+    }
+    assert client.calls[1]["llm_params"] == {
+        "temperature": 0.2,
+        "think": False,
+        "num_predict": 128,
+    }
+    assert requested_parameters == {"temperature": 0.2, "num_predict": 64}
+
+
+def test_cloud_auxiliary_generation_parameters_are_unchanged() -> None:
+    from src.backend.server.routes import von_routes
+
+    class _RecordingCloudClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def generate(self, **kwargs: Any) -> str:
+            self.calls.append(dict(kwargs))
+            return "ok"
+
+    client = _RecordingCloudClient()
+    von_routes._llm_generate_buttonify(
+        client,
+        "prompt",
+        "gpt-5.6-luna",
+        {"temperature": 0.4},
+    )
+
+    assert client.calls == [
+        {
+            "prompt": "prompt",
+            "context": [],
+            "model": "gpt-5.6-luna",
+            "llm_params": {"temperature": 0.4},
+        }
+    ]
+
+
 @pytest.fixture()
 def app(monkeypatch: pytest.MonkeyPatch) -> Flask:
     monkeypatch.setenv("VON_USE_MOCK_DB", "1")


### PR DESCRIPTION
## Outcome

Prevent local reasoning models from spending minutes or thousands of tokens on mechanical spoken-backfill and button-choice transforms after the main answer.

## Changes

- pass Ollama `think=false` for narration and buttonification only
- cap their provider output budgets at 512 and 128 tokens
- preserve a lower caller-supplied limit and leave cloud-provider parameters unchanged
- translate the Ollama thinking control at the client transport boundary

## Evidence

- focused route tests: 3 passed
- Ollama transport/cache plus spoken-backfill tests: 10 passed
- affected route/near-neighbour tests: 4 passed
- `py_compile`, `git diff --check`, and focused Ruff F/E9 checks passed
- live Mac Ollama qwen3:8b buttonify returned `["Continue", "Stop"]` in 0.13s with the candidate, despite a caller request for 4096 output tokens

A separate Personal-profile session/window-binding failure prevented that browser request from reaching the model; it is recorded as JVNAUTOSCI-2706. The DGX Primary Labs browser replay remains the final post-deployment acceptance check.

Jira: JVNAUTOSCI-2705