### PR TITLE
Preserve latest credential footer after reload

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -34569,26 +34569,14 @@ function getLatestLlmDebugEntryForExport() {
         return null;
     }
 
-    const getTurnTimestamp = (turnId) => {
-        if (typeof turnId !== 'string') {
-            return 0;
-        }
-        const parts = turnId.split('-');
-        const tail = parts.length > 1 ? Number.parseInt(parts[parts.length - 1], 10) : 0;
-        return Number.isFinite(tail) ? tail : 0;
-    };
-
+    // Entries are inserted in transcript order. Updating an existing Map key
+    // (for example, when its stored Thinking details are loaded) preserves
+    // that order. Turn IDs are opaque and commonly contain UUIDs, so parsing a
+    // UUID fragment as a timestamp can select an older turn after reload.
     let latest = null;
     for (const [turnId, debugData] of llmDebugData.entries()) {
         const executionContextBinding = llmDebugExecutionContextBindings.get(turnId) || null;
-        if (!latest) {
-            latest = { turnId, debugData, executionContextBinding, timestamp: getTurnTimestamp(turnId) };
-            continue;
-        }
-        const nextTimestamp = getTurnTimestamp(turnId);
-        if (nextTimestamp >= latest.timestamp) {
-            latest = { turnId, debugData, executionContextBinding, timestamp: nextTimestamp };
-        }
+        latest = { turnId, debugData, executionContextBinding };
     }
     return latest;
 }

--- a/tests/frontend/chatTabLatestLlmExecutionTelemetry.test.js
+++ b/tests/frontend/chatTabLatestLlmExecutionTelemetry.test.js
@@ -573,4 +573,46 @@ describe('chatTab latest execution telemetry publication', () => {
             }),
         );
     });
+
+    test('uses transcript order rather than opaque UUID fragments after history reload', () => {
+        const chatTab = require(chatTabModulePath);
+
+        chatTab.__testOnly_clearLlmDebugData();
+        chatTab.setLlmDebugDataForTurn('a-bb7954fc-3f06-468f-9224-25ddc16962e3', {
+            timestamp: '2026-09-03T15:38:44.000Z',
+            history_location: { session_id: 'conversation-a', history_index: 1 },
+        });
+        chatTab.setLlmDebugDataForTurn('a-0a6886ec-e894-4913-958f-a395dd85e59d', {
+            timestamp: '2026-09-03T16:12:57.000Z',
+            history_location: { session_id: 'conversation-a', history_index: 3 },
+            llm_execution_summary: {
+                schema_version: 'history_llm_execution_summary.v1',
+                model: 'gpt-5.6-luna',
+                llm_interaction: {
+                    requested_model: 'gpt-5.6-luna',
+                    calls: [{
+                        type: 'adaptive_turn_model_call',
+                        model: 'gpt-5.6-luna',
+                        provider: 'openai',
+                        transport: {
+                            credential_source: 'backup',
+                            credential_failover_used: true,
+                            primary_credential_failure_kind: 'quota_exhausted',
+                        },
+                    }],
+                },
+            },
+        });
+
+        expect(chatTab.__testOnly_getLatestLlmExecutionTelemetry()).toEqual(
+            expect.objectContaining({
+                turn_id: 'a-0a6886ec-e894-4913-958f-a395dd85e59d',
+                credential_source: 'backup',
+                credential_failover_used: true,
+                primary_credential_failure_kind: 'quota_exhausted',
+                actual_model: 'gpt-5.6-luna',
+                actual_provider: 'openai',
+            }),
+        );
+    });
 });


### PR DESCRIPTION
## Outcome
Ensure the footer reports the credential used by the latest assistant turn after history reload.

## Cause
The frontend parsed the final fragment of an opaque UUID turn ID as a timestamp. UUID lexical/numeric shape could therefore rank an older turn above the latest transcript turn.

## Change
- select the latest execution telemetry entry by canonical transcript insertion order
- preserve order when stored Thinking data updates an existing Map entry
- add a regression using the two live DGX turn-ID shapes that reproduced the failure

## Validation
- 312 focused frontend tests passed
- frontend static lint passed for `chatTab.js`
- `git diff --check` passed

Jira: JVNAUTOSCI-2715