### PR TITLE
Keep startup seed receipts stable across index churn

### DIFF
--- a/src/backend/services/startup_seed_freshness_service.py
+++ b/src/backend/services/startup_seed_freshness_service.py
@@ -25,9 +25,10 @@ from typing import Any
 from urllib.parse import parse_qsl, unquote, urlsplit
 
 from bson import BSON, ObjectId
-from bson.json_util import CANONICAL_JSON_OPTIONS, dumps as bson_json_dumps
+from bson.json_util import CANONICAL_JSON_OPTIONS
+from bson.json_util import dumps as bson_json_dumps
 
-STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION = "startup_seed_freshness_receipt.v2"
+STARTUP_SEED_FRESHNESS_RECEIPT_SCHEMA_VERSION = "startup_seed_freshness_receipt.v3"
 _RECEIPT_FILE_SCHEMA_VERSION = "startup_seed_freshness_receipts.v1"
 _DEFAULT_RECEIPT_PATH = (
     Path(__file__).resolve().parents[3]
@@ -38,6 +39,16 @@ _DEFAULT_RECEIPT_PATH = (
 _RECEIPT_LOCK = threading.Lock()
 _WATCHED_COLLECTIONS = ("concepts", "text_relations", "text_values")
 _DDL_OPERATION_TYPES = frozenset({"drop", "rename", "dropDatabase", "invalidate"})
+_CONCEPT_DERIVED_INDEX_FIELDS = frozenset(
+    {
+        "embedding_error",
+        "embedding_status",
+        "embedding_updated_at",
+        "inherited_salient_binary_predicates",
+        "inherited_salient_computed_at",
+        "inherited_salient_error",
+    }
+)
 
 
 def _text(value: Any) -> str:
@@ -87,9 +98,7 @@ def _max_events() -> int:
 
 def _max_snapshot_documents() -> int:
     try:
-        configured = int(
-            os.getenv("VON_STARTUP_SEED_SNAPSHOT_MAX_DOCUMENTS", "5000")
-        )
+        configured = int(os.getenv("VON_STARTUP_SEED_SNAPSHOT_MAX_DOCUMENTS", "5000"))
     except (TypeError, ValueError):
         configured = 5_000
     return max(100, min(configured, 100_000))
@@ -322,6 +331,27 @@ def _event_relevance(
     document = full_document if isinstance(full_document, Mapping) else {}
 
     if collection_name == "concepts":
+        if operation_type == "update":
+            update_description = event.get("updateDescription")
+            if isinstance(update_description, Mapping):
+                changed_paths = {
+                    _text(path)
+                    for path in (
+                        *(update_description.get("updatedFields") or {}).keys(),
+                        *(update_description.get("removedFields") or ()),
+                        *(
+                            entry.get("field")
+                            for entry in update_description.get("truncatedArrays") or ()
+                            if isinstance(entry, Mapping)
+                        ),
+                    )
+                    if _text(path)
+                }
+                if changed_paths and all(
+                    path.split(".", 1)[0] in _CONCEPT_DERIVED_INDEX_FIELDS
+                    for path in changed_paths
+                ):
+                    return False, True
         if document_id and document_id in set(
             tracked_ids.get("concept_document_ids") or ()
         ):
@@ -470,8 +500,12 @@ def _build_dependency_snapshot(
         digest.update(collection_name.encode("utf-8"))
         digest.update(b"\0")
         for document in sorted(documents, key=lambda item: _text(item.get("_id"))):
+            digest_document = dict(document)
+            if collection_name == "concepts":
+                for field_name in _CONCEPT_DERIVED_INDEX_FIELDS:
+                    digest_document.pop(field_name, None)
             encoded = bson_json_dumps(
-                document,
+                digest_document,
                 json_options=CANONICAL_JSON_OPTIONS,
                 sort_keys=True,
                 separators=(",", ":"),

--- a/tests/backend/test_startup_seed_freshness_service.py
+++ b/tests/backend/test_startup_seed_freshness_service.py
@@ -63,7 +63,9 @@ class _FakeSnapshotCollection:
     def find(self, query: Mapping[str, Any]):
         def matches(document: Mapping[str, Any]) -> bool:
             for field_name, condition in query.items():
-                allowed = condition.get("$in") if isinstance(condition, Mapping) else None
+                allowed = (
+                    condition.get("$in") if isinstance(condition, Mapping) else None
+                )
                 if allowed is None or document.get(field_name) not in allowed:
                     return False
             return True
@@ -84,6 +86,10 @@ class _FakeSnapshotDatabase:
                         "_id": "concept-document",
                         "concept_id": "#V#subject",
                         "name": "Subject",
+                        "embedding_status": "pending",
+                        "embedding_updated_at": "before",
+                        "inherited_salient_binary_predicates": ["#V#old"],
+                        "inherited_salient_computed_at": 1,
                     }
                 ]
             ),
@@ -148,7 +154,7 @@ def _record(
     )
 
 
-def _check(monkeypatch: pytest.MonkeyPatch, db: _FakeDatabase) -> dict[str, Any]:
+def _check(monkeypatch: pytest.MonkeyPatch, db: Any) -> dict[str, Any]:
     monkeypatch.setattr(freshness, "_get_db", lambda: db)
     return freshness.check_startup_seed_freshness(
         family_id="test_family",
@@ -157,6 +163,30 @@ def _check(monkeypatch: pytest.MonkeyPatch, db: _FakeDatabase) -> dict[str, Any]
         concept_ids=["#V#subject"],
         text_relation_subject_ids=["#V#subject"],
         text_relation_predicates=["#V#has_config"],
+    )
+
+
+def _record_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    db: _FakeSnapshotDatabase,
+) -> dict[str, Any]:
+    monkeypatch.setattr(freshness, "_get_db", lambda: db)
+    observation = freshness.begin_startup_seed_freshness_observation(
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+    )
+    return freshness.record_startup_seed_freshness(
+        family_id="test_family",
+        source_digest="source-digest",
+        producer_schema_version="producer.v1",
+        concept_ids=["#V#subject"],
+        text_relation_subject_ids=["#V#subject"],
+        text_relation_predicates=["#V#has_config"],
+        tracked_concept_document_ids=["concept-document"],
+        tracked_text_relation_document_ids=["relation-document"],
+        tracked_text_value_document_ids=["text-document"],
+        observation=observation,
     )
 
 
@@ -278,6 +308,77 @@ def test_standalone_snapshot_detects_new_relevant_relation(
     assert checked["fresh"] is False
     assert checked["reason"] == "dependency_snapshot_mismatch"
     assert checked["verification_mode"] == "dependency_snapshot"
+
+
+def test_standalone_snapshot_ignores_derived_concept_index_churn(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeSnapshotDatabase()
+    recorded = _record_snapshot(monkeypatch, db)
+    assert recorded["persisted"] is True
+
+    concept = db.collections["concepts"].documents[0]
+    concept["embedding_status"] = "indexed"
+    concept["embedding_updated_at"] = "after"
+    concept["inherited_salient_binary_predicates"] = ["#V#new"]
+    concept["inherited_salient_computed_at"] = 2
+
+    checked = _check(monkeypatch, db)
+    assert checked["fresh"] is True
+    assert checked["reason"] == "dependency_snapshot_receipt_current"
+
+
+def test_standalone_snapshot_still_detects_semantic_concept_change(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeSnapshotDatabase()
+    recorded = _record_snapshot(monkeypatch, db)
+    assert recorded["persisted"] is True
+
+    db.collections["concepts"].documents[0]["name"] = "Changed"
+
+    checked = _check(monkeypatch, db)
+    assert checked["fresh"] is False
+    assert checked["reason"] == "dependency_snapshot_mismatch"
+
+
+def test_change_stream_ignores_derived_concept_index_churn(
+    receipt_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _FakeDatabase(
+        [
+            _FakeChangeStream(resume_token={"_data": "recorded"}),
+            _FakeChangeStream(
+                events=[
+                    {
+                        "operationType": "update",
+                        "ns": {"coll": "concepts"},
+                        "documentKey": {"_id": "concept-document"},
+                        "fullDocument": {"concept_id": "#V#subject"},
+                        "updateDescription": {
+                            "updatedFields": {
+                                "embedding_status": "indexed",
+                                "embedding_updated_at": "after",
+                            },
+                            "removedFields": ["embedding_error"],
+                        },
+                    }
+                ],
+                resume_token={"_data": "advanced"},
+            ),
+        ]
+    )
+
+    recorded = _record(monkeypatch, db)
+    checked = _check(monkeypatch, db)
+
+    assert recorded["persisted"] is True
+    assert checked["fresh"] is True
+    assert checked["reason"] == "dependency_receipt_current"
+    assert checked["events_examined"] == 1
 
 
 def test_standalone_snapshot_change_during_verification_is_not_persisted(


### PR DESCRIPTION
## Outcome
Standalone-Mongo startup seed freshness receipts remain current when the concept indexer changes derived embedding or inherited-salience cache fields. Canonical concept, relation, and text-value changes still invalidate receipts.

## Evidence
- Exact DGX cause: `#V#predicate.embedding_updated_at` changed after reconciliation and invalidated two whole-document digests.
- `tests/backend/test_startup_seed_freshness_service.py`: 18 passed.
- Related startup/health suites: 65 passed.
- Ruff and `git diff --check` pass.

## Jira
JVNAUTOSCI-2712