### PR TITLE
Expose single-concept effect bounds

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -10520,6 +10520,7 @@ def _concepts_create_input_schema() -> Schema:
                 None,
             ],
         },
+        array_length_constraints={"concepts": (1, 1)},
         allow_unknown=True,
         description=(
             "Governed create_concepts input: parent_id is one exact semantic type "

--- a/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
+++ b/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
@@ -219,6 +219,11 @@ def _build_dynamic_input_schema(
             for field_name in target_schema.comma_separated_list_fields
             if field_name in remaining_fields
         ),
+        array_length_constraints={
+            field_name: limits
+            for field_name, limits in target_schema.array_length_constraints.items()
+            if field_name in remaining_fields
+        },
     )
 
 

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -321,6 +321,11 @@ class MethodCatalogue:
                 for field_name in schema.comma_separated_list_fields
                 if isinstance(field_name, str) and field_name
             ],
+            "array_length_constraints": {
+                field_name: list(limits)
+                for field_name, limits in schema.array_length_constraints.items()
+                if isinstance(field_name, str) and field_name
+            },
         }
 
     def snapshot(self) -> Dict[str, Dict[str, Any]]:

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -11144,6 +11144,7 @@ class InternalMCPChatOrchestrator:
         enum_values = mcp_schema.get("enum_values")
         scalar_source_fields = mcp_schema.get("scalar_source_fields")
         comma_separated_list_fields = mcp_schema.get("comma_separated_list_fields")
+        array_length_constraints = mcp_schema.get("array_length_constraints")
         description = mcp_schema.get("description")
 
         properties: Dict[str, Any] = {}
@@ -11195,6 +11196,36 @@ class InternalMCPChatOrchestrator:
                         values, (str, bytes, bytearray)
                     ):
                         properties[field_name]["enum"] = list(values)
+
+        if isinstance(array_length_constraints, Mapping):
+            for field_name, limits in array_length_constraints.items():
+                field_schema = properties.get(field_name)
+                if not isinstance(field_schema, dict):
+                    continue
+                field_types = field_schema.get("type")
+                is_array = field_types == "array" or (
+                    isinstance(field_types, list) and "array" in field_types
+                )
+                if (
+                    not is_array
+                    or not isinstance(limits, Sequence)
+                    or isinstance(limits, (str, bytes, bytearray))
+                    or len(limits) != 2
+                ):
+                    continue
+                minimum, maximum = limits
+                if (
+                    isinstance(minimum, int)
+                    and not isinstance(minimum, bool)
+                    and minimum >= 0
+                ):
+                    field_schema["minItems"] = minimum
+                if (
+                    isinstance(maximum, int)
+                    and not isinstance(maximum, bool)
+                    and maximum >= 0
+                ):
+                    field_schema["maxItems"] = maximum
 
         json_schema = {
             "type": "object",
@@ -19199,6 +19230,9 @@ class InternalMCPChatOrchestrator:
             required_fields: dict[str, Any] = {}
             optional_fields: dict[str, Any] = {}
             enum_values: dict[str, Sequence[Any]] = {}
+            array_length_constraints: dict[
+                str, tuple[int | None, int | None]
+            ] = {}
             for field_name, field_schema in properties.items():
                 if not isinstance(field_name, str) or not field_name.strip():
                     continue
@@ -19213,6 +19247,24 @@ class InternalMCPChatOrchestrator:
                         raw_enum, (str, bytes, bytearray)
                     ):
                         enum_values[field_name] = tuple(raw_enum)
+                    raw_minimum = field_schema.get("minItems")
+                    raw_maximum = field_schema.get("maxItems")
+                    minimum = (
+                        raw_minimum
+                        if isinstance(raw_minimum, int)
+                        and not isinstance(raw_minimum, bool)
+                        and raw_minimum >= 0
+                        else None
+                    )
+                    maximum = (
+                        raw_maximum
+                        if isinstance(raw_maximum, int)
+                        and not isinstance(raw_maximum, bool)
+                        and raw_maximum >= 0
+                        else None
+                    )
+                    if minimum is not None or maximum is not None:
+                        array_length_constraints[field_name] = (minimum, maximum)
                 if field_name in required_names:
                     required_fields[field_name] = expected
                 else:
@@ -19261,6 +19313,7 @@ class InternalMCPChatOrchestrator:
                     else ()
                 ),
                 enum_values=enum_values,
+                array_length_constraints=array_length_constraints,
                 scalar_source_fields=(
                     {
                         str(field_name).strip(): tuple(
@@ -19377,6 +19430,24 @@ class InternalMCPChatOrchestrator:
                     and not isinstance(values, (str, bytes, bytearray))
                 }
                 if isinstance(raw_schema.get("enum_values"), Mapping)
+                else {}
+            ),
+            array_length_constraints=(
+                {
+                    str(field_name).strip(): (
+                        limits[0] if isinstance(limits[0], int) else None,
+                        limits[1] if isinstance(limits[1], int) else None,
+                    )
+                    for field_name, limits in raw_schema.get(
+                        "array_length_constraints", {}
+                    ).items()
+                    if isinstance(field_name, str)
+                    and field_name.strip()
+                    and isinstance(limits, Sequence)
+                    and not isinstance(limits, (str, bytes, bytearray))
+                    and len(limits) == 2
+                }
+                if isinstance(raw_schema.get("array_length_constraints"), Mapping)
                 else {}
             ),
             scalar_source_fields=(

--- a/src/backend/integrations/internal_mcp/schemas.py
+++ b/src/backend/integrations/internal_mcp/schemas.py
@@ -136,6 +136,8 @@ class Schema:
         description: human readable context for diagnostics / errors.
         comma_separated_list_fields: list-valued fields whose string items may
             be safely split on commas at the tool boundary.
+        array_length_constraints: per-field ``(minimum, maximum)`` item counts
+            exposed in JSON Schema and enforced by payload validation.
     """
 
     required: Mapping[str, JsonCompatibleType] = field(default_factory=dict)
@@ -147,6 +149,9 @@ class Schema:
     enum_values: Mapping[str, Sequence[Any]] = field(default_factory=dict)
     scalar_source_fields: Mapping[str, Sequence[str]] = field(default_factory=dict)
     comma_separated_list_fields: Sequence[str] = field(default_factory=tuple)
+    array_length_constraints: Mapping[
+        str, tuple[int | None, int | None]
+    ] = field(default_factory=dict)
 
     def expect(self, key: str) -> JsonCompatibleType | None:
         if key in self.required:
@@ -236,6 +241,22 @@ def schema_to_json_schema(schema: "Schema") -> Dict[str, Any]:
         enum_values = schema.enum_values.get(field_name)
         if enum_values:
             properties[field_name]["enum"] = list(enum_values)
+
+    for field_name, limits in schema.array_length_constraints.items():
+        field_schema = properties.get(field_name)
+        if not isinstance(field_schema, dict):
+            continue
+        field_types = field_schema.get("type")
+        is_array = field_types == "array" or (
+            isinstance(field_types, list) and "array" in field_types
+        )
+        if not is_array or not isinstance(limits, tuple) or len(limits) != 2:
+            continue
+        minimum, maximum = limits
+        if isinstance(minimum, int) and not isinstance(minimum, bool) and minimum >= 0:
+            field_schema["minItems"] = minimum
+        if isinstance(maximum, int) and not isinstance(maximum, bool) and maximum >= 0:
+            field_schema["maxItems"] = maximum
 
     payload: Dict[str, Any] = {
         "type": "object",
@@ -371,6 +392,30 @@ def validate_payload(
             allowed_values = ", ".join(repr(item) for item in enum_values)
             errors.append(
                 f"Optional field '{key}' expected one of {allowed_values} but received {value!r}."
+            )
+
+    for key, limits in schema.array_length_constraints.items():
+        value = payload.get(key)
+        if not isinstance(value, list) or not isinstance(limits, tuple) or len(limits) != 2:
+            continue
+        minimum, maximum = limits
+        if (
+            isinstance(minimum, int)
+            and not isinstance(minimum, bool)
+            and minimum >= 0
+            and len(value) < minimum
+        ):
+            errors.append(
+                f"Field '{key}' expected at least {minimum} item(s) but received {len(value)}."
+            )
+        if (
+            isinstance(maximum, int)
+            and not isinstance(maximum, bool)
+            and maximum >= 0
+            and len(value) > maximum
+        ):
+            errors.append(
+                f"Field '{key}' expected at most {maximum} item(s) but received {len(value)}."
             )
 
     return not errors, errors

--- a/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
+++ b/src/backend/languagemodels/structured_tool_calling/providers/ollama_client.py
@@ -176,6 +176,8 @@ INSTRUCTIONS:
 3. You can only call tools listed above.
 4. The payload must be a JSON object that matches that tool's Input JSON schema.
    Copy argument names exactly and do not add undeclared fields.
+   Obey minItems and maxItems. If maxItems is 1, emit a separate tool-call
+   object for each intended item instead of batching items in that argument.
 5. Ensure all JSON is valid and complete.
 6. Do not include any text after the JSON.
 

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -463,6 +463,9 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "global_general",
         None,
     ]
+    assert create_definition.input_schema.array_length_constraints == {
+        "concepts": (1, 1)
+    }
     marker_definition = catalogue.get("record_source_processing_marker")
     assert marker_definition.ordinary_turn_trusted_argument_bindings == {
         "namespace": "turn_namespace",

--- a/tests/backend/test_internal_mcp_dynamic_tool_registration.py
+++ b/tests/backend/test_internal_mcp_dynamic_tool_registration.py
@@ -221,6 +221,7 @@ def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
                 "mode": ("value",),
             },
             comma_separated_list_fields=("filters",),
+            array_length_constraints={"filters": (1, 3)},
         ),
         category="read",
     )
@@ -238,6 +239,7 @@ def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
     assert schema.enum_values == {"scope": ("brief", "full")}
     assert schema.scalar_source_fields == {"target": ("concept_id",)}
     assert schema.comma_separated_list_fields == ("filters",)
+    assert schema.array_length_constraints == {"filters": (1, 3)}
 
     catalogue = MethodCatalogue()
     catalogue.register(base_definition)

--- a/tests/backend/test_mcp_tool_contract_registry.py
+++ b/tests/backend/test_mcp_tool_contract_registry.py
@@ -209,13 +209,21 @@ def test_schema_to_json_schema_includes_items_for_arrays() -> None:
         Schema(
             required={"names": list},
             optional={"aliases": (list, type(None))},
+            array_length_constraints={
+                "names": (1, 1),
+                "aliases": (0, 3),
+            },
         )
     )
 
     assert payload["properties"]["names"]["type"] == "array"
     assert payload["properties"]["names"]["items"] == {}
+    assert payload["properties"]["names"]["minItems"] == 1
+    assert payload["properties"]["names"]["maxItems"] == 1
     assert payload["properties"]["aliases"]["type"] == ["array", "null"]
     assert payload["properties"]["aliases"]["items"] == {}
+    assert payload["properties"]["aliases"]["minItems"] == 0
+    assert payload["properties"]["aliases"]["maxItems"] == 3
 
 
 def test_vontology_stdio_payload_array_schemas_define_items() -> None:

--- a/tests/backend/test_schema_coercion.py
+++ b/tests/backend/test_schema_coercion.py
@@ -263,6 +263,23 @@ def test_schema_enum_values_are_validated() -> None:
     ]
 
 
+def test_schema_array_length_constraints_are_validated() -> None:
+    schema = Schema(
+        required={"concepts": list},
+        array_length_constraints={"concepts": (1, 1)},
+    )
+
+    ok, errors = validate_payload(
+        schema,
+        {"concepts": [{"name": "First"}, {"name": "Second"}]},
+    )
+
+    assert ok is False
+    assert errors == [
+        "Field 'concepts' expected at most 1 item(s) but received 2."
+    ]
+
+
 def test_gateway_invoke_extracts_declared_scalar_from_object_payload() -> None:
     observed: dict[str, object] = {}
 
@@ -328,12 +345,13 @@ def test_schema_aliases_are_normalised_without_mutating_unrelated_fields() -> No
 def test_schema_metadata_round_trips_to_json_schema_extensions() -> None:
     schema = Schema(
         required={"profile": str},
-        optional={"query": str},
+        optional={"query": str, "fields": list},
         aliases={"identity": "profile"},
         batch_propagated_fields=("profile",),
         enum_values={"profile": ("zhan-gmail", "lab-gmail")},
         scalar_source_fields={"query": ("search_query",)},
         comma_separated_list_fields=("query",),
+        array_length_constraints={"fields": (1, 2)},
     )
 
     json_schema = schema_to_json_schema(schema)
@@ -342,6 +360,8 @@ def test_schema_metadata_round_trips_to_json_schema_extensions() -> None:
     assert json_schema["x-von-batch-propagated-fields"] == ["profile"]
     assert json_schema["x-von-scalar-source-fields"] == {"query": ["search_query"]}
     assert json_schema["x-von-comma-separated-list-fields"] == ["query"]
+    assert json_schema["properties"]["fields"]["minItems"] == 1
+    assert json_schema["properties"]["fields"]["maxItems"] == 2
     assert json_schema["properties"]["profile"]["enum"] == [
         "zhan-gmail",
         "lab-gmail",
@@ -361,6 +381,7 @@ def test_orchestrator_schema_conversion_preserves_tool_argument_metadata() -> No
             "enum_values": {"profile": ["zhan-gmail", "lab-gmail"]},
             "scalar_source_fields": {"query": ["search_query"]},
             "comma_separated_list_fields": ["fields"],
+            "array_length_constraints": {"fields": [1, 4]},
         }
     )
 
@@ -369,6 +390,8 @@ def test_orchestrator_schema_conversion_preserves_tool_argument_metadata() -> No
     assert json_schema["x-von-batch-propagated-fields"] == ["profile"]
     assert json_schema["x-von-scalar-source-fields"] == {"query": ["search_query"]}
     assert json_schema["x-von-comma-separated-list-fields"] == ["fields"]
+    assert json_schema["properties"]["fields"]["minItems"] == 1
+    assert json_schema["properties"]["fields"]["maxItems"] == 4
     assert json_schema["properties"]["profile"]["enum"] == [
         "zhan-gmail",
         "lab-gmail",

--- a/tests/backend/test_structured_tool_calling_client.py
+++ b/tests/backend/test_structured_tool_calling_client.py
@@ -256,6 +256,8 @@ class TestOllamaToolCallParsing:
                             "names": {
                                 "type": "array",
                                 "items": {"type": "string"},
+                                "minItems": 1,
+                                "maxItems": 1,
                             }
                         },
                         "additionalProperties": False,
@@ -267,10 +269,12 @@ class TestOllamaToolCallParsing:
 
         assert "Input JSON schema:" in prompt
         assert '"names": {"items": {"type": "string"}' in prompt
+        assert '"maxItems": 1' in prompt
         assert '"additionalProperties": false' in prompt
         assert '"payload": {' in prompt
         assert '"payload": "<tool_arguments>"' not in prompt
         assert "do not add undeclared fields" in prompt
+        assert "emit a separate tool-call" in prompt
 
 
 class TestTemperatureGuards:


### PR DESCRIPTION
Jira: JVNAUTOSCI-2705

Advertises and validates the one-core-concept create_concepts boundary as minItems 1 and maxItems 1 across the internal MCP schema surfaces. The Ollama constrained prompt now explicitly tells local models to emit separate tool calls when maxItems is 1.

Validation:
- 8 focused backend schema, catalogue, orchestrator, dynamic-proxy and Ollama-prompt tests passed
- Default create_concepts JSON Schema read-back showed minItems 1 and maxItems 1
- Python compileall and git diff check passed

The existing unrelated Jira family registry expectation failure was observed in a broader interrupted run; it predates and is outside this patch.