### PR TITLE
Show credential source in Thinking LLM details

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -5385,6 +5385,11 @@ function buildRetainedThinkingCardRequestFromDebugData(turnId, debugData) {
         debugData.timestamp || diagnostics?.completed_at_utc || diagnostics?.started_at_utc
     );
     const requestId = normaliseThinkingActivityString(diagnostics?.request_id || debugData.request_id);
+    const llmExecutionTelemetry = buildLatestLlmExecutionTelemetrySummary(
+        turnId,
+        debugData,
+        llmDebugExecutionContextBindings.get(turnId) || null
+    );
     const request = {
         clientRequestId: requestId || null,
         resultTurnId: turnId,
@@ -5406,6 +5411,12 @@ function buildRetainedThinkingCardRequestFromDebugData(turnId, debugData) {
             debugData.llm_usage_cost_summary
             && typeof debugData.llm_usage_cost_summary === 'object'
         ) ? { ...debugData.llm_usage_cost_summary } : null,
+        // Retained Thinking details may use only the bounded source label from
+        // this exact turn. Never carry a key, filename, or provider exception
+        // into the presentation model.
+        thinkingCredentialSource: normaliseThinkingCredentialSource(
+            llmExecutionTelemetry?.credential_source
+        ),
         criticOutput: criticOutput ? cloneThinkingCriticObject(criticOutput) : null,
         thinkingCriticPanelOpen: false,
         thinkingCardMode: loadStoredThinkingCardMode(),
@@ -7109,6 +7120,10 @@ export function __testOnly_buildThinkingCardProgressViewModel(request = null) {
     return buildThinkingCardProgressViewModel(request);
 }
 
+export function __testOnly_buildRetainedThinkingCardRequestFromDebugData(turnId, debugData) {
+    return buildRetainedThinkingCardRequestFromDebugData(turnId, debugData);
+}
+
 export function __testOnly_buildThinkingDiagnosticsPayload(request = null) {
     return buildThinkingDiagnosticsPayload(request);
 }
@@ -7844,7 +7859,17 @@ function normaliseThinkingProgressContract(value) {
     };
 }
 
-function normaliseThinkingCardLlmLifecycle(value) {
+function normaliseThinkingCredentialSource(...values) {
+    for (const value of values) {
+        const source = normaliseThinkingActivityString(value).toLowerCase();
+        if (source === 'primary' || source === 'backup') {
+            return source;
+        }
+    }
+    return null;
+}
+
+function normaliseThinkingCardLlmLifecycle(value, request = null) {
     if (!value || typeof value !== 'object') {
         return null;
     }
@@ -7873,6 +7898,14 @@ function normaliseThinkingCardLlmLifecycle(value) {
     const provider = normaliseThinkingActivityString(
         value.provider || value.selected_provider || value.llm_selected_provider
     ) || null;
+    const credentialSource = normaliseThinkingCredentialSource(
+        value.credential_source,
+        value.transport?.credential_source,
+        value.transport_metadata?.credential_source,
+        request?.thinkingCredentialSource,
+        request?.llmExecutionTelemetry?.credential_source,
+        request?.llm_execution_telemetry?.credential_source
+    );
     const fallbackAttemptNo = Number.isFinite(value.fallback_attempt_no)
         ? Number(value.fallback_attempt_no)
         : (Number.isFinite(value.llm_fallback_attempt_no) ? Number(value.llm_fallback_attempt_no) : null);
@@ -7887,6 +7920,7 @@ function normaliseThinkingCardLlmLifecycle(value) {
         && !contextSummary
         && !model
         && !provider
+        && !credentialSource
         && fallbackAttemptNo === null
         && fallbackCandidateCount === null
     ) {
@@ -7912,6 +7946,7 @@ function normaliseThinkingCardLlmLifecycle(value) {
                 : (Number.isFinite(llmRequest?.tool_count) ? Number(llmRequest.tool_count) : null)),
         model,
         provider,
+        credential_source: credentialSource,
         prepared_at_utc: normaliseThinkingActivityString(
             value.prepared_at_utc || value.llm_request_prepared_at_utc
         ) || null,
@@ -7977,6 +8012,9 @@ function buildThinkingCardLlmLifecycleText(llmLifecycle, options = {}) {
     }
     if (options.includeProvider && llmLifecycle.provider) {
         bits.push(`Provider: ${llmLifecycle.provider}`);
+    }
+    if (options.includeCredential && llmLifecycle.credential_source) {
+        bits.push(`Credential: ${llmLifecycle.credential_source} key`);
     }
     if (
         Number.isFinite(llmLifecycle.fallback_attempt_no)
@@ -8205,7 +8243,8 @@ function normaliseThinkingCardProgressViewModel(rawViewModel, request = null) {
         workflowDiscovery
     );
     const llmLifecycle = normaliseThinkingCardLlmLifecycle(
-        rawViewModel.llm_input_lifecycle || rawViewModel.llm_lifecycle || rawViewModel.latest_llm_exchange
+        rawViewModel.llm_input_lifecycle || rawViewModel.llm_lifecycle || rawViewModel.latest_llm_exchange,
+        request
     );
     const waitState = (rawViewModel.wait_state && typeof rawViewModel.wait_state === 'object')
         ? {
@@ -8557,7 +8596,8 @@ function buildThinkingCardProgressViewModel(request) {
     });
     const llmDiagnosticData = findLatestThinkingCardLlmDiagnosticData(request);
     const llmLifecycle = normaliseThinkingCardLlmLifecycle(
-        llmDiagnosticData || latestProgress
+        llmDiagnosticData || latestProgress,
+        request
     );
     const presentation = buildThinkingProgressPresentation(latestProgress, request);
     const selectedWorkflow = normaliseThinkingCardSelectedWorkflow({
@@ -8742,7 +8782,10 @@ function renderThinkingCardProgressSynopsisHTML(viewModel, mode = THINKING_CARD_
 
     const llmLifecycleText = buildThinkingCardLlmLifecycleText(
         viewModel.llm_input_lifecycle,
-        { includeProvider: renderMode === THINKING_CARD_MODE_DEBUG }
+        {
+            includeProvider: renderMode === THINKING_CARD_MODE_DEBUG,
+            includeCredential: renderMode === THINKING_CARD_MODE_DEBUG
+        }
     );
     const auxiliaryLlmLifecycle = isAuxiliaryThinkingCardLlmLifecycle(viewModel.llm_input_lifecycle);
     const showLlmLifecycle = !auxiliaryLlmLifecycle || renderMode === THINKING_CARD_MODE_DEBUG;

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,6 +1,7 @@
 import {
     __testOnly_buildThinkingProgressPresentation,
     __testOnly_buildThinkingCardProgressViewModel,
+    __testOnly_buildRetainedThinkingCardRequestFromDebugData,
     __testOnly_buildThinkingDiagnosticsPayload,
     __testOnly_buildDiagnosticsExportRequestPayload,
     __testOnly_buildWorkflowMonitorExportPayload,
@@ -5998,6 +5999,92 @@ describe('thinking activity history normalisation', () => {
             context_message_count: 5,
             tool_definition_count: 2
         }));
+    });
+
+    test('shows the exact retained turn backup credential in debug LLM input details', () => {
+        const request = __testOnly_buildRetainedThinkingCardRequestFromDebugData(
+            'turn-backup-credential',
+            {
+                timestamp: '2026-09-03T16:12:00Z',
+                llm_interaction: {
+                    requested_model: 'gpt-5.6-luna',
+                    calls: [
+                        {
+                            model: 'gpt-5.6-luna',
+                            provider: 'openai',
+                            transport: {
+                                credential_source: 'backup',
+                                credential_failover_used: true,
+                                primary_credential_failure_kind: 'quota_exhausted'
+                            }
+                        }
+                    ]
+                },
+                turn_execution_diagnostics: {
+                    request_id: 'req-backup-credential',
+                    latest_progress: {
+                        status: 'completed',
+                        stage: 'completed',
+                        progress_view_model: {
+                            llm_input_lifecycle: {
+                                state: 'completed',
+                                model: 'gpt-5.6-luna',
+                                provider: 'openai'
+                            }
+                        }
+                    }
+                }
+            }
+        );
+        request.thinkingCardMode = 'debug';
+
+        const html = __testOnly_renderThinkingCardBodyHTML(request);
+        expect(html).toContain('Model: gpt-5.6-luna');
+        expect(html).toContain('Provider: openai');
+        expect(html).toContain('Credential: backup key');
+        expect(html).not.toContain('quota_exhausted');
+    });
+
+    test('shows primary credential provenance from live lifecycle telemetry in debug mode', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            thinkingCardMode: 'debug',
+            latestProgress: {
+                status: 'completed',
+                stage: 'completed',
+                progress_view_model: {
+                    llm_input_lifecycle: {
+                        state: 'completed',
+                        model: 'gemini-2.5-pro',
+                        provider: 'gemini',
+                        credential_source: 'primary'
+                    }
+                }
+            }
+        });
+
+        expect(html).toContain('Provider: gemini');
+        expect(html).toContain('Credential: primary key');
+    });
+
+    test('does not render an unrecognised credential-source value', () => {
+        const html = __testOnly_renderThinkingCardBodyHTML({
+            thinkingCardMode: 'debug',
+            latestProgress: {
+                status: 'completed',
+                stage: 'completed',
+                progress_view_model: {
+                    llm_input_lifecycle: {
+                        state: 'completed',
+                        model: 'gpt-5.6-luna',
+                        provider: 'openai',
+                        credential_source: 'sk-must-not-render'
+                    }
+                }
+            }
+        });
+
+        expect(html).not.toContain('Credential:');
+        expect(html).not.toContain('sk-must-not-render');
     });
 
     test('renders default paper-memory synopsis without foregrounding debug noise', () => {


### PR DESCRIPTION
> **Merge impact:** Debug Thinking details identify whether the exact displayed LLM call used the primary or backup provider credential, without exposing key material.
>
> Merge decision: ready — exact-turn extraction, allow-listing, focused frontend coverage, static lint, and whitespace checks pass; live served-build acceptance follows merge and deployment.

## User outcome

A user inspecting the Thinking detail LLM input row can see `Credential: primary key` or `Credential: backup key` alongside the execution provider and model.

## Material changes

- Reuse the bounded credential source already extracted for the exact turn under JVNAUTOSCI-2715.
- Add only `primary` and `backup` to the Thinking lifecycle view model.
- Render the credential label in Debug mode beside provider metadata.
- Recover the bounded source from the exact retained turn when stored Thinking details are loaded.

## Evidence

- 315 focused and adjacent frontend tests passed across the Thinking card, latest-execution telemetry, and model footer suites.
- New coverage proves retained backup display, live primary display, and rejection of an unrecognised secret-like credential source.
- Targeted static frontend lint passed.
- `git diff --check` passed.

## Ship boundary

- **Minimum ship criteria:** Primary and backup appear from exact-turn telemetry in the Debug LLM input row; unknown values do not render; required CI passes; post-merge browser read-back confirms the served UI.
- **Stop-ship conditions:** The UI infers current configuration instead of exact execution provenance, displays an unrecognised value, or exposes key material.
- **Non-blocking observations:** The label remains Debug-mode detail because that is the existing mode where provider transport metadata is shown.
- **Non-goals:** New backend telemetry, cross-provider fallback, credential configuration, or changing the always-visible footer.