### PR TITLE
Fix stale browser window session recovery

### DIFF
--- a/src/frontend/web/von_interface/static/js/apiService.js
+++ b/src/frontend/web/von_interface/static/js/apiService.js
@@ -34,6 +34,15 @@ async function ensureUniqueWindowSessionId() {
 }
 
 /**
+ * Replace a tab ID that the server has authoritatively bound to another actor.
+ * The rejected request has no effect, so callers may retry once with the new
+ * opaque ID while the authenticated server session remains the actor authority.
+ */
+async function replaceMismatchedWindowSessionId(expectedSessionId) {
+  return windowSessionIdentityCoordinator.replaceWindowSessionId(expectedSessionId);
+}
+
+/**
  * Builds the standard headers object for fetch requests.
  * Includes Content-Type and the window session header.
  */
@@ -57,6 +66,33 @@ export {
 // ============================================================================
 // Standard HTTP Helpers with Window Session Support
 // ============================================================================
+
+function buildHttpError(response, payload) {
+  const err = new Error(
+    (payload && (payload.error || payload.message)) || `HTTP ${response.status}`
+  );
+  err.status = response.status;
+  err.payload = payload;
+  const retryAfterHeader = response.headers?.get?.('Retry-After');
+  const parsedRetryAfter = Number.parseInt(retryAfterHeader || '', 10);
+  if (Number.isFinite(parsedRetryAfter)) {
+    err.retryAfterSeconds = parsedRetryAfter;
+  }
+  return err;
+}
+
+async function readJsonPayload(response) {
+  try {
+    return await response.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function isWindowSessionActorMismatch(response, payload) {
+  return response.status === 403
+    && payload?.error_code === 'window_session_actor_mismatch';
+}
 
 export async function getJson(url) {
   const res = await fetch(url, {
@@ -111,13 +147,27 @@ export async function getJsonDetailed(url, options = {}) {
 }
 
 export async function postJson(url, data) {
-  const res = await fetch(url, {
+  let headers = await buildHeaders();
+  let res = await fetch(url, {
     method: 'POST',
-    headers: await buildHeaders(),
+    headers,
     body: data ? JSON.stringify(data) : '{}'
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+  if (res.ok) return res.json();
+
+  let payload = await readJsonPayload(res);
+  if (isWindowSessionActorMismatch(res, payload)) {
+    await replaceMismatchedWindowSessionId(headers[WINDOW_SESSION_HEADER]);
+    headers = await buildHeaders();
+    res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: data ? JSON.stringify(data) : '{}'
+    });
+    if (res.ok) return res.json();
+    payload = await readJsonPayload(res);
+  }
+  throw buildHttpError(res, payload);
 }
 
 export async function postJsonDetailed(url, data, options = {}) {

--- a/src/frontend/web/von_interface/static/js/utils/windowSessionIdentity.js
+++ b/src/frontend/web/von_interface/static/js/utils/windowSessionIdentity.js
@@ -140,26 +140,34 @@ export function createWindowSessionIdentityCoordinator(options = {}) {
         });
     };
 
+    const replaceWindowSessionId = async (expectedSessionId = null) => {
+        const previousSessionId = getOrCreateWindowSessionId();
+        if (expectedSessionId && previousSessionId !== expectedSessionId) {
+            return ensureUniqueWindowSessionId();
+        }
+        let replacementSessionId = createWindowSessionId();
+        while (replacementSessionId === previousSessionId) {
+            replacementSessionId = createWindowSessionId();
+        }
+        inMemorySessionId = replacementSessionId;
+        try {
+            storage?.setItem(storageKey, replacementSessionId);
+        } catch {
+            // Keep the in-memory replacement for this document.
+        }
+        established = false;
+        ensurePromise = null;
+        const settledSessionId = await ensureUniqueWindowSessionId();
+        dispatchIdentityChanged(previousSessionId, settledSessionId);
+        return settledSessionId;
+    };
+
     const rotateLateCollision = () => {
         if (lateRotationPromise || !established) {
             return;
         }
         lateRotationPromise = (async () => {
-            const previousSessionId = getOrCreateWindowSessionId();
-            let replacementSessionId = createWindowSessionId();
-            while (replacementSessionId === previousSessionId) {
-                replacementSessionId = createWindowSessionId();
-            }
-            inMemorySessionId = replacementSessionId;
-            try {
-                storage?.setItem(storageKey, replacementSessionId);
-            } catch {
-                // Keep the in-memory replacement for this document.
-            }
-            established = false;
-            ensurePromise = null;
-            const settledSessionId = await ensureUniqueWindowSessionId();
-            dispatchIdentityChanged(previousSessionId, settledSessionId);
+            await replaceWindowSessionId();
         })().finally(() => {
             lateRotationPromise = null;
         });
@@ -380,6 +388,7 @@ export function createWindowSessionIdentityCoordinator(options = {}) {
         close,
         ensureUniqueWindowSessionId,
         getWindowSessionId: getOrCreateWindowSessionId,
+        replaceWindowSessionId,
     };
 }
 

--- a/tests/frontend/apiServiceWindowSessionIdentity.test.js
+++ b/tests/frontend/apiServiceWindowSessionIdentity.test.js
@@ -88,4 +88,67 @@ describe('apiService window-session request barrier', () => {
 
         incumbent.close();
     });
+
+    test('replaces a server-owned tab ID and retries only after typed actor mismatch', async () => {
+        sessionStorage.setItem('von_window_session_id', 'ws_owned_by_another_actor');
+        global.fetch = jest
+            .fn()
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 403,
+                json: async () => ({
+                    error: 'window_session_actor_mismatch',
+                    error_code: 'window_session_actor_mismatch',
+                }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({ status: 'updated' }),
+            });
+
+        const { postJson } = require(apiServicePath);
+        await expect(postJson('/von/api/session/set_organisation', {
+            organisation_concept_id: null,
+        })).resolves.toEqual({ status: 'updated' });
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const firstWindowSessionId = global.fetch.mock.calls[0][1]
+            .headers['X-Von-Window-Session'];
+        const replacementWindowSessionId = global.fetch.mock.calls[1][1]
+            .headers['X-Von-Window-Session'];
+        expect(firstWindowSessionId).toBe('ws_owned_by_another_actor');
+        expect(replacementWindowSessionId).toMatch(/^ws_/);
+        expect(replacementWindowSessionId).not.toBe(firstWindowSessionId);
+        expect(sessionStorage.getItem('von_window_session_id'))
+            .toBe(replacementWindowSessionId);
+    });
+
+    test('does not replace or retry a membership denial', async () => {
+        sessionStorage.setItem('von_window_session_id', 'ws_current_actor');
+        global.fetch = jest.fn(async () => ({
+            ok: false,
+            status: 403,
+            json: async () => ({
+                error: 'organisation_membership_required',
+                error_code: 'organisation_membership_required',
+            }),
+        }));
+
+        const { postJson } = require(apiServicePath);
+        const request = postJson('/von/api/session/set_organisation', {
+            organisation_concept_id: '#V#not_my_org',
+        });
+
+        await expect(request).rejects.toMatchObject({
+            message: 'organisation_membership_required',
+            status: 403,
+            payload: {
+                error_code: 'organisation_membership_required',
+            },
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(sessionStorage.getItem('von_window_session_id'))
+            .toBe('ws_current_actor');
+    });
 });


### PR DESCRIPTION
## Outcome

A stale tab ID that is durably owned by another authenticated actor no longer leaves a fresh Von tab split between Personal browser state and an organisation-scoped trusted session.

## Change

- replace the opaque window-session ID after an exact typed `window_session_actor_mismatch` rejection
- retry the rejected JSON POST once with the new ID
- preserve fail-closed organisation membership: `organisation_membership_required` is not retried
- retain same-origin duplicate-tab collision recovery through the existing coordinator

## Validation

- 9/9 window-session identity and request-barrier tests
- 13/13 organisation-switch and neighbouring settings tests
- changed-file ESLint clean
- full frontend run: 578 pass, with the same 9 pre-existing failures reproduced on clean `efd05579`

Jira: JVNAUTOSCI-2711