### PR TITLE
JVNAUTOSCI-2715: preserve credential provenance after history reload

### DIFF
--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -10453,10 +10453,19 @@ def _add_chat_history_message(
         organisation_concept_id=organisation_concept_id,
         role_in_org=role_in_org,
     )
+    stored_message = dict(message)
+    if stored_message.get("role") == "assistant" and isinstance(
+        llm_debug_data, Mapping
+    ):
+        llm_execution_summary = (
+            chat_history_service.build_history_llm_execution_summary(llm_debug_data)
+        )
+        if llm_execution_summary is not None:
+            stored_message["llm_execution_summary"] = llm_execution_summary
     chat_history_service.add_message_to_history(
         user_id,
         session_id,
-        message,
+        stored_message,
         llm_debug_data=llm_debug_data,
         skip_rag_indexing=skip_rag_indexing,
         **context_kwargs,
@@ -15822,6 +15831,55 @@ def _with_viewer_scoped_history_reference_manifests(
     return projected
 
 
+def _with_latest_history_llm_execution_summary(
+    messages: list[dict[str, Any]],
+    *,
+    owner_user_id: str,
+    owner_namespace: str | None,
+    session_id: str,
+) -> list[dict[str, Any]]:
+    """Add one bounded footer summary without exposing the full debug payload."""
+
+    projected = [dict(message) for message in messages]
+    for index in range(len(projected) - 1, -1, -1):
+        message = projected[index]
+        if message.get("role") != "assistant":
+            continue
+        if isinstance(message.get("llm_execution_summary"), Mapping):
+            break
+        location = message.get("history_location")
+        history_index = (
+            location.get("history_index") if isinstance(location, Mapping) else None
+        )
+        if not isinstance(history_index, int) or history_index < 0:
+            break
+        try:
+            debug_data = chat_history_service.get_chat_history_debug_entry(
+                user_id=owner_user_id,
+                session_id=session_id,
+                history_index=history_index,
+                namespace=owner_namespace,
+            )
+            if not debug_data and owner_namespace is not None:
+                debug_data = chat_history_service.get_chat_history_debug_entry(
+                    user_id=owner_user_id,
+                    session_id=session_id,
+                    history_index=history_index,
+                    namespace=None,
+                )
+            summary = chat_history_service.build_history_llm_execution_summary(
+                debug_data
+            )
+            if summary is not None:
+                message["llm_execution_summary"] = summary
+        except Exception as exc:
+            current_app.logger.debug(
+                "Could not project latest history LLM execution summary: %s", exc
+            )
+        break
+    return projected
+
+
 @von_bp.route("/history", methods=["GET"])
 def history():
     """Retrieve chat history segments for the current user."""
@@ -16025,6 +16083,13 @@ def history():
                 flattened_history,
                 user_concept_id=user_concept_id,
                 organisation_concept_id=organisation_concept_id,
+            )
+        else:
+            flattened_history = _with_latest_history_llm_execution_summary(
+                flattened_history,
+                owner_user_id=owner_user_id,
+                owner_namespace=owner_namespace,
+                session_id=session_id,
             )
         segments_returned = len(selected_segments)
         history_truncated = bool(meta.get("history_truncated"))

--- a/src/backend/services/chat_history_service.py
+++ b/src/backend/services/chat_history_service.py
@@ -72,6 +72,8 @@ _CONVERSATION_SEARCH_TEXT_INDEX_NAME = "conversation_search_text_v1"
 _CONCEPT_QA_ACTIVE_KEY_INDEX_NAME = "concept_q_and_a_active_key_unique_v1"
 _CONVERSATION_SEARCH_MAX_SEGMENT_CHARS = 5_000
 _MAX_FOCAL_CONCEPT_IDS = 4
+HISTORY_LLM_EXECUTION_SUMMARY_SCHEMA_VERSION = "history_llm_execution_summary.v1"
+_HISTORY_LLM_EXECUTION_SUMMARY_STRING_MAX_CHARS = 240
 CHAT_SESSION_ORIGIN_KIND_BROWSER_TEST_FIXTURE = "browser_test_fixture"
 CHAT_SESSION_ORIGIN_KIND_BENCHMARK_HARNESS = "benchmark_harness"
 CHAT_SESSION_ORIGIN_KIND_CODING_AGENT_TEST = "coding_agent_test"
@@ -86,6 +88,124 @@ CHAT_SESSION_AGENT_CREATED_ORIGIN_KINDS = frozenset(
         "agent_test",
     }
 )
+
+
+def _bounded_history_llm_execution_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned[:_HISTORY_LLM_EXECUTION_SUMMARY_STRING_MAX_CHARS]
+
+
+def build_history_llm_execution_summary(
+    llm_debug_data: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project only safe model and credential provenance needed after reload.
+
+    The full debug payload can contain prompts, tool results, and other material
+    that normal history deliberately omits.  This projection is an explicit
+    allow-list and must remain small enough to return with ordinary history.
+    """
+
+    if not isinstance(llm_debug_data, Mapping):
+        return None
+    raw_interaction = llm_debug_data.get("llm_interaction")
+    if not isinstance(raw_interaction, Mapping):
+        return None
+
+    projected_calls: list[dict[str, Any]] = []
+    raw_calls = raw_interaction.get("calls")
+    if isinstance(raw_calls, list):
+        for raw_call in raw_calls:
+            if not isinstance(raw_call, Mapping):
+                continue
+            projected_call: dict[str, Any] = {}
+            for field_name in ("type", "model", "provider", "stage", "status"):
+                clean_value = _bounded_history_llm_execution_string(
+                    raw_call.get(field_name)
+                )
+                if clean_value is not None:
+                    projected_call[field_name] = clean_value
+            if isinstance(raw_call.get("success"), bool):
+                projected_call["success"] = raw_call["success"]
+
+            transport_candidates = (
+                raw_call.get("transport"),
+                raw_call.get("transport_metadata"),
+                (
+                    raw_call.get("candidate", {}).get("transport_metadata")
+                    if isinstance(raw_call.get("candidate"), Mapping)
+                    else None
+                ),
+                (
+                    raw_call.get("candidate", {}).get("llm_transport")
+                    if isinstance(raw_call.get("candidate"), Mapping)
+                    else None
+                ),
+                (
+                    raw_call.get("metadata", {}).get("transport_metadata")
+                    if isinstance(raw_call.get("metadata"), Mapping)
+                    else None
+                ),
+            )
+            projected_transport: dict[str, Any] = {}
+            for raw_transport in transport_candidates:
+                if not isinstance(raw_transport, Mapping):
+                    continue
+                source = _bounded_history_llm_execution_string(
+                    raw_transport.get("credential_source")
+                )
+                if source and source.lower() in {"primary", "backup"}:
+                    projected_transport["credential_source"] = source.lower()
+                if isinstance(raw_transport.get("credential_failover_used"), bool):
+                    projected_transport["credential_failover_used"] = raw_transport[
+                        "credential_failover_used"
+                    ]
+                failure_kind = _bounded_history_llm_execution_string(
+                    raw_transport.get("primary_credential_failure_kind")
+                )
+                if failure_kind is not None:
+                    projected_transport["primary_credential_failure_kind"] = (
+                        failure_kind
+                    )
+            if projected_transport:
+                projected_call["transport"] = projected_transport
+            if projected_call:
+                projected_calls.append(projected_call)
+
+    projected_interaction: dict[str, Any] = {"calls": projected_calls}
+    for field_name in (
+        "requested_model",
+        "requested_provider",
+        "ordinary_turn_terminal_status",
+    ):
+        clean_value = _bounded_history_llm_execution_string(
+            raw_interaction.get(field_name)
+        )
+        if clean_value is not None:
+            projected_interaction[field_name] = clean_value
+
+    top_level_model = _bounded_history_llm_execution_string(llm_debug_data.get("model"))
+    if not projected_calls and len(projected_interaction) == 1 and not top_level_model:
+        return None
+
+    summary: dict[str, Any] = {
+        "schema_version": HISTORY_LLM_EXECUTION_SUMMARY_SCHEMA_VERSION,
+        "llm_interaction": projected_interaction,
+    }
+    if top_level_model is not None:
+        summary["model"] = top_level_model
+    timestamp = _bounded_history_llm_execution_string(
+        llm_debug_data.get("timestamp")
+        or llm_debug_data.get("interaction_timestamp_utc")
+    )
+    if timestamp is not None:
+        summary["timestamp"] = timestamp
+    return summary
+
+
 CHAT_SESSION_PROVENANCE_FIELDS = (
     "mode",
     "origin_kind",
@@ -1685,6 +1805,9 @@ def _split_history_into_segments_with_locations(
                 author_user_id = owner_user_id
         if author_user_id:
             copied["author_user_id"] = author_user_id
+        llm_execution_summary = entry.get("llm_execution_summary")
+        if isinstance(llm_execution_summary, Mapping):
+            copied["llm_execution_summary"] = dict(llm_execution_summary)
         if include_debug and "llm_debug_data" in entry:
             copied["llm_debug_data"] = entry.get("llm_debug_data")
         existing_location = entry.get("history_location")

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -569,11 +569,20 @@ function deriveLlmExecutionContextBinding(debugData, baseBinding = null) {
         binding.conversation_session_id = historySessionId;
     }
 
+    const historyExecutionSummary = (
+        debugData?.llm_execution_summary
+        && typeof debugData.llm_execution_summary === 'object'
+    ) ? debugData.llm_execution_summary : null;
     const llmInteraction = debugData?.llm_interaction && typeof debugData.llm_interaction === 'object'
         ? debugData.llm_interaction
+        : (
+            historyExecutionSummary?.llm_interaction
+            && typeof historyExecutionSummary.llm_interaction === 'object'
+        )
+        ? historyExecutionSummary.llm_interaction
         : null;
     const requestedModel = normaliseLlmExecutionContextString(
-        llmInteraction?.requested_model || debugData?.model,
+        llmInteraction?.requested_model || debugData?.model || historyExecutionSummary?.model,
     );
     if (requestedModel) {
         const interactionCalls = Array.isArray(llmInteraction?.calls) ? llmInteraction.calls : [];
@@ -913,11 +922,17 @@ function buildLatestLlmExecutionTelemetrySummary(turnId, debugData, executionCon
         return null;
     }
 
+    const historyExecutionSummary = (
+        debugData.llm_execution_summary
+        && typeof debugData.llm_execution_summary === 'object'
+    ) ? debugData.llm_execution_summary : null;
     const llmInteraction = (debugData.llm_interaction && typeof debugData.llm_interaction === 'object')
         ? debugData.llm_interaction
         : ((debugData.metadata?.llm_interaction && typeof debugData.metadata.llm_interaction === 'object')
             ? debugData.metadata.llm_interaction
-            : null);
+            : ((historyExecutionSummary?.llm_interaction && typeof historyExecutionSummary.llm_interaction === 'object')
+                ? historyExecutionSummary.llm_interaction
+                : null));
     const rawCalls = Array.isArray(llmInteraction?.calls) ? llmInteraction.calls : [];
     const callModels = [];
     const callProviders = [];
@@ -988,7 +1003,11 @@ function buildLatestLlmExecutionTelemetrySummary(turnId, debugData, executionCon
     const uniqueCallProviders = normaliseTelemetryStringArray([...callProviders, ...fallbackCallProviders]);
     const requestedModel = (typeof llmInteraction?.requested_model === 'string' && llmInteraction.requested_model.trim())
         ? llmInteraction.requested_model.trim()
-        : ((typeof debugData.model === 'string' && debugData.model.trim()) ? debugData.model.trim() : null);
+        : ((typeof debugData.model === 'string' && debugData.model.trim())
+            ? debugData.model.trim()
+            : ((typeof historyExecutionSummary?.model === 'string' && historyExecutionSummary.model.trim())
+                ? historyExecutionSummary.model.trim()
+                : null));
     const topLevelError = (typeof debugData.error === 'string' && debugData.error.trim())
         ? debugData.error.trim()
         : null;
@@ -1027,7 +1046,7 @@ function buildLatestLlmExecutionTelemetrySummary(turnId, debugData, executionCon
             ? { ...executionContextBinding }
             : null,
         turn_id: typeof turnId === 'string' ? turnId : null,
-        timestamp: debugData.timestamp ?? null,
+        timestamp: debugData.timestamp ?? historyExecutionSummary?.timestamp ?? null,
         requested_model: effectiveRequestedModel,
         actual_model: effectiveActualModel,
         actual_provider: effectiveActualProvider,
@@ -29575,6 +29594,9 @@ function rehydrateHistory(scrollableField, historyMessages, options = {}) {
             if (msg.role === 'assistant') {
                 const merged = {
                     ...(msg.llm_debug_data && typeof msg.llm_debug_data === 'object' ? msg.llm_debug_data : {}),
+                    llm_execution_summary: (
+                        msg.llm_execution_summary && typeof msg.llm_execution_summary === 'object'
+                    ) ? msg.llm_execution_summary : null,
                     history_location: msg.history_location || null,
                     reference_manifest: msg.reference_manifest
                         || msg.llm_debug_data?.reference_manifest

--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -1494,6 +1494,7 @@ export async function setModelInfoFooterText() {
       && actualProvider.trim().toLowerCase() !== configuredProvider.trim().toLowerCase();
     const failureReason = executionTelemetry?.primaryFailureReason || executionTelemetry?.error || '';
     const recoveredFailureReason = executionTelemetry?.recoveredFailureReason || '';
+    const credentialSource = executionTelemetry?.credentialSource || '';
     const credentialFailoverUsed = executionTelemetry?.credentialFailoverUsed === true;
     const explicitStageModelOverride = !!executionTelemetry?.explicitStageModelOverride;
     const activeLlmSelectionModes = new Set([
@@ -1564,6 +1565,7 @@ export async function setModelInfoFooterText() {
     if (configuredModel) titleParts.push(`Configured model: ${configuredModel}`);
     if (llmHost) titleParts.push(`Host: ${llmHost}`);
     if (errorMsg) titleParts.push(`Error: ${errorMsg}`);
+    if (credentialSource) titleParts.push(`Credential: ${credentialSource} key`);
     if (executionOverlayActive) {
       const hasHardFailure = !!failureReason || unexpectedModelMismatch;
       llmClass = hasHardFailure ? 'fatal' : 'warning';
@@ -1572,7 +1574,6 @@ export async function setModelInfoFooterText() {
       if (actualProvider) titleParts.push(`Executed provider: ${actualProvider}`);
       if (actualModel) titleParts.push(`Executed model: ${actualModel}`);
       if (credentialFailoverUsed) {
-        titleParts.push('Credential: backup key');
         if (executionTelemetry.primaryCredentialFailureKind) {
           titleParts.push(`Primary credential failure: ${executionTelemetry.primaryCredentialFailureKind}`);
         }
@@ -1629,8 +1630,8 @@ export async function setModelInfoFooterText() {
     if (executionOverlayActive) {
       accessibilityParts.push(`Last execution status ${executionStatusLabel}`);
     }
-    if (credentialFailoverUsed) {
-      accessibilityParts.push('Credential backup key');
+    if (credentialSource) {
+      accessibilityParts.push(`Credential ${credentialSource} key`);
     }
     if (failureReason) {
       accessibilityParts.push(`Failure reason ${failureReason}`);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -87,6 +87,7 @@ import {
     __testOnly_getConversationTranscriptTurnsSnapshot,
     __testOnly_copyConversationInfoToClipboard,
     __testOnly_clearLlmDebugData,
+    __testOnly_getLatestLlmExecutionTelemetry,
     __testOnly_resetChatRequestState,
     __testOnly_refreshConversationRuntimeCostSnapshot,
     __testOnly_setConversationRuntimeCostLiveSummary,
@@ -226,6 +227,61 @@ describe('external conversation imports', () => {
         expect(headers[1]).not.toContain('Von •');
         expect(scrollableField.querySelector('.chat-edit-button')).toBeNull();
         expect(scrollableField.querySelector('.btn-delete-exchange')).toBeNull();
+    });
+});
+
+describe('history LLM execution summary rehydration', () => {
+    afterEach(() => {
+        __testOnly_clearLlmDebugData();
+        document.body.innerHTML = '';
+    });
+
+    test('restores bounded backup credential provenance without full debug data', () => {
+        const scrollableField = document.createElement('div');
+        scrollableField.id = 'scrollableField';
+        document.body.appendChild(scrollableField);
+
+        __test_only__rehydrateHistory(scrollableField, [
+            {
+                role: 'assistant',
+                content: 'BACKUP-FOOTER-PASS',
+                timestamp: '2026-09-03T15:38:44Z',
+                turn_id: 'a-request-backup',
+                history_location: {
+                    session_id: 'session-backup',
+                    history_index: 3
+                },
+                llm_execution_summary: {
+                    schema_version: 'history_llm_execution_summary.v1',
+                    model: 'gpt-5.6-luna',
+                    llm_interaction: {
+                        requested_model: 'gpt-5.6-luna',
+                        calls: [
+                            {
+                                type: 'adaptive_turn_model_call',
+                                model: 'gpt-5.6-luna',
+                                provider: 'openai',
+                                transport: {
+                                    credential_source: 'backup',
+                                    credential_failover_used: true,
+                                    primary_credential_failure_kind: 'quota_exhausted'
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ], { scrollToBottom: false });
+
+        expect(__testOnly_getLatestLlmExecutionTelemetry()).toEqual(
+            expect.objectContaining({
+                actual_model: 'gpt-5.6-luna',
+                actual_provider: 'openai',
+                credential_source: 'backup',
+                credential_failover_used: true,
+                primary_credential_failure_kind: 'quota_exhausted'
+            })
+        );
     });
 });
 
@@ -2853,6 +2909,23 @@ describe('loadChatHistory degraded handling', () => {
                                 role: 'assistant',
                                 content: 'Done',
                                 timestamp: '2026-06-02T14:13:00Z',
+                                llm_execution_summary: {
+                                    schema_version: 'history_llm_execution_summary.v1',
+                                    model: 'gpt-5.6-luna',
+                                    llm_interaction: {
+                                        requested_model: 'gpt-5.6-luna',
+                                        calls: [
+                                            {
+                                                model: 'gpt-5.6-luna',
+                                                provider: 'openai',
+                                                transport: {
+                                                    credential_source: 'primary',
+                                                    credential_failover_used: false
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
                                 history_location: {
                                     session_id: 'session-1',
                                     history_index: 4
@@ -2929,6 +3002,13 @@ describe('loadChatHistory degraded handling', () => {
 
         await __testOnly_loadChatHistory({ segments: 1 });
 
+        expect(__testOnly_getLatestLlmExecutionTelemetry()).toEqual(
+            expect.objectContaining({
+                credential_source: 'primary',
+                credential_failover_used: false,
+                actual_model: 'gpt-5.6-luna'
+            })
+        );
         const eagerDebugFetches = global.fetch.mock.calls.filter(
             ([url]) => typeof url === 'string' && url.startsWith('/von/history/debug?')
         );

--- a/tests/backend/test_chat_history_service_segments.py
+++ b/tests/backend/test_chat_history_service_segments.py
@@ -1060,3 +1060,35 @@ def test_get_chat_history_segments_keeps_debug_projection_when_requested(
     assert collection.pipeline is not None
     projection = collection.pipeline[1]["$project"]
     assert "$slice" in projection["history"]
+
+
+def test_split_history_preserves_bounded_execution_summary_without_debug():
+    from src.backend.services import chat_history_service
+
+    summary = {
+        "schema_version": "history_llm_execution_summary.v1",
+        "llm_interaction": {
+            "calls": [
+                {
+                    "model": "gpt-5.6-luna",
+                    "provider": "openai",
+                    "transport": {"credential_source": "primary"},
+                }
+            ]
+        },
+    }
+    segments = chat_history_service._split_history_into_segments_with_locations(
+        [
+            {
+                "role": "assistant",
+                "content": "Done",
+                "llm_execution_summary": summary,
+                "llm_debug_data": {"messages": ["private"]},
+            }
+        ],
+        session_id="session-summary",
+        include_debug=False,
+    )
+
+    assert segments[0][0]["llm_execution_summary"] == summary
+    assert "llm_debug_data" not in segments[0][0]

--- a/tests/backend/test_von_history_debug_endpoint.py
+++ b/tests/backend/test_von_history_debug_endpoint.py
@@ -374,6 +374,155 @@ def test_history_endpoint_projects_reference_manifest_for_legacy_turn(monkeypatc
     assert references[instance_id]["reference_type"] == "workflow_instance"
 
 
+def test_history_endpoint_projects_bounded_latest_llm_credential_summary(monkeypatch):
+    from src.backend.server.routes.von_routes import von_bp
+
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#test_user",
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.get_effective_context",
+        lambda *_args, **_kwargs: {"namespace": "#V#test_user@org"},
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.has_chat_history_session",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.get_chat_history_session_state",
+        lambda **_kwargs: {
+            "history": [
+                {
+                    "role": "assistant",
+                    "content": "Used the backup credential.",
+                    "timestamp": "2026-09-03T15:38:44Z",
+                    "turn_id": "a-request-backup",
+                    "history_location": {
+                        "session_id": "session-backup",
+                        "history_index": 3,
+                    },
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "src.backend.server.routes.von_routes.chat_history_service.get_chat_history_debug_entry",
+        lambda **_kwargs: {
+            "model": "gpt-5.6-luna",
+            "messages": [{"role": "user", "content": "private prompt"}],
+            "llm_interaction": {
+                "requested_model": "gpt-5.6-luna",
+                "calls": [
+                    {
+                        "type": "adaptive_turn_model_call",
+                        "model": "gpt-5.6-luna",
+                        "provider": "openai",
+                        "transport": {
+                            "credential_source": "backup",
+                            "credential_failover_used": True,
+                            "primary_credential_failure_kind": "quota_exhausted",
+                            "api_key": "sk-must-not-leak",
+                        },
+                        "response": "private provider response",
+                    }
+                ],
+            },
+        },
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(von_bp, url_prefix="/von")
+
+    response = app.test_client().get(
+        "/von/history",
+        query_string={
+            "session_id": "session-backup",
+            "segments": 1,
+            "include_debug": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    message = response.get_json()["history"][0]
+    assert "llm_debug_data" not in message
+    assert message["llm_execution_summary"] == {
+        "schema_version": "history_llm_execution_summary.v1",
+        "model": "gpt-5.6-luna",
+        "llm_interaction": {
+            "requested_model": "gpt-5.6-luna",
+            "calls": [
+                {
+                    "type": "adaptive_turn_model_call",
+                    "model": "gpt-5.6-luna",
+                    "provider": "openai",
+                    "transport": {
+                        "credential_source": "backup",
+                        "credential_failover_used": True,
+                        "primary_credential_failure_kind": "quota_exhausted",
+                    },
+                }
+            ],
+        },
+    }
+    response_text = response.get_data(as_text=True)
+    assert "sk-must-not-leak" not in response_text
+    assert "private prompt" not in response_text
+    assert "private provider response" not in response_text
+
+
+def test_add_chat_history_message_persists_bounded_llm_execution_summary(monkeypatch):
+    from src.backend.server.routes import von_routes
+
+    stored: dict[str, object] = {}
+
+    def _store(_user_id, _session_id, message, **kwargs):
+        stored["message"] = message
+        stored["debug"] = kwargs.get("llm_debug_data")
+
+    monkeypatch.setattr(
+        von_routes.chat_history_service,
+        "add_message_to_history",
+        _store,
+    )
+
+    debug = {
+        "model": "gpt-5.6-luna",
+        "llm_interaction": {
+            "requested_model": "gpt-5.6-luna",
+            "calls": [
+                {
+                    "model": "gpt-5.6-luna",
+                    "provider": "openai",
+                    "transport": {
+                        "credential_source": "primary",
+                        "credential_failover_used": False,
+                        "api_key": "sk-never-project",
+                    },
+                }
+            ],
+        },
+    }
+    von_routes._add_chat_history_message(
+        user_id="#V#test_user",
+        session_id="session-primary",
+        message={"role": "assistant", "content": "Done"},
+        llm_debug_data=debug,
+    )
+
+    message = stored["message"]
+    assert isinstance(message, dict)
+    assert message["llm_execution_summary"]["llm_interaction"]["calls"][0][
+        "transport"
+    ] == {
+        "credential_source": "primary",
+        "credential_failover_used": False,
+    }
+    assert "sk-never-project" not in repr(message["llm_execution_summary"])
+    assert stored["debug"] is debug
+
+
 def test_history_debug_returns_stored_turn_execution_diagnostics(monkeypatch):
     from src.backend.server.routes.von_routes import von_bp
 

--- a/tests/frontend/footerLlmExecutionStatus.test.js
+++ b/tests/frontend/footerLlmExecutionStatus.test.js
@@ -303,6 +303,36 @@ describe('footer latest LLM execution status', () => {
         expect(modelButton.title).not.toContain('sk-');
     });
 
+    test('identifies primary-key use in the tooltip without changing the model label', async () => {
+        const { setModelInfoFooterText } = require(domUtilsPath);
+
+        await setModelInfoFooterText();
+
+        window.__vonLatestLlmExecutionTelemetry = bindExecutionTelemetry({
+            requested_model: 'gpt-5.4-mini',
+            actual_model: 'gpt-5.4-mini',
+            actual_provider: 'openai',
+            call_models: ['gpt-5.4-mini'],
+            execution_succeeded: true,
+            fallback_used: false,
+            credential_source: 'primary',
+            credential_failover_used: false,
+        });
+        document.dispatchEvent(new CustomEvent('von:latestLlmExecutionTelemetryUpdated', {
+            detail: window.__vonLatestLlmExecutionTelemetry
+        }));
+        await flushUiTicks();
+
+        const modelSegment = await waitForModelSegment((seg) => (
+            seg.querySelector('.concept-footer-button')?.textContent?.trim() === 'gpt-5.4-mini'
+            && seg.querySelector('.concept-footer-button')?.title?.includes('Credential: primary key')
+        ));
+        const modelButton = modelSegment.querySelector('.concept-footer-button');
+        expect(modelButton.textContent.trim()).toBe('gpt-5.4-mini');
+        expect(modelButton.title).toContain('Credential: primary key');
+        expect(modelButton.getAttribute('aria-label')).toContain('Credential primary key');
+    });
+
     test('does not turn footer red for OpenAI alias resolution (dated snapshot)', async () => {
         const { setModelInfoFooterText } = require(domUtilsPath);
 


### PR DESCRIPTION
## Outcome
- persist a tightly allow-listed LLM execution summary beside assistant history turns
- project the same bounded summary for legacy turns without exposing full debug payloads
- restore backup-key footer state after reload
- identify primary or backup credential use in the model tooltip

## Security boundary
Ordinary history receives model/provider names and three credential-provenance fields only. Tests prove prompts, provider responses, and key material are excluded. Full Thinking/debug data remains lazy-loaded.

## Validation
- 311 focused frontend tests passed
- 29 focused backend tests passed
- frontend static lint passed
- Python compile and undefined-name checks passed
- git diff --check passed

Live DGX before/after-reload browser validation will follow the merged deployment.

Jira: JVNAUTOSCI-2715