### PR TITLE
Support startup seed receipts on standalone Mongo

### DIFF
--- a/src/backend/services/concept_summary_field_vontology_service.py
+++ b/src/backend/services/concept_summary_field_vontology_service.py
@@ -434,10 +434,15 @@ def reconcile_canonical_concept_summary_fields(
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
     source_digest = _startup_source_digest(bundle)
+    scope = _startup_freshness_scope(bundle)
     passes: list[dict[str, Any]] = []
 
     def run_canonical_pass() -> dict[str, Any]:
-        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        observation = seed_freshness.begin_startup_seed_freshness_observation(
+            concept_ids=scope["concept_ids"],
+            text_relation_subject_ids=scope["text_relation_subject_ids"],
+            text_relation_predicates=scope["text_relation_predicates"],
+        )
         report = _bootstrap_canonical_concept_summary_fields(
             asset_path=asset_path,
             freshness_context={
@@ -515,6 +520,11 @@ def ensure_concept_summary_fields_current_for_startup(
         text_relation_predicates=scope["text_relation_predicates"],
     )
     public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    read_strategy = (
+        "dependency_snapshot_receipt"
+        if freshness_check.get("verification_mode") == "dependency_snapshot"
+        else "dependency_receipt"
+    )
     if freshness_check.get("fresh"):
         metadata = freshness_check.get("metadata")
         metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
@@ -531,7 +541,7 @@ def ensure_concept_summary_fields_current_for_startup(
             "seed_version": bundle.get("seed_version"),
             "source_tag": metadata.get("source_tag") or bundle.get("source_tag"),
             "managed_by": metadata.get("managed_by") or bundle.get("managed_by"),
-            "read_strategy": "dependency_receipt",
+            "read_strategy": read_strategy,
             "read_phases": 1,
             "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
@@ -550,7 +560,7 @@ def ensure_concept_summary_fields_current_for_startup(
         "asset_path": bundle.get("asset_path"),
         "schema_version": bundle.get("schema_version"),
         "seed_version": bundle.get("seed_version"),
-        "read_strategy": "dependency_receipt",
+        "read_strategy": read_strategy,
         "read_phases": 1,
         "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
         "duration_ms": int((time.perf_counter() - started_at) * 1000),

--- a/src/backend/services/constitutive_relation_requirement_service.py
+++ b/src/backend/services/constitutive_relation_requirement_service.py
@@ -409,10 +409,15 @@ def reconcile_canonical_constitutive_relation_requirement_profiles(
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
     source_digest = _startup_source_digest(bundle)
+    scope = _startup_freshness_scope(bundle)
     passes: list[dict[str, Any]] = []
 
     def run_canonical_pass() -> dict[str, Any]:
-        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        observation = seed_freshness.begin_startup_seed_freshness_observation(
+            concept_ids=scope["concept_ids"],
+            text_relation_subject_ids=scope["text_relation_subject_ids"],
+            text_relation_predicates=scope["text_relation_predicates"],
+        )
         report = ensure_canonical_constitutive_relation_requirement_profiles(
             asset_path=asset_path,
             freshness_context={
@@ -473,7 +478,7 @@ def ensure_constitutive_relation_requirement_profiles_current_for_startup(
     *,
     asset_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Check the release receipt without reading or writing canonical profiles."""
+    """Check freshness without running reconciliation or canonical writes."""
 
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
@@ -489,13 +494,18 @@ def ensure_constitutive_relation_requirement_profiles_current_for_startup(
         text_relation_predicates=scope["text_relation_predicates"],
     )
     public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    read_strategy = (
+        "dependency_snapshot_receipt"
+        if freshness_check.get("verification_mode") == "dependency_snapshot"
+        else "dependency_receipt"
+    )
     common = {
         "skipped": True,
         "changed": False,
         "asset_path": bundle.get("asset_path"),
         "schema_version": bundle.get("schema_version"),
         "seed_version": bundle.get("seed_version"),
-        "read_strategy": "dependency_receipt",
+        "read_strategy": read_strategy,
         "read_phases": 1,
         "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
         "duration_ms": int((time.perf_counter() - started_at) * 1000),

--- a/src/backend/services/publication_scope_profile_vontology_service.py
+++ b/src/backend/services/publication_scope_profile_vontology_service.py
@@ -560,10 +560,15 @@ def reconcile_canonical_publication_scope_profiles(
     started_at = time.perf_counter()
     bundle = _load_seed_bundle(asset_path)
     source_digest = _startup_source_digest(bundle)
+    scope = _startup_freshness_scope(bundle)
     passes: list[dict[str, Any]] = []
 
     def run_canonical_pass() -> dict[str, Any]:
-        observation = seed_freshness.begin_startup_seed_freshness_observation()
+        observation = seed_freshness.begin_startup_seed_freshness_observation(
+            concept_ids=scope["concept_ids"],
+            text_relation_subject_ids=scope["text_relation_subject_ids"],
+            text_relation_predicates=scope["text_relation_predicates"],
+        )
         report = _bootstrap_canonical_publication_scope_profiles(
             asset_path=asset_path,
             freshness_context={
@@ -640,6 +645,11 @@ def ensure_publication_scope_profiles_current_for_startup(
         text_relation_predicates=scope["text_relation_predicates"],
     )
     public_check = seed_freshness.public_startup_seed_freshness_result(freshness_check)
+    read_strategy = (
+        "dependency_snapshot_receipt"
+        if freshness_check.get("verification_mode") == "dependency_snapshot"
+        else "dependency_receipt"
+    )
     if freshness_check.get("fresh"):
         metadata = freshness_check.get("metadata")
         metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
@@ -656,7 +666,7 @@ def ensure_publication_scope_profiles_current_for_startup(
             "seed_version": bundle.get("seed_version"),
             "source_tag": metadata.get("source_tag") or bundle.get("source_tag"),
             "managed_by": metadata.get("managed_by") or bundle.get("managed_by"),
-            "read_strategy": "dependency_receipt",
+            "read_strategy": read_strategy,
             "read_phases": 1,
             "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
@@ -675,7 +685,7 @@ def ensure_publication_scope_profiles_current_for_startup(
         "asset_path": bundle.get("asset_path"),
         "schema_version": bundle.get("schema_version"),
         "seed_version": bundle.get("seed_version"),
-        "read_strategy": "dependency_receipt",
+        "read_strategy": read_strategy,
         "read_phases": 1,
         "canonical_read_batches": {"concepts": 0, "text_assertions": 0},
         "duration_ms": int((time.perf_counter() - started_at) * 1000),

--- a/src/backend/services/startup_seed_freshness_service.py
+++ b/src/backend/services/startup_seed_freshness_service.py
@@ -4,8 +4,10 @@ The receipts in this module are derived support state.  They never replace
 Vontology as authority: a missing, incompatible, or unresumable receipt makes
 the affected startup subsystem unavailable until an explicit release or
 maintenance reconciliation verifies canonical state and publishes a new
-receipt.  Ordinary process startup never turns that miss into hidden canonical
-reads or writes.
+receipt. Replica-set deployments use change-stream checkpoints. Standalone
+Mongo deployments, where change streams do not exist, compare a bounded digest
+of the exact dependency documents; ordinary startup still never performs seed
+reconciliation or hidden canonical writes.
 """
 
 from __future__ import annotations
@@ -22,9 +24,10 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, unquote, urlsplit
 
-from bson import BSON
+from bson import BSON, ObjectId
+from bson.json_util import CANONICAL_JSON_OPTIONS, dumps as bson_json_dumps
 
-STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION = "startup_seed_freshness_receipt.v1"
+STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION = "startup_seed_freshness_receipt.v2"
 _RECEIPT_FILE_SCHEMA_VERSION = "startup_seed_freshness_receipts.v1"
 _DEFAULT_RECEIPT_PATH = (
     Path(__file__).resolve().parents[3]
@@ -80,6 +83,16 @@ def _max_events() -> int:
     except (TypeError, ValueError):
         configured = 10_000
     return max(1, min(configured, 1_000_000))
+
+
+def _max_snapshot_documents() -> int:
+    try:
+        configured = int(
+            os.getenv("VON_STARTUP_SEED_SNAPSHOT_MAX_DOCUMENTS", "5000")
+        )
+    except (TypeError, ValueError):
+        configured = 5_000
+    return max(100, min(configured, 100_000))
 
 
 def _dependency_scope(
@@ -354,6 +367,126 @@ def _watch_pipeline() -> list[dict[str, Any]]:
     ]
 
 
+def _snapshot_find(
+    db: Any,
+    *,
+    collection_name: str,
+    query: Mapping[str, Any],
+    remaining: int,
+) -> list[Mapping[str, Any]]:
+    if remaining <= 0:
+        raise ValueError("dependency_snapshot_document_limit_exceeded")
+    cursor = db[collection_name].find(dict(query)).limit(remaining + 1)
+    documents = [dict(document) for document in cursor]
+    if len(documents) > remaining:
+        raise ValueError("dependency_snapshot_document_limit_exceeded")
+    return documents
+
+
+def _text_value_id_candidates(relations: Sequence[Mapping[str, Any]]) -> list[Any]:
+    candidates: list[Any] = []
+    for relation in relations:
+        for field_name in ("text_value_id", "object_text_id"):
+            value = relation.get(field_name)
+            if value is None or value in candidates:
+                continue
+            candidates.append(value)
+            if isinstance(value, str) and ObjectId.is_valid(value):
+                object_id = ObjectId(value)
+                if object_id not in candidates:
+                    candidates.append(object_id)
+    return candidates
+
+
+def _build_dependency_snapshot(
+    db: Any,
+    *,
+    scope: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    """Digest the bounded raw documents that the canonical seed depends on."""
+
+    concept_ids = _normalised_strings(scope.get("concept_ids"))
+    subject_ids = _normalised_strings(scope.get("text_relation_subject_ids"))
+    predicates = _normalised_strings(scope.get("text_relation_predicates"))
+    if not concept_ids and not subject_ids and not predicates:
+        return {
+            "success": False,
+            "reason": "dependency_snapshot_scope_missing",
+        }
+
+    maximum = _max_snapshot_documents()
+    counts: dict[str, int] = {}
+    try:
+        concepts = _snapshot_find(
+            db,
+            collection_name="concepts",
+            query={"concept_id": {"$in": concept_ids}},
+            remaining=maximum,
+        )
+        counts["concepts"] = len(concepts)
+        remaining = maximum - len(concepts)
+
+        relations: list[Mapping[str, Any]] = []
+        if subject_ids and predicates:
+            relations = _snapshot_find(
+                db,
+                collection_name="text_relations",
+                query={
+                    "subject_concept_id": {"$in": subject_ids},
+                    "predicate": {"$in": predicates},
+                },
+                remaining=remaining,
+            )
+        counts["text_relations"] = len(relations)
+        remaining -= len(relations)
+
+        text_values: list[Mapping[str, Any]] = []
+        value_ids = _text_value_id_candidates(relations)
+        if value_ids:
+            text_values = _snapshot_find(
+                db,
+                collection_name="text_values",
+                query={"_id": {"$in": value_ids}},
+                remaining=remaining,
+            )
+        counts["text_values"] = len(text_values)
+    except Exception as exc:  # noqa: BLE001 - a snapshot failure is typed
+        return {
+            "success": False,
+            "reason": (
+                "dependency_snapshot_document_limit_exceeded"
+                if str(exc) == "dependency_snapshot_document_limit_exceeded"
+                else "dependency_snapshot_read_failed"
+            ),
+            "error_type": type(exc).__name__,
+        }
+
+    digest = hashlib.sha256()
+    for collection_name, documents in (
+        ("concepts", concepts),
+        ("text_relations", relations),
+        ("text_values", text_values),
+    ):
+        digest.update(collection_name.encode("utf-8"))
+        digest.update(b"\0")
+        for document in sorted(documents, key=lambda item: _text(item.get("_id"))):
+            encoded = bson_json_dumps(
+                document,
+                json_options=CANONICAL_JSON_OPTIONS,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+    return {
+        "success": True,
+        "reason": "dependency_snapshot_captured",
+        "_dependency_snapshot_sha256": digest.hexdigest(),
+        "document_counts": counts,
+        "query_count": 2 + int(bool(value_ids)),
+    }
+
+
 def _drain_changes(
     *,
     db: Any,
@@ -464,7 +597,12 @@ def _drain_changes(
                 pass
 
 
-def begin_startup_seed_freshness_observation() -> dict[str, Any]:
+def begin_startup_seed_freshness_observation(
+    *,
+    concept_ids: Sequence[str] = (),
+    text_relation_subject_ids: Sequence[str] = (),
+    text_relation_predicates: Sequence[str] = (),
+) -> dict[str, Any]:
     """Capture a server operation time before canonical verification begins."""
 
     if not _receipts_enabled():
@@ -474,9 +612,17 @@ def begin_startup_seed_freshness_observation() -> dict[str, Any]:
         hello = db.command("hello")
         operation_time = hello.get("operationTime")
         if operation_time is None:
+            scope = _dependency_scope(
+                concept_ids=concept_ids,
+                text_relation_subject_ids=text_relation_subject_ids,
+                text_relation_predicates=text_relation_predicates,
+            )
+            snapshot = _build_dependency_snapshot(db, scope=scope)
+            if not snapshot.get("success"):
+                return _public_result(snapshot)
             return {
-                "success": False,
-                "reason": "mongo_operation_time_unavailable",
+                **snapshot,
+                "verification_mode": "dependency_snapshot",
             }
         return {
             "success": True,
@@ -557,13 +703,6 @@ def check_startup_seed_freshness(
             "reason": "tracked_dependency_ids_missing",
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
         }
-    token = _decode_resume_token(entry.get("resume_token_bson_base64"))
-    if token is None:
-        return {
-            **base_result,
-            "reason": "resume_token_invalid",
-            "duration_ms": int((time.perf_counter() - started_at) * 1000),
-        }
     try:
         db = _get_db()
         authority_fingerprint = _current_authority_fingerprint(db)
@@ -578,6 +717,60 @@ def check_startup_seed_freshness(
         return {
             **base_result,
             "reason": "authority_fingerprint_mismatch",
+            "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if entry.get("verification_mode") == "dependency_snapshot":
+        snapshot = _build_dependency_snapshot(db, scope=scope)
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        if not snapshot.get("success"):
+            return {
+                **base_result,
+                **_public_result(snapshot),
+                "verification_mode": "dependency_snapshot",
+                "duration_ms": duration_ms,
+            }
+        expected_digest = _text(entry.get("dependency_snapshot_sha256"))
+        actual_digest = _text(snapshot.get("_dependency_snapshot_sha256"))
+        if not expected_digest or actual_digest != expected_digest:
+            return {
+                **base_result,
+                "reason": "dependency_snapshot_mismatch",
+                "verification_mode": "dependency_snapshot",
+                "document_counts": snapshot.get("document_counts"),
+                "query_count": snapshot.get("query_count"),
+                "duration_ms": duration_ms,
+            }
+        refreshed_entry = {
+            **dict(entry),
+            "last_checked_at_epoch_seconds": time.time(),
+        }
+        try:
+            _persist_receipt_entry(family_id, refreshed_entry)
+        except Exception as exc:  # noqa: BLE001 - persistence failure is a miss
+            return {
+                **base_result,
+                "reason": "receipt_checkpoint_persist_failed",
+                "verification_mode": "dependency_snapshot",
+                "error_type": type(exc).__name__,
+                "duration_ms": duration_ms,
+            }
+        return {
+            **base_result,
+            "fresh": True,
+            "reason": "dependency_snapshot_receipt_current",
+            "verification_mode": "dependency_snapshot",
+            "document_counts": snapshot.get("document_counts"),
+            "query_count": snapshot.get("query_count"),
+            "verified_at_epoch_seconds": entry.get("verified_at_epoch_seconds"),
+            "metadata": dict(entry.get("metadata") or {}),
+            "duration_ms": duration_ms,
+        }
+
+    token = _decode_resume_token(entry.get("resume_token_bson_base64"))
+    if token is None:
+        return {
+            **base_result,
+            "reason": "resume_token_invalid",
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
         }
     drained = _drain_changes(
@@ -677,6 +870,64 @@ def record_startup_seed_freshness(
             "reason": "authority_fingerprint_unavailable",
             "error_type": type(exc).__name__,
             "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        }
+    if observation.get("verification_mode") == "dependency_snapshot":
+        snapshot = _build_dependency_snapshot(db, scope=scope)
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        if not snapshot.get("success"):
+            return {
+                **base_result,
+                **_public_result(snapshot),
+                "verification_mode": "dependency_snapshot",
+                "duration_ms": duration_ms,
+            }
+        initial_digest = _text(observation.get("_dependency_snapshot_sha256"))
+        current_digest = _text(snapshot.get("_dependency_snapshot_sha256"))
+        if not initial_digest or current_digest != initial_digest:
+            return {
+                **base_result,
+                "reason": "dependency_snapshot_changed_during_verification",
+                "verification_mode": "dependency_snapshot",
+                "document_counts": snapshot.get("document_counts"),
+                "query_count": snapshot.get("query_count"),
+                "duration_ms": duration_ms,
+            }
+        now = time.time()
+        entry = {
+            "schema_version": STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION,
+            "family_id": family_id,
+            "source_digest": source_digest,
+            "producer_schema_version": producer_schema_version,
+            "authority_fingerprint": authority_fingerprint,
+            "dependency_scope": scope,
+            "tracked_ids": tracked_ids,
+            "verification_mode": "dependency_snapshot",
+            "dependency_snapshot_sha256": current_digest,
+            "verified_at_epoch_seconds": now,
+            "last_checked_at_epoch_seconds": now,
+            "metadata": dict(metadata or {}),
+        }
+        try:
+            _persist_receipt_entry(family_id, entry)
+        except Exception as exc:  # noqa: BLE001 - persistence failure is non-current
+            return {
+                **base_result,
+                "reason": "receipt_persist_failed",
+                "verification_mode": "dependency_snapshot",
+                "error_type": type(exc).__name__,
+                "duration_ms": duration_ms,
+            }
+        return {
+            **base_result,
+            "persisted": True,
+            "reason": "dependency_snapshot_receipt_persisted",
+            "verification_mode": "dependency_snapshot",
+            "document_counts": snapshot.get("document_counts"),
+            "query_count": snapshot.get("query_count"),
+            "tracked_dependency_counts": {
+                key: len(value) for key, value in tracked_ids.items()
+            },
+            "duration_ms": duration_ms,
         }
     drained = _drain_changes(
         db=db,

--- a/tests/backend/test_concept_summary_field_resolver.py
+++ b/tests/backend/test_concept_summary_field_resolver.py
@@ -433,7 +433,10 @@ def test_summary_field_explicit_reconciliation_verifies_after_write(
     observations: list[dict[str, Any]] = []
     recorded: list[dict[str, Any]] = []
 
-    def _observe() -> dict[str, Any]:
+    def _observe(**kwargs) -> dict[str, Any]:
+        assert kwargs["concept_ids"]
+        assert kwargs["text_relation_subject_ids"]
+        assert kwargs["text_relation_predicates"]
         observation = {
             "success": True,
             "_start_at_operation_time": f"before-pass-{len(observations) + 1}",

--- a/tests/backend/test_constitutive_relation_requirement_service.py
+++ b/tests/backend/test_constitutive_relation_requirement_service.py
@@ -485,7 +485,7 @@ def test_reconciliation_rechecks_after_materialising_profile(monkeypatch):
     monkeypatch.setattr(
         service.seed_freshness,
         "begin_startup_seed_freshness_observation",
-        lambda: {"success": True},
+        lambda **_kwargs: {"success": True},
     )
     monkeypatch.setattr(
         service,

--- a/tests/backend/test_publication_scope_profile_service.py
+++ b/tests/backend/test_publication_scope_profile_service.py
@@ -694,7 +694,10 @@ def test_publication_profile_explicit_reconciliation_publishes_current_receipt(
     observations: list[dict[str, Any]] = []
     recorded: list[dict[str, Any]] = []
 
-    def _observe() -> dict[str, Any]:
+    def _observe(**kwargs) -> dict[str, Any]:
+        assert kwargs["concept_ids"]
+        assert kwargs["text_relation_subject_ids"]
+        assert kwargs["text_relation_predicates"]
         observation = {
             "success": True,
             "_start_at_operation_time": f"before-pass-{len(observations) + 1}",

--- a/tests/backend/test_startup_seed_freshness_service.py
+++ b/tests/backend/test_startup_seed_freshness_service.py
@@ -51,6 +51,65 @@ class _FakeDatabase:
         return self._streams.pop(0)
 
 
+class _FakeSnapshotCursor(list):
+    def limit(self, count: int):
+        return _FakeSnapshotCursor(self[:count])
+
+
+class _FakeSnapshotCollection:
+    def __init__(self, documents: list[dict[str, Any]]) -> None:
+        self.documents = documents
+
+    def find(self, query: Mapping[str, Any]):
+        def matches(document: Mapping[str, Any]) -> bool:
+            for field_name, condition in query.items():
+                allowed = condition.get("$in") if isinstance(condition, Mapping) else None
+                if allowed is None or document.get(field_name) not in allowed:
+                    return False
+            return True
+
+        return _FakeSnapshotCursor(
+            [dict(document) for document in self.documents if matches(document)]
+        )
+
+
+class _FakeSnapshotDatabase:
+    name = "von_db"
+
+    def __init__(self) -> None:
+        self.collections = {
+            "concepts": _FakeSnapshotCollection(
+                [
+                    {
+                        "_id": "concept-document",
+                        "concept_id": "#V#subject",
+                        "name": "Subject",
+                    }
+                ]
+            ),
+            "text_relations": _FakeSnapshotCollection(
+                [
+                    {
+                        "_id": "relation-document",
+                        "subject_concept_id": "#V#subject",
+                        "predicate": "#V#has_config",
+                        "text_value_id": "text-document",
+                    }
+                ]
+            ),
+            "text_values": _FakeSnapshotCollection(
+                [{"_id": "text-document", "text": "configuration"}]
+            ),
+        }
+
+    def command(self, name: str) -> dict[str, Any]:
+        assert name == "hello"
+        return {"isWritablePrimary": True}
+
+    def __getitem__(self, collection_name: str) -> _FakeSnapshotCollection:
+        return self.collections[collection_name]
+
+
 @pytest.fixture
 def receipt_environment(
     tmp_path: Path,
@@ -134,6 +193,122 @@ def test_receipt_round_trip_skips_unrelated_changes(
     assert "resume_token" not in str(checked)
     assert db.watch_calls[0]["kwargs"]["start_at_operation_time"] == ("operation-time")
     assert "resume_after" in db.watch_calls[1]["kwargs"]
+
+
+def test_standalone_mongo_uses_bounded_dependency_snapshot_receipt(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeSnapshotDatabase()
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+
+    observation = freshness.begin_startup_seed_freshness_observation(
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+    recorded = freshness.record_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+        tracked_concept_document_ids=["concept-document"],
+        tracked_text_relation_document_ids=["relation-document"],
+        tracked_text_value_document_ids=["text-document"],
+        observation=observation,
+        metadata={"counts": {"items": 1}},
+    )
+    checked = _check(monkeypatch, db)
+
+    assert observation["verification_mode"] == "dependency_snapshot"
+    assert recorded["persisted"] is True
+    assert recorded["reason"] == "dependency_snapshot_receipt_persisted"
+    assert checked["fresh"] is True
+    assert checked["reason"] == "dependency_snapshot_receipt_current"
+    assert checked["verification_mode"] == "dependency_snapshot"
+    assert checked["document_counts"] == {
+        "concepts": 1,
+        "text_relations": 1,
+        "text_values": 1,
+    }
+    assert receipt_environment.exists()
+    assert "dependency_snapshot_sha256" not in str(checked)
+
+
+def test_standalone_snapshot_detects_new_relevant_relation(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeSnapshotDatabase()
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+    observation = freshness.begin_startup_seed_freshness_observation(
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+    recorded = freshness.record_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+        tracked_concept_document_ids=["concept-document"],
+        tracked_text_relation_document_ids=["relation-document"],
+        tracked_text_value_document_ids=["text-document"],
+        observation=observation,
+    )
+    assert recorded["persisted"] is True
+
+    db.collections["text_relations"].documents.append(
+        {
+            "_id": "new-relation",
+            "subject_concept_id": "#V#subject",
+            "predicate": "#V#has_config",
+            "text_value_id": "new-text",
+        }
+    )
+    db.collections["text_values"].documents.append(
+        {"_id": "new-text", "text": "changed configuration"}
+    )
+
+    checked = _check(monkeypatch, db)
+    assert checked["fresh"] is False
+    assert checked["reason"] == "dependency_snapshot_mismatch"
+    assert checked["verification_mode"] == "dependency_snapshot"
+
+
+def test_standalone_snapshot_change_during_verification_is_not_persisted(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeSnapshotDatabase()
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+    observation = freshness.begin_startup_seed_freshness_observation(
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+    db.collections["concepts"].documents[0]["name"] = "Changed"
+
+    recorded = freshness.record_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+        tracked_concept_document_ids=["concept-document"],
+        tracked_text_relation_document_ids=["relation-document"],
+        tracked_text_value_document_ids=["text-document"],
+        observation=observation,
+    )
+
+    assert recorded["persisted"] is False
+    assert recorded["reason"] == "dependency_snapshot_changed_during_verification"
+    assert not receipt_environment.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Outcome
Allow explicit seed reconciliation and startup freshness checks to converge on standalone Mongo deployments such as the DGX local database.

## Mechanism
- Preserve change-stream checkpoints on replica sets.
- When `hello` has no `operationTime`, digest the bounded exact dependency documents before and after canonical verification.
- Persist only a quiet-window match; startup recomputes the same read-only digest.
- Include concepts, newly relevant text relations, and referenced text values.
- Keep authority fingerprint, source digest, producer version, scope, and document bound checks.

## Validation
- 59 freshness/materialisation tests
- 19 deployment/health tests
- standalone round-trip, relevant insertion invalidation, and concurrent-change denial
- narrow fatal-lint, Python compilation, and diff checks

Live DGX reconciliation and restart/read-back follows merge.

Jira: JVNAUTOSCI-2712