### PR TITLE
Preserve pre-cutover authority in narrow migrations

### DIFF
--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -64,8 +64,11 @@ See: docs/engineering/security_considerations.md.
 
 ### Operator migration and recovery
 
-The login-email migration accepts only an explicit reviewed allow-list. It
-never scans or copies `#V#has_email`:
+The login-email migration normally accepts only an explicit reviewed
+allow-list. For a database being upgraded from the pre-cutover runtime, an
+explicit compatibility mode copies the unambiguous `#V#has_email` bindings
+that the old login reader already treated as authority. This is retrospective
+only; later ordinary contact-email assertions remain non-authoritative:
 
 ```sh
 python -m src.backend.utilities.migrate_von_login_email_bindings \
@@ -73,22 +76,32 @@ python -m src.backend.utilities.migrate_von_login_email_bindings \
 
 python -m src.backend.utilities.migrate_von_login_email_bindings \
   --binding '#V#person_id=person@example.org' --apply --approved
+
+python -m src.backend.utilities.migrate_von_login_email_bindings \
+  --preserve-pre-cutover-authority
+
+python -m src.backend.utilities.migrate_von_login_email_bindings \
+  --preserve-pre-cutover-authority --apply --approved
 ```
 
-Run the first command before applying. If it reports a missing user or an
-address already bound to another user, correct that exact conflict and rerun
-the dry run; do not work around it by adding a generic email relation.
+Run the relevant command without `--apply --approved` before applying. If it
+reports a missing user or an address already bound to another user, correct
+that exact conflict and rerun the dry run; do not work around it by adding a
+generic email relation.
 
 The organisation-membership migration likewise performs a dry run by default.
-It copies only legacy membership pairs backed by exactly one scoped operational
-role. If it reports conflicting legacy roles, resolve each pair explicitly
+Its pre-cutover compatibility mode copies every legacy membership pair that the
+old reader accepted, retaining the old `member` default where no role was
+stored. If it reports conflicting legacy roles, resolve each pair explicitly
 with the exact `--role-override` form shown by `--help`, for example:
 
 ```sh
 python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+  --preserve-pre-cutover-authority \
   --role-override '#V#person_id=#V#organisation_id=owner'
 
 python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+  --preserve-pre-cutover-authority \
   --role-override '#V#person_id=#V#organisation_id=owner' \
   --apply --approved
 ```

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -113,6 +113,10 @@ address authenticate as the person. Login-email bindings are an explicit
 operator-reviewed allow-list, are unique across user concepts, and fail closed
 when absent, stale, or ambiguous. An unbound OAuth identity must not inherit a
 browser-supplied or prior-session concept and must not auto-create a user.
+For a database upgraded from the pre-cutover reader, an explicitly approved
+one-time migration may preserve the unambiguous `#V#has_email` bindings that
+already granted login authority before this boundary existed. The migration
+does not make subsequent ordinary contact-email assertions authoritative.
 
 `#V#hasVonLoginEmail` specialises and entails `#V#has_email`; the reverse
 inference is forbidden. Generic ontology mutation surfaces reserve the narrow

--- a/src/backend/services/organisation_membership_predicate_migration_service.py
+++ b/src/backend/services/organisation_membership_predicate_migration_service.py
@@ -1,10 +1,16 @@
 """Migrate operational organisation membership to narrow predicates.
 
 The historical implementation treated generic ``memberOf`` assertions as Von
-access grants.  This migration deliberately does not copy every generic
-membership edge.  An old edge is eligible only when it is paired with the
-scoped legacy role relation written by the former governed membership
-lifecycle.  Generic-only ontology facts remain descriptive and grant nothing.
+access grants.  By default this migration deliberately does not copy every
+generic membership edge: an old edge is eligible only when it is paired with
+the scoped legacy role relation written by the former governed membership
+lifecycle.
+
+The explicitly approved ``preserve_pre_cutover_authority`` mode instead copies
+every legacy membership edge that the pre-cutover reader accepted.  Pairs
+without a stored role receive the same ``member`` default that reader used.
+This is a one-time compatibility operation over facts that existed at cutover;
+it does not make later generic ontology assertions authoritative.
 
 The migration is non-destructive and idempotent.  It creates the narrow
 predicate vocabulary, represents that ``memberOfVonOrg`` specialises (and
@@ -221,7 +227,13 @@ def audit_von_organisation_membership_predicates(
                 }
             )
         elif predicates and not roles:
-            generic_only.append({**common, "legacy_membership_predicates": predicates})
+            generic_only.append(
+                {
+                    **common,
+                    "legacy_membership_predicates": predicates,
+                    "already_narrow": pair in narrow_pairs,
+                }
+            )
         elif roles and not predicates:
             role_only.append({**common, "legacy_roles": roles})
         else:
@@ -370,8 +382,14 @@ def migrate_von_organisation_membership_predicates(
     approved: bool = False,
     sample_limit: int = 20,
     role_overrides: Iterable[Mapping[str, Any]] | None = None,
+    preserve_pre_cutover_authority: bool = False,
 ) -> dict[str, Any]:
-    """Copy only evidenced operational memberships to the narrow vocabulary."""
+    """Copy legacy memberships to the narrow vocabulary.
+
+    The default remains conservative.  When explicitly requested, the
+    pre-cutover compatibility mode also copies generic-only pairs with the old
+    reader's default ``member`` role.
+    """
 
     try:
         normalised_overrides = _normalise_role_overrides(role_overrides)
@@ -402,6 +420,21 @@ def migrate_von_organisation_membership_predicates(
         ],
     }
     eligible_records = list(audit["eligible_operational_memberships"])
+    compatibility_records: list[dict[str, Any]] = []
+    if preserve_pre_cutover_authority:
+        for record in audit["generic_only_non_authority_samples"]:
+            compatibility_record = {
+                "user_concept_id": record["user_concept_id"],
+                "organisation_concept_id": record["organisation_concept_id"],
+                "role": "member",
+                "legacy_membership_predicates": list(
+                    record.get("legacy_membership_predicates", [])
+                ),
+                "already_narrow": bool(record.get("already_narrow")),
+                "legacy_default_role_applied": True,
+            }
+            compatibility_records.append(compatibility_record)
+            eligible_records.append(compatibility_record)
     resolved_conflicts: list[dict[str, Any]] = []
     unresolved_conflicts: list[dict[str, Any]] = []
     override_errors: list[dict[str, Any]] = []
@@ -453,7 +486,10 @@ def migrate_von_organisation_membership_predicates(
         "schema_version": MIGRATION_SCHEMA_VERSION,
         "dry_run": bool(dry_run),
         "approved": bool(approved),
+        "preserve_pre_cutover_authority": bool(preserve_pre_cutover_authority),
         "audit": public_audit,
+        "pre_cutover_default_member_count": len(compatibility_records),
+        "pre_cutover_default_member_records": compatibility_records[:sample_count],
         "resolved_conflict_count": len(resolved_conflicts),
         "resolved_conflicts": resolved_conflicts[:sample_count],
         "unresolved_conflict_count": len(unresolved_conflicts),
@@ -481,7 +517,10 @@ def migrate_von_organisation_membership_predicates(
             "success": True,
             "effect_status": "not_started",
             "would_migrate_count": len(eligible_records),
-            "generic_only_relations_will_grant_authority": False,
+            "legacy_generic_only_pairs_will_be_copied": bool(
+                preserve_pre_cutover_authority
+            ),
+            "future_generic_relations_will_grant_authority": False,
         }
 
     vocabulary = ensure_von_organisation_membership_vocabulary()
@@ -564,7 +603,8 @@ def migrate_von_organisation_membership_predicates(
         "already_current": already_current[: max(0, int(sample_limit))],
         "failures": failures[: max(0, int(sample_limit))],
         "missing_read_back_pairs": missing_read_back[:sample_count],
-        "generic_only_relations_grant_authority": False,
+        "legacy_generic_only_pairs_copied": bool(preserve_pre_cutover_authority),
+        "future_generic_relations_grant_authority": False,
     }
 
 

--- a/src/backend/services/von_login_email_migration_service.py
+++ b/src/backend/services/von_login_email_migration_service.py
@@ -1,9 +1,11 @@
 """Create and populate the narrow Von login-email authority predicate.
 
-Unlike organisation membership, there is intentionally no data-driven legacy
-migration here.  Ordinary ``#V#has_email`` values may be contact addresses and
-are never copied into authentication authority.  An operator must provide the
-exact reviewed ``(user, email)`` allow-list.
+The default path accepts an exact reviewed ``(user, email)`` allow-list.
+Databases upgraded from the pre-cutover runtime may instead use the explicitly
+approved compatibility path.  It copies every unambiguous ``#V#has_email``
+binding that the old login reader already treated as authentication authority.
+This retrospective copy does not make later contact-email assertions
+authoritative.
 """
 
 from __future__ import annotations
@@ -12,6 +14,10 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
+from ..db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
 from ..security.access_control import bypass_access_control
 from . import concept_service
 from .relationship_write_service import add_dynamic_relationship
@@ -25,6 +31,7 @@ from .von_user_authentication_service import (
 )
 
 MIGRATION_SCHEMA_VERSION = "von_login_email_predicate_migration.v1"
+LEGACY_AUDIT_SCHEMA_VERSION = "von_login_email_legacy_authority_audit.v1"
 
 
 def _normalise_concept_id(value: object) -> str:
@@ -134,6 +141,243 @@ def ensure_von_login_email_vocabulary() -> dict[str, Any]:
             "generic_predicate": GENERIC_EMAIL_PREDICATE,
             "reverse_inference_allowed": False,
         },
+    }
+
+
+def audit_legacy_von_login_email_bindings(*, sample_limit: int = 20) -> dict[str, Any]:
+    """Inventory login authority accepted by the pre-cutover email reader."""
+
+    sample_limit = max(0, int(sample_limit))
+    grouped: dict[str, dict[str, Any]] = {}
+    invalid: list[dict[str, Any]] = []
+    relations = TextRelationsRepository.find({"predicate": GENERIC_EMAIL_PREDICATE})
+    relation_count = 0
+    for relation in relations:
+        relation_count += 1
+        if not isinstance(relation, Mapping):
+            invalid.append(
+                {
+                    "relation_id": "",
+                    "reason_code": "legacy_email_relation_not_mapping",
+                }
+            )
+            continue
+        relation_id = str(relation.get("_id") or "")
+        user_id = _normalise_concept_id(relation.get("subject_concept_id"))
+        text_value_id = relation.get("object_text_id")
+        text_value = (
+            TextValuesRepository.find_one_by_id(text_value_id)
+            if text_value_id is not None
+            else None
+        )
+        try:
+            email = normalise_von_login_email(
+                text_value.get("text") if isinstance(text_value, Mapping) else None
+            )
+        except ValueError:
+            invalid.append(
+                {
+                    "relation_id": relation_id,
+                    "user_concept_id": user_id,
+                    "reason_code": "legacy_login_email_invalid",
+                }
+            )
+            continue
+        if user_id is None:
+            invalid.append(
+                {
+                    "relation_id": relation_id,
+                    "email": email,
+                    "reason_code": "legacy_login_email_user_required",
+                }
+            )
+            continue
+        record = grouped.setdefault(
+            email,
+            {
+                "email": email,
+                "user_concept_ids": set(),
+                "legacy_relation_count": 0,
+            },
+        )
+        record["user_concept_ids"].add(user_id)
+        record["legacy_relation_count"] += 1
+
+    eligible: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    for email in sorted(grouped):
+        record = grouped[email]
+        user_ids = sorted(record["user_concept_ids"])
+        common = {
+            "email": email,
+            "legacy_relation_count": record["legacy_relation_count"],
+        }
+        if len(user_ids) != 1:
+            conflicts.append(
+                {
+                    **common,
+                    "user_concept_ids": user_ids,
+                    "reason_code": "legacy_login_email_maps_to_multiple_users",
+                }
+            )
+            continue
+        user_id = user_ids[0]
+        with bypass_access_control():
+            user = ConceptsRepository.find_one(
+                {"concept_id": user_id},
+                projection={"_id": 1, "concept_id": 1},
+            )
+        if not isinstance(user, Mapping):
+            conflicts.append(
+                {
+                    **common,
+                    "user_concept_id": user_id,
+                    "reason_code": "user_concept_not_found",
+                }
+            )
+            continue
+        existing_user_ids = list_von_login_email_user_ids(email)
+        other_user_ids = [item for item in existing_user_ids if item != user_id]
+        if other_user_ids:
+            conflicts.append(
+                {
+                    **common,
+                    "user_concept_id": user_id,
+                    "existing_user_concept_ids": other_user_ids,
+                    "reason_code": "login_email_bound_to_other_user",
+                }
+            )
+            continue
+        eligible.append(
+            {
+                **common,
+                "user_concept_id": user_id,
+                "already_bound": existing_user_ids == [user_id],
+            }
+        )
+
+    return {
+        "schema_version": LEGACY_AUDIT_SCHEMA_VERSION,
+        "legacy_email_predicate": GENERIC_EMAIL_PREDICATE,
+        "narrow_login_email_predicate": LOGIN_EMAIL_PREDICATE,
+        "legacy_relation_count": relation_count,
+        "normalised_email_count": len(grouped),
+        "eligible_binding_count": len(eligible),
+        "already_bound_count": sum(1 for item in eligible if item["already_bound"]),
+        "conflict_count": len(conflicts),
+        "invalid_relation_count": len(invalid),
+        "eligible_bindings": eligible[:sample_limit],
+        "conflicts": conflicts[:sample_limit],
+        "invalid_relations": invalid[:sample_limit],
+        "complete": True,
+    }
+
+
+def migrate_legacy_von_login_email_bindings(
+    *,
+    dry_run: bool = True,
+    approved: bool = False,
+    sample_limit: int = 20,
+) -> dict[str, Any]:
+    """Copy all unambiguous pre-cutover login authority to the narrow predicate."""
+
+    audit = audit_legacy_von_login_email_bindings(
+        sample_limit=max(sample_limit, 100_000)
+    )
+    sample_count = max(0, int(sample_limit))
+    bindings = list(audit["eligible_bindings"])
+    public_audit = {
+        **audit,
+        "eligible_bindings": bindings[:sample_count],
+        "conflicts": audit["conflicts"][:sample_count],
+        "invalid_relations": audit["invalid_relations"][:sample_count],
+    }
+    common = {
+        "schema_version": MIGRATION_SCHEMA_VERSION,
+        "migration_mode": "preserve_pre_cutover_authority",
+        "dry_run": bool(dry_run),
+        "approved": bool(approved),
+        "audit": public_audit,
+        "requested_binding_count": len(bindings),
+        "future_generic_contact_emails_grant_authority": False,
+    }
+    if not dry_run and not approved:
+        return {
+            **common,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "explicit_migration_approval_required",
+        }
+    if audit["conflict_count"] or audit["invalid_relation_count"]:
+        return {
+            **common,
+            "success": False,
+            "effect_status": "not_started",
+            "error_code": "legacy_login_email_inventory_requires_resolution",
+        }
+    if dry_run:
+        return {
+            **common,
+            "success": True,
+            "effect_status": "dry_run",
+            "would_migrate_count": len(bindings),
+        }
+
+    vocabulary = ensure_von_login_email_vocabulary()
+    migrated: list[dict[str, Any]] = []
+    already_current: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for binding in bindings:
+        user_id = binding["user_concept_id"]
+        email = binding["email"]
+        if binding.get("already_bound"):
+            already_current.append({"user_concept_id": user_id, "email": email})
+            continue
+        try:
+            result = bind_von_login_email(
+                user_concept_id=user_id,
+                email=email,
+                provenance={
+                    "migration_schema_version": MIGRATION_SCHEMA_VERSION,
+                    "migration_mode": "preserve_pre_cutover_authority",
+                    "approved": True,
+                },
+            )
+            migrated.append(result)
+        except Exception as exc:  # noqa: BLE001 - report resumable partial migration
+            failures.append(
+                {
+                    "user_concept_id": user_id,
+                    "email": email,
+                    "error_class": type(exc).__name__,
+                    "error": str(exc),
+                }
+            )
+
+    missing_read_back: list[dict[str, Any]] = []
+    for binding in bindings:
+        user_ids = list_von_login_email_user_ids(binding["email"])
+        if user_ids != [binding["user_concept_id"]]:
+            missing_read_back.append(
+                {
+                    "user_concept_id": binding["user_concept_id"],
+                    "email": binding["email"],
+                    "actual_user_concept_ids": user_ids,
+                }
+            )
+    success = not failures and not missing_read_back
+    return {
+        **common,
+        "success": success,
+        "effect_status": "succeeded" if success else "partial_success",
+        "vocabulary": vocabulary,
+        "migrated_count": len(migrated),
+        "already_current_count": len(already_current),
+        "failed_count": len(failures),
+        "migrated": migrated[:sample_count],
+        "already_current": already_current[:sample_count],
+        "failures": failures[:sample_count],
+        "missing_read_back_bindings": missing_read_back[:sample_count],
     }
 
 
@@ -273,7 +517,10 @@ def migrate_explicit_von_login_email_bindings(
 
 
 __all__ = [
+    "LEGACY_AUDIT_SCHEMA_VERSION",
     "MIGRATION_SCHEMA_VERSION",
+    "audit_legacy_von_login_email_bindings",
     "ensure_von_login_email_vocabulary",
     "migrate_explicit_von_login_email_bindings",
+    "migrate_legacy_von_login_email_bindings",
 ]

--- a/src/backend/utilities/migrate_von_login_email_bindings.py
+++ b/src/backend/utilities/migrate_von_login_email_bindings.py
@@ -8,8 +8,15 @@ Examples:
     python -m src.backend.utilities.migrate_von_login_email_bindings \
       --binding '#V#alice=alice@example.org' --apply --approved
 
-The command never discovers or copies ``#V#has_email`` contact values.  Every
-authority-bearing login address must appear explicitly as ``USER=EMAIL``.
+    python -m src.backend.utilities.migrate_von_login_email_bindings \
+      --preserve-pre-cutover-authority
+
+    python -m src.backend.utilities.migrate_von_login_email_bindings \
+      --preserve-pre-cutover-authority --apply --approved
+
+The normal mode never discovers or copies ``#V#has_email`` contact values.
+The explicit pre-cutover compatibility mode copies only the unambiguous legacy
+bindings that the old login reader already accepted.
 """
 
 from __future__ import annotations
@@ -19,6 +26,7 @@ import json
 
 from src.backend.services.von_login_email_migration_service import (
     migrate_explicit_von_login_email_bindings,
+    migrate_legacy_von_login_email_bindings,
 )
 
 
@@ -37,18 +45,28 @@ def _parse_binding(raw: str) -> dict[str, str]:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Populate hasVonLoginEmail only from an explicit reviewed allow-list."
+            "Populate hasVonLoginEmail from an explicit allow-list or the "
+            "pre-cutover compatibility inventory."
         )
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
         "--binding",
         action="append",
         type=_parse_binding,
-        required=True,
         metavar="USER_CONCEPT_ID=EMAIL",
         help=(
             "Exact user/email login binding. Repeat for every permitted address; "
             "ordinary has_email values are never copied."
+        ),
+    )
+    mode.add_argument(
+        "--preserve-pre-cutover-authority",
+        action="store_true",
+        help=(
+            "Copy every unambiguous has_email binding accepted by the "
+            "pre-cutover login reader. Future has_email assertions remain "
+            "non-authoritative."
         ),
     )
     parser.add_argument(
@@ -59,15 +77,28 @@ def main() -> int:
     parser.add_argument(
         "--approved",
         action="store_true",
-        help="Explicitly approve this authority-bearing allow-list.",
+        help="Explicitly approve the selected authority-bearing migration.",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=20,
+        help="Maximum detailed legacy records to include in the JSON report.",
     )
     args = parser.parse_args()
 
-    report = migrate_explicit_von_login_email_bindings(
-        bindings=args.binding,
-        dry_run=not args.apply,
-        approved=args.approved,
-    )
+    if args.preserve_pre_cutover_authority:
+        report = migrate_legacy_von_login_email_bindings(
+            dry_run=not args.apply,
+            approved=args.approved,
+            sample_limit=args.sample_limit,
+        )
+    else:
+        report = migrate_explicit_von_login_email_bindings(
+            bindings=args.binding,
+            dry_run=not args.apply,
+            approved=args.approved,
+        )
     print(json.dumps(report, indent=2, sort_keys=True, default=str))
     return 0 if report.get("success") is True else 1
 

--- a/src/backend/utilities/migrate_von_organisation_membership_predicates.py
+++ b/src/backend/utilities/migrate_von_organisation_membership_predicates.py
@@ -5,6 +5,9 @@ Examples:
     python -m src.backend.utilities.migrate_von_organisation_membership_predicates
     python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
       --role-override '#V#user=#V#organisation=owner'
+    python -m src.backend.utilities.migrate_von_organisation_membership_predicates \
+      --preserve-pre-cutover-authority \
+      --role-override '#V#user=#V#organisation=member'
     python -m src.backend.utilities.migrate_von_organisation_membership_predicates --apply --approved
 
 The default is a read-only dry run.  Applying requires both flags so an
@@ -56,6 +59,15 @@ def main() -> int:
         help="Maximum detailed records to include in the JSON report.",
     )
     parser.add_argument(
+        "--preserve-pre-cutover-authority",
+        action="store_true",
+        help=(
+            "Copy every legacy membership edge accepted by the pre-cutover "
+            "reader, using its default member role when no role was stored. "
+            "This does not make future generic edges authoritative."
+        ),
+    )
+    parser.add_argument(
         "--role-override",
         action="append",
         type=_parse_role_override,
@@ -74,6 +86,7 @@ def main() -> int:
         approved=args.approved,
         sample_limit=args.sample_limit,
         role_overrides=args.role_override,
+        preserve_pre_cutover_authority=args.preserve_pre_cutover_authority,
     )
     print(json.dumps(report, indent=2, sort_keys=True, default=str))
     return 0 if report.get("success") is True else 1

--- a/tests/backend/test_organisation_membership_predicate_migration_service.py
+++ b/tests/backend/test_organisation_membership_predicate_migration_service.py
@@ -102,7 +102,75 @@ def test_apply_migrates_only_role_backed_operational_membership(monkeypatch):
     assert report["migrated_count"] == 1
     assert create_calls == [(governed[0], governed[1], "owner")]
     assert descriptive not in narrow_pairs
-    assert report["generic_only_relations_grant_authority"] is False
+    assert report["future_generic_relations_grant_authority"] is False
+
+
+def test_pre_cutover_mode_copies_generic_only_pair_with_old_member_default(
+    monkeypatch,
+):
+    governed = ("#V#governed_user", "#V#von_org")
+    legacy_default = ("#V#legacy_user", "#V#legacy_org")
+    narrow_pairs: set[tuple[str, str]] = set()
+    roles: dict[tuple[str, str], str] = {}
+    create_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        migration,
+        "_legacy_edge_pairs",
+        lambda: {
+            governed: {"memberOf"},
+            legacy_default: {"#V#member_of_organisation"},
+        },
+    )
+    monkeypatch.setattr(
+        migration,
+        "_legacy_role_pairs",
+        lambda: ({governed: {"owner"}}, []),
+    )
+    monkeypatch.setattr(
+        migration, "_narrow_membership_pairs", lambda: set(narrow_pairs)
+    )
+    monkeypatch.setattr(
+        migration,
+        "ensure_von_organisation_membership_vocabulary",
+        lambda: {"success": True},
+    )
+
+    def resolve(user_id, organisation_id):
+        role = roles.get((user_id, organisation_id))
+        if role is None:
+            return None
+        return {
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+            "role": role,
+        }
+
+    def create(*, user_concept_id, organisation_concept_id, role):
+        pair = (user_concept_id, organisation_concept_id)
+        create_calls.append((user_concept_id, organisation_concept_id, role))
+        narrow_pairs.add(pair)
+        roles[pair] = role
+        return {"relationship_created": True}
+
+    monkeypatch.setattr(migration, "resolve_user_organisation_membership", resolve)
+    monkeypatch.setattr(migration, "create_organisation_membership", create)
+
+    report = migration.migrate_von_organisation_membership_predicates(
+        dry_run=False,
+        approved=True,
+        preserve_pre_cutover_authority=True,
+    )
+
+    assert report["success"] is True
+    assert report["migrated_count"] == 2
+    assert create_calls == [
+        (governed[0], governed[1], "owner"),
+        (legacy_default[0], legacy_default[1], "member"),
+    ]
+    assert report["pre_cutover_default_member_count"] == 1
+    assert report["legacy_generic_only_pairs_copied"] is True
+    assert report["future_generic_relations_grant_authority"] is False
 
 
 def test_apply_requires_explicit_approval(monkeypatch):

--- a/tests/backend/test_von_login_email_migration_service.py
+++ b/tests/backend/test_von_login_email_migration_service.py
@@ -3,6 +3,227 @@ from __future__ import annotations
 from src.backend.services import von_login_email_migration_service as migration
 
 
+def test_legacy_audit_deduplicates_same_user_email_relations(monkeypatch):
+    relations = [
+        {
+            "_id": "r1",
+            "subject_concept_id": "#V#alice",
+            "object_text_id": "tv1",
+        },
+        {
+            "_id": "r2",
+            "subject_concept_id": "#V#alice",
+            "object_text_id": "tv2",
+        },
+        {
+            "_id": "r3",
+            "subject_concept_id": "#V#bob",
+            "object_text_id": "tv3",
+        },
+    ]
+    text_values = {
+        "tv1": {"text": "Alice@Example.ORG"},
+        "tv2": {"text": "alice@example.org"},
+        "tv3": {"text": "bob@example.org"},
+    }
+    monkeypatch.setattr(
+        migration.TextRelationsRepository,
+        "find",
+        lambda *_args, **_kwargs: relations,
+    )
+    monkeypatch.setattr(
+        migration.TextValuesRepository,
+        "find_one_by_id",
+        lambda value_id: text_values.get(value_id),
+    )
+    monkeypatch.setattr(
+        migration.ConceptsRepository,
+        "find_one",
+        lambda query, **_kwargs: {"concept_id": query["concept_id"]},
+    )
+    monkeypatch.setattr(migration, "list_von_login_email_user_ids", lambda _email: [])
+
+    report = migration.audit_legacy_von_login_email_bindings()
+
+    assert report["legacy_relation_count"] == 3
+    assert report["normalised_email_count"] == 2
+    assert report["eligible_binding_count"] == 2
+    assert report["conflict_count"] == 0
+    alice = next(
+        item
+        for item in report["eligible_bindings"]
+        if item["user_concept_id"] == "#V#alice"
+    )
+    assert alice["email"] == "alice@example.org"
+    assert alice["legacy_relation_count"] == 2
+
+
+def test_legacy_audit_rejects_normalised_email_shared_by_users(monkeypatch):
+    relations = [
+        {
+            "_id": "r1",
+            "subject_concept_id": "#V#alice",
+            "object_text_id": "tv1",
+        },
+        {
+            "_id": "r2",
+            "subject_concept_id": "#V#bob",
+            "object_text_id": "tv2",
+        },
+    ]
+    text_values = {
+        "tv1": {"text": "shared@example.org"},
+        "tv2": {"text": "SHARED@example.org"},
+    }
+    monkeypatch.setattr(
+        migration.TextRelationsRepository,
+        "find",
+        lambda *_args, **_kwargs: relations,
+    )
+    monkeypatch.setattr(
+        migration.TextValuesRepository,
+        "find_one_by_id",
+        lambda value_id: text_values.get(value_id),
+    )
+
+    report = migration.audit_legacy_von_login_email_bindings()
+
+    assert report["eligible_binding_count"] == 0
+    assert report["conflict_count"] == 1
+    assert report["conflicts"][0]["reason_code"] == (
+        "legacy_login_email_maps_to_multiple_users"
+    )
+
+
+def test_apply_legacy_bindings_uses_canonical_writer_and_reads_back(monkeypatch):
+    binding = {
+        "user_concept_id": "#V#alice",
+        "email": "alice@example.org",
+        "legacy_relation_count": 1,
+        "already_bound": False,
+    }
+    audit = {
+        "schema_version": migration.LEGACY_AUDIT_SCHEMA_VERSION,
+        "legacy_email_predicate": "#V#has_email",
+        "narrow_login_email_predicate": "#V#hasVonLoginEmail",
+        "legacy_relation_count": 1,
+        "normalised_email_count": 1,
+        "eligible_binding_count": 1,
+        "already_bound_count": 0,
+        "conflict_count": 0,
+        "invalid_relation_count": 0,
+        "eligible_bindings": [binding],
+        "conflicts": [],
+        "invalid_relations": [],
+        "complete": True,
+    }
+    bound: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        migration,
+        "audit_legacy_von_login_email_bindings",
+        lambda **_kwargs: audit,
+    )
+    monkeypatch.setattr(
+        migration,
+        "ensure_von_login_email_vocabulary",
+        lambda: {"success": True},
+    )
+
+    def bind(*, user_concept_id, email, provenance):
+        bound[email] = [user_concept_id]
+        return {
+            "success": True,
+            "user_concept_id": user_concept_id,
+            "email": email,
+            "relation_created": True,
+            "provenance": provenance,
+        }
+
+    monkeypatch.setattr(migration, "bind_von_login_email", bind)
+    monkeypatch.setattr(
+        migration,
+        "list_von_login_email_user_ids",
+        lambda email: bound.get(email, []),
+    )
+
+    report = migration.migrate_legacy_von_login_email_bindings(
+        dry_run=False,
+        approved=True,
+    )
+
+    assert report["success"] is True
+    assert report["migrated_count"] == 1
+    assert report["missing_read_back_bindings"] == []
+    assert report["future_generic_contact_emails_grant_authority"] is False
+
+
+def test_legacy_migration_fails_closed_on_audit_conflict(monkeypatch):
+    audit = {
+        "schema_version": migration.LEGACY_AUDIT_SCHEMA_VERSION,
+        "legacy_email_predicate": "#V#has_email",
+        "narrow_login_email_predicate": "#V#hasVonLoginEmail",
+        "legacy_relation_count": 2,
+        "normalised_email_count": 1,
+        "eligible_binding_count": 0,
+        "already_bound_count": 0,
+        "conflict_count": 1,
+        "invalid_relation_count": 0,
+        "eligible_bindings": [],
+        "conflicts": [
+            {
+                "email": "shared@example.org",
+                "user_concept_ids": ["#V#alice", "#V#bob"],
+                "reason_code": "legacy_login_email_maps_to_multiple_users",
+            }
+        ],
+        "invalid_relations": [],
+        "complete": True,
+    }
+    monkeypatch.setattr(
+        migration,
+        "audit_legacy_von_login_email_bindings",
+        lambda **_kwargs: audit,
+    )
+
+    report = migration.migrate_legacy_von_login_email_bindings()
+
+    assert report["success"] is False
+    assert report["effect_status"] == "not_started"
+    assert report["error_code"] == "legacy_login_email_inventory_requires_resolution"
+
+
+def test_legacy_migration_apply_requires_explicit_approval(monkeypatch):
+    audit = {
+        "schema_version": migration.LEGACY_AUDIT_SCHEMA_VERSION,
+        "legacy_email_predicate": "#V#has_email",
+        "narrow_login_email_predicate": "#V#hasVonLoginEmail",
+        "legacy_relation_count": 0,
+        "normalised_email_count": 0,
+        "eligible_binding_count": 0,
+        "already_bound_count": 0,
+        "conflict_count": 0,
+        "invalid_relation_count": 0,
+        "eligible_bindings": [],
+        "conflicts": [],
+        "invalid_relations": [],
+        "complete": True,
+    }
+    monkeypatch.setattr(
+        migration,
+        "audit_legacy_von_login_email_bindings",
+        lambda **_kwargs: audit,
+    )
+
+    report = migration.migrate_legacy_von_login_email_bindings(
+        dry_run=False,
+        approved=False,
+    )
+
+    assert report["success"] is False
+    assert report["effect_status"] == "not_started"
+    assert report["error_code"] == "explicit_migration_approval_required"
+
+
 def test_dry_run_uses_only_explicit_bindings_and_never_scans_contact_email(
     monkeypatch,
 ):


### PR DESCRIPTION
## Outcome

- add an explicitly approved compatibility mode that copies every legacy organisation membership the old reader accepted, retaining its default `member` role
- add a matching login-email mode that copies every unambiguous `has_email` binding already accepted by the old login reader
- keep future generic membership and contact-email assertions non-authoritative
- document the retrospective/forward boundary and fail-closed operator commands

## Live Mac/Atlas dry-run

- 34 organisation authority pairs: 7 explicit-role, 26 legacy default-member, 1 Michael/SAIL conflict explicitly resolved to the old effective `member` role
- 20 unique login-email bindings from 21 legacy relations: 1 already narrow, 19 to create
- zero email conflicts, missing users, invalid emails, or invalid role records

## Validation

- 20 focused migration/authentication tests passed
- expanded near-neighbour run: 63 passed; 5 unchanged session-route tests require unavailable localhost MongoDB
- compileall and targeted Ruff passed
- both CLI help surfaces and both live dry-runs passed

Jira: JVNAUTOSCI-2717