### PR TITLE
Make durable cancellation win late provider races

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -13623,11 +13623,7 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
 
             progress_tracker = ProgressTracker(
                 callback=_progress_update,
-                cancellation_checker=(
-                    _is_background_cancellation_requested
-                    if background_task_id is not None
-                    else None
-                ),
+                cancellation_checker=_is_background_cancellation_requested,
                 task_id=background_task_id,
             )
 
@@ -13705,6 +13701,10 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
             conversation_observation_state=conversation_observation_state,
             model_registry_snapshot=turn_model_registry_snapshot,
         )
+        # A provider may finish or fail just after the user presses Stop.  The
+        # durable queue intent is authoritative for that exact attempt, so do
+        # not project the provider's now-stale outcome back to the browser.
+        _check_background_cancellation("direct adaptive turn completion")
         llm_interaction["duration_ms"] = (
             time.perf_counter() - adaptive_turn_started
         ) * 1000.0

--- a/tests/backend/test_von_generate_background_submission.py
+++ b/tests/backend/test_von_generate_background_submission.py
@@ -352,6 +352,50 @@ def test_foreground_generate_returns_json_when_cancelled_during_context_setup(
     assert adaptive_turn.calls == []
 
 
+def test_foreground_cancellation_wins_over_late_provider_failure(monkeypatch):
+    import src.backend.server.routes.von_routes as von_routes
+
+    task_registry = _CapturingTaskRegistry()
+    adaptive_turn = _StubAdaptiveTurn(
+        AdaptiveTurnResult(
+            response_text="Provider failed after Stop",
+            extra_messages=(),
+            tool_invocations=(),
+            aux_llm_calls=(),
+            terminal_status="model_error",
+        )
+    )
+    app = _make_app(monkeypatch, adaptive_turn, task_registry)
+
+    def _finish_provider_after_cancellation(**kwargs):
+        task_registry.cancelled_task_ids.add("late-provider-result")
+        return adaptive_turn.execute(**kwargs)
+
+    monkeypatch.setattr(
+        von_routes,
+        "execute_adaptive_turn",
+        _finish_provider_after_cancellation,
+    )
+
+    response = app.test_client().post(
+        "/von/generate",
+        json={
+            "prompt": "Stop this provider call",
+            "background": False,
+            "background_task_id": "late-provider-result",
+            "client_request_id": "late-provider-result",
+            "model": "gpt-5.4-nano",
+        },
+        headers={"X-Von-Window-Session": "window-123"},
+    )
+
+    assert response.status_code == 409
+    assert response.is_json
+    assert response.get_json()["terminal_status"] == "cancelled"
+    assert response.get_json()["request_id"] == "late-provider-result"
+    assert len(adaptive_turn.calls) == 1
+
+
 def test_background_generate_reentry_passes_authorised_inputs_to_adaptive_turn(
     monkeypatch,
 ):


### PR DESCRIPTION
## Outcome

A foreground Stop that is durably recorded now remains authoritative if the provider completes or fails immediately afterwards. The browser receives the typed cancelled result instead of a stale provider outcome.

## Validation

- 116 focused backend tests passed
- adds a regression for persisted cancellation racing a late `model_error`
- deployed failure was reproduced on the DGX and recorded on JVNAUTOSCI-2714

Jira: JVNAUTOSCI-2714