### PR TITLE
Expose Ollama tool input schemas

### DIFF
--- a/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
@@ -145,8 +145,15 @@ class OllamaClient(LLMClient):
         instructions and examples to elicit proper JSON formatting.
         """
 
-        tool_descriptions = "\n".join(
-            [f"- {tool.name}: {tool.description}" for tool in available_tools]
+        tool_descriptions = "\n\n".join(
+            [
+                (
+                    f"- {tool.name}: {tool.description}\n"
+                    "  Input JSON schema: "
+                    f"{json.dumps(tool.input_schema, sort_keys=True)}"
+                )
+                for tool in available_tools
+            ]
         )
 
         constraint_prompt = f"""You are a helpful assistant that can invoke tools.
@@ -160,15 +167,17 @@ INSTRUCTIONS:
 {json.dumps({
     "action": "call_tool",
     "tool": "<tool_name>",
-    "payload": "<tool_arguments>"
+    "payload": {"<argument_name>": "<value>"}
 }, indent=2)}
 
    If you need to call multiple tools, respond with a JSON array of tool calls
    or multiple JSON objects separated by newlines.
 
 3. You can only call tools listed above.
-4. Ensure all JSON is valid and complete.
-5. Do not include any text after the JSON.
+4. The payload must be a JSON object that matches that tool's Input JSON schema.
+   Copy argument names exactly and do not add undeclared fields.
+5. Ensure all JSON is valid and complete.
+6. Do not include any text after the JSON.
 
 USER REQUEST:
 {prompt}

--- a/tests/backend/test_structured_tool_calling_client.py
+++ b/tests/backend/test_structured_tool_calling_client.py
@@ -242,6 +242,36 @@ class TestOllamaToolCallParsing:
             '{"status":"no tool requested","payload":{"reason":"done"}}'
         )
 
+    def test_constrained_prompt_exposes_exact_tool_input_schema(self):
+        client = self._client()
+        prompt = client._build_constrained_prompt(
+            "Find the exact capabilities needed.",
+            [
+                ToolDefinition(
+                    name="turn_capabilities",
+                    description="Inspect delegated capabilities.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {
+                            "names": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            }
+                        },
+                        "additionalProperties": False,
+                    },
+                )
+            ],
+            system_message=None,
+        )
+
+        assert "Input JSON schema:" in prompt
+        assert '"names": {"items": {"type": "string"}' in prompt
+        assert '"additionalProperties": false' in prompt
+        assert '"payload": {' in prompt
+        assert '"payload": "<tool_arguments>"' not in prompt
+        assert "do not add undeclared fields" in prompt
+
 
 class TestTemperatureGuards:
     """Tests for model-specific temperature safeguards."""


### PR DESCRIPTION
## Outcome

Fixes the next failure exposed by the live DGX Primary Labs replay. The prompt-based Ollama tool transport now shows the exact JSON input schema beside each available tool, uses an object-valued payload example, and tells the model to copy declared argument names without adding fields.

Without this, Qwen guessed `filter` for `turn_capabilities`; the actual field is `names`, so the server returned the entire capability catalogue and the next model call produced no answer.

## Evidence

- `4 passed` — Ollama parsing/prompt contract tests
- changed Python compiles
- Ruff E9/F checks and `git diff --check` pass

## Jira

[JVNAUTOSCI-2705](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2705)

[JVNAUTOSCI-2705]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ