### PR TITLE
Keep natural publication scope explicit in create_concepts

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -1633,6 +1633,8 @@ _CREATE_CONCEPTS_SCOPE_MODE_ALIASES: dict[str, str] = {
     "user_only_default": _CREATE_CONCEPTS_SCOPE_USER_ONLY,
     "organisation_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
     "organization_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
+    "organisation": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
+    "organization": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
     "org_general": _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
     "global_general": _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
     "global": _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
@@ -1753,6 +1755,96 @@ def _normalise_create_concepts_scope_mode(raw_value: Any) -> str | None:
     return _CREATE_CONCEPTS_SCOPE_MODE_ALIASES.get(cleaned)
 
 
+def _resolve_create_concepts_scope_mode(
+    arguments: Mapping[str, Any],
+) -> tuple[str, str, dict[str, Any] | None]:
+    """Resolve supported scope aliases without silently changing audience."""
+
+    supplied: list[tuple[str, Any, str]] = []
+    for field_name in (
+        "scope_mode",
+        "visibility_scope_mode",
+        "publication_scope",
+    ):
+        raw_value = arguments.get(field_name)
+        if raw_value is None:
+            continue
+        normalised_value = _normalise_create_concepts_scope_mode(raw_value)
+        if normalised_value is None:
+            payload = make_error_response(
+                "invalid_parameter",
+                f"Invalid {field_name} '{raw_value}'.",
+                details={
+                    "field": field_name,
+                    "value": raw_value,
+                    "supported_scope_modes": sorted(
+                        _CREATE_CONCEPTS_SCOPE_MODE_ALIASES
+                    ),
+                },
+                suggestions=[
+                    "Use user_only_default for actor-private concepts",
+                    (
+                        "Use organisation or organisation_general for "
+                        "organisation-scoped shared concepts"
+                    ),
+                    "Use global_general for broadly visible concepts",
+                ],
+            )
+            payload.update(
+                {
+                    "effect_status": "not_started",
+                    "mutation_outcome": "not_started",
+                    "changed": False,
+                }
+            )
+            return (
+                _CREATE_CONCEPTS_SCOPE_USER_ONLY,
+                f"request.{field_name}",
+                payload,
+            )
+        supplied.append((field_name, raw_value, normalised_value))
+
+    if not supplied:
+        return (
+            _CREATE_CONCEPTS_SCOPE_USER_ONLY,
+            "default.user_only_default",
+            None,
+        )
+
+    distinct_modes = {normalised_value for _, _, normalised_value in supplied}
+    if len(distinct_modes) > 1:
+        payload = make_error_response(
+            "conflicting_scope_mode_fields",
+            (
+                "Conflicting publication-scope fields were supplied; "
+                "no mutation started."
+            ),
+            details={
+                "supplied_scope_fields": {
+                    field_name: raw_value for field_name, raw_value, _ in supplied
+                },
+                "normalised_scope_modes": sorted(distinct_modes),
+            },
+            suggestions=[
+                (
+                    "Supply exactly one of scope_mode, visibility_scope_mode, "
+                    "or publication_scope"
+                )
+            ],
+        )
+        payload.update(
+            {
+                "effect_status": "not_started",
+                "mutation_outcome": "not_started",
+                "changed": False,
+            }
+        )
+        return _CREATE_CONCEPTS_SCOPE_USER_ONLY, "conflict", payload
+
+    field_name, _, scope_mode = supplied[0]
+    return scope_mode, f"request.{field_name}", None
+
+
 @_governed_ontology_mutation("create_concepts")
 def _create_concepts(**kwargs):
     from .transport import (
@@ -1839,36 +1931,11 @@ def _create_concepts(**kwargs):
                     ),
                 ],
             )
-    raw_scope_mode = kwargs.get("scope_mode")
-    if raw_scope_mode is None:
-        raw_scope_mode = kwargs.get("visibility_scope_mode")
-    scope_mode = _normalise_create_concepts_scope_mode(raw_scope_mode)
-    if raw_scope_mode is None:
-        scope_mode = _CREATE_CONCEPTS_SCOPE_USER_ONLY
-    if (
-        raw_scope_mode is not None
-        and isinstance(raw_scope_mode, str)
-        and raw_scope_mode.strip()
-        and scope_mode is None
-    ):
-        return make_error_response(
-            "invalid_parameter",
-            f"Invalid scope_mode '{raw_scope_mode}'.",
-            details={
-                "scope_mode": raw_scope_mode,
-                "supported_scope_modes": [
-                    _CREATE_CONCEPTS_SCOPE_DEFAULT,
-                    _CREATE_CONCEPTS_SCOPE_USER_ONLY,
-                    _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
-                    _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
-                ],
-            },
-            suggestions=[
-                "Use scope_mode='user_only_default' for actor-private concepts",
-                "Use scope_mode='organisation_general' for organisation-scoped shared concepts",
-                "Use scope_mode='global_general' for broadly visible concepts",
-            ],
-        )
+    scope_mode, scope_mode_source, scope_mode_error = (
+        _resolve_create_concepts_scope_mode(kwargs)
+    )
+    if scope_mode_error is not None:
+        return scope_mode_error
 
     from ...services.workflow_event_integration_service import (
         resolve_event_actor_context,
@@ -2794,11 +2861,7 @@ def _create_concepts(**kwargs):
         "parent_resolution": parent_resolution.to_dict(),
         "scope_selection": {
             "requested_scope_mode": scope_mode or _CREATE_CONCEPTS_SCOPE_USER_ONLY,
-            "scope_mode_source": (
-                "request.scope_mode"
-                if isinstance(raw_scope_mode, str) and raw_scope_mode.strip()
-                else "default.user_only_default"
-            ),
+            "scope_mode_source": scope_mode_source,
             "created_by_concept_id": actor_user_id,
             "organisation_concept_id": actor_org_id,
             "effective_scope_modes": applied_scope_modes,
@@ -10518,6 +10581,7 @@ def _concepts_create_input_schema() -> Schema:
             "namespace": (str, type(None)),
             "scope_mode": (str, type(None)),
             "visibility_scope_mode": (str, type(None)),
+            "publication_scope": (str, type(None)),
             "created_by_concept_id": (str, type(None)),
             "organisation_concept_id": (str, type(None)),
         },
@@ -10533,6 +10597,20 @@ def _concepts_create_input_schema() -> Schema:
             "scope_mode": [
                 _CREATE_CONCEPTS_SCOPE_USER_ONLY,
                 _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
+                _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
+                None,
+            ],
+            "publication_scope": [
+                "private",
+                "user_only",
+                _CREATE_CONCEPTS_SCOPE_USER_ONLY,
+                "organisation",
+                "organization",
+                _CREATE_CONCEPTS_SCOPE_ORGANISATION_GENERAL,
+                "organization_general",
+                "org_general",
+                "global",
+                "public",
                 _CREATE_CONCEPTS_SCOPE_GLOBAL_GENERAL,
                 None,
             ],
@@ -10571,7 +10649,10 @@ def _concepts_create_input_schema() -> Schema:
             "after creation through separate add_relationship effects using exact "
             "existing predicate IDs. Omit scope_mode for actor-private visibility, "
             "or choose exactly 'user_only_default', 'organisation_general', or "
-            "'global_general' according to the intended audience. The requested "
+            "'global_general' according to the intended audience. "
+            "publication_scope is a compatibility alias and accepts natural "
+            "'organisation'/'organization' values. Conflicting scope fields are "
+            "rejected before mutation. The requested "
             "scope succeeds only under the authenticated actor's matching live "
             "authority; denial never silently creates a narrower private concept. "
             "Optional namespace is propagated for tenancy attribution. Unknown "

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -1451,6 +1451,26 @@
                             "null"
                         ]
                     },
+                    "publication_scope": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "enum": [
+                            "private",
+                            "user_only",
+                            "user_only_default",
+                            "organisation",
+                            "organization",
+                            "organisation_general",
+                            "organization_general",
+                            "org_general",
+                            "global",
+                            "public",
+                            "global_general",
+                            null
+                        ]
+                    },
                     "ontology_delegation_id": {
                         "type": "string",
                         "description": "Opaque server-issued delegation for this exact canonical ontology mutation. It does not identify or authenticate a user."
@@ -1465,7 +1485,7 @@
                     "concepts"
                 ],
                 "additionalProperties": true,
-                "description": "Governed create_concepts input: parent_id is one exact semantic type concept ID, and concepts must contain exactly one core concept specification: {name, kind, concept_id?, description?, notes?, vontology_path?, instance_of_type?}. kind is 'instance' for an individual, 'type' for a subtype, or 'predicate' for a relationship type. duplicate_resolution_mode='canonical_id_only' skips semantic name resolution after an exact concept-ID miss; omitting it preserves the default semantic duplicate check. A name match may block a duplicate and return a candidate for inspection, but it is never silently treated as person identity by this governed command. This effect idempotently reuses only the exact requested actor-visible concept. Reuse requires compatible kind and direct or transitive requested typing, then returns that effective existing ID and its actual publication context. Requested description, notes, path, and creation scope are reported as satisfied or unapplied; reuse never silently mutates them. When an actor-hidden ID collision prevents an instance create, the failure may advertise one executable create_actor_scoped_referent_after_id_conflict action. Use that action's complete arguments to opt into collision_resolution_mode='actor_scoped_referent'; the server derives the actor-private ID from trusted actor context and does not create an alias or identity/equivalence assertion. Recovery mode treats requested_concept_id only as an identity seed; it does not inspect or confirm whether that ID is occupied. This governed effect does not accept batched concepts, external identity or identity review fields, attributes, tags, linked concepts, duplicate suffixing, or multiple parents. Add further classifications or relationships after creation through separate add_relationship effects using exact existing predicate IDs. Omit scope_mode for actor-private visibility, or choose exactly 'user_only_default', 'organisation_general', or 'global_general' according to the intended audience. The requested scope succeeds only under the authenticated actor's matching live authority; denial never silently creates a narrower private concept. Optional namespace is propagated for tenancy attribution. Unknown top-level fields remain tolerated for orchestrator-added context but do not enlarge the governed effect."
+                "description": "Governed create_concepts input: parent_id is one exact semantic type concept ID, and concepts must contain exactly one core concept specification: {name, kind, concept_id?, description?, notes?, vontology_path?, instance_of_type?}. kind is 'instance' for an individual, 'type' for a subtype, or 'predicate' for a relationship type. duplicate_resolution_mode='canonical_id_only' skips semantic name resolution after an exact concept-ID miss; omitting it preserves the default semantic duplicate check. A name match may block a duplicate and return a candidate for inspection, but it is never silently treated as person identity by this governed command. This effect idempotently reuses only the exact requested actor-visible concept. Reuse requires compatible kind and direct or transitive requested typing, then returns that effective existing ID and its actual publication context. Requested description, notes, path, and creation scope are reported as satisfied or unapplied; reuse never silently mutates them. When an actor-hidden ID collision prevents an instance create, the failure may advertise one executable create_actor_scoped_referent_after_id_conflict action. Use that action's complete arguments to opt into collision_resolution_mode='actor_scoped_referent'; the server derives the actor-private ID from trusted actor context and does not create an alias or identity/equivalence assertion. Recovery mode treats requested_concept_id only as an identity seed; it does not inspect or confirm whether that ID is occupied. This governed effect does not accept batched concepts, external identity or identity review fields, attributes, tags, linked concepts, duplicate suffixing, or multiple parents. Add further classifications or relationships after creation through separate add_relationship effects using exact existing predicate IDs. Omit scope_mode for actor-private visibility, or choose exactly 'user_only_default', 'organisation_general', or 'global_general' according to the intended audience. publication_scope is a compatibility alias and accepts natural 'organisation'/'organization' values. Conflicting scope fields are rejected before mutation. The requested scope succeeds only under the authenticated actor's matching live authority; denial never silently creates a narrower private concept. Optional namespace is propagated for tenancy attribution. Unknown top-level fields remain tolerated for orchestrator-added context but do not enlarge the governed effect."
             }
         },
         {

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -1,6 +1,38 @@
 import pytest
 
 
+def test_create_concepts_publication_scope_alias_resolves_without_authority_change():
+    from src.backend.integrations.internal_mcp.catalogue import (
+        _resolve_create_concepts_scope_mode,
+    )
+
+    scope_mode, source, error = _resolve_create_concepts_scope_mode(
+        {"publication_scope": "organisation"}
+    )
+
+    assert error is None
+    assert scope_mode == "organisation_general"
+    assert source == "request.publication_scope"
+
+
+def test_create_concepts_scope_alias_conflict_is_not_started():
+    from src.backend.integrations.internal_mcp.catalogue import (
+        _resolve_create_concepts_scope_mode,
+    )
+
+    _, _, error = _resolve_create_concepts_scope_mode(
+        {
+            "scope_mode": "user_only_default",
+            "publication_scope": "organisation",
+        }
+    )
+
+    assert error is not None
+    assert error["error_code"] == "conflicting_scope_mode_fields"
+    assert error["effect_status"] == "not_started"
+    assert error["changed"] is False
+
+
 @pytest.fixture
 def trusted_gmail_operator(monkeypatch):
     """Explicit local-operator provenance for handler-mechanics tests."""
@@ -462,6 +494,10 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "organisation_general",
         "global_general",
         None,
+    ]
+    assert "publication_scope" in create_definition.input_schema.optional
+    assert "organisation" in create_definition.input_schema.enum_values[
+        "publication_scope"
     ]
     assert create_definition.input_schema.array_length_constraints == {
         "concepts": (1, 1)

--- a/tests/backend/test_mcp_create_concepts_unknown_fields.py
+++ b/tests/backend/test_mcp_create_concepts_unknown_fields.py
@@ -249,11 +249,56 @@ def test_create_concepts_scope_mode_organisation_general():
 
     assert first_result.get("success") is True
     assert "specific_to_user" not in relationships
-    assert relationships.get(CANONICAL_SPECIFIC_TO_ORG_PREDICATE) == ["#V#scope_org"]
+    assert relationships.get(CANONICAL_SPECIFIC_TO_ORG_PREDICATE) == [
+        "#V#scope_org"
+    ]
     scope_selection = result.get("scope_selection") or {}
     assert scope_selection.get("requested_scope_mode") == "organisation_general"
     assert scope_selection.get("scope_mode_source") == "request.scope_mode"
     assert "organisation_general" in (scope_selection.get("effective_scope_modes") or [])
+
+
+def test_create_concepts_publication_scope_organisation_alias():
+    """The natural publication_scope alias must retain organisation audience."""
+    import uuid
+
+    unique_name = f"scope_mode_test_publication_alias_{uuid.uuid4().hex[:8]}"
+    result = _create_concepts(
+        parent_id="#V#abstract_object",
+        namespace="#V#scope_user@scope_org",
+        publication_scope="organisation",
+        concepts=[{"name": unique_name, "kind": "type"}],
+    )
+    first_result = (result.get("results") or [{}])[0]
+    relationships = (first_result.get("concept") or {}).get("relationships") or {}
+
+    assert first_result.get("success") is True
+    assert "specific_to_user" not in relationships
+    assert relationships.get(CANONICAL_SPECIFIC_TO_ORG_PREDICATE) == ["#V#scope_org"]
+    scope_selection = result.get("scope_selection") or {}
+    assert scope_selection.get("requested_scope_mode") == "organisation_general"
+    assert scope_selection.get("scope_mode_source") == "request.publication_scope"
+
+
+def test_create_concepts_rejects_conflicting_scope_aliases_before_mutation():
+    result = _create_concepts(
+        parent_id="#V#abstract_object",
+        namespace="#V#scope_user@scope_org",
+        scope_mode="user_only_default",
+        publication_scope="organisation",
+        concepts=[{"name": "scope_mode_test_conflict", "kind": "type"}],
+    )
+
+    assert result.get("success") is False
+    assert result.get("error_code") == "conflicting_scope_mode_fields"
+    assert result.get("effect_status") == "not_started"
+    assert result.get("changed") is False
+    assert (
+        ConceptsRepository.collection().find_one(
+            {"concept_id": "#V#scope_mode_test_conflict"}
+        )
+        is None
+    )
 
 
 def test_create_concepts_scope_mode_global_general():
@@ -292,6 +337,18 @@ def test_create_concepts_scope_mode_org_general_requires_org_context():
     }
 
     result = _create_concepts(**payload)
+    assert result.get("success") is False
+    assert result.get("error_code") == "missing_organisation_context"
+
+
+def test_create_concepts_publication_scope_org_requires_org_context():
+    result = _create_concepts(
+        parent_id="#V#abstract_object",
+        namespace="#V#scope_user",
+        publication_scope="organisation",
+        concepts=[{"name": "scope_mode_test_missing_org_alias", "kind": "type"}],
+    )
+
     assert result.get("success") is False
     assert result.get("error_code") == "missing_organisation_context"
 


### PR DESCRIPTION
## Outcome
Prevent organisation-intended concepts from silently defaulting to user-private when a model uses the natural top-level `publication_scope` field.

## Authority boundary
`publication_scope: organisation` normalises to the existing `organisation_general` mode. Trusted actor and organisation resolution remains unchanged. Conflicting audience fields fail before mutation, and organisation scope still requires trusted organisation context.

## Validation
- focused alias and conflict unit tests
- catalogue schema and generated manifest parity
- existing scope integration cases retained (skipped locally without disposable Mongo)
- Python compilation and diff checks

The DGX browser replay after deployment is the canonical positive write/read-back check.

Jira: JVNAUTOSCI-2705