### PR TITLE
JVNAUTOSCI-2716: Label Personal tabs with the user name

### DIFF
--- a/src/frontend/web/von_interface/static/js/domUtils.js
+++ b/src/frontend/web/von_interface/static/js/domUtils.js
@@ -99,24 +99,32 @@ function formatVonDocumentTitle(organisationName) {
 }
 
 /**
- * Update the browser tab title for the active organisation.
+ * Update the browser tab title for the active organisation or personal user.
  *
- * The stored organisation name is shown immediately, then replaced with the
- * shortest represented name when the concept read succeeds. Request ordering
- * prevents a slow read for a previously active organisation from winning.
+ * The stored name is shown immediately, then replaced with the shortest
+ * represented name when the concept read succeeds. Request ordering prevents
+ * a slow read for a previously active context from winning.
  * @param {Object|null} orgContext - Optional already-read organisation context
+ * @param {boolean} isPersonalContext - Whether Personal was explicitly selected
  * @returns {Promise<void>}
  */
-export async function updateDocumentTitle(orgContext = getSessionScopedOrgContext()) {
+export async function updateDocumentTitle(
+  orgContext = getSessionScopedOrgContext(),
+  isPersonalContext = hasSessionPersonalOrgContext(),
+) {
   const requestGeneration = ++_documentTitleRequestGeneration;
-  const orgConceptId = orgContext?.concept_id || null;
-  const fallbackName = orgContext?.name || null;
+  const userContext = isPersonalContext ? readSessionScopedJson('von_current_user') : null;
+  const targetConceptId = orgContext?.concept_id || userContext?.concept_id || null;
+  const fallbackName = orgContext?.name
+    || userContext?.name
+    || userContext?.display_name
+    || (isPersonalContext ? 'Personal' : null);
 
   document.title = formatVonDocumentTitle(fallbackName);
-  if (!orgConceptId) return;
+  if (!targetConceptId) return;
 
   try {
-    const response = await fetch(`/api/concepts/${encodeURIComponent(orgConceptId)}`);
+    const response = await fetch(`/api/concepts/${encodeURIComponent(targetConceptId)}`);
     if (!response.ok) return;
 
     const doc = await response.json();
@@ -126,15 +134,21 @@ export async function updateDocumentTitle(orgContext = getSessionScopedOrgContex
     const shortestName = selectShortestNameForContext(names);
     if (!shortestName) return;
 
-    const currentOrgConceptId = getSessionScopedOrgContext()?.concept_id || null;
+    const currentTargetConceptId = isPersonalContext
+      ? readSessionScopedJson('von_current_user')?.concept_id || null
+      : getSessionScopedOrgContext()?.concept_id || null;
+    const contextStillActive = isPersonalContext
+      ? hasSessionPersonalOrgContext()
+      : !hasSessionPersonalOrgContext();
     if (
       requestGeneration === _documentTitleRequestGeneration
-      && currentOrgConceptId === orgConceptId
+      && contextStillActive
+      && currentTargetConceptId === targetConceptId
     ) {
       document.title = formatVonDocumentTitle(shortestName);
     }
   } catch (error) {
-    console.warn('[domUtils] Unable to load the organisation name for the browser title:', error);
+    console.warn('[domUtils] Unable to load the context name for the browser title:', error);
   }
 }
 

--- a/tests/frontend/documentTitleOrganisation.test.js
+++ b/tests/frontend/documentTitleOrganisation.test.js
@@ -9,6 +9,13 @@ function storeOrganisation(conceptId, name) {
     }));
 }
 
+function storeUser(conceptId, name) {
+    sessionStorage.setItem('von_current_user', JSON.stringify({
+        concept_id: conceptId,
+        name,
+    }));
+}
+
 describe('organisation-aware browser title', () => {
     beforeEach(() => {
         jest.resetModules();
@@ -54,6 +61,37 @@ describe('organisation-aware browser title', () => {
         await updateDocumentTitle();
 
         expect(document.title).toBe('Von');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('uses the shortest represented user name for Personal context', async () => {
+        storeOrganisation('#V#primary_labs', 'Primary Labs');
+        storeUser('#V#michael_witbrock', 'Michael Witbrock');
+        sessionStorage.setItem('von_org_selection', 'personal');
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                names: [
+                    { name: 'Michael Witbrock', language: 'en-NZ', type: 'NL' },
+                    { name: 'Michael', language: 'en-NZ', type: 'ABBR' },
+                ],
+            }),
+        });
+
+        const { updateDocumentTitle } = require(domUtilsPath);
+        await updateDocumentTitle();
+
+        expect(document.title).toBe('Von · Michael');
+        expect(global.fetch).toHaveBeenCalledWith('/api/concepts/%23V%23michael_witbrock');
+    });
+
+    test('uses Personal when no usable user name is available', async () => {
+        sessionStorage.setItem('von_org_selection', 'personal');
+
+        const { updateDocumentTitle } = require(domUtilsPath);
+        await updateDocumentTitle();
+
+        expect(document.title).toBe('Von · Personal');
         expect(global.fetch).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- label an explicitly selected Personal context with the shortest represented user name
- fall back to `Von · Personal` if the user name is unavailable
- retain bare `Von` only for unauthenticated/loading/unresolved context

## Validation
- 43 focused and neighbouring frontend tests passed
- frontend static lint passed
- `git diff --check` passed

Jira: JVNAUTOSCI-2716