### PR TITLE
Repair Ollama tool parsing and screen backfill

### DIFF
--- a/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
@@ -285,43 +285,58 @@ USER REQUEST:
         Accepts a single JSON object, a JSON array of tool calls, or multiple
         JSON objects separated by whitespace.
         """
-        stripped = text.strip()
-        if not stripped:
-            return []
-
-        if stripped.startswith("{") or stripped.startswith("["):
-            try:
-                parsed = json.loads(stripped)
-            except json.JSONDecodeError:
-                parsed = None
-
-            if isinstance(parsed, dict):
-                if parsed.get("action") == "call_tool":
-                    return [parsed]
-            if isinstance(parsed, list):
-                calls: List[Dict[str, Any]] = []
-                for item in parsed:
-                    if isinstance(item, dict) and item.get("action") == "call_tool":
-                        calls.append(item)
-                    else:
-                        return []
-                return calls
-
-        import re
-
         calls: List[Dict[str, Any]] = []
-        for json_match in re.finditer(
-            r'\{[^{}]*"action"\s*:\s*"call_tool"[^{}]*\}',
-            text,
-        ):
-            try:
-                obj = json.loads(json_match.group())
-            except json.JSONDecodeError:
-                return []
-            if isinstance(obj, dict):
-                calls.append(obj)
+        for _, _, decoded_calls in self._json_tool_call_segments(text):
+            calls.extend(decoded_calls)
 
         return calls
+
+    def _json_tool_call_segments(
+        self, text: str
+    ) -> List[tuple[int, int, List[Dict[str, Any]]]]:
+        """Decode complete tool-call JSON values and retain their source spans.
+
+        ``json.loads`` cannot consume consecutive top-level JSON objects, while
+        the former regular-expression fallback could not cross nested payload
+        objects. Ollama's constrained prompt explicitly permits both forms, so
+        use ``raw_decode`` from each plausible JSON boundary instead.
+        """
+
+        decoder = json.JSONDecoder()
+        segments: List[tuple[int, int, List[Dict[str, Any]]]] = []
+        cursor = 0
+
+        while cursor < len(text):
+            object_start = text.find("{", cursor)
+            array_start = text.find("[", cursor)
+            candidates = [index for index in (object_start, array_start) if index >= 0]
+            if not candidates:
+                break
+            start = min(candidates)
+            try:
+                parsed, end = decoder.raw_decode(text, start)
+            except json.JSONDecodeError:
+                cursor = start + 1
+                continue
+
+            decoded_calls: List[Dict[str, Any]] = []
+            if isinstance(parsed, dict) and parsed.get("action") == "call_tool":
+                decoded_calls = [parsed]
+            elif (
+                isinstance(parsed, list)
+                and parsed
+                and all(
+                    isinstance(item, dict) and item.get("action") == "call_tool"
+                    for item in parsed
+                )
+            ):
+                decoded_calls = list(parsed)
+
+            if decoded_calls:
+                segments.append((start, end, decoded_calls))
+            cursor = max(end, start + 1)
+
+        return segments
 
     def _remove_json_from_text(
         self,
@@ -331,16 +346,18 @@ USER REQUEST:
         """Remove JSON tool calls from response text."""
         import re
 
-        cleaned = text
-        if cleaned.strip().startswith("["):
-            try:
-                if isinstance(json.loads(cleaned.strip()), list):
-                    return ""
-            except json.JSONDecodeError:
-                pass
+        del tool_calls  # Source spans are exact; reconstructed JSON is not.
+        segments = self._json_tool_call_segments(text)
+        if not segments:
+            return text.strip()
 
-        for tool_call in tool_calls:
-            json_str = json.dumps(tool_call)
-            cleaned = re.sub(re.escape(json_str), "", cleaned)
+        parts: List[str] = []
+        cursor = 0
+        for start, end, _ in segments:
+            parts.append(text[cursor:start])
+            cursor = end
+        parts.append(text[cursor:])
+        cleaned = "".join(parts)
+        cleaned = re.sub(r"```(?:json)?\s*```", "", cleaned, flags=re.IGNORECASE)
 
         return cleaned.strip()

--- a/src/backend/server/routes/generate_route_support.py
+++ b/src/backend/server/routes/generate_route_support.py
@@ -5,7 +5,10 @@ import time
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Callable, Mapping, Sequence, cast
 
-from src.backend.languagemodels.llm_interface import ModelExecutionEligibilityError
+from src.backend.languagemodels.llm_interface import (
+    ModelExecutionEligibilityError,
+    OllamaClient,
+)
 from src.backend.services.debug_payload_store import (
     compact_debug_payload_for_storage,
     default_tool_message_threshold_bytes,
@@ -16,6 +19,7 @@ from src.backend.services.python_decision_authority_service import (
 
 SCREEN_BACKFILL_STAGE_CONCEPT_ID = "#V#screen_backfill_stage"
 SCREEN_BACKFILL_STAGE_PROMPT_IDS = ("#V#von_screen_content_prompt_for_witbrock",)
+_OLLAMA_SCREEN_BACKFILL_NUM_PREDICT_LIMIT = 2048
 
 
 def _normalise_prompt_concept_ids(values: Any) -> list[str]:
@@ -235,10 +239,21 @@ def _invoke_presenter_screen_backfill_prompt(
         {"status": "llm_call_start", "stage": "screen_backfill", "model": model_name}
     )
     try:
+        generate_kwargs: dict[str, Any] = {
+            "prompt": represented_screen_prompt,
+            "context": screen_context_messages,
+            "model": model_name,
+        }
+        if isinstance(llm_client, OllamaClient):
+            # Screen synthesis is a presentation transform. Disable hidden
+            # reasoning and cap output so a local reasoning model cannot spend
+            # minutes thinking without producing a usable <screen> block.
+            generate_kwargs["llm_params"] = {
+                "think": False,
+                "num_predict": _OLLAMA_SCREEN_BACKFILL_NUM_PREDICT_LIMIT,
+            }
         synthesis_response = llm_client.generate(
-            prompt=represented_screen_prompt,
-            context=screen_context_messages,
-            model=model_name,
+            **generate_kwargs,
         )
     except Exception as exc:
         screen_duration_ms = (time.perf_counter() - llm_start) * 1000.0

--- a/tests/backend/test_generate_route_support_debug_payload_offload.py
+++ b/tests/backend/test_generate_route_support_debug_payload_offload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from src.backend.server.routes.generate_route_support import (
+    _invoke_presenter_screen_backfill_prompt,
     _persist_generate_turn_messages,
 )
 from src.backend.services.blob_store import BlobRef
@@ -53,6 +54,64 @@ class _FakeBlobStore:
         return [
             write["key"] for write in self.writes if write["key"].startswith(prefix)
         ]
+
+
+def test_screen_backfill_bounds_local_ollama_generation(monkeypatch) -> None:
+    import src.backend.server.routes.generate_route_support as support
+
+    class _FakeOllamaClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def generate(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return "<screen>usable answer</screen>"
+
+    monkeypatch.setattr(support, "OllamaClient", _FakeOllamaClient)
+    client = _FakeOllamaClient()
+
+    response, model = _invoke_presenter_screen_backfill_prompt(
+        llm_client=client,
+        represented_screen_prompt="Return one screen block.",
+        context_messages=[{"role": "user", "content": "evidence"}],
+        context_telemetry={"prompt_concept_ids": ["#V#screen_prompt"]},
+        model_name="qwen3.5:27b",
+        record_stage_llm_call=lambda **_kwargs: None,
+        emit_stage_progress=lambda _event: None,
+        infer_provider=lambda _model: "ollama",
+    )
+
+    assert response == "<screen>usable answer</screen>"
+    assert model == "qwen3.5:27b"
+    assert client.calls[0]["llm_params"] == {
+        "think": False,
+        "num_predict": 2048,
+    }
+
+
+def test_screen_backfill_does_not_send_ollama_options_to_cloud_client() -> None:
+    class _FakeCloudClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def generate(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return "<screen>usable answer</screen>"
+
+    client = _FakeCloudClient()
+
+    _invoke_presenter_screen_backfill_prompt(
+        llm_client=client,
+        represented_screen_prompt="Return one screen block.",
+        context_messages=[],
+        context_telemetry={},
+        model_name="gpt-5.2",
+        record_stage_llm_call=lambda **_kwargs: None,
+        emit_stage_progress=lambda _event: None,
+        infer_provider=lambda _model: "openai",
+    )
+
+    assert "llm_params" not in client.calls[0]
 
 
 def test_persist_generate_turn_messages_offloads_tool_message_content(

--- a/tests/backend/test_structured_tool_calling_client.py
+++ b/tests/backend/test_structured_tool_calling_client.py
@@ -11,6 +11,9 @@ from src.backend.languagemodels.structured_tool_calling import (
     ToolDefinition,
     get_llm_client,
 )
+from src.backend.languagemodels.structured_tool_calling.providers.ollama_client import (
+    OllamaClient,
+)
 
 
 def _install_openai_temperature_registry(monkeypatch) -> dict[str, object]:
@@ -163,6 +166,81 @@ class TestGetLLMClient:
         client = get_llm_client(config)
 
         assert isinstance(client, OllamaClient)
+
+
+class TestOllamaToolCallParsing:
+    """Ollama text transport accepts every format its prompt advertises."""
+
+    @staticmethod
+    def _client() -> OllamaClient:
+        client = OllamaClient.__new__(OllamaClient)
+        client.config = LLMClientConfig(model="qwen3.5:27b")
+        return client
+
+    @staticmethod
+    def _tools() -> list[ToolDefinition]:
+        return [
+            ToolDefinition(
+                name="turn_capabilities",
+                description="List available capabilities.",
+                input_schema={"type": "object", "properties": {}},
+            ),
+            ToolDefinition(
+                name="turn_list_evidence",
+                description="List gathered evidence.",
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    def test_parses_newline_separated_calls_with_nested_payloads(self):
+        response = self._client()._parse_response(
+            """{
+  "action": "call_tool",
+  "tool": "turn_capabilities",
+  "payload": {"names": ["create_concepts"], "filter": {"exact": true}}
+}
+{
+  "action": "call_tool",
+  "tool": "turn_list_evidence",
+  "payload": {}
+}""",
+            self._tools(),
+        )
+
+        assert [call.tool_name for call in response.tool_calls] == [
+            "turn_capabilities",
+            "turn_list_evidence",
+        ]
+        assert response.tool_calls[0].payload == {
+            "names": ["create_concepts"],
+            "filter": {"exact": True},
+        }
+        assert response.text_response == ""
+
+    def test_removes_fenced_tool_calls_but_preserves_natural_text(self):
+        response = self._client()._parse_response(
+            """Checking the available evidence.
+```json
+{"action":"call_tool","tool":"turn_list_evidence","payload":{}}
+```""",
+            self._tools(),
+        )
+
+        assert [call.tool_name for call in response.tool_calls] == [
+            "turn_list_evidence"
+        ]
+        assert response.text_response == "Checking the available evidence."
+
+    def test_preserves_unrelated_json_as_answer_text(self):
+        response = self._client()._parse_response(
+            '{"status":"no tool requested","payload":{"reason":"done"}}',
+            self._tools(),
+        )
+
+        assert response.tool_calls == []
+        assert response.text_response == (
+            '{"status":"no tool requested","payload":{"reason":"done"}}'
+        )
 
 
 class TestTemperatureGuards:


### PR DESCRIPTION
## Outcome

Fixes the two code defects exposed by the live DGX Primary Labs representation replay:

- parse the newline-separated nested JSON tool calls that the Ollama constrained prompt already permits, and remove their exact source spans from visible response text;
- disable hidden thinking and cap output for local Ollama presenter screen backfill, without changing cloud-client parameters.

The DGX deployment profile will separately enable `VON_INTERNAL_MCP_ENABLE=1` after merge; that environment-specific change is not committed.

## Evidence

- `3 passed` — focused Ollama parser cases
- `5 passed` — route-support tests, including Ollama/cloud parameter separation
- `2 passed` — neighbouring represented screen-backfill tests
- changed Python files compile
- Ruff E9/F checks and `git diff --check` pass

## Jira

[JVNAUTOSCI-2705](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2705)

[JVNAUTOSCI-2705]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ