### PR TITLE
Bind sends after new conversation creation

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -10725,8 +10725,8 @@ def _resolve_generate_namespace_context(
     """Resolve generate-time namespace with provenance and mismatch diagnostics.
 
     Ordering strategy:
-    1. Preserve effective window/flask context namespace.
-    2. Prefer an org-scoped namespace when any org context is present.
+    1. Preserve an authoritative window context, including explicit Personal.
+    2. Otherwise prefer an org-scoped namespace when any org context is present.
     3. Fall back to user-only namespace derivation.
     """
 
@@ -10783,7 +10783,17 @@ def _resolve_generate_namespace_context(
     )
 
     org_candidates = [c for c in candidates if c.get("org_scoped")]
-    selected = (
+    authoritative_window_candidate = None
+    if effective_source == "window_session":
+        authoritative_window_candidate = next(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.get("source") == "effective_context.namespace"
+            ),
+            None,
+        )
+    selected = authoritative_window_candidate or (
         org_candidates[0] if org_candidates else (candidates[0] if candidates else None)
     )
 
@@ -10817,7 +10827,9 @@ def _resolve_generate_namespace_context(
         ),
         "candidates": candidates,
         "mismatch_detected": mismatch_detected,
-        "org_scope_preferred": bool(org_candidates),
+        "org_scope_preferred": bool(
+            isinstance(selected, dict) and selected.get("org_scoped")
+        ),
     }
     if mismatch_detected:
         report["mismatch_reason"] = "multiple_namespace_candidates"
@@ -20311,18 +20323,26 @@ def _resolve_history_request_scope_hints(
     effective_namespace = requested_namespace or _clean_optional_text(
         effective_context.get("namespace")
     )
-    effective_org = (
-        requested_org
-        or _normalise_concept_id(effective_context.get("organisation_id"))
-        or _normalise_concept_id(session.get("organisation_concept_id"))
+    authoritative_window_scope = bool(
+        effective_context.get("source") == "window_session"
+        and _clean_optional_text(effective_context.get("namespace"))
     )
+    effective_org = requested_org or _normalise_concept_id(
+        effective_context.get("organisation_id")
+    )
+    if not effective_org and not authoritative_window_scope:
+        effective_org = _normalise_concept_id(
+            session.get("organisation_concept_id")
+        )
 
     if not effective_org:
-        for namespace_candidate in (
+        namespace_candidates = [
             requested_namespace,
             effective_context.get("namespace"),
-            session.get("namespace"),
-        ):
+        ]
+        if not authoritative_window_scope:
+            namespace_candidates.append(session.get("namespace"))
+        for namespace_candidate in namespace_candidates:
             cleaned_candidate = _clean_optional_text(namespace_candidate)
             if not cleaned_candidate or "@" not in cleaned_candidate:
                 continue

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 _DETERMINISTIC_RAG_DOC_NAMESPACE = uuid.UUID("8c5a7fa9-9a7c-4f0f-8c1f-f4ad7f9f6fd7")
 _SESSION_NAME_MAX_LEN = 80
+_SESSION_CONTEXT_UNSET = object()
 CONVERSATION_SITUATION_TEXT_MAX_CHARS = 12_000
 _CONVERSATION_SITUATION_SOURCE_MAX_CHARS = 120
 _CONVERSATION_SITUATION_UPDATER_MAX_CHARS = 160
@@ -6071,9 +6072,9 @@ def create_chat_session(
     user_id: str,
     session_id: str,
     session_name: Optional[str] = None,
-    namespace: Optional[str] = None,
-    organisation_concept_id: Optional[str] = None,
-    role_in_org: Optional[str] = None,
+    namespace: Any = _SESSION_CONTEXT_UNSET,
+    organisation_concept_id: Any = _SESSION_CONTEXT_UNSET,
+    role_in_org: Any = _SESSION_CONTEXT_UNSET,
     mode: Optional[str] = None,
     origin_kind: Optional[str] = None,
     created_by_actor_concept_id: Optional[str] = None,
@@ -6102,7 +6103,9 @@ def create_chat_session(
             It is inserted atomically with the session so its active key can be
             protected by the partial unique index.
 
-    If namespace/org/role not provided, falls back to Flask session context.
+    Omitted namespace/org/role values fall back to Flask session context.
+    Explicit ``None`` values remain authoritative so a Personal window cannot
+    inherit an organisation or role from another tab's Flask session.
     """
     if not isinstance(user_id, str) or not user_id:
         raise ChatHistoryServiceError("user_id is required.")
@@ -6117,11 +6120,21 @@ def create_chat_session(
 
     # JVNAUTOSCI-1011: Prefer explicit context params, fall back to Flask session
     session_context = get_session_context()
-    effective_namespace = namespace or session_context.get("namespace")
-    effective_org = organisation_concept_id or session_context.get(
-        "organisation_concept_id"
+    effective_namespace = (
+        session_context.get("namespace")
+        if namespace is _SESSION_CONTEXT_UNSET
+        else namespace
     )
-    effective_role = role_in_org or session_context.get("role_in_org")
+    effective_org = (
+        session_context.get("organisation_concept_id")
+        if organisation_concept_id is _SESSION_CONTEXT_UNSET
+        else organisation_concept_id
+    )
+    effective_role = (
+        session_context.get("role_in_org")
+        if role_in_org is _SESSION_CONTEXT_UNSET
+        else role_in_org
+    )
 
     # Derive namespace from context if not explicitly provided
     ns = effective_namespace

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -6553,6 +6553,7 @@ function updateSendButtonForCurrentChatState() {
     if (!sendButton) {
         return;
     }
+    const chatCreationInFlight = Boolean(newChatCreationInFlight);
     const uploadInFlight = !!getInFlightUploadStateForSession(activeChatSessionId);
     const queueSubmissionInFlight = !!getQueuedChatPromptSubmissionInFlight(
         activeChatSessionId
@@ -6577,13 +6578,22 @@ function updateSendButtonForCurrentChatState() {
         && conceptQaSession.lifecycle === 'active'
         && !conceptQaActionAllowed(conceptQaSession, 'submit_turn')
     );
-    sendButton.disabled = uploadInFlight
+    sendButton.disabled = chatCreationInFlight
+        || uploadInFlight
         || queueSubmissionInFlight
         || readOnly
         || conceptQaBusy
         || conceptQaTerminal
         || conceptQaAwaitingInitialQuestion;
-    sendButton.setAttribute('aria-busy', queueSubmissionInFlight || conceptQaBusy ? 'true' : 'false');
+    sendButton.setAttribute(
+        'aria-busy',
+        chatCreationInFlight || queueSubmissionInFlight || conceptQaBusy ? 'true' : 'false'
+    );
+    if (chatCreationInFlight) {
+        sendButton.textContent = 'Creating conversation…';
+        sendButton.title = 'Waiting for the new conversation to be ready.';
+        return;
+    }
     if (readOnly) {
         sendButton.textContent = 'Read-only import';
         sendButton.title = 'Continue this imported snapshot before sending a new message.';
@@ -27960,10 +27970,12 @@ function createNewChatSession() {
         } finally {
             if (newChatCreationInFlight === creation) {
                 newChatCreationInFlight = null;
+                updateSendButtonForCurrentChatState();
             }
         }
     })();
     newChatCreationInFlight = creation;
+    updateSendButtonForCurrentChatState();
     return creation;
 }
 
@@ -36921,6 +36933,17 @@ async function handleSendPrompt(options = {}) {
     const selectedQueueEntry = (!fromQueue && !hasPromptOverride)
         ? getSelectedChatPromptQueueEntryForSend()
         : null;
+    const directComposerSubmission = (
+        !fromQueue
+        && !hasPromptOverride
+        && !selectedQueueEntry
+    );
+    if (directComposerSubmission && newChatCreationInFlight) {
+        const createdSession = await newChatCreationInFlight;
+        if (!createdSession || pendingChatOrganisationSwitchId !== null) {
+            return;
+        }
+    }
     let targetSessionId = normaliseHistorySessionId(
         options?.sessionId
         ?? selectedQueueEntry?.sessionId
@@ -36959,12 +36982,6 @@ async function handleSendPrompt(options = {}) {
     const promptText = promptForSend.trim();
     const assistantOpening = options?.turnKind === 'assistant_opening';
     const allowEmptyPrompt = assistantOpening && options?.allowEmptyPrompt === true;
-    const directComposerSubmission = (
-        !fromQueue
-        && !hasPromptOverride
-        && !selectedQueueEntry
-    );
-
     if (
         directComposerSubmission
         && getInFlightUploadStateForSession(targetSessionId)

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -10404,6 +10404,127 @@ describe('chat session composer state', () => {
         expect(activeNewTab?.textContent).not.toContain('session-');
     });
 
+    test('send waits for an in-flight new chat and targets the created session once', async () => {
+        const promptInput = document.getElementById('promptInput');
+        initializePromptCartoucheOverlay(promptInput);
+        promptInput.value = 'Send only in the new conversation';
+        promptInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        let created = false;
+        let resolveCreate;
+        const createResponse = new Promise((resolve) => {
+            resolveCreate = resolve;
+        });
+        const generateBodies = [];
+
+        global.fetch = jest.fn((url, options = {}) => {
+            if (typeof url === 'string' && url.startsWith('/api/settings/')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ show_tool_use_during_thinking: true })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/sessions')) {
+                const sessions = [{
+                    session_id: 'session-current',
+                    session_name: 'Current chat',
+                    message_count: 2,
+                    last_message_at: '2026-04-13T05:00:00Z'
+                }];
+                if (created) {
+                    sessions.unshift({
+                        session_id: 'session-new',
+                        session_name: null,
+                        message_count: 0,
+                        last_message_at: '2026-04-13T18:30:00Z'
+                    });
+                }
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        authenticated: true,
+                        active_session_id: created ? 'session-new' : 'session-current',
+                        sessions
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/session/create_chat_session')) {
+                return createResponse;
+            }
+            if (typeof url === 'string' && url.startsWith('/von/api/session/chat_session_links')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ session_links: {} })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/progress/')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        status: 'completed',
+                        phase: 'tool_execute',
+                        phase_label: 'Executing tools',
+                        result_summary: 'Completed'
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/history/length')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        history_length: 1,
+                        session_count: 2,
+                        authenticated: true
+                    })
+                });
+            }
+            if (typeof url === 'string' && url.startsWith('/von/generate')) {
+                generateBodies.push(JSON.parse(options.body || '{}'));
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({
+                        response: 'New conversation response',
+                        session_id: 'session-new',
+                        conversation_session_id: 'session-new',
+                        conversation_session_name: null,
+                        llm_debug: { model: 'gemma4:latest' }
+                    })
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+
+        await expect(__testOnly_refreshChatSessionTabs()).resolves.toBeUndefined();
+        document.querySelector('.chat-session-tab-new').click();
+
+        const sendButton = document.getElementById('sendButton');
+        expect(sendButton.disabled).toBe(true);
+        expect(sendButton.textContent).toBe('Creating conversation…');
+        expect(sendButton.getAttribute('aria-busy')).toBe('true');
+
+        const sendPromise = sendMessage();
+        await Promise.resolve();
+        expect(generateBodies).toHaveLength(0);
+
+        created = true;
+        resolveCreate({
+            ok: true,
+            json: async () => ({
+                session_id: 'session-new',
+                session_name: null,
+                history: []
+            })
+        });
+        await expect(sendPromise).resolves.toBeUndefined();
+
+        expect(generateBodies).toHaveLength(1);
+        expect(generateBodies[0].conversation_session_id).toBe('session-new');
+        expect(generateBodies[0].prompt).toBe('Send only in the new conversation');
+        expect(document.querySelector('.chat-session-tab.is-active')?.dataset.sessionId)
+            .toBe('session-new');
+        expect(sendButton.disabled).toBe(false);
+    });
+
     test('new chat reports creation failure without blocking the page', async () => {
         const promptInput = document.getElementById('promptInput');
         promptInput.value = 'Keep this draft';
@@ -10437,6 +10558,8 @@ describe('chat session composer state', () => {
         const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
 
         document.querySelector('.chat-session-tab-new').click();
+        const sendPromise = sendMessage();
+        await expect(sendPromise).resolves.toBeUndefined();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(promptSpy).not.toHaveBeenCalled();
@@ -10446,6 +10569,9 @@ describe('chat session composer state', () => {
         expect(promptInput.value).toBe('Keep this draft');
         expect(document.querySelector('.chat-session-tab.is-active')?.dataset.sessionId)
             .toBe('session-current');
+        expect(global.fetch.mock.calls.some(([url]) => (
+            typeof url === 'string' && url.startsWith('/von/generate')
+        ))).toBe(false);
     });
 
     test('first send without an active conversation creates a real session before generate', async () => {

--- a/tests/backend/test_chat_history_session_management.py
+++ b/tests/backend/test_chat_history_session_management.py
@@ -57,6 +57,20 @@ def test_create_chat_session_preserves_explicit_name_and_leaves_unnamed_session_
     assert doc["history"] == []
     assert result["is_agent_created"] is False
 
+    personal_result = chat_history_service.create_chat_session(
+        user_id="#V#user",
+        session_id="s-personal",
+        namespace="#V#user",
+        organisation_concept_id=None,
+        role_in_org=None,
+    )
+
+    assert personal_result["session_id"] == "s-personal"
+    personal_doc = stored[("#V#user", "s-personal")]
+    assert personal_doc["namespace"] == "#V#user"
+    assert "organisation_concept_id" not in personal_doc
+    assert "role_in_org" not in personal_doc
+
     unnamed_result = chat_history_service.create_chat_session(
         user_id="#V#user",
         session_id="s-2",

--- a/tests/backend/test_von_generate_rag_trace.py
+++ b/tests/backend/test_von_generate_rag_trace.py
@@ -275,6 +275,65 @@ def test_generate_prefers_window_effective_namespace_and_reports_mismatch(
     assert all(ns == "#V#user@window_org" for ns in captured_namespaces if ns is not None)
 
 
+def test_generate_namespace_resolution_keeps_personal_window_over_stale_flask_org():
+    from src.backend.server.routes.von_routes import (
+        _resolve_generate_namespace_context,
+    )
+
+    namespace_report = _resolve_generate_namespace_context(
+        user_concept_id="#V#user",
+        effective_context={
+            "user_id": "#V#user",
+            "organisation_id": None,
+            "role": None,
+            "namespace": "#V#user",
+            "chat_session_id": "test-session",
+            "source": "window_session",
+        },
+        flask_session_snapshot={
+            "user_concept_id": "#V#user",
+            "namespace": "#V#user@stale_org",
+            "organisation_concept_id": "#V#stale_org",
+            "role_in_org": "member",
+            "session_id": "test-session",
+        },
+    )
+
+    assert namespace_report["mismatch_detected"] is True
+    assert namespace_report["effective_context_source"] == "window_session"
+    assert namespace_report["session_namespace"] == "#V#user@stale_org"
+    assert namespace_report["namespace"] == "#V#user"
+    assert namespace_report["namespace_source"] == "effective_context.namespace"
+    assert namespace_report["org_scope_preferred"] is False
+
+
+def test_history_scope_resolution_keeps_personal_window_over_stale_flask_org():
+    from flask import session
+    from src.backend.server.routes.von_routes import (
+        _resolve_history_request_scope_hints,
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.secret_key = "test-secret"
+    with flask_app.test_request_context("/von/history"):
+        session["namespace"] = "#V#user@stale_org"
+        session["organisation_concept_id"] = "#V#stale_org"
+        namespace, organisation_concept_id = _resolve_history_request_scope_hints(
+            user_concept_id="#V#user",
+            effective_context={
+                "user_id": "#V#user",
+                "organisation_id": None,
+                "role": None,
+                "namespace": "#V#user",
+                "chat_session_id": "test-session",
+                "source": "window_session",
+            },
+        )
+
+    assert namespace == "#V#user"
+    assert organisation_concept_id is None
+
+
 def test_generate_rag_trace_marks_unauthenticated(app):
     client = app.test_client()
 

--- a/tests/backend/test_window_session_multi_org_isolation.py
+++ b/tests/backend/test_window_session_multi_org_isolation.py
@@ -490,6 +490,62 @@ class TestCreateChatSessionUsesWindowContext:
         history_payload = history_resp.get_json()
         assert history_payload["active_session_id"] == payload["session_id"]
 
+    def test_create_session_keeps_explicit_personal_window_context(
+        self, monkeypatch, app_client
+    ):
+        """A Personal window must not inherit stale Flask organisation state."""
+        _, client = app_client
+        created_sessions: list[dict] = []
+
+        import src.backend.services.chat_history_service as chat_history_service
+        from src.backend.server.routes import von_routes
+
+        def capture_create(*args, **kwargs):
+            created_sessions.append(kwargs.copy())
+            return {
+                "session_id": kwargs.get("session_id", "new_session"),
+                "session_name": kwargs.get("session_name", "New Session"),
+            }
+
+        monkeypatch.setattr(chat_history_service, "create_chat_session", capture_create)
+        monkeypatch.setattr(
+            von_routes,
+            "get_effective_context",
+            lambda *_args, **_kwargs: {
+                "namespace": "#V#michael_witbrock",
+                "organisation_id": None,
+                "role": None,
+            },
+        )
+        monkeypatch.setattr(
+            von_routes,
+            "_set_active_chat_session_for_request",
+            lambda **_kwargs: None,
+        )
+
+        with client.session_transaction() as sess:
+            sess["user_id"] = "michael_witbrock"
+            sess["user_concept_id"] = "#V#michael_witbrock"
+            sess["namespace"] = (
+                "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+            )
+            sess["organisation_concept_id"] = (
+                "university_of_auckland_strong_ai_lab"
+            )
+            sess["role_in_org"] = "owner"
+
+        resp = client.post(
+            "/von/api/session/create_chat_session",
+            json={"session_name": "Personal Discussion"},
+            headers={"X-Von-Window-Session": "ws_create_personal_test"},
+        )
+
+        assert resp.status_code == 200
+        assert len(created_sessions) == 1
+        assert created_sessions[0]["namespace"] == "#V#michael_witbrock"
+        assert created_sessions[0]["organisation_concept_id"] is None
+        assert created_sessions[0]["role_in_org"] is None
+
     def test_create_session_marks_browser_test_fixture_sessions(
         self, monkeypatch, app_client
     ):


### PR DESCRIPTION
Jira: JVNAUTOSCI-2706

Makes new-conversation creation an explicit composer busy state and makes direct composer submissions await the canonical created session before resolving their target. A failed creation preserves the draft and cannot fall back to generating in the old conversation.

The authenticated Personal-profile replay also exposed stale browser-wide organisation fallback after a window had authoritatively selected Personal. The repair now distinguishes omitted session context from explicit `None`, and both generate-time and history-read namespace resolution preserve the authoritative window scope.

Validation:
- Full chatTab Jest file passed: 277 tests
- Focused neighbouring frontend replay passed: 3 tests covering creation, immediate send and creation failure
- Four focused backend scope tests passed, covering session creation, route propagation, generation namespace and history namespace
- Authenticated Personal Chrome acceptance on Mac build `94feb0d8`: New plus immediate Enter visibly held the draft, created Personal session `b4d0d6eb-1713-4d64-a19b-227d5f73f5c9`, completed queue record `d8a67626-2e3a-4db6-83ed-b01809f51f65`, invoked allowed local `gemma4:latest`, persisted the Personal transcript, and rendered it after restart with no authorisation error
- git diff check and Python compile passed