### PR TITLE
JVNAUTOSCI-2716: Show active organisation in browser title

### DIFF
--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -13,6 +13,7 @@ import {
   subscribeToWorkflowCapabilityIndexStatus,
 } from './utils/workflowCapabilityStatusCoordinator.js';
 import { createFooterOrganisationSwitcher } from './components/footerOrganisationSwitcher.js';
+import { selectShortestNameForContext } from './utils/nameSelection.js';
 
 export const elements = {};
 
@@ -88,6 +89,54 @@ let _orgDescriptionCacheId = null;
 
 // Default fallback description concept ID (Von system description)
 const VON_SYSTEM_CONCEPT_ID = '#V#von_system';
+const VON_DOCUMENT_TITLE = 'Von';
+
+let _documentTitleRequestGeneration = 0;
+
+function formatVonDocumentTitle(organisationName) {
+  const name = typeof organisationName === 'string' ? organisationName.trim() : '';
+  return name ? `${VON_DOCUMENT_TITLE} · ${name}` : VON_DOCUMENT_TITLE;
+}
+
+/**
+ * Update the browser tab title for the active organisation.
+ *
+ * The stored organisation name is shown immediately, then replaced with the
+ * shortest represented name when the concept read succeeds. Request ordering
+ * prevents a slow read for a previously active organisation from winning.
+ * @param {Object|null} orgContext - Optional already-read organisation context
+ * @returns {Promise<void>}
+ */
+export async function updateDocumentTitle(orgContext = getSessionScopedOrgContext()) {
+  const requestGeneration = ++_documentTitleRequestGeneration;
+  const orgConceptId = orgContext?.concept_id || null;
+  const fallbackName = orgContext?.name || null;
+
+  document.title = formatVonDocumentTitle(fallbackName);
+  if (!orgConceptId) return;
+
+  try {
+    const response = await fetch(`/api/concepts/${encodeURIComponent(orgConceptId)}`);
+    if (!response.ok) return;
+
+    const doc = await response.json();
+    const names = Array.isArray(doc.names) && doc.names.length
+      ? doc.names
+      : (Array.isArray(doc.raw_doc?.names) ? doc.raw_doc.names : []);
+    const shortestName = selectShortestNameForContext(names);
+    if (!shortestName) return;
+
+    const currentOrgConceptId = getSessionScopedOrgContext()?.concept_id || null;
+    if (
+      requestGeneration === _documentTitleRequestGeneration
+      && currentOrgConceptId === orgConceptId
+    ) {
+      document.title = formatVonDocumentTitle(shortestName);
+    }
+  } catch (error) {
+    console.warn('[domUtils] Unable to load the organisation name for the browser title:', error);
+  }
+}
 
 /**
  * Fetch organisation description from Vontology text relations.
@@ -142,15 +191,19 @@ async function fetchOrganisationDescription(orgConceptId) {
  * Update the header organisation name display.
  */
 export function updateHeaderOrgName() {
+  const orgContext = getSessionScopedOrgContext();
+  const documentTitleUpdate = updateDocumentTitle(orgContext);
+
   const headerOrgNameEl = document.getElementById('headerOrgName');
-  if (!headerOrgNameEl) return;
+  if (!headerOrgNameEl) return documentTitleUpdate;
 
   // Read current org from session-scoped storage
-  const orgName = getSessionScopedOrgContext()?.name || null;
+  const orgName = orgContext?.name || null;
 
   const displayName = orgName || 'Personal';
   headerOrgNameEl.textContent = displayName;
   headerOrgNameEl.title = displayName;
+  return documentTitleUpdate;
 }
 
 /**

--- a/tests/frontend/documentTitleOrganisation.test.js
+++ b/tests/frontend/documentTitleOrganisation.test.js
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+
+const domUtilsPath = '../../src/frontend/web/von_interface/static/js/domUtils.js';
+
+function storeOrganisation(conceptId, name) {
+    localStorage.setItem('von_org_context', JSON.stringify({
+        concept_id: conceptId,
+        name,
+    }));
+}
+
+describe('organisation-aware browser title', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        sessionStorage.clear();
+        document.documentElement.lang = 'en-NZ';
+        document.title = 'Von';
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    test('uses the shortest represented name in the preferred language', async () => {
+        storeOrganisation('#V#primary_labs', 'Primary Laboratories Incorporated');
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                raw_doc: {
+                    names: [
+                        { name: 'Primary Laboratories Incorporated', language: 'en-NZ', type: 'NL' },
+                        { name: 'Primary Labs', language: 'en-NZ', type: 'ABBR' },
+                        { name: 'Laboratoires Primaires', language: 'fr', type: 'NL' },
+                    ],
+                },
+            }),
+        });
+
+        const { updateDocumentTitle } = require(domUtilsPath);
+        await updateDocumentTitle();
+
+        expect(document.title).toBe('Von · Primary Labs');
+        expect(global.fetch).toHaveBeenCalledWith('/api/concepts/%23V%23primary_labs');
+    });
+
+    test('uses Von alone when there is no active organisation', async () => {
+        const { updateDocumentTitle } = require(domUtilsPath);
+        document.title = 'Old title';
+
+        await updateDocumentTitle();
+
+        expect(document.title).toBe('Von');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('retains the stored organisation name when the concept read fails', async () => {
+        storeOrganisation('#V#primary_labs', 'Primary Labs');
+        global.fetch.mockResolvedValue({ ok: false });
+
+        const { updateDocumentTitle } = require(domUtilsPath);
+        await updateDocumentTitle();
+
+        expect(document.title).toBe('Von · Primary Labs');
+    });
+
+    test('does not let a stale organisation read overwrite a newer title', async () => {
+        let resolveFirstRead;
+        const firstRead = new Promise((resolve) => {
+            resolveFirstRead = resolve;
+        });
+        global.fetch
+            .mockReturnValueOnce(firstRead)
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ names: [{ name: 'Second', language: 'en-NZ', type: 'NL' }] }),
+            });
+
+        const { updateDocumentTitle } = require(domUtilsPath);
+        storeOrganisation('#V#first_org', 'First organisation');
+        const firstUpdate = updateDocumentTitle();
+
+        storeOrganisation('#V#second_org', 'Second organisation');
+        const secondUpdate = updateDocumentTitle();
+        await secondUpdate;
+
+        resolveFirstRead({
+            ok: true,
+            json: async () => ({ names: [{ name: 'First', language: 'en-NZ', type: 'NL' }] }),
+        });
+        await firstUpdate;
+
+        expect(document.title).toBe('Von · Second');
+    });
+});

--- a/tests/frontend/footerOrgContextFallback.test.js
+++ b/tests/frontend/footerOrgContextFallback.test.js
@@ -34,11 +34,12 @@ describe('footer org context fallback', () => {
     test('uses von_org_context to render org footer segment', async () => {
         const { setModelInfoFooterText, updateHeaderOrgName } = require(domUtilsPath);
 
-        updateHeaderOrgName();
+        await updateHeaderOrgName();
         await setModelInfoFooterText();
 
         expect(document.querySelector('#headerOrgName')?.textContent)
             .toBe('The Lu Witbrock Household');
+        expect(document.title).toBe('Von · The Lu Witbrock Household');
         const orgSegment = Array.from(document.querySelectorAll('.footer-segment'))
             .find((seg) => seg.querySelector('.footer-label-inline')?.textContent?.trim() === 'Org:');
         expect(orgSegment).toBeTruthy();


### PR DESCRIPTION
## Summary
- show `Von · <shortest represented organisation name>` in the browser tab
- retain the stored organisation name while names load or if the read fails
- reset to `Von` without an active organisation and reject stale switch responses

## Validation
- `npx jest --runInBand tests/frontend/nameSelection.test.js tests/frontend/orgSwitchStorage.test.js tests/frontend/orgSwitchRefreshChatTabs.test.js tests/frontend/footerOrganisationSwitcher.test.js tests/frontend/documentTitleOrganisation.test.js tests/frontend/footerOrgContextFallback.test.js tests/frontend/chatConversationLayout.test.js` (41 tests passed)
- `npm run lint:frontend:static -- src/frontend/web/von_interface/static/js/domUtils.js`
- `git diff --check`

## Broader baseline
The full frontend suite currently has 9 failures in four unrelated suites; the same failures reproduce unchanged on `origin/main`.

Jira: JVNAUTOSCI-2716