### PR TITLE
Recover denied stale organisation selection to Personal

### DIFF
--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -41,6 +41,7 @@ import {
   resolveBrowserBootstrapOrganisationContext,
   resolveBrowserBootstrapUserContext
 } from './utils/runtimeIdentityBootstrap.js';
+import { recoverPersonalContextAfterMembershipDenial } from './utils/organisationSessionRecovery.js';
 import { hydrateStoredSelectionsFromUserPreferences } from './utils/userPreferenceBootstrap.js';
 import { isVontologyBusy, loadKeyConceptsForUser, preloadVontologyData, selectVontologyNodeByIdentifier, setupVontologySearchUI } from './vontology.js';
 
@@ -406,9 +407,27 @@ async function syncFlaskSessionOrg() {
 
     console.log('[main] Syncing organisation to window session from storage:', orgConceptId,
       context.organisation_id ? `(was: ${context.organisation_id} from ${context.context_source})` : '(no previous org)');
-    const syncData = await postJson('/von/api/session/set_organisation', {
-      organisation_concept_id: orgConceptId
-    });
+    let syncData;
+    try {
+      syncData = await postJson('/von/api/session/set_organisation', {
+        organisation_concept_id: orgConceptId
+      });
+    } catch (err) {
+      const currentUser = parseStoredContextValue(localStorage.getItem('von_current_user'));
+      const recovery = await recoverPersonalContextAfterMembershipDenial({
+        error: err,
+        postJson,
+        userContext: currentUser,
+      });
+      if (!recovery) {
+        throw err;
+      }
+      console.warn(
+        '[main] Stored organisation is unavailable to the authenticated user; recovered to Personal:',
+        orgConceptId
+      );
+      return recovery;
+    }
     console.log('[main] Window session org synced:', syncData);
     if (syncData.namespace) {
       setSessionScopedNamespace(syncData.namespace);

--- a/src/frontend/web/von_interface/static/js/utils/organisationSessionRecovery.js
+++ b/src/frontend/web/von_interface/static/js/utils/organisationSessionRecovery.js
@@ -1,0 +1,44 @@
+import { resolveBrowserBootstrapNamespace } from './runtimeIdentityBootstrap.js';
+import {
+    setSessionScopedNamespace,
+    setSessionScopedOrgContext,
+} from './sessionScopedStorage.js';
+
+export function isOrganisationMembershipDenial(error) {
+    return error?.status === 403
+        && error?.payload?.error_code === 'organisation_membership_required';
+}
+
+/**
+ * A stored organisation is only a preference, never authority. If the server
+ * rejects it for the authenticated actor, replace it with an explicit Personal
+ * binding before any settings or history request can inherit a cookie fallback.
+ */
+export async function recoverPersonalContextAfterMembershipDenial({
+    error,
+    postJson,
+    userContext = null,
+} = {}) {
+    if (!isOrganisationMembershipDenial(error)) {
+        return null;
+    }
+    if (typeof postJson !== 'function') {
+        throw new TypeError('postJson is required to recover the Personal context');
+    }
+
+    setSessionScopedOrgContext(null);
+    const namespace = resolveBrowserBootstrapNamespace({
+        userContext,
+        explicitPersonal: true,
+    });
+    setSessionScopedNamespace(namespace || null);
+
+    const response = await postJson('/von/api/session/set_organisation', {
+        organisation_concept_id: null,
+    });
+    return {
+        recovered_to_personal: true,
+        namespace: namespace || null,
+        response,
+    };
+}

--- a/tests/frontend/organisationSessionRecovery.test.js
+++ b/tests/frontend/organisationSessionRecovery.test.js
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+
+const modulePath = '../../src/frontend/web/von_interface/static/js/utils/organisationSessionRecovery.js';
+
+describe('organisation session recovery', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    test('turns a typed membership denial into an explicit Personal binding', async () => {
+        localStorage.setItem('von_current_org', JSON.stringify({
+            concept_id: '#V#unavailable_org',
+            name: 'Unavailable Org',
+        }));
+        localStorage.setItem('von_org_context', JSON.stringify({
+            concept_id: '#V#unavailable_org',
+        }));
+        localStorage.setItem(
+            'current_user_namespace',
+            '#V#michael_witbrock@unavailable_org'
+        );
+        sessionStorage.setItem(
+            'current_user_namespace',
+            '#V#michael_witbrock@unavailable_org'
+        );
+        const postJson = jest.fn().mockResolvedValue({
+            organisation_concept_id: null,
+            namespace: '#V#michael_witbrock',
+        });
+        const error = Object.assign(new Error('organisation_membership_required'), {
+            status: 403,
+            payload: { error_code: 'organisation_membership_required' },
+        });
+
+        const { recoverPersonalContextAfterMembershipDenial } = require(modulePath);
+        const result = await recoverPersonalContextAfterMembershipDenial({
+            error,
+            postJson,
+            userContext: { concept_id: '#V#michael_witbrock' },
+        });
+
+        expect(result).toMatchObject({
+            recovered_to_personal: true,
+            namespace: '#V#michael_witbrock',
+        });
+        expect(postJson).toHaveBeenCalledTimes(1);
+        expect(postJson).toHaveBeenCalledWith('/von/api/session/set_organisation', {
+            organisation_concept_id: null,
+        });
+        expect(sessionStorage.getItem('von_org_selection')).toBe('personal');
+        expect(sessionStorage.getItem('von_current_org')).toBeNull();
+        expect(localStorage.getItem('von_current_org')).toBeNull();
+        expect(localStorage.getItem('von_org_context')).toBeNull();
+        expect(sessionStorage.getItem('current_user_namespace'))
+            .toBe('#V#michael_witbrock');
+        expect(localStorage.getItem('current_user_namespace'))
+            .toBe('#V#michael_witbrock');
+    });
+
+    test('does not reinterpret another error as an organisation recovery', async () => {
+        const postJson = jest.fn();
+        const error = Object.assign(new Error('HTTP 500'), {
+            status: 500,
+            payload: { error_code: 'internal_error' },
+        });
+
+        const { recoverPersonalContextAfterMembershipDenial } = require(modulePath);
+        await expect(recoverPersonalContextAfterMembershipDenial({
+            error,
+            postJson,
+            userContext: { concept_id: '#V#michael_witbrock' },
+        })).resolves.toBeNull();
+
+        expect(postJson).not.toHaveBeenCalled();
+        expect(sessionStorage.getItem('von_org_selection')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Outcome
A fresh authenticated tab no longer keeps retrying or repopulating a stored organisation that the trusted server rejects for that actor. It settles into an explicit Personal context before settings and history initialise.

## Authority and scope
- Browser organisation state remains only a preference.
- Recovery triggers only for typed HTTP 403 `organisation_membership_required`.
- The server is explicitly rebound with `organisation_concept_id: null`; no membership or authority is inferred.
- Other errors retain the existing failure path.

## Validation
- 12 focused frontend tests pass.
- Static frontend lint passes.
- Live replay to follow on the Mac runtime after merge.

Jira: JVNAUTOSCI-2711