### PR TITLE
JVNAUTOSCI-2718: Restore Personal conversation management

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -43283,8 +43283,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="read",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             description=(
                 "List recent owned and accepted-shared conversations visible to the "
@@ -43305,8 +43307,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="read",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             description=(
                 "Search titles, actor-specific display names, and user-visible "
@@ -43329,8 +43333,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="read",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             description=(
                 "Read a bounded stored transcript, situation, and exact observations for "
@@ -43347,8 +43353,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="read",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             description=(
                 "Traverse the exact stored transcript of one owned or accepted-shared "
@@ -43366,8 +43374,10 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="read",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             description=(
                 "Inspect up to 50 owned or accepted-shared conversations with independent "
@@ -43388,9 +43398,11 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="write",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
                 "request_id": "turn_id",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             ordinary_turn_effect=True,
             description=(
@@ -43409,9 +43421,11 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
             category="write",
             ordinary_turn_trusted_argument_bindings={
                 "acting_user_concept_id": "actor_user_concept_id",
-                "organisation_concept_id": "actor_organisation_concept_id",
                 "namespace": "turn_namespace",
                 "request_id": "turn_id",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
             },
             ordinary_turn_effect=True,
             description=(

--- a/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
+++ b/src/backend/integrations/internal_mcp/dynamic_tool_loader.py
@@ -470,6 +470,9 @@ def load_dynamic_method_definitions(
         trusted_bindings = (
             target_definition.ordinary_turn_trusted_argument_bindings
         )
+        optional_trusted_bindings = (
+            target_definition.ordinary_turn_optional_trusted_argument_bindings
+        )
         trusted_choice_bindings = (
             target_definition.ordinary_turn_trusted_argument_choice_bindings
         )
@@ -486,6 +489,12 @@ def load_dynamic_method_definitions(
             trusted_argument_names.update(
                 str(argument_name)
                 for argument_name in trusted_choice_bindings
+                if isinstance(argument_name, str) and argument_name
+            )
+        if isinstance(optional_trusted_bindings, Mapping):
+            trusted_argument_names.update(
+                str(argument_name)
+                for argument_name in optional_trusted_bindings
                 if isinstance(argument_name, str) and argument_name
             )
         fixed_trusted_argument_names = sorted(
@@ -600,6 +609,16 @@ def load_dynamic_method_definitions(
                 dict(target_definition.ordinary_turn_trusted_argument_bindings)
                 if isinstance(
                     target_definition.ordinary_turn_trusted_argument_bindings,
+                    Mapping,
+                )
+                else None
+            ),
+            ordinary_turn_optional_trusted_argument_bindings=(
+                dict(
+                    target_definition.ordinary_turn_optional_trusted_argument_bindings
+                )
+                if isinstance(
+                    target_definition.ordinary_turn_optional_trusted_argument_bindings,
                     Mapping,
                 )
                 else None

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -145,6 +145,13 @@ class MethodDefinition:
     ordinary_turn_excluded_reason: str | None = None
     # Map capability arguments to values resolved by the trusted entry point.
     ordinary_turn_trusted_argument_bindings: Mapping[str, str] | None = None
+    # Trusted bindings whose value may legitimately be absent for this method.
+    # The argument remains hidden from the model and is injected only when the
+    # trusted entry point supplies it, but absence does not remove the method
+    # from the ordinary-turn capability projection.
+    ordinary_turn_optional_trusted_argument_bindings: (
+        Mapping[str, str] | None
+    ) = None
     # Map capability arguments to actor-authorised constrained choices resolved
     # by the trusted entry point. The model may choose only from that bounded
     # set; dispatch maps the stable selector to the current runtime value.
@@ -362,6 +369,14 @@ class MethodCatalogue:
                     dict(definition.ordinary_turn_trusted_argument_bindings)
                     if isinstance(
                         definition.ordinary_turn_trusted_argument_bindings,
+                        Mapping,
+                    )
+                    else None
+                ),
+                "ordinary_turn_optional_trusted_argument_bindings": (
+                    dict(definition.ordinary_turn_optional_trusted_argument_bindings)
+                    if isinstance(
+                        definition.ordinary_turn_optional_trusted_argument_bindings,
                         Mapping,
                     )
                     else None

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -2704,6 +2704,7 @@ def _capability_catalogue(
                 str(argument_name)
                 for bindings in (
                     definition.ordinary_turn_trusted_argument_bindings,
+                    definition.ordinary_turn_optional_trusted_argument_bindings,
                     definition.ordinary_turn_fixed_arguments,
                 )
                 if isinstance(bindings, Mapping)
@@ -3345,6 +3346,11 @@ def _model_visible_input_schema(
     bindings = definition.ordinary_turn_trusted_argument_bindings
     if isinstance(bindings, Mapping):
         hidden_arguments.update(str(argument_name) for argument_name in bindings)
+    optional_bindings = definition.ordinary_turn_optional_trusted_argument_bindings
+    if isinstance(optional_bindings, Mapping):
+        hidden_arguments.update(
+            str(argument_name) for argument_name in optional_bindings
+        )
     fixed_arguments = definition.ordinary_turn_fixed_arguments
     if isinstance(fixed_arguments, Mapping):
         hidden_arguments.update(str(argument_name) for argument_name in fixed_arguments)
@@ -3516,22 +3522,26 @@ def _trusted_tool_payload_with_diagnostics(
         return dict(model_payload), None
     schema = definition.input_schema
     payload: MutableMapping[str, Any] = dict(model_payload)
-    bindings = definition.ordinary_turn_trusted_argument_bindings
     trusted_values = trusted_argument_values or {}
-    if isinstance(bindings, Mapping):
+    for bindings in (
+        definition.ordinary_turn_trusted_argument_bindings,
+        definition.ordinary_turn_optional_trusted_argument_bindings,
+    ):
+        if not isinstance(bindings, Mapping):
+            continue
         for argument_name, binding_key in bindings.items():
             canonical_argument = str(argument_name)
             trusted_value = trusted_values.get(str(binding_key))
+            payload.pop(canonical_argument, None)
+            for alias, canonical in schema.aliases.items():
+                if canonical == canonical_argument:
+                    payload.pop(alias, None)
             if not (
                 isinstance(trusted_value, str)
                 and trusted_value.strip()
                 and not is_unresolved_tool_argument_placeholder(trusted_value)
             ):
                 continue
-            payload.pop(canonical_argument, None)
-            for alias, canonical in schema.aliases.items():
-                if canonical == canonical_argument:
-                    payload.pop(alias, None)
             payload[canonical_argument] = trusted_value.strip()
     binding_diagnostics: dict[str, Any] = {}
     choice_bindings = definition.ordinary_turn_trusted_argument_choice_bindings

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -2474,6 +2474,98 @@ def test_server_bound_capability_argument_is_not_model_visible() -> None:
     assert "x-von-argument-aliases" not in input_schema
 
 
+def test_optional_trusted_binding_is_hidden_and_does_not_require_a_value() -> None:
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="actor_resource_list",
+            handler=lambda **_kwargs: {"success": True},
+            input_schema=Schema(
+                optional={
+                    "query": str,
+                    "acting_user_concept_id": (str, type(None)),
+                    "organisation_concept_id": (str, type(None)),
+                },
+                allow_unknown=False,
+            ),
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "acting_user_concept_id": "actor_user_concept_id",
+            },
+            ordinary_turn_optional_trusted_argument_bindings={
+                "organisation_concept_id": "actor_organisation_concept_id",
+            },
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue,
+        transport=InternalMCPTransport(read_timeout_sec=1.0),
+        enabled=True,
+    )
+    personal_trusted = {
+        "actor_user_concept_id": "#V#person",
+        "actor_organisation_concept_id": None,
+    }
+
+    delegated = ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#person",
+        trusted_argument_values=personal_trusted,
+    )
+    assert delegated == ("actor_resource_list",)
+    assert ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#person",
+        trusted_argument_values={"actor_organisation_concept_id": "#V#org"},
+    ) == ()
+    assert ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id=None,
+        trusted_argument_values=personal_trusted,
+    ) == ()
+
+    capability = _capability_catalogue(
+        gateway,
+        delegated,
+        {"names": ["actor_resource_list"]},
+        trusted_argument_values=personal_trusted,
+    )["capabilities"][0]
+    assert capability["server_bound_arguments"] == [
+        "acting_user_concept_id",
+        "organisation_concept_id",
+    ]
+    assert set(capability["input_schema"]["properties"]) == {"query"}
+
+    personal_payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="actor_resource_list",
+        model_payload={
+            "query": "mine",
+            "acting_user_concept_id": "#V#attacker",
+            "organisation_concept_id": "#V#attacker_org",
+        },
+        trusted_argument_values=personal_trusted,
+    )
+    assert personal_payload == {
+        "query": "mine",
+        "acting_user_concept_id": "#V#person",
+    }
+
+    organisation_payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="actor_resource_list",
+        model_payload={"organisation_concept_id": "#V#attacker_org"},
+        trusted_argument_values={
+            **personal_trusted,
+            "actor_organisation_concept_id": "#V#trusted_org",
+        },
+    )
+    assert organisation_payload == {
+        "acting_user_concept_id": "#V#person",
+        "organisation_concept_id": "#V#trusted_org",
+    }
+
+
 def test_authorised_resource_choices_expose_only_stable_selectors() -> None:
     gateway = _gmail_choice_gateway(lambda **_kwargs: {"success": True})
     trusted = {"gmail_profile": _gmail_profile_choices(default=None)}

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -390,6 +390,15 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "store_text_assertion",
         "upsert_scoped_assertion",
     } <= actor_without_org
+    assert {
+        "conversation_list",
+        "conversation_search",
+        "conversation_get",
+        "conversation_transcript_page",
+        "conversation_inspect_batch",
+        "conversation_manage",
+        "conversation_manage_batch",
+    } <= actor_without_org
 
     # Capabilities that can persist state remain write-category even when
     # their primary output is a report or ranking.

--- a/tests/backend/test_internal_mcp_conversation_management.py
+++ b/tests/backend/test_internal_mcp_conversation_management.py
@@ -29,8 +29,10 @@ def test_conversation_tools_are_actor_bound_and_manage_is_a_bounded_effect():
         assert definition.category == "read"
         assert definition.ordinary_turn_trusted_argument_bindings == {
             "acting_user_concept_id": "actor_user_concept_id",
-            "organisation_concept_id": "actor_organisation_concept_id",
             "namespace": "turn_namespace",
+        }
+        assert definition.ordinary_turn_optional_trusted_argument_bindings == {
+            "organisation_concept_id": "actor_organisation_concept_id",
         }
 
     manage = catalogue.get("conversation_manage")
@@ -38,15 +40,20 @@ def test_conversation_tools_are_actor_bound_and_manage_is_a_bounded_effect():
     assert manage.ordinary_turn_effect is True
     assert manage.ordinary_turn_trusted_argument_bindings == {
         "acting_user_concept_id": "actor_user_concept_id",
-        "organisation_concept_id": "actor_organisation_concept_id",
         "namespace": "turn_namespace",
         "request_id": "turn_id",
+    }
+    assert manage.ordinary_turn_optional_trusted_argument_bindings == {
+        "organisation_concept_id": "actor_organisation_concept_id",
     }
     batch = catalogue.get("conversation_manage_batch")
     assert batch.category == "write"
     assert batch.ordinary_turn_effect is True
     assert batch.ordinary_turn_trusted_argument_bindings == (
         manage.ordinary_turn_trusted_argument_bindings
+    )
+    assert batch.ordinary_turn_optional_trusted_argument_bindings == (
+        manage.ordinary_turn_optional_trusted_argument_bindings
     )
 
 

--- a/tests/backend/test_internal_mcp_dynamic_tool_registration.py
+++ b/tests/backend/test_internal_mcp_dynamic_tool_registration.py
@@ -315,6 +315,51 @@ def test_dynamic_proxy_cannot_fix_a_trusted_bound_argument(monkeypatch):
     assert failure["conflicting_argument_names"] == ["profile"]
 
 
+def test_dynamic_proxy_preserves_optional_trusted_binding(monkeypatch):
+    _set_dynamic_tool_docs(
+        monkeypatch,
+        [
+            {
+                "concept_id": "#V#dynamic_conversation_proxy",
+                "attributes": {
+                    "mcp_tool_name": "conversation_proxy",
+                    "dynamic_registration_enabled": True,
+                    "dynamic_registration_approved": True,
+                    "dynamic_target_tool_name": "conversation_base",
+                    "dynamic_fixed_payload": {"query": "recent"},
+                },
+            }
+        ],
+    )
+    optional_binding = {
+        "organisation_concept_id": "actor_organisation_concept_id",
+    }
+    base_definition = MethodDefinition(
+        name="conversation_base",
+        handler=lambda **kwargs: {"success": True, **kwargs},
+        input_schema=Schema(
+            optional={
+                "query": str,
+                "organisation_concept_id": (str, type(None)),
+            },
+            allow_unknown=False,
+        ),
+        category="read",
+        ordinary_turn_optional_trusted_argument_bindings=optional_binding,
+    )
+
+    load_result = load_dynamic_method_definitions(
+        base_definitions={"conversation_base": base_definition},
+        protected_method_names={"conversation_base"},
+    )
+
+    assert len(load_result.definitions) == 1
+    assert (
+        load_result.definitions[0].ordinary_turn_optional_trusted_argument_bindings
+        == optional_binding
+    )
+
+
 def test_dynamic_proxy_cannot_bypass_ordinary_turn_fixed_argument(monkeypatch):
     _set_dynamic_tool_docs(
         monkeypatch,


### PR DESCRIPTION
> Merge impact: Personal-context users regain the existing actor-scoped conversation search, inspection, and reversible management path.
>
> Merge decision: ready — targeted authority, catalogue, conversation-management, and dynamic-proxy evidence is green; no stop-ship condition was observed.

## User outcome

An authenticated user in Personal context can find, inspect, label or rename, and otherwise manage their own Von conversations. This repairs [JVNAUTOSCI-2718](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2718).

## Material changes

- Add explicit optional trusted argument bindings to internal MCP method metadata.
- Keep optional bindings hidden from model-visible schemas.
- Strip model-supplied values when the trusted optional value is absent, and overwrite them when trusted context supplies a value.
- Mark organisation_concept_id optional only for the seven existing conversation tools; acting user and namespace remain mandatory.
- Preserve this boundary through dynamic proxies.

No prompt, workflow, label taxonomy, database schema, or broad organisation-authority policy changes.

## Evidence

- 49/49 internal MCP catalogue tests passed.
- 14/14 conversation-management tests passed.
- 10/10 dynamic-tool registration tests passed.
- 8 focused adaptive/catalogue/conversation authority tests passed.
- 82 additional adaptive-turn tests ran without failure before the slow full-file run was stopped after 8m18s; this interrupted run is supporting evidence, not a pass claim.
- Fatal Ruff checks E9,F63,F7,F82 passed for all changed files.
- Python compileall and git diff --check passed.
- Candidate live-catalogue probe exposed exactly the seven restored conversation tools in Personal context (108 total versus the diagnosed 101).

Post-merge deployment acceptance will use the authenticated Mac Personal browser path and canonical effect read-back.

## Ship boundary

- Minimum ship criteria: Personal delegation contains all seven existing conversation tools; scope arguments remain server-bound; organisation context still injects its exact trusted value; unauthenticated and missing-user paths remain denied; affected suites pass.
- Stop-ship conditions: cross-user or cross-namespace access, a model-selectable organisation, missing Personal mutation capability, or a success claim without effect receipt and canonical read-back. None observed.
- Non-blocking observations: the repository-wide Ruff invocation reports pre-existing legacy findings; the scoped fatal gate passes. The complete adaptive-turn file is unusually slow without local Mongo and was not used as a conjunctive gate.
- Non-goals: arbitrary conversation tags, a new labelling taxonomy, RAG-history fallback, Messages authority changes, or DGX deployment.

[JVNAUTOSCI-2718]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ