### PR TITLE
Avoid Mongo health-probe recovery cascades

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -1563,6 +1563,28 @@ def _invalidate_real_client_for_recovery(
         return True
 
 
+def _health_probe_failure_is_driver_recovery_in_progress(exc: Exception) -> bool:
+    """Return whether PyMongo is already cancelling or repairing this pool.
+
+    ``_OperationCancelled`` is a private PyMongo control-flow error raised when
+    a topology or pool is being shut down. ``connection pool paused`` is the
+    driver's transient state while its monitor re-establishes the server. If a
+    periodic advisory ping treats either as a new route failure, dropping the
+    shared client can cancel every unrelated operation using that client and
+    start a repeated reconnect cycle. Let PyMongo finish its own recovery and
+    probe again at the normal interval instead.
+
+    Ordinary application operations still classify these errors as transient;
+    this narrow exception applies only to the periodic health probe deciding
+    whether to replace the process-wide client.
+    """
+
+    return (
+        type(exc).__name__ == "_OperationCancelled"
+        or "connection pool paused" in str(exc).lower()
+    )
+
+
 def _ensure_active_client_is_healthy() -> None:
     if _mongo_client_real is None or not _claim_due_health_check():
         return
@@ -1638,6 +1660,13 @@ def _ensure_active_client_is_healthy() -> None:
             else:
                 client.admin.command("ping", maxTimeMS=timeout_ms)
         except Exception as exc:
+            if _health_probe_failure_is_driver_recovery_in_progress(exc):
+                logger.warning(
+                    "[mongo_recovery] Periodic ping deferred while PyMongo "
+                    "recovers the active pool: %s",
+                    exc,
+                )
+                return
             with _CONNECTION_CONDITION:
                 still_current = (
                     _mongo_client_real is client

--- a/tests/backend/test_mongo_client_singleflight.py
+++ b/tests/backend/test_mongo_client_singleflight.py
@@ -4,9 +4,13 @@ import threading
 import time
 
 import pytest
-from pymongo.errors import ConnectionFailure
+from pymongo.errors import AutoReconnect, ConnectionFailure
 
 from src.backend.db import mongo_client as mc
+
+
+class _OperationCancelled(Exception):
+    """Test double matching PyMongo's private recovery exception name."""
 
 
 class _FakeAdmin:
@@ -16,10 +20,12 @@ class _FakeAdmin:
         ping_started: threading.Event | None = None,
         release_ping: threading.Event | None = None,
         fail_ping: bool = False,
+        ping_error: Exception | None = None,
     ) -> None:
         self.ping_started = ping_started
         self.release_ping = release_ping
         self.fail_ping = fail_ping
+        self.ping_error = ping_error
         self.ping_count = 0
 
     def command(self, name: str, **_kwargs):
@@ -31,6 +37,8 @@ class _FakeAdmin:
                 self.ping_started.set()
             if self.release_ping is not None:
                 assert self.release_ping.wait(timeout=2)
+            if self.ping_error is not None:
+                raise self.ping_error
             if self.fail_ping:
                 raise ConnectionFailure("simulated health failure")
         return {"ok": 1}
@@ -428,6 +436,71 @@ def test_late_health_failure_cannot_erase_newer_client_and_probes_coalesce(
     assert probing_result[0]["client"] is replacement
     assert mc._mongo_client_real is replacement
     assert replacement.closed is False
+
+
+@pytest.mark.parametrize(
+    "probe_error",
+    (
+        _OperationCancelled("operation cancelled"),
+        AutoReconnect("127.0.0.1:27017: connection pool paused"),
+    ),
+)
+def test_periodic_probe_does_not_invalidate_while_driver_pool_is_recovering(
+    monkeypatch,
+    probe_error: Exception,
+) -> None:
+    recovering = _FakeClient(
+        "recovering",
+        _FakeAdmin(ping_error=probe_error),
+    )
+    with mc._CONNECTION_CONDITION:
+        mc._mongo_client_real = recovering
+        mc._last_auto_recovery_check_at = 0.0
+        original_generation = mc._connection_generation
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY", "1")
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY_CHECK_INTERVAL_SECONDS", "0.001")
+    connect_attempted = False
+
+    def _unexpected_connect(_uri: str, **_kwargs):
+        nonlocal connect_attempted
+        connect_attempted = True
+        raise AssertionError("driver-owned pool recovery must not replace the client")
+
+    monkeypatch.setattr(mc, "_try_connect_uri", _unexpected_connect)
+
+    db = mc.get_db()
+
+    assert db is not None
+    assert db["client"] is recovering
+    assert mc._mongo_client_real is recovering
+    assert mc._connection_generation == original_generation
+    assert connect_attempted is False
+    assert recovering.closed is False
+
+
+def test_periodic_probe_still_invalidates_genuine_transport_failure(
+    monkeypatch,
+) -> None:
+    failed = _FakeClient(
+        "failed",
+        _FakeAdmin(ping_error=ConnectionFailure("network unreachable")),
+    )
+    replacement = _FakeClient("replacement")
+    with mc._CONNECTION_CONDITION:
+        mc._mongo_client_real = failed
+        mc._last_auto_recovery_check_at = 0.0
+        original_generation = mc._connection_generation
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY", "1")
+    monkeypatch.setenv("VON_MONGO_AUTO_RECOVERY_CHECK_INTERVAL_SECONDS", "0.001")
+    monkeypatch.setattr(mc, "_try_connect_uri", lambda _uri, **_kwargs: replacement)
+
+    db = mc.get_db()
+
+    assert db is not None
+    assert db["client"] is replacement
+    assert mc._mongo_client_real is replacement
+    assert mc._connection_generation == original_generation + 1
+    assert failed.closed is False
 
 
 def test_ordinary_healthy_get_db_does_not_enter_connection_condition(


### PR DESCRIPTION
## Outcome
Let PyMongo finish its own paused-pool and operation-cancellation recovery without a periodic advisory ping invalidating the process-wide client and cancelling unrelated operations. Genuine transport failures still replace the client.

## Evidence
- `11 passed` focused single-flight suite.
- `47 passed` across connection-manager, DNS fallback, Mongo recovery, and single-flight suites.
- Negative control confirms an ordinary `ConnectionFailure` still invalidates and reconnects.

Jira: JVNAUTOSCI-2707