### PR TITLE
Make chat cancellation durable across restarts

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -11858,6 +11858,42 @@ def _build_focal_conversation_runtime_envelope(
 
 @von_bp.route("/generate", methods=["POST"])
 def generate():  # pyright: ignore[reportGeneralTypeIssues]
+    """Return a typed cancellation response even during early request setup.
+
+    Most of the implementation has a cancellation boundary around model work,
+    but durable cancellation can now be observed during the earlier identity,
+    history, or client-setup phases.  Preserve the exception for an internal
+    background re-entry so its task registry remains the terminal owner; a
+    foreground browser request receives the same JSON contract regardless of
+    which safe cancellation point noticed the intent.
+    """
+
+    try:
+        return _generate_impl()
+    except CancellationRequested:
+        payload = request.get_json(silent=True)
+        payload = payload if isinstance(payload, Mapping) else {}
+        background_reentry = bool(payload.get("background_progress")) and bool(
+            _normalise_non_empty_text(payload.get("background_task_id"))
+        )
+        if background_reentry:
+            raise
+        request_id = _normalise_non_empty_text(payload.get("client_request_id"))
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "terminal_status": "cancelled",
+                    "error": "generate_task_cancelled",
+                    "detail": "Cancellation was acknowledged by the running turn.",
+                    "request_id": request_id,
+                }
+            ),
+            409,
+        )
+
+
+def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
     """Handle text generation requests."""
     data = request.get_json() or {}
     raw_turn_kind = data.get("turn_kind")

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1667,6 +1667,7 @@ def cancel_chat_prompt_queue_route(queue_id: str):
     if isinstance(scope, tuple):
         return scope
     try:
+        cancellation_pending = False
         record = chat_prompt_queue_service.cancel_prompt_record(
             scope=scope,
             queue_id=queue_id,
@@ -1693,7 +1694,21 @@ def cancel_chat_prompt_queue_route(queue_id: str):
             )
         finally:
             wake_chat_prompt_queue_dispatcher()
-        return jsonify({"success": True, "item": record})
+    except chat_prompt_queue_service.ConversationTurnAlreadyActive:
+        try:
+            record = chat_prompt_queue_service.request_prompt_cancellation(
+                scope=scope,
+                queue_id=queue_id,
+            )
+            cancellation_pending = True
+            wake_chat_prompt_queue_dispatcher()
+        except Exception as exc:
+            return _chat_prompt_queue_error_response(
+                exc,
+                action="cancel",
+                queue_id=queue_id,
+                scope=scope,
+            )
     except Exception as exc:
         return _chat_prompt_queue_error_response(
             exc,
@@ -1701,6 +1716,13 @@ def cancel_chat_prompt_queue_route(queue_id: str):
             queue_id=queue_id,
             scope=scope,
         )
+    return jsonify(
+        {
+            "success": True,
+            "item": record,
+            "status": "cancelling" if cancellation_pending else "cancelled",
+        }
+    )
 
 
 @von_bp.route("/api/chat_prompt_queue/<queue_id>/claim", methods=["POST"])
@@ -7679,11 +7701,19 @@ def cancel_task(task_id: str):
         )
 
     queue_id = _normalise_non_empty_text(getattr(status, "queue_id", None))
+    queue_cancellation_status = "cancelling"
+    queue_cancellation_record = None
     if queue_id:
         try:
             cancelled_record = chat_prompt_queue_service.cancel_prompt_record(
                 scope=scope,
                 queue_id=queue_id,
+            )
+            queue_cancellation_record = cancelled_record
+            queue_cancellation_status = (
+                str(cancelled_record.get("status") or "cancelled")
+                if isinstance(cancelled_record, Mapping)
+                else "cancelled"
             )
             try:
                 reconcile_linked_task_execution_terminal(
@@ -7709,17 +7739,37 @@ def cancel_task(task_id: str):
             finally:
                 wake_chat_prompt_queue_dispatcher()
         except chat_prompt_queue_service.ConversationTurnAlreadyActive:
-            # The running generate request owns this fence and observes the
-            # cancellation flag; its teardown will terminalise the exact
-            # attempt as cancelled.
-            pass
+            # Preserve the user's decision on the exact durable attempt.  The
+            # running provider call keeps its conversation fence until it can
+            # observe cancellation; a replacement server can then reconcile
+            # this intent without replaying the stopped turn.
+            queue_cancellation_record = (
+                chat_prompt_queue_service.request_prompt_cancellation(
+                    scope=scope,
+                    queue_id=queue_id,
+                    attempt_id=_normalise_non_empty_text(
+                        getattr(status, "attempt_id", None)
+                    ),
+                )
+            )
+            wake_chat_prompt_queue_dispatcher()
         except chat_prompt_queue_service.ChatPromptQueueRecordNotFound:
             # The exact attempt may already have reached a terminal state.
             pass
 
     return (
         jsonify(
-            {"success": True, "task_id": task_id, "message": "Cancellation requested"}
+            {
+                "success": True,
+                "task_id": task_id,
+                "message": "Cancellation requested",
+                "status": queue_cancellation_status,
+                **(
+                    {"item": queue_cancellation_record}
+                    if isinstance(queue_cancellation_record, Mapping)
+                    else {}
+                ),
+            }
         ),
         200,
     )
@@ -11981,19 +12031,32 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
         _emit_generate_progress(payload)
 
     def _is_background_cancellation_requested() -> bool:
-        if background_task_id is None:
+        if background_task_id is not None:
+            try:
+                is_requested = getattr(
+                    background_task_registry,
+                    "is_cancellation_requested",
+                    None,
+                )
+                if callable(is_requested) and bool(
+                    is_requested(background_task_id)
+                ):
+                    return True
+            except Exception:
+                pass
+        admission_token = getattr(g, _TURN_ADMISSION_CONTEXT_KEY, None)
+        if admission_token is None or not getattr(admission_token, "queue_id", None):
             return False
         try:
-            is_requested = getattr(
-                background_task_registry,
-                "is_cancellation_requested",
-                None,
+            return chat_prompt_queue_service.is_prompt_cancellation_requested(
+                scope=admission_token.scope,
+                queue_id=admission_token.queue_id,
+                attempt_id=admission_token.attempt_id,
             )
-            if callable(is_requested):
-                return bool(is_requested(background_task_id))
         except Exception:
+            # The in-memory flag remains the low-latency path. A transient
+            # read failure here must not manufacture cancellation.
             return False
-        return False
 
     def _check_background_cancellation(subtask: str) -> None:
         if not _is_background_cancellation_requested():
@@ -15550,6 +15613,19 @@ def generate():  # pyright: ignore[reportGeneralTypeIssues]
             error_text="generate_task_cancelled",
             error_class="CancellationRequested",
         )
+        if background_task_id is None:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "terminal_status": "cancelled",
+                        "error": "generate_task_cancelled",
+                        "detail": "Cancellation was acknowledged by the running turn.",
+                        "request_id": request_id,
+                    }
+                ),
+                409,
+            )
         raise
     except Exception as e:
         if assistant_opening_claimed:

--- a/src/backend/services/chat_prompt_queue_dispatch_service.py
+++ b/src/backend/services/chat_prompt_queue_dispatch_service.py
@@ -285,6 +285,7 @@ class ChatPromptQueueDispatcher:
         self._task_launch_reconciliation_failed_count = 0
         self._task_execution_reconciled_count = 0
         self._task_execution_reconciliation_retry_count = 0
+        self._interrupted_cancellation_reconciled_count = 0
         self._linked_terminal_backfilled_count = 0
         self._linked_terminal_backfill_complete = False
         self._terminal_retention_backfilled_count = 0
@@ -336,6 +337,8 @@ class ChatPromptQueueDispatcher:
             raise RuntimeError("chat prompt dispatcher is not configured")
 
         if self._reconcile_one_linked_terminal():
+            return True
+        if self._reconcile_one_interrupted_cancellation():
             return True
         if self._reconcile_one_task_launch():
             return True
@@ -430,6 +433,43 @@ class ChatPromptQueueDispatcher:
                 source="queue_dispatcher",
                 error=error,
             )
+        return True
+
+    def _reconcile_one_interrupted_cancellation(self) -> bool:
+        """Terminalise one cancellation left by a stopped server process."""
+
+        try:
+            record = (
+                chat_prompt_queue_service.terminalise_one_interrupted_cancellation(
+                    current_server_instance_id=SERVER_INSTANCE_ID,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - durable intent remains retryable
+            with self._lock:
+                self._last_error = f"{type(exc).__name__}: {exc}"
+            _logger.warning(
+                "[chat_prompt_dispatch] Interrupted cancellation reconciliation "
+                "deferred: %s",
+                exc,
+            )
+            return False
+        if record is None:
+            return False
+        try:
+            reconcile_linked_task_execution_terminal(
+                record,
+                status=chat_prompt_queue_service.STATUS_CANCELLED,
+                source="interrupted_queue_cancellation",
+            )
+        except Exception as exc:  # noqa: BLE001 - terminal marker owns retry
+            _logger.warning(
+                "[chat_prompt_dispatch] Cancelled queue TaskExecution projection "
+                "deferred: %s",
+                exc,
+            )
+        with self._lock:
+            self._interrupted_cancellation_reconciled_count += 1
+            self._last_error = None
         return True
 
     def _reconcile_one_handoff(self) -> bool:
@@ -671,6 +711,9 @@ class ChatPromptQueueDispatcher:
                 ),
                 "task_execution_reconciliation_retry_count": (
                     self._task_execution_reconciliation_retry_count
+                ),
+                "interrupted_cancellation_reconciled_count": (
+                    self._interrupted_cancellation_reconciled_count
                 ),
                 "linked_terminal_backfilled_count": (
                     self._linked_terminal_backfilled_count

--- a/src/backend/services/chat_prompt_queue_service.py
+++ b/src/backend/services/chat_prompt_queue_service.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Sequence
 from uuid import uuid4
 
-from pymongo import ReturnDocument
+from pymongo import ASCENDING, ReturnDocument
 from pymongo.collection import Collection
 from pymongo.errors import DuplicateKeyError
 
@@ -1075,6 +1075,12 @@ def serialise_queue_record(doc: Mapping[str, Any] | None) -> dict[str, Any] | No
         "lease_acquired_at": _serialise_datetime(doc.get("lease_acquired_at")),
         "lease_heartbeat_at": _serialise_datetime(doc.get("lease_heartbeat_at")),
         "lease_expires_at": _serialise_datetime(doc.get("lease_expires_at")),
+        "cancellation_requested": isinstance(
+            doc.get("cancellation_requested_at"), datetime
+        ),
+        "cancellation_requested_at": _serialise_datetime(
+            doc.get("cancellation_requested_at")
+        ),
         "next_dispatch_at": _serialise_datetime(doc.get("next_dispatch_at")),
         "purge_after": _serialise_datetime(doc.get("purge_after")),
         "stale_advisory": bool(doc.get("stale_advisory")),
@@ -3587,6 +3593,10 @@ def requeue_prompt_record(
             "A server-dispatched attempt cannot be replayed without reconciling "
             "its exact turn and effect receipts"
         )
+    if isinstance(existing.get("cancellation_requested_at"), datetime):
+        raise ChatPromptQueueReconciliationRequired(
+            "This turn has a durable cancellation request and cannot be replayed"
+        )
 
     transition_guard: dict[str, Any] = {}
     if existing.get("active_conversation_key"):
@@ -3673,6 +3683,120 @@ def requeue_prompt_record(
     return record
 
 
+def request_prompt_cancellation(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    attempt_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist cancellation intent without releasing a live conversation fence.
+
+    A provider call cannot always be interrupted.  The executing turn retains
+    its fence until it observes this request and terminalises, while a
+    replacement one-server runtime may safely complete the cancellation after
+    the former process has stopped.
+    """
+
+    queue_id_clean = _coerce_scope_value(queue_id, field="queue_id")
+    attempt_id_clean = _coerce_scope_value(
+        attempt_id,
+        field="attempt_id",
+        required=False,
+    )
+    query: dict[str, Any] = {
+        **_compatible_scope_query(scope),
+        "queue_id": queue_id_clean,
+        "status": STATUS_IN_PROGRESS,
+        "active_conversation_key": {"$exists": True},
+    }
+    if attempt_id_clean:
+        query["attempt_id"] = attempt_id_clean
+
+    coll = _collection()
+    now = _now()
+    doc = coll.find_one_and_update(
+        {**query, "cancellation_requested_at": {"$exists": False}},
+        {
+            "$set": {
+                **_scope_query(scope),
+                "cancellation_requested_at": now,
+                "updated_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        # The exact same request is idempotent.  A terminal state is not
+        # rewritten: its first durable outcome remains authoritative.
+        doc = coll.find_one(
+            {**query, "cancellation_requested_at": {"$type": "date"}}
+        )
+    record = serialise_queue_record(doc)
+    if record is None:
+        raise _transition_not_found_error(
+            scope=scope,
+            queue_id=queue_id_clean,
+            expected_statuses=[STATUS_IN_PROGRESS],
+            fallback_message="executing prompt was not available for cancellation",
+        )
+    return record
+
+
+def is_prompt_cancellation_requested(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    attempt_id: str | None = None,
+) -> bool:
+    """Return whether the exact admitted attempt has durable cancellation intent."""
+
+    query: dict[str, Any] = {
+        **_compatible_scope_query(scope),
+        "queue_id": _coerce_scope_value(queue_id, field="queue_id"),
+        "status": STATUS_IN_PROGRESS,
+        "cancellation_requested_at": {"$type": "date"},
+    }
+    attempt_id_clean = _coerce_scope_value(
+        attempt_id,
+        field="attempt_id",
+        required=False,
+    )
+    if attempt_id_clean:
+        query["attempt_id"] = attempt_id_clean
+    return _collection().find_one(query, {"_id": 1}) is not None
+
+
+def terminalise_one_interrupted_cancellation(
+    *,
+    current_server_instance_id: str,
+) -> dict[str, Any] | None:
+    """Cancel one requested turn whose bound one-server runtime has stopped."""
+
+    current_instance = _coerce_scope_value(
+        current_server_instance_id,
+        field="current_server_instance_id",
+    )
+    coll = _collection()
+    existing = coll.find_one(
+        {
+            "status": STATUS_IN_PROGRESS,
+            "active_conversation_key": {"$exists": True},
+            "attempt_id": {"$type": "string", "$ne": ""},
+            "server_instance_id": {"$type": "string", "$ne": current_instance},
+            "cancellation_requested_at": {"$type": "date"},
+        },
+        sort=[("cancellation_requested_at", ASCENDING), ("_id", ASCENDING)],
+    )
+    if not isinstance(existing, Mapping):
+        return None
+    return finish_prompt_record(
+        scope=_queue_scope_values(existing),
+        queue_id=str(existing.get("queue_id") or ""),
+        status=STATUS_CANCELLED,
+        attempt_id=str(existing.get("attempt_id") or ""),
+    )
+
+
 def finish_prompt_record(
     *,
     scope: Mapping[str, Any],
@@ -3714,6 +3838,14 @@ def finish_prompt_record(
                 "A server-dispatched queue row can only be terminalised by its "
                 "exact admitted attempt"
             )
+    if (
+        isinstance(existing_for_terminal, Mapping)
+        and isinstance(existing_for_terminal.get("cancellation_requested_at"), datetime)
+    ):
+        # Once durable cancellation won the CAS, a late provider response may
+        # not publish completion or failure for the same exact attempt.
+        status = STATUS_CANCELLED
+        error = None
     error_clean = _coerce_text(
         error,
         field="error",

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -34230,6 +34230,17 @@ function setThinkingState(isThinking, request = activeChatRequest, options = {})
 
     if (abortButton) {
         abortButton.setAttribute('aria-hidden', isThinking ? 'false' : 'true');
+        const cancellationRequested = isThinking
+            && request?.backgroundCancellationRequested === true;
+        abortButton.disabled = cancellationRequested;
+        abortButton.setAttribute(
+            'aria-label',
+            cancellationRequested ? 'Cancellation requested' : 'Stop generating'
+        );
+        abortButton.setAttribute(
+            'title',
+            cancellationRequested ? 'Waiting for the running turn to stop' : 'Stop generating'
+        );
     }
     if (retryButton) {
         const canRetryThinkingRequest = isThinking
@@ -34307,13 +34318,16 @@ function restorePromptEditingState(request, options = {}) {
     }
 }
 
-async function requestObservedServerDispatchCancellation(request) {
+async function requestServerCancellation(request) {
     const requestId = (typeof request?.clientRequestId === 'string')
         ? request.clientRequestId.trim()
         : '';
+    const queueId = (typeof request?.promptQueueRecordId === 'string')
+        ? request.promptQueueRecordId.trim()
+        : '';
+    const observedServerDispatch = request?.observingServerDispatch === true;
     if (
-        !requestId
-        || request?.observingServerDispatch !== true
+        (!queueId && (!observedServerDispatch || !requestId))
         || request?.backgroundCancellationRequested === true
     ) {
         return false;
@@ -34321,9 +34335,11 @@ async function requestObservedServerDispatchCancellation(request) {
     request.backgroundCancellationRequested = true;
     try {
         const response = await fetch(
-            `/von/api/task/cancel/${encodeURIComponent(requestId)}`,
+            observedServerDispatch
+                ? `/von/api/task/cancel/${encodeURIComponent(requestId)}`
+                : `/von/api/chat_prompt_queue/${encodeURIComponent(queueId)}`,
             {
-                method: 'POST',
+                method: observedServerDispatch ? 'POST' : 'DELETE',
                 headers: buildChatFetchHeaders({
                     'Content-Type': 'application/json'
                 }),
@@ -34338,7 +34354,7 @@ async function requestObservedServerDispatchCancellation(request) {
                 || `HTTP ${response.status}`
             );
         }
-        publishChatPromptQueueChange('observed_retry_cancellation_requested');
+        publishChatPromptQueueChange('turn_cancellation_requested');
         return true;
     } catch (error) {
         request.backgroundCancellationRequested = false;
@@ -34358,8 +34374,30 @@ function abortActiveChatRequest(options = {}) {
 
     const request = activeChatRequest;
     const observingServerDispatch = request.observingServerDispatch === true;
-    if (observingServerDispatch) {
-        void requestObservedServerDispatchCancellation(request);
+    const canRequestServerCancellation = observingServerDispatch
+        || (typeof request.promptQueueRecordId === 'string'
+            && request.promptQueueRecordId.trim());
+    if (canRequestServerCancellation) {
+        const previousProgress = cloneThinkingLatestProgress(request.latestProgress);
+        const cancellationPromise = requestServerCancellation(request);
+        request.latestProgress = {
+            ...(request.latestProgress && typeof request.latestProgress === 'object'
+                ? request.latestProgress
+                : {}),
+            status: 'cancelling',
+            phase: 'cancelling',
+            phase_label: 'Cancelling',
+            result_summary: 'Cancellation requested; waiting for the running turn to stop.'
+        };
+        syncActiveChatSessionThinkingState();
+        void cancellationPromise.then((acknowledged) => {
+            if (acknowledged || !isLiveChatRequest(request)) {
+                return;
+            }
+            request.latestProgress = previousProgress;
+            syncActiveChatSessionThinkingState();
+        });
+        return;
     }
     request.aborted = true;
     releaseRequestFileCopyBinding(request);
@@ -37674,6 +37712,10 @@ async function handleSendPrompt(options = {}) {
             request.serverQueueTerminalObserved = true;
             acknowledgeQueuedSource();
             deliverSuccessfulResponseData(data, 'generate_response');
+        } else if (String(data?.terminal_status || '').toLowerCase() === 'cancelled') {
+            request.serverQueueTerminalObserved = true;
+            acknowledgeQueuedSource();
+            deliverCancelledResponseData(data);
         } else if (
             data?.retryable === true
             || response.status === 429

--- a/tests/backend/test_chat_prompt_queue_dispatch_service.py
+++ b/tests/backend/test_chat_prompt_queue_dispatch_service.py
@@ -34,6 +34,11 @@ def isolate_dispatcher_queue_reconciliation(monkeypatch):
         "reconcile_next_server_dispatch_handoff",
         lambda: None,
     )
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "terminalise_one_interrupted_cancellation",
+        lambda **_kwargs: None,
+    )
 
 
 def _reserved_record() -> dict[str, object]:
@@ -85,6 +90,40 @@ def test_dispatcher_leaves_accepted_reservation_for_admission(
     assert released == []
     assert failed == []
     assert dispatcher.snapshot()["accepted_count"] == 1
+
+
+def test_dispatcher_terminalises_requested_cancellation_before_new_work(
+    monkeypatch,
+) -> None:
+    cancelled = {
+        "queue_id": "queue-cancelled",
+        "status": "cancelled",
+    }
+    monkeypatch.setattr(
+        dispatch_service.chat_prompt_queue_service,
+        "terminalise_one_interrupted_cancellation",
+        lambda **_kwargs: dict(cancelled),
+    )
+    reconcile = MagicMock()
+    monkeypatch.setattr(
+        dispatch_service,
+        "reconcile_linked_task_execution_terminal",
+        reconcile,
+    )
+    submit = MagicMock()
+    dispatcher = dispatch_service.ChatPromptQueueDispatcher()
+    dispatcher.configure(app=object(), submit=submit)
+
+    assert dispatcher.run_once() is True
+    submit.assert_not_called()
+    reconcile.assert_called_once_with(
+        cancelled,
+        status=dispatch_service.chat_prompt_queue_service.STATUS_CANCELLED,
+        source="interrupted_queue_cancellation",
+    )
+    assert (
+        dispatcher.snapshot()["interrupted_cancellation_reconciled_count"] == 1
+    )
 
 
 def test_blocked_handoff_falls_through_to_unrelated_ready_dispatch(
@@ -849,3 +888,55 @@ def test_queue_cancellation_terminalises_linked_execution(monkeypatch) -> None:
         status="cancelled",
         source="queue_cancellation",
     )
+
+
+def test_queue_cancellation_requests_bound_turn_without_releasing_fence(
+    monkeypatch,
+) -> None:
+    from src.backend.server.routes import von_routes
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+    scope = {
+        "user_concept_id": "#V#user",
+        "organisation_concept_id": "#V#org",
+        "namespace": "#V#user@org",
+    }
+    requested = {
+        "queue_id": "queue-1",
+        "status": "in_progress",
+        "cancellation_requested": True,
+    }
+    monkeypatch.setattr(
+        von_routes,
+        "_get_current_chat_prompt_queue_scope",
+        lambda: dict(scope),
+    )
+    monkeypatch.setattr(
+        von_routes.chat_prompt_queue_service,
+        "cancel_prompt_record",
+        MagicMock(
+            side_effect=(
+                von_routes.chat_prompt_queue_service.ConversationTurnAlreadyActive(
+                    "still executing",
+                    queue_id="queue-1",
+                )
+            )
+        ),
+    )
+    persist = MagicMock(return_value=dict(requested))
+    monkeypatch.setattr(
+        von_routes.chat_prompt_queue_service,
+        "request_prompt_cancellation",
+        persist,
+    )
+
+    with app.test_request_context("/von/api/chat_prompt_queue/queue-1"):
+        response = von_routes.cancel_chat_prompt_queue_route("queue-1")
+
+    assert response.get_json() == {
+        "success": True,
+        "item": requested,
+        "status": "cancelling",
+    }
+    persist.assert_called_once_with(scope=scope, queue_id="queue-1")

--- a/tests/backend/test_chat_prompt_queue_routes.py
+++ b/tests/backend/test_chat_prompt_queue_routes.py
@@ -529,7 +529,9 @@ def test_failed_task_retry_preserves_task_and_conversation_lineage(
     )
 
 
-def test_queue_routes_cannot_release_a_live_server_bound_turn(client) -> None:
+def test_queue_routes_preserve_cancellation_intent_without_releasing_live_turn(
+    client,
+) -> None:
     created = client.post(
         "/von/api/chat_prompt_queue",
         json={"prompt_raw": "Keep the durable fence", "session_id": "session-1"},
@@ -557,16 +559,18 @@ def test_queue_routes_cannot_release_a_live_server_bound_turn(client) -> None:
 
     assert requeue.status_code == 409
     assert requeue.get_json()["error_code"] == "conversation_turn_active"
-    assert cancel.status_code == 409
-    assert cancel.get_json()["error_code"] == "conversation_turn_active"
+    assert cancel.status_code == 200
+    assert cancel.get_json()["status"] == "cancelling"
+    assert cancel.get_json()["item"]["cancellation_requested"] is True
     assert finish.status_code == 404
 
-    chat_prompt_queue_service.finish_prompt_record(
+    terminal = chat_prompt_queue_service.finish_prompt_record(
         scope=scope,
         queue_id=created["queue_id"],
         status=chat_prompt_queue_service.STATUS_COMPLETED,
         attempt_id="attempt-live",
     )
+    assert terminal["status"] == chat_prompt_queue_service.STATUS_CANCELLED
 
 
 def test_legacy_routes_cannot_complete_or_replay_server_dispatch_rows(client) -> None:

--- a/tests/backend/test_chat_prompt_queue_service.py
+++ b/tests/backend/test_chat_prompt_queue_service.py
@@ -376,6 +376,100 @@ def test_requeue_releases_conversation_fence_and_request_correlation() -> None:
     assert rebound["server_instance_id"] == "server-b"
 
 
+def test_durable_cancellation_survives_restart_and_prevents_replay() -> None:
+    scope = queue_service.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    queued = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Stop this exact turn",
+        session_id="session-a",
+    )
+    bound = queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        client_request_id="request-a",
+        attempt_id="attempt-a",
+        conversation_key="conversation-key-a",
+        server_instance_id="server-a",
+    )
+
+    requested = queue_service.request_prompt_cancellation(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        attempt_id="attempt-a",
+    )
+    replay = queue_service.request_prompt_cancellation(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        attempt_id="attempt-a",
+    )
+
+    assert requested["status"] == queue_service.STATUS_IN_PROGRESS
+    assert requested["cancellation_requested"] is True
+    assert replay["cancellation_requested_at"] == requested["cancellation_requested_at"]
+    assert queue_service.is_prompt_cancellation_requested(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        attempt_id="attempt-a",
+    )
+    with pytest.raises(queue_service.ChatPromptQueueReconciliationRequired):
+        queue_service.requeue_prompt_record(
+            scope=scope,
+            queue_id=queued["queue_id"],
+            current_server_instance_id="server-b",
+        )
+    assert (
+        queue_service.terminalise_one_interrupted_cancellation(
+            current_server_instance_id="server-a"
+        )
+        is None
+    )
+
+    terminal = queue_service.terminalise_one_interrupted_cancellation(
+        current_server_instance_id="server-b"
+    )
+
+    assert terminal is not None
+    assert terminal["status"] == queue_service.STATUS_CANCELLED
+    assert terminal["attempt_id"] == bound["attempt_id"]
+    assert queue_service.list_active_queue_records(scope=scope) == []
+
+
+def test_durable_cancellation_wins_over_late_provider_completion() -> None:
+    scope = queue_service.build_queue_scope(user_concept_id="#V#user")
+    queued = queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw="Provider is still running",
+        session_id="session-a",
+    )
+    queue_service.bind_queue_record_to_turn(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        client_request_id="request-a",
+        attempt_id="attempt-a",
+        conversation_key="conversation-key-a",
+        server_instance_id="server-a",
+    )
+    queue_service.request_prompt_cancellation(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        attempt_id="attempt-a",
+    )
+
+    terminal = queue_service.finish_prompt_record(
+        scope=scope,
+        queue_id=queued["queue_id"],
+        status=queue_service.STATUS_COMPLETED,
+        attempt_id="attempt-a",
+    )
+
+    assert terminal["status"] == queue_service.STATUS_CANCELLED
+    assert terminal["last_error"] is None
+
+
 def test_queue_scope_isolation() -> None:
     first_scope = queue_service.build_queue_scope(
         user_concept_id="#V#user_a",

--- a/tests/backend/test_von_generate_background_submission.py
+++ b/tests/backend/test_von_generate_background_submission.py
@@ -313,6 +313,45 @@ def test_generate_requires_rebind_for_unknown_window_context(monkeypatch):
     assert adaptive_turn.calls == []
 
 
+def test_foreground_generate_returns_json_when_cancelled_during_context_setup(
+    monkeypatch,
+):
+    adaptive_turn = _StubAdaptiveTurn(
+        AdaptiveTurnResult(
+            response_text="must not run",
+            extra_messages=(),
+            tool_invocations=(),
+            aux_llm_calls=(),
+        )
+    )
+    task_registry = _CapturingTaskRegistry()
+    task_registry.cancelled_task_ids.add("cancel-during-context")
+    app = _make_app(monkeypatch, adaptive_turn, task_registry)
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={
+            "prompt": "Stop before model work",
+            "background": False,
+            "background_task_id": "cancel-during-context",
+            "client_request_id": "cancel-during-context",
+            "model": "gpt-5.4-nano",
+        },
+        headers={"X-Von-Window-Session": "window-123"},
+    )
+
+    assert response.status_code == 409
+    assert response.is_json
+    assert response.get_json() == {
+        "success": False,
+        "terminal_status": "cancelled",
+        "error": "generate_task_cancelled",
+        "detail": "Cancellation was acknowledged by the running turn.",
+        "request_id": "cancel-during-context",
+    }
+    assert adaptive_turn.calls == []
+
+
 def test_background_generate_reentry_passes_authorised_inputs_to_adaptive_turn(
     monkeypatch,
 ):

--- a/tests/backend/test_von_route_json_safe_payloads.py
+++ b/tests/backend/test_von_route_json_safe_payloads.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from flask import Flask, g, jsonify
 
@@ -211,3 +212,64 @@ def test_task_cancellation_terminalises_its_still_queued_prompt(monkeypatch) -> 
 
     assert response.status_code == 200
     assert cancelled == [(scope, "queue-1")]
+
+
+def test_task_cancellation_persists_intent_for_the_bound_attempt(monkeypatch) -> None:
+    app = Flask(__name__)
+    app.register_blueprint(von_routes.von_bp, url_prefix="/von")
+    scope = {
+        "user_concept_id": "#V#test_user",
+        "organisation_concept_id": "#V#test_org",
+        "namespace": "#V#test_user@test_org",
+    }
+    status = SimpleNamespace(
+        status="running",
+        queue_id="queue-1",
+        attempt_id="attempt-1",
+    )
+    persisted: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        von_routes,
+        "_get_current_chat_prompt_queue_scope",
+        lambda: scope,
+    )
+    monkeypatch.setattr(
+        von_routes,
+        "_get_background_task_status_for_scope",
+        lambda _task_id, _scope: status,
+    )
+    monkeypatch.setattr(
+        von_routes.background_task_registry,
+        "request_cancellation_for_scope",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        von_routes.chat_prompt_queue_service,
+        "cancel_prompt_record",
+        MagicMock(
+            side_effect=(
+                von_routes.chat_prompt_queue_service.ConversationTurnAlreadyActive(
+                    "still executing",
+                    queue_id="queue-1",
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        von_routes.chat_prompt_queue_service,
+        "request_prompt_cancellation",
+        lambda **kwargs: persisted.append(kwargs) or {
+            "queue_id": "queue-1",
+            "status": "in_progress",
+            "cancellation_requested": True,
+        },
+    )
+
+    response = app.test_client().post("/von/api/task/cancel/task-1")
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "cancelling"
+    assert persisted == [
+        {"scope": scope, "queue_id": "queue-1", "attempt_id": "attempt-1"}
+    ]

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -1832,6 +1832,7 @@ describe('chat task queue', () => {
     test('Stop cancels the exact server-owned retry without submitting another generation', async () => {
         const {
             __testOnly_refreshChatPromptQueueFromServer,
+            __testOnly_getLiveChatRequestForSession,
         } = require(chatTabModulePath);
         const fetchCalls = [];
 
@@ -1888,6 +1889,7 @@ describe('chat task queue', () => {
 
         await __testOnly_refreshChatPromptQueueFromServer();
         await Promise.resolve();
+        const observedRequest = __testOnly_getLiveChatRequestForSession('session-1');
         expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden'))
             .toBe('false');
 
@@ -1901,7 +1903,16 @@ describe('chat task queue', () => {
         expect(fetchCalls.some(({ url }) => String(url).startsWith('/von/generate')))
             .toBe(false);
         expect(document.getElementById('thinkingCardWrapper')?.getAttribute('aria-hidden'))
-            .toBe('true');
+            .toBe('false');
+        expect(observedRequest?.aborted).toBe(false);
+        expect(observedRequest?.backgroundCancellationRequested).toBe(true);
+        expect(observedRequest?.latestProgress).toMatchObject({
+            status: 'cancelling',
+            phase_label: 'Cancelling'
+        });
+        expect(document.getElementById('abortButton')?.disabled).toBe(true);
+        expect(document.getElementById('abortButton')?.getAttribute('aria-label'))
+            .toBe('Cancellation requested');
         expect(document.getElementById('promptInput')?.value).toBe('');
     }, 15000);
 


### PR DESCRIPTION
## Outcome
Stop generating now persists cancellation on the exact durable queue attempt, keeps the conversation fence until teardown, and reconciles safely after a server restart without replaying the stopped prompt. The Thinking card remains visibly Cancelling until canonical terminal observation.

## Validation
- 77 queue, route, and dispatcher tests passed
- 56 admission and background-task neighbour tests passed
- 31 frontend chat queue tests passed
- syntax, undefined-name, and diff checks passed
- two unrelated tool-progress tests reproduce identically on unchanged main (HTTP 409 window-context baseline)

## Jira
JVNAUTOSCI-2714