### PR TITLE
Fix live backup-key footer disclosure

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -946,6 +946,7 @@ function buildLatestLlmExecutionTelemetrySummary(turnId, debugData, executionCon
             actualProvider = provider;
         }
         const transportCandidates = [
+            call.transport,
             call.transport_metadata,
             call.candidate?.transport_metadata,
             call.candidate?.llm_transport,

--- a/tests/frontend/chatTabLatestLlmExecutionTelemetry.test.js
+++ b/tests/frontend/chatTabLatestLlmExecutionTelemetry.test.js
@@ -538,4 +538,39 @@ describe('chatTab latest execution telemetry publication', () => {
             }),
         );
     });
+
+    test('publishes backup-credential telemetry from the live adaptive-turn call shape', () => {
+        const chatTab = require(chatTabModulePath);
+
+        chatTab.__testOnly_clearLlmDebugData();
+        chatTab.setLlmDebugDataForTurn('a-live-backup-key', {
+            timestamp: '2026-09-03T15:26:53.031668Z',
+            model: 'gpt-5.6-luna',
+            llm_interaction: {
+                requested_model: 'gpt-5.6-luna',
+                calls: [
+                    {
+                        type: 'adaptive_turn_model_call',
+                        model: 'gpt-5.6-luna',
+                        provider: 'openai',
+                        transport: {
+                            credential_source: 'backup',
+                            credential_failover_used: true,
+                            primary_credential_failure_kind: 'quota_exhausted',
+                        },
+                    },
+                ],
+            },
+        });
+
+        expect(chatTab.__testOnly_getLatestLlmExecutionTelemetry()).toEqual(
+            expect.objectContaining({
+                credential_source: 'backup',
+                credential_failover_used: true,
+                primary_credential_failure_kind: 'quota_exhausted',
+                actual_model: 'gpt-5.6-luna',
+                actual_provider: 'openai',
+            }),
+        );
+    });
 });


### PR DESCRIPTION
Jira: JVNAUTOSCI-2715

Live browser acceptance found that successful backup-key failover was retained under llm_interaction.calls[].transport, while the footer telemetry extractor did not inspect that live adaptive-turn field.

This adds the missing live transport path and a regression test using the exact stored call shape.

Validation:
- 32 focused frontend tests passed
- static frontend lint passed
- git diff --check passed

Post-merge acceptance requires DGX deployment and an authenticated browser replay showing gpt-5.6-luna · backup key in the model footer.