### PR TITLE
Preserve nested MCP tool schemas

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -10489,6 +10489,23 @@ def _organisation_membership_receipt_output_schema() -> Schema:
 
 
 def _concepts_create_input_schema() -> Schema:
+    concept_item_schema = Schema(
+        required={"name": str, "kind": str},
+        optional={
+            "concept_id": (str, type(None)),
+            "description": (str, type(None)),
+            "notes": (str, type(None)),
+            "vontology_path": (str, type(None)),
+            "instance_of_type": (str, type(None)),
+        },
+        enum_values={"kind": ["instance", "type", "predicate"]},
+        allow_unknown=False,
+        description=(
+            "one core concept specification; publication scope belongs in the "
+            "top-level scope_mode field and semantic typing belongs in the "
+            "top-level parent_id field"
+        ),
+    )
     return Schema(
         required={
             "parent_id": str,
@@ -10521,6 +10538,7 @@ def _concepts_create_input_schema() -> Schema:
             ],
         },
         array_length_constraints={"concepts": (1, 1)},
+        array_item_schemas={"concepts": concept_item_schema},
         allow_unknown=True,
         description=(
             "Governed create_concepts input: parent_id is one exact semantic type "

--- a/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
+++ b/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
@@ -224,6 +224,11 @@ def _build_dynamic_input_schema(
             for field_name, limits in target_schema.array_length_constraints.items()
             if field_name in remaining_fields
         },
+        array_item_schemas={
+            field_name: item_schema
+            for field_name, item_schema in target_schema.array_item_schemas.items()
+            if field_name in remaining_fields
+        },
     )
 
 

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -25,6 +25,7 @@ from .schemas import (
     SchemaValidationError,
     coerce_payload_types,
     normalise_payload_aliases,
+    schema_to_json_schema,
     validate_payload,
 )
 from .transport import (
@@ -326,6 +327,14 @@ class MethodCatalogue:
                 for field_name, limits in schema.array_length_constraints.items()
                 if isinstance(field_name, str) and field_name
             },
+            "array_item_schemas": {
+                field_name: schema_to_json_schema(item_schema)
+                for field_name, item_schema in schema.array_item_schemas.items()
+                if isinstance(field_name, str)
+                and field_name
+                and isinstance(item_schema, Schema)
+            },
+            "json_schema": schema_to_json_schema(schema),
         }
 
     def snapshot(self) -> Dict[str, Dict[str, Any]]:

--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -42,6 +42,7 @@ from .schemas import (
     coerce_payload_types,
     expected_to_json_schema,
     normalise_payload_aliases,
+    schema_to_json_schema,
     validate_payload,
 )
 from .tool_call_contracts import (
@@ -11136,6 +11137,20 @@ class InternalMCPChatOrchestrator:
 
         MCP schemas use required/optional dicts, JSON Schema uses properties + required list.
         """
+        if (
+            mcp_schema.get("type") == "object"
+            and isinstance(mcp_schema.get("properties"), Mapping)
+        ):
+            return copy.deepcopy(dict(mcp_schema))
+
+        complete_json_schema = mcp_schema.get("json_schema")
+        if (
+            isinstance(complete_json_schema, Mapping)
+            and complete_json_schema.get("type") == "object"
+            and isinstance(complete_json_schema.get("properties"), Mapping)
+        ):
+            return copy.deepcopy(dict(complete_json_schema))
+
         required_fields = mcp_schema.get("required", {})
         optional_fields = mcp_schema.get("optional", {})
         allow_unknown = mcp_schema.get("allow_unknown")
@@ -11145,6 +11160,7 @@ class InternalMCPChatOrchestrator:
         scalar_source_fields = mcp_schema.get("scalar_source_fields")
         comma_separated_list_fields = mcp_schema.get("comma_separated_list_fields")
         array_length_constraints = mcp_schema.get("array_length_constraints")
+        array_item_schemas = mcp_schema.get("array_item_schemas")
         description = mcp_schema.get("description")
 
         properties: Dict[str, Any] = {}
@@ -11226,6 +11242,22 @@ class InternalMCPChatOrchestrator:
                     and maximum >= 0
                 ):
                     field_schema["maxItems"] = maximum
+
+        if isinstance(array_item_schemas, Mapping):
+            for field_name, item_schema in array_item_schemas.items():
+                field_schema = properties.get(field_name)
+                if not isinstance(field_schema, dict):
+                    continue
+                field_types = field_schema.get("type")
+                is_array = field_types == "array" or (
+                    isinstance(field_types, list) and "array" in field_types
+                )
+                if not is_array:
+                    field_schema["type"] = "array"
+                if isinstance(item_schema, McpSchema):
+                    field_schema["items"] = schema_to_json_schema(item_schema)
+                elif isinstance(item_schema, Mapping):
+                    field_schema["items"] = copy.deepcopy(dict(item_schema))
 
         json_schema = {
             "type": "object",
@@ -19233,6 +19265,7 @@ class InternalMCPChatOrchestrator:
             array_length_constraints: dict[
                 str, tuple[int | None, int | None]
             ] = {}
+            array_item_schemas: dict[str, McpSchema] = {}
             for field_name, field_schema in properties.items():
                 if not isinstance(field_name, str) or not field_name.strip():
                     continue
@@ -19265,6 +19298,14 @@ class InternalMCPChatOrchestrator:
                     )
                     if minimum is not None or maximum is not None:
                         array_length_constraints[field_name] = (minimum, maximum)
+                    raw_items = field_schema.get("items")
+                    if (
+                        isinstance(raw_items, Mapping)
+                        and raw_items.get("type") == "object"
+                    ):
+                        array_item_schemas[field_name] = _schema_from_json_schema(
+                            raw_items
+                        )
                 if field_name in required_names:
                     required_fields[field_name] = expected
                 else:
@@ -19314,6 +19355,7 @@ class InternalMCPChatOrchestrator:
                 ),
                 enum_values=enum_values,
                 array_length_constraints=array_length_constraints,
+                array_item_schemas=array_item_schemas,
                 scalar_source_fields=(
                     {
                         str(field_name).strip(): tuple(
@@ -19386,6 +19428,14 @@ class InternalMCPChatOrchestrator:
         ):
             return _schema_from_json_schema(raw_schema)
 
+        complete_json_schema = raw_schema.get("json_schema")
+        if (
+            isinstance(complete_json_schema, Mapping)
+            and complete_json_schema.get("type") == "object"
+            and isinstance(complete_json_schema.get("properties"), Mapping)
+        ):
+            return _schema_from_json_schema(complete_json_schema)
+
         return McpSchema(
             required=_coerce_fields(raw_schema.get("required") or {}),
             optional=_coerce_fields(raw_schema.get("optional") or {}),
@@ -19448,6 +19498,20 @@ class InternalMCPChatOrchestrator:
                     and len(limits) == 2
                 }
                 if isinstance(raw_schema.get("array_length_constraints"), Mapping)
+                else {}
+            ),
+            array_item_schemas=(
+                {
+                    str(field_name).strip(): _schema_from_json_schema(item_schema)
+                    for field_name, item_schema in raw_schema.get(
+                        "array_item_schemas", {}
+                    ).items()
+                    if isinstance(field_name, str)
+                    and field_name.strip()
+                    and isinstance(item_schema, Mapping)
+                    and item_schema.get("type") == "object"
+                }
+                if isinstance(raw_schema.get("array_item_schemas"), Mapping)
                 else {}
             ),
             scalar_source_fields=(

--- a/src/backend/integrations/internal_mcp/schemas.py
+++ b/src/backend/integrations/internal_mcp/schemas.py
@@ -138,6 +138,8 @@ class Schema:
             be safely split on commas at the tool boundary.
         array_length_constraints: per-field ``(minimum, maximum)`` item counts
             exposed in JSON Schema and enforced by payload validation.
+        array_item_schemas: per-field schemas for object items in list-valued
+            fields, exposed recursively and enforced for every supplied item.
     """
 
     required: Mapping[str, JsonCompatibleType] = field(default_factory=dict)
@@ -152,6 +154,7 @@ class Schema:
     array_length_constraints: Mapping[
         str, tuple[int | None, int | None]
     ] = field(default_factory=dict)
+    array_item_schemas: Mapping[str, "Schema"] = field(default_factory=dict)
 
     def expect(self, key: str) -> JsonCompatibleType | None:
         if key in self.required:
@@ -257,6 +260,17 @@ def schema_to_json_schema(schema: "Schema") -> Dict[str, Any]:
             field_schema["minItems"] = minimum
         if isinstance(maximum, int) and not isinstance(maximum, bool) and maximum >= 0:
             field_schema["maxItems"] = maximum
+
+    for field_name, item_schema in schema.array_item_schemas.items():
+        field_schema = properties.get(field_name)
+        if not isinstance(field_schema, dict) or not isinstance(item_schema, Schema):
+            continue
+        field_types = field_schema.get("type")
+        is_array = field_types == "array" or (
+            isinstance(field_types, list) and "array" in field_types
+        )
+        if is_array:
+            field_schema["items"] = schema_to_json_schema(item_schema)
 
     payload: Dict[str, Any] = {
         "type": "object",
@@ -416,6 +430,22 @@ def validate_payload(
         ):
             errors.append(
                 f"Field '{key}' expected at most {maximum} item(s) but received {len(value)}."
+            )
+
+    for key, item_schema in schema.array_item_schemas.items():
+        value = payload.get(key)
+        if not isinstance(value, list) or not isinstance(item_schema, Schema):
+            continue
+        for index, item in enumerate(value):
+            if not isinstance(item, Mapping):
+                errors.append(
+                    f"Field '{key}[{index}]' expected an object but received "
+                    f"{type(item).__name__}."
+                )
+                continue
+            _, item_errors = validate_payload(item_schema, item)
+            errors.extend(
+                f"Field '{key}[{index}]': {item_error}" for item_error in item_errors
             )
 
     return not errors, errors

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -1352,7 +1352,60 @@
                     },
                     "concepts": {
                         "type": "array",
-                        "items": {}
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                        "instance",
+                                        "type",
+                                        "predicate"
+                                    ]
+                                },
+                                "concept_id": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "description": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "notes": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "vontology_path": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "instance_of_type": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "kind"
+                            ],
+                            "additionalProperties": false,
+                            "description": "one core concept specification; publication scope belongs in the top-level scope_mode field and semantic typing belongs in the top-level parent_id field"
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
                     },
                     "collision_resolution_mode": {
                         "type": [

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -466,6 +466,14 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
     assert create_definition.input_schema.array_length_constraints == {
         "concepts": (1, 1)
     }
+    create_item_schema = create_definition.input_schema.array_item_schemas["concepts"]
+    assert create_item_schema.required == {"name": str, "kind": str}
+    assert create_item_schema.enum_values["kind"] == [
+        "instance",
+        "type",
+        "predicate",
+    ]
+    assert create_item_schema.allow_unknown is False
     marker_definition = catalogue.get("record_source_processing_marker")
     assert marker_definition.ordinary_turn_trusted_argument_bindings == {
         "namespace": "turn_namespace",

--- a/tests/backend/test_internal_mcp_dynamic_tool_registration.py
+++ b/tests/backend/test_internal_mcp_dynamic_tool_registration.py
@@ -205,7 +205,7 @@ def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
         handler=lambda **kwargs: {"success": True, **kwargs},
         input_schema=Schema(
             required={"target": str, "mode": str},
-            optional={"filters": list, "scope": str},
+            optional={"filters": list, "records": list, "scope": str},
             allow_unknown=False,
             aliases={
                 "target_id": "target",
@@ -222,6 +222,9 @@ def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
             },
             comma_separated_list_fields=("filters",),
             array_length_constraints={"filters": (1, 3)},
+            array_item_schemas={
+                "records": Schema(required={"field": str}, allow_unknown=False)
+            },
         ),
         category="read",
     )
@@ -240,6 +243,7 @@ def test_dynamic_proxy_preserves_unfixed_target_schema_semantics(monkeypatch):
     assert schema.scalar_source_fields == {"target": ("concept_id",)}
     assert schema.comma_separated_list_fields == ("filters",)
     assert schema.array_length_constraints == {"filters": (1, 3)}
+    assert schema.array_item_schemas["records"].required == {"field": str}
 
     catalogue = MethodCatalogue()
     catalogue.register(base_definition)

--- a/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
+++ b/tests/backend/test_mcp_create_concepts_duplicate_resolution_mode.py
@@ -769,7 +769,7 @@ def test_duplicate_resolution_mode_schema_and_handler_reject_unknown_value() -> 
         schema,
         {
             "parent_id": _PARENT_ID,
-            "concepts": [],
+            "concepts": [{"name": "Canonical item", "kind": "instance"}],
             "duplicate_resolution_mode": "canonical_id_only",
         },
     )
@@ -780,7 +780,7 @@ def test_duplicate_resolution_mode_schema_and_handler_reject_unknown_value() -> 
         schema,
         {
             "parent_id": _PARENT_ID,
-            "concepts": [],
+            "concepts": [{"name": "Default item", "kind": "instance"}],
             "duplicate_resolution_mode": None,
         },
     )
@@ -791,7 +791,7 @@ def test_duplicate_resolution_mode_schema_and_handler_reject_unknown_value() -> 
         schema,
         {
             "parent_id": _PARENT_ID,
-            "concepts": [],
+            "concepts": [{"name": "Rejected item", "kind": "instance"}],
             "duplicate_resolution_mode": "semantic",
         },
     )

--- a/tests/backend/test_schema_coercion.py
+++ b/tests/backend/test_schema_coercion.py
@@ -280,6 +280,36 @@ def test_schema_array_length_constraints_are_validated() -> None:
     ]
 
 
+def test_schema_array_item_contract_is_advertised_and_validated() -> None:
+    item_schema = Schema(
+        required={"name": str, "kind": str},
+        enum_values={"kind": ("instance", "type", "predicate")},
+        allow_unknown=False,
+    )
+    schema = Schema(
+        required={"concepts": list},
+        array_item_schemas={"concepts": item_schema},
+    )
+
+    json_schema = schema_to_json_schema(schema)
+    advertised_item = json_schema["properties"]["concepts"]["items"]
+    assert advertised_item["required"] == ["name", "kind"]
+    assert advertised_item["properties"]["kind"]["enum"] == [
+        "instance",
+        "type",
+        "predicate",
+    ]
+    assert advertised_item["additionalProperties"] is False
+
+    ok, errors = validate_payload(
+        schema,
+        {"concepts": [{"name": "Website", "type": "#V#individual"}]},
+    )
+    assert ok is False
+    assert any("Missing required field 'kind'" in error for error in errors)
+    assert any("Unexpected field 'type'" in error for error in errors)
+
+
 def test_gateway_invoke_extracts_declared_scalar_from_object_payload() -> None:
     observed: dict[str, object] = {}
 
@@ -395,6 +425,102 @@ def test_orchestrator_schema_conversion_preserves_tool_argument_metadata() -> No
     assert json_schema["properties"]["profile"]["enum"] == [
         "zhan-gmail",
         "lab-gmail",
+    ]
+
+
+def test_orchestrator_schema_conversion_preserves_array_item_contract() -> None:
+    orchestrator = cast(Any, object.__new__(InternalMCPChatOrchestrator))
+
+    json_schema = orchestrator._mcp_schema_to_json_schema(
+        {
+            "required": ["concepts"],
+            "optional": [],
+            "array_item_schemas": {
+                "concepts": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "kind": {
+                            "type": "string",
+                            "enum": ["instance", "type", "predicate"],
+                        },
+                    },
+                    "required": ["name", "kind"],
+                    "additionalProperties": False,
+                }
+            },
+        }
+    )
+
+    assert json_schema["properties"]["concepts"]["items"]["required"] == [
+        "name",
+        "kind",
+    ]
+
+
+def test_orchestrator_preserves_an_existing_json_schema_without_reinterpreting_it(
+) -> None:
+    orchestrator = cast(Any, object.__new__(InternalMCPChatOrchestrator))
+    supplied = {
+        "type": "object",
+        "properties": {
+            "concepts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["concepts"],
+        "additionalProperties": False,
+    }
+
+    converted = orchestrator._mcp_schema_to_json_schema(supplied)
+
+    assert converted == supplied
+    assert converted is not supplied
+
+
+def test_gateway_snapshot_preserves_complete_nested_schema_for_orchestrator() -> None:
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="create_one",
+            handler=lambda **kwargs: {"success": True, **kwargs},
+            input_schema=Schema(
+                required={"concepts": list},
+                array_item_schemas={
+                    "concepts": Schema(
+                        required={"name": str, "kind": str},
+                        enum_values={
+                            "kind": ("instance", "type", "predicate")
+                        },
+                        allow_unknown=False,
+                    )
+                },
+            ),
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    orchestrator = cast(Any, object.__new__(InternalMCPChatOrchestrator))
+
+    json_schema = orchestrator._mcp_schema_to_json_schema(
+        gateway.describe_methods()["create_one"]["input_schema"]
+    )
+
+    item_schema = json_schema["properties"]["concepts"]["items"]
+    assert item_schema["required"] == ["name", "kind"]
+    assert item_schema["properties"]["kind"]["enum"] == [
+        "instance",
+        "type",
+        "predicate",
     ]
 
 


### PR DESCRIPTION
## Outcome
Expose and validate the exact per-item contract for list-valued MCP arguments, beginning with `create_concepts`, so local structured models receive required `name`/`kind`, enum, and closed-item constraints.

## Evidence
- Live DGX failure: Qwen invented `type` and `visibility` after the nested item schema was lost.
- 165 passed / 1 stale contradictory fixture found in the broad focused suite; fixture corrected to satisfy the already-declared singleton constraint.
- 17 targeted schema, create-concepts, generated-manifest, and determinism checks passed after correction.
- Generated MCP manifest regenerated with 166 tools.

Jira: JVNAUTOSCI-2705