### PR TITLE
Keep dynamic accessible labels in sync

### DIFF
--- a/src/frontend/web/von_interface/static/js/suppressTooltips.js
+++ b/src/frontend/web/von_interface/static/js/suppressTooltips.js
@@ -18,14 +18,23 @@
         if (el.hasAttribute('data-keep-title')) return;
         const title = el.getAttribute('title');
         if (!title) return;
-        // Preserve original title if not already stored
-        if (!el.hasAttribute(ORIGINAL_TITLE_ATTR)) {
-            el.setAttribute(ORIGINAL_TITLE_ATTR, title);
-        }
-        // Promote to aria-label if no accessible name
-        if (!el.hasAttribute('aria-label') && !el.hasAttribute('aria-labelledby')) {
+        const previousOriginalTitle = el.getAttribute(ORIGINAL_TITLE_ATTR);
+        const currentAriaLabel = el.getAttribute('aria-label');
+        const ariaLabelWasPromotedFromTitle = (
+            previousOriginalTitle !== null
+            && currentAriaLabel === previousOriginalTitle
+        );
+        // Keep an automatically promoted label in sync with a dynamic title,
+        // while preserving an independently authored accessible name.
+        if (
+            !el.hasAttribute('aria-labelledby')
+            && (!currentAriaLabel || ariaLabelWasPromotedFromTitle)
+        ) {
             el.setAttribute('aria-label', title);
         }
+        // Retain the latest value so the restore hook and the next mutation can
+        // distinguish an auto-promoted label from an authored one.
+        el.setAttribute(ORIGINAL_TITLE_ATTR, title);
         el.removeAttribute('title');
     }
 

--- a/tests/frontend/suppressTooltips.test.js
+++ b/tests/frontend/suppressTooltips.test.js
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+
+const suppressTooltipsPath = '../../src/frontend/web/von_interface/static/js/suppressTooltips.js';
+
+async function flushMutationObserver() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('dynamic native-tooltip suppression', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = '<span id="serverBuildInfo"></span>';
+        delete window.__VON_TOOLTIP_SUPPRESS_ACTIVE__;
+        delete window.__VON_RESTORE_TITLES;
+        require(suppressTooltipsPath);
+    });
+
+    afterEach(() => {
+        if (typeof window.__VON_RESTORE_TITLES === 'function') {
+            window.__VON_RESTORE_TITLES();
+        }
+        delete window.__VON_TOOLTIP_SUPPRESS_ACTIVE__;
+        delete window.__VON_RESTORE_TITLES;
+    });
+
+    test('keeps an auto-promoted build label in sync with title updates', async () => {
+        const buildInfo = document.getElementById('serverBuildInfo');
+
+        buildInfo.title = 'Build old | Commit 11111111';
+        await flushMutationObserver();
+        expect(buildInfo.getAttribute('aria-label')).toBe('Build old | Commit 11111111');
+        expect(buildInfo.getAttribute('data-original-title')).toBe('Build old | Commit 11111111');
+        expect(buildInfo.hasAttribute('title')).toBe(false);
+
+        buildInfo.title = 'Build new | Commit 22222222';
+        await flushMutationObserver();
+        expect(buildInfo.getAttribute('aria-label')).toBe('Build new | Commit 22222222');
+        expect(buildInfo.getAttribute('data-original-title')).toBe('Build new | Commit 22222222');
+        expect(buildInfo.hasAttribute('title')).toBe(false);
+    });
+
+    test('does not replace an independently authored accessible label', async () => {
+        const buildInfo = document.getElementById('serverBuildInfo');
+        buildInfo.setAttribute('aria-label', 'Current application build');
+
+        buildInfo.title = 'Build old | Commit 11111111';
+        await flushMutationObserver();
+        buildInfo.title = 'Build new | Commit 22222222';
+        await flushMutationObserver();
+
+        expect(buildInfo.getAttribute('aria-label')).toBe('Current application build');
+        expect(buildInfo.getAttribute('data-original-title')).toBe('Build new | Commit 22222222');
+    });
+});


### PR DESCRIPTION
> **Merge impact:** Dynamically refreshed footer details expose the same current value to sighted users, assistive technology, and browser agents instead of retaining their first accessible label.
>
> Merge decision: ready — the causal observer path is covered by a focused post-load update test and neighbouring footer suites; required CI is the remaining merge gate.

## User outcome

After a Von deployment or runtime refresh, the footer build indicator reports the same build in visible text and its accessible label.

## Material changes

- Refresh an aria-label only when it exactly matches the tooltip suppressor previous auto-promoted title.
- Keep data-original-title current for subsequent mutations and the restore hook.
- Preserve independently authored aria-label and aria-labelledby names.
- Add focused dynamic-update and authored-label regression tests.

Jira: JVNAUTOSCI-2709.

## Evidence

- 30 focused Jest tests passed across suppressTooltips, footerBuildInfo, footerLlmExecutionStatus, and footerDbBadgeOutageStates.
- Static frontend lint passed.
- node --check and git diff --check passed.
- Live pre-fix DGX evidence: visible build b5da7123 while aria-label retained 564dd0c4 after full navigation.

## Ship boundary

- **Minimum ship criteria:** required CI passes and the focused observer tests remain green.
- **Stop-ship conditions:** authored labels are overwritten, dynamic labels remain stale, or footer status rendering regresses.
- **Non-blocking observations:** this is accessibility and browser-agent accuracy; the visible build text was already current.
- **Non-goals:** no footer redesign, health endpoint change, or deployment-process change.