### PR TITLE
Recover once from invalid provider tool calls

### DIFF
--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -283,6 +283,8 @@ _PROVIDER_RETRY_WAIT_SLICE_SECONDS = 1.0
 _MAX_PROVIDER_RETRY_METADATA_SECONDS = 3_600.0
 _MODEL_EVIDENCE_PREVIEW_MAX_CHARS = 240
 _CAPABILITY_PURPOSE_MAX_CHARS = 160
+_TOOL_CALL_DIAGNOSTIC_RECOVERY_MAX_ITEMS = 4
+_TOOL_CALL_DIAGNOSTIC_MESSAGE_MAX_CHARS = 500
 _CAPABILITY_CATALOGUE_SCHEMA_VERSION = "adaptive_turn_capabilities.v1"
 _CAPABILITY_PLAN_PROFILE_SCHEMA_VERSION = "capability_plan_profile.v1"
 _CAPABILITY_EFFECT_PROFILE_SCHEMA_VERSION = "capability_effect_profile.v1"
@@ -6913,6 +6915,8 @@ def execute_adaptive_turn(
 
     seen_request_digests: set[str] = set()
     model_liveness_recovery_used = False
+    tool_call_diagnostic_recovery_used = False
+    tool_call_diagnostic_recovery_event: dict[str, Any] | None = None
     last_partial_text = ""
     final_synthesis = False
     answer_only = False
@@ -9375,6 +9379,21 @@ def execute_adaptive_turn(
             if isinstance(response.model, str) and response.model.strip()
             else None
         )
+        provider_tool_call_diagnostics = [
+            {
+                key: str(diagnostic.get(key) or "")[:limit]
+                for key, limit in (
+                    ("error_code", 120),
+                    ("tool", 200),
+                    ("message", _TOOL_CALL_DIAGNOSTIC_MESSAGE_MAX_CHARS),
+                )
+                if diagnostic.get(key) is not None
+            }
+            for diagnostic in response.tool_call_diagnostics[
+                :_TOOL_CALL_DIAGNOSTIC_RECOVERY_MAX_ITEMS
+            ]
+            if isinstance(diagnostic, Mapping)
+        ]
         llm_calls.append(
             {
                 "call_id": model_call_id,
@@ -9400,6 +9419,15 @@ def execute_adaptive_turn(
                 "response": response.text_response,
                 "transport": dict(response.transport_metadata),
                 "tool_call_count": len(response.tool_calls),
+                **(
+                    {
+                        "provider_tool_call_diagnostics": (
+                            provider_tool_call_diagnostics
+                        )
+                    }
+                    if provider_tool_call_diagnostics
+                    else {}
+                ),
             }
         )
         emit_model_call_end(llm_calls[-1])
@@ -9407,9 +9435,87 @@ def execute_adaptive_turn(
             last_partial_text = response.text_response.strip()
             last_partial_effect_generation = request_effect_generation
         calls = list(response.tool_calls)
+        if (
+            tool_call_diagnostic_recovery_event is not None
+            and tool_call_diagnostic_recovery_event.get("repair_succeeded") is None
+            and (calls or response.text_response.strip())
+        ):
+            tool_call_diagnostic_recovery_event["repair_succeeded"] = True
+            tool_call_diagnostic_recovery_event["repair_result_call_id"] = (
+                model_call_id
+            )
         if not calls:
             if response.text_response.strip():
                 return finish(response.text_response.strip())
+            if provider_tool_call_diagnostics:
+                available_tool_names = [tool.name for tool in request_tools]
+                if tool_call_diagnostic_recovery_used:
+                    if tool_call_diagnostic_recovery_event is not None:
+                        tool_call_diagnostic_recovery_event[
+                            "repair_succeeded"
+                        ] = False
+                        tool_call_diagnostic_recovery_event[
+                            "repair_result_call_id"
+                        ] = model_call_id
+                    aux_calls.append(
+                        {
+                            "type": "adaptive_turn_tool_call_protocol_recovery",
+                            "schema_version": (
+                                "adaptive_turn_tool_call_protocol_recovery.v1"
+                            ),
+                            "call_id": model_call_id,
+                            "action": "terminal_invalid_tool_call",
+                            "repair_attempted": True,
+                            "repair_succeeded": False,
+                            "available_tool_names": available_tool_names,
+                            "diagnostics": provider_tool_call_diagnostics,
+                        }
+                    )
+                    return finish(
+                        "The model attempted an invalid capability request and "
+                        "did not repair it on the bounded retry.",
+                        status="model_tool_call_invalid",
+                    )
+
+                tool_call_diagnostic_recovery_used = True
+                continuation = None
+                pending_results = []
+                diagnostic_json = json.dumps(
+                    provider_tool_call_diagnostics,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+                exact_tools = ", ".join(available_tool_names) or "none"
+                current_context.append(
+                    {
+                        "role": "system",
+                        "content": (
+                            "The provider rejected your previous tool-call "
+                            "output, leaving neither a valid call nor a visible "
+                            "answer. Repair it once and continue the existing "
+                            "user task. Call only these exact exposed tool "
+                            f"names: {exact_tools}. A delegated capability name "
+                            "is not itself an exposed tool; place it inside the "
+                            "declared payload of the appropriate exposed "
+                            "wrapper. Provider diagnostics: "
+                            f"{diagnostic_json}"
+                        ),
+                    }
+                )
+                tool_call_diagnostic_recovery_event = {
+                    "type": "adaptive_turn_tool_call_protocol_recovery",
+                    "schema_version": (
+                        "adaptive_turn_tool_call_protocol_recovery.v1"
+                    ),
+                    "call_id": model_call_id,
+                    "action": "fresh_retry_with_contract_feedback",
+                    "repair_attempted": True,
+                    "repair_succeeded": None,
+                    "available_tool_names": available_tool_names,
+                    "diagnostics": provider_tool_call_diagnostics,
+                }
+                aux_calls.append(tool_call_diagnostic_recovery_event)
+                continue
             if final_synthesis and not answer_only:
                 enter_answer_only("evidence_call_failed")
                 continue

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -2088,6 +2088,128 @@ def test_machine_observations_are_bounded_separate_and_not_redispatched() -> Non
     assert "reconcile that outcome into the visible answer" in system_message
 
 
+def test_invalid_provider_tool_call_gets_one_contract_informed_repair() -> None:
+    invoked_queries: list[str] = []
+
+    def _read(**kwargs: Any) -> dict[str, Any]:
+        invoked_queries.append(str(kwargs.get("query")))
+        return {"success": True, "value": "grounded result"}
+
+    diagnostic = {
+        "schema_version": "tool_call_validation.v1",
+        "status": "invalid",
+        "tool": "general_read",
+        "error_code": "unknown_tool",
+        "message": "Unknown tool requested: general_read",
+        "payload": {"must_not_be_replayed": "x" * 10_000},
+    }
+    client = _SequenceClient(
+        LLMResponse(text_response="", tool_call_diagnostics=[diagnostic]),
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="corrected-read",
+                    payload={
+                        "name": "general_read",
+                        "arguments": {"query": "grounded value"},
+                    },
+                )
+            ],
+        ),
+        LLMResponse(text_response="The grounded result is available."),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(_read),
+        prompt="Read the grounded value.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        turn_id="turn-tool-call-diagnostic-repair",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert result.terminal_status == "completed"
+    assert result.response_text == "The grounded result is available."
+    assert invoked_queries == ["grounded value"]
+    assert len(client.calls) == 3
+    repair_context = next(
+        item
+        for item in client.calls[1]["context"]
+        if item.get("role") == "system"
+        and "provider rejected your previous tool-call" in item.get("content", "")
+    )
+    assert "turn_invoke_capability" in repair_context["content"]
+    assert "delegated capability name is not itself an exposed tool" in (
+        repair_context["content"]
+    )
+    assert "must_not_be_replayed" not in repair_context["content"]
+    assert result.llm_calls[0]["provider_tool_call_diagnostics"] == [
+        {
+            "error_code": "unknown_tool",
+            "tool": "general_read",
+            "message": "Unknown tool requested: general_read",
+        }
+    ]
+    recovery = next(
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_tool_call_protocol_recovery"
+    )
+    assert recovery["action"] == "fresh_retry_with_contract_feedback"
+    assert recovery["repair_attempted"] is True
+    assert recovery["repair_succeeded"] is True
+    assert recovery["repair_result_call_id"] == (
+        "turn-tool-call-diagnostic-repair:llm:2"
+    )
+
+
+def test_repeated_invalid_provider_tool_call_returns_typed_non_success() -> None:
+    diagnostic = {
+        "error_code": "unknown_tool",
+        "tool": "general_read",
+        "message": "Unknown tool requested: general_read",
+    }
+    client = _SequenceClient(
+        LLMResponse(text_response="", tool_call_diagnostics=[diagnostic]),
+        LLMResponse(text_response="", tool_call_diagnostics=[diagnostic]),
+    )
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True}),
+        prompt="Read the grounded value.",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        turn_id="turn-tool-call-diagnostic-repeat",
+        turn_budget_seconds=10,
+        final_synthesis_reserve_seconds=2,
+    )
+
+    assert len(client.calls) == 2
+    assert result.terminal_status == "model_tool_call_invalid"
+    assert result.response_text == (
+        "The model attempted an invalid capability request and did not repair "
+        "it on the bounded retry."
+    )
+    recovery_events = [
+        item
+        for item in result.aux_llm_calls
+        if item.get("type") == "adaptive_turn_tool_call_protocol_recovery"
+    ]
+    assert [event["action"] for event in recovery_events] == [
+        "fresh_retry_with_contract_feedback",
+        "terminal_invalid_tool_call",
+    ]
+    assert recovery_events[0]["repair_succeeded"] is False
+    assert recovery_events[0]["repair_result_call_id"] == (
+        "turn-tool-call-diagnostic-repeat:llm:2"
+    )
+
+
 def test_oversized_machine_observation_is_omitted_without_partial_projection() -> None:
     projection = _bounded_conversation_observation_projection(
         [

--- a/tests/backend/test_structured_tool_calling_client.py
+++ b/tests/backend/test_structured_tool_calling_client.py
@@ -1,6 +1,7 @@
 """Tests for LLMClient interface and factory."""
 
 import asyncio
+import logging
 import types
 
 import pytest
@@ -175,6 +176,7 @@ class TestOllamaToolCallParsing:
     def _client() -> OllamaClient:
         client = OllamaClient.__new__(OllamaClient)
         client.config = LLMClientConfig(model="qwen3.5:27b")
+        client.logger = logging.getLogger(__name__)
         return client
 
     @staticmethod
@@ -241,6 +243,24 @@ class TestOllamaToolCallParsing:
         assert response.text_response == (
             '{"status":"no tool requested","payload":{"reason":"done"}}'
         )
+
+    def test_unknown_tool_is_removed_and_exposed_as_typed_diagnostic(self):
+        response = self._client()._parse_response(
+            '{"action":"call_tool","tool":"general_read","payload":{}}',
+            self._tools(),
+        )
+
+        assert response.tool_calls == []
+        assert response.text_response == ""
+        assert response.tool_call_diagnostics == [
+            {
+                "schema_version": "tool_call_contract_validation.v1",
+                "status": "invalid",
+                "tool": "general_read",
+                "error_code": "unknown_tool",
+                "message": "Unknown tool requested: general_read",
+            }
+        ]
 
     def test_constrained_prompt_exposes_exact_tool_input_schema(self):
         client = self._client()


### PR DESCRIPTION
> **Merge impact:** An authenticated Von turn whose model names a delegated capability instead of the exposed wrapper gets one contract-informed chance to repair, and otherwise fails with a typed diagnostic instead of a misleading blank non-answer.
>
> Merge decision: ready — focused tests cover the exact failure, successful repair, bounded payload projection, repeated-invalid termination, and the Ollama parser seam; required CI is the remaining merge gate.

## User outcome

Von can continue an authorised task after one malformed provider tool call rather than abandoning it as a blank model response. This is the final code-side blocker currently observed in the Primary Labs browser representation tracked by JVNAUTOSCI-2705.

## Material changes

- Project bounded provider tool-call diagnostics into adaptive-turn telemetry.
- On an empty response with invalid-call diagnostics, perform one fresh retry with exact exposed tool names and no rejected payload replay.
- Record whether that repair produced a real call or answer.
- Return typed model_tool_call_invalid if the retry is also invalid.
- Add focused adaptive-turn and Ollama parser regression coverage.

Jira: JVNAUTOSCI-2705.

## Evidence

- 3 focused adaptive tests passed: ordinary neighbouring read, repaired wrapper call, repeated-invalid typed non-success.
- 10 recovery and answer-boundary adaptive tests passed.
- 5 Ollama parser and constrained-prompt tests passed.
- compileall, git diff --check, and Ruff E9/F63/F7/F82 checks passed.
- A broader structured-tool client run reached 16 passes before an unrelated later provider test hung in the local harness and was stopped after a bounded wait; the entire affected Ollama class had already passed.

## Ship boundary

- **Minimum ship criteria:** required CI passes and the branch merges without widening the one-retry protocol boundary.
- **Stop-ship conditions:** payload replay, unbounded retries, a blank second failure, or failure of the exact adaptive/Ollama regression tests.
- **Non-blocking observations:** DGX deployment and live authenticated representation replay are Jira incident-closure evidence, not a code-merge gate for this generic repair.
- **Non-goals:** no Primary-specific facts or routing, no Qwen-specific branch, no tool-name aliasing, no workflow-index redesign, and no Sol-family model use.