### PR TITLE
Fix governed Von login email administration

### DIFF
--- a/docs/engineering/access_control_and_namespaces.md
+++ b/docs/engineering/access_control_and_namespaces.md
@@ -46,6 +46,17 @@ The authoritative identity is derived by the backend.
   - The reverse inference is forbidden: `#V#has_email` never grants login.
   - One user may have several explicit login-email values, but an address bound
     to more than one user is rejected as ambiguous.
+  - Organisation admins and owners can inspect a current member's narrow login
+    bindings through the dedicated internal capability. Binding and removal are
+    idempotent, receipted, and canonically read back. A bind request, including
+    certification that an existing binding is globally unambiguous, and any
+    removal that would change a multi-organisation person's global login
+    identity require management authority across all of that person's
+    represented organisations (or the separate Von operational-administrator
+    role).
+  - This capability does not widen generic concept visibility, promote a
+    descriptive `#V#has_email` value, disclose a conflicting person's identity,
+    or revoke an existing browser session when a binding is removed.
   - An unbound address does not inherit the browser's prior user concept and
     does not auto-create a new Von user.
   - Sessions issued through the old email-resolution path do not carry the

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -110,8 +110,8 @@ Google OAuth email addresses must resolve only through the dedicated
 `#V#hasVonLoginEmail` predicate. The ordinary `#V#has_email` predicate is
 descriptive contact information: adding it to a person must never let that
 address authenticate as the person. Login-email bindings are an explicit
-operator-reviewed allow-list, are unique across user concepts, and fail closed
-when absent, stale, or ambiguous. An unbound OAuth identity must not inherit a
+governed allow-list, are unique across user concepts, and fail closed when
+absent, stale, or ambiguous. An unbound OAuth identity must not inherit a
 browser-supplied or prior-session concept and must not auto-create a user.
 For a database upgraded from the pre-cutover reader, an explicitly approved
 one-time migration may preserve the unambiguous `#V#has_email` bindings that
@@ -124,6 +124,22 @@ predicate so only the dedicated identity-binding lifecycle can change it.
 Newly resolved Google sessions carry a versioned login-assurance marker at the
 trusted session boundary. Pre-cutover email sessions lack that evidence and
 must fail closed rather than retaining an actor or organisation scope.
+
+The internal conversational lifecycle separates inspection from mutation.
+`get_von_login_email_bindings` reads only the narrow predicate for a represented
+member of the actor's server-bound current organisation and requires the
+actor's live `MANAGE_MEMBERS` permission there. `manage_von_login_email_binding`
+uses the same exact-organisation check, actor-bound idempotency, a durable
+receipt, conflict-safe serialisation, and canonical read-back. Because a login
+binding authenticates the global person, a real bind or removal additionally
+requires the actor to administer every organisation the target can enter, or
+to hold the separate Von operational-administrator role. A bind request also
+requires that authority before certifying an existing address as globally
+unambiguous; the dedicated read can still report the target's current bindings
+without making that stronger claim. An absent removal is a target-local no-op.
+Generic KB visibility remains unchanged, and a conflict does not disclose the
+other bound identity. Removing a binding prevents future OAuth resolution but
+does not terminate an already active session.
 
 ### 1a. Narrow endpoint safeguard implemented in December 2024
 

--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -963,6 +963,7 @@ ONTOLOGY_MUTATION_RECEIPTS_COLLECTION_NAME = "ontology_mutation_receipts"
 ORGANISATION_MEMBERSHIP_RECEIPTS_COLLECTION_NAME = (
     "organisation_membership_mutation_receipts"
 )
+VON_LOGIN_EMAIL_RECEIPTS_COLLECTION_NAME = "von_login_email_mutation_receipts"
 META_RELATIONS_COLLECTION_NAME = "meta_relations"  # New collection for relation elicitation meta-data (JVNAUTOSCI-371)
 RELATIONSHIP_EXTENT_INDEX_COLLECTION_NAME = "relationship_extent_index"
 
@@ -2368,6 +2369,39 @@ def _ensure_organisation_membership_receipt_indexes(coll: Collection) -> None:
     coll.create_index([("status", ASCENDING)], name="status_1")
 
 
+def _ensure_von_login_email_receipt_indexes(coll: Collection) -> None:
+    """Keep authentication-identity effects actor-bound and replayable."""
+
+    coll.create_index(
+        [("receipt_id", ASCENDING)],
+        name="receipt_id_unique",
+        unique=True,
+    )
+    coll.create_index(
+        [
+            ("actor_concept_id", ASCENDING),
+            ("request_id", ASCENDING),
+        ],
+        name="actor_request_unique",
+        unique=True,
+    )
+    coll.create_index(
+        [
+            ("actor_concept_id", ASCENDING),
+            ("created_at", DESCENDING),
+        ],
+        name="actor_created_at_desc",
+    )
+    coll.create_index(
+        [
+            ("organisation_concept_id", ASCENDING),
+            ("created_at", DESCENDING),
+        ],
+        name="organisation_created_at_desc",
+    )
+    coll.create_index([("status", ASCENDING)], name="status_1")
+
+
 def _ensure_relationship_extent_index_indexes(coll: Collection) -> None:
     existing = [idx for idx in coll.list_indexes() if isinstance(idx, Mapping)]
     existing_names = {str(idx.get("name") or "") for idx in existing if idx.get("name")}
@@ -2897,6 +2931,19 @@ def get_organisation_membership_receipts_collection() -> Collection | None:
             db,
             ORGANISATION_MEMBERSHIP_RECEIPTS_COLLECTION_NAME,
             _ensure_organisation_membership_receipt_indexes,
+        )
+    return None
+
+
+def get_von_login_email_receipts_collection() -> Collection | None:
+    """Return durable receipts for governed login-email effects."""
+
+    db = get_db()
+    if db is not None:
+        return _ensure_collection_indexes_once(
+            db,
+            VON_LOGIN_EMAIL_RECEIPTS_COLLECTION_NAME,
+            _ensure_von_login_email_receipt_indexes,
         )
     return None
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -771,6 +771,91 @@ def _manage_organisation_membership(**kwargs):
     return result
 
 
+def _get_von_login_email_bindings(**kwargs):
+    from ...services.von_login_email_governance_service import (
+        get_von_login_email_bindings,
+    )
+
+    try:
+        return get_von_login_email_bindings(
+            user_concept_id=kwargs.get("user_concept_id"),
+            organisation_concept_id=kwargs.get("organisation_concept_id"),
+            acting_actor_concept_id=kwargs.get("acting_actor_concept_id"),
+        )
+    except RuntimeError:
+        return make_error_response(
+            "von_login_email_governance_unavailable",
+            "Login-email authority verification is unavailable.",
+        )
+
+
+def _manage_von_login_email_binding(**kwargs):
+    from ...services.von_login_email_governance_service import manage_von_login_email
+    from .transport import record_internal_mcp_effect_receipt
+
+    try:
+        result = manage_von_login_email(
+            action=kwargs.get("action"),
+            user_concept_id=kwargs.get("user_concept_id"),
+            organisation_concept_id=kwargs.get("organisation_concept_id"),
+            email=kwargs.get("email"),
+            request_id=kwargs.get("request_id"),
+            reason=kwargs.get("reason"),
+            acting_actor_concept_id=kwargs.get("acting_actor_concept_id"),
+        )
+    except RuntimeError:
+        return make_error_response(
+            "von_login_email_governance_unavailable",
+            "Login-email authority verification or durable receipts are unavailable.",
+        )
+    receipt = result.get("governance_receipt") if isinstance(result, dict) else None
+    if isinstance(receipt, Mapping) and receipt.get("receipt_id"):
+        record_internal_mcp_effect_receipt(
+            {
+                "schema_version": "internal_mcp_von_login_email_effect.v1",
+                "success": bool(result.get("success")),
+                "effect_status": result.get("effect_status"),
+                "mutation_outcome": result.get("mutation_outcome"),
+                "changed": result.get("changed"),
+                "receipt_id": receipt.get("receipt_id"),
+                "request_id": receipt.get("request_id"),
+                "action": receipt.get("action"),
+                "user_concept_id": receipt.get("user_concept_id"),
+                "organisation_concept_id": receipt.get("organisation_concept_id"),
+                "governance_receipt_status": receipt.get("status"),
+                "canonical_read_back": result.get("canonical_read_back"),
+                "error_code": result.get("error_code"),
+                "outcome_finality": (
+                    result.get("outcome_finality")
+                    or (
+                        "terminal"
+                        if result.get("effect_status")
+                        in {"succeeded", "not_started"}
+                        else "requires_canonical_reconciliation"
+                    )
+                ),
+            }
+        )
+    return result
+
+
+def _get_von_login_email_management_receipt(**kwargs):
+    from ...services.von_login_email_governance_service import (
+        get_von_login_email_management_receipt,
+    )
+
+    try:
+        return get_von_login_email_management_receipt(
+            receipt_id=kwargs.get("receipt_id"),
+            acting_actor_concept_id=kwargs.get("acting_actor_concept_id"),
+        )
+    except RuntimeError:
+        return make_error_response(
+            "von_login_email_governance_unavailable",
+            "Login-email receipts are unavailable.",
+        )
+
+
 def _get_organisation_membership_receipt(**kwargs):
     from ...services.organisation_membership_governance_service import (
         get_organisation_membership_receipt,
@@ -10522,6 +10607,114 @@ def _manage_organisation_membership_output_schema() -> Schema:
         },
         allow_unknown=True,
         description="Governed membership effect, receipt, and canonical read-back.",
+    )
+
+
+def _von_login_email_bindings_input_schema() -> Schema:
+    return Schema(
+        required={
+            "user_concept_id": str,
+            "organisation_concept_id": str,
+        },
+        optional={
+            "acting_actor_concept_id": (str, type(None)),
+        },
+        allow_unknown=True,
+        description=(
+            "Read the canonical Von login-email bindings for one member of the "
+            "trusted actor's selected organisation."
+        ),
+    )
+
+
+def _von_login_email_bindings_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "actor_concept_id": str,
+            "user_concept_id": str,
+            "organisation_concept_id": str,
+            "login_emails": list,
+            "total_count": int,
+            "authority_decision": (dict, type(None)),
+            "canonical_read_back": (dict, type(None)),
+            "error_code": str,
+            "error": str,
+        },
+        allow_unknown=True,
+        description="Admin-scoped canonical Von login-email binding read-back.",
+    )
+
+
+def _manage_von_login_email_binding_input_schema() -> Schema:
+    return Schema(
+        required={
+            "action": str,
+            "user_concept_id": str,
+            "organisation_concept_id": str,
+            "email": str,
+            "request_id": str,
+        },
+        optional={
+            "reason": (str, type(None)),
+            "acting_actor_concept_id": (str, type(None)),
+        },
+        enum_values={"action": ["bind", "remove"]},
+        allow_unknown=True,
+        description=(
+            "Bind or remove one exact canonical Von login email. request_id is "
+            "actor-bound and idempotent."
+        ),
+    )
+
+
+def _manage_von_login_email_binding_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "effect_status": str,
+            "mutation_outcome": str,
+            "outcome_finality": str,
+            "changed": (bool, type(None)),
+            "postcondition_preexisting": bool,
+            "action": str,
+            "actor_concept_id": str,
+            "user_concept_id": str,
+            "organisation_concept_id": str,
+            "email": str,
+            "authority_decision": (dict, type(None)),
+            "canonical_read_back": (dict, type(None)),
+            "governance_receipt": dict,
+            "error_code": str,
+            "error": str,
+        },
+        allow_unknown=True,
+        description="Governed login-email effect, receipt, and canonical read-back.",
+    )
+
+
+def _von_login_email_management_receipt_input_schema() -> Schema:
+    return Schema(
+        required={"receipt_id": str},
+        optional={
+            "acting_actor_concept_id": (str, type(None)),
+        },
+        allow_unknown=True,
+        description="Read one actor-owned Von login-email management receipt.",
+    )
+
+
+def _von_login_email_management_receipt_output_schema() -> Schema:
+    return Schema(
+        required={"success": bool},
+        optional={
+            "governance_receipt": dict,
+            "response_projection": (dict, type(None)),
+            "error_code": str,
+            "error": str,
+        },
+        allow_unknown=True,
+        description="Actor-bound Von login-email management receipt read-back.",
     )
 
 
@@ -20867,6 +21060,40 @@ _RAG_DEGRADED_EXCEPTION_TOKENS = (
 )
 
 
+def _rag_row_contains_hidden_generic_text(row: Any) -> bool:
+    """Reject legacy index rows containing dedicated authentication identity."""
+
+    from ...services.text_relation_read_policy import (
+        is_hidden_from_generic_text_reads,
+        text_contains_hidden_generic_predicate,
+    )
+
+    if not isinstance(row, Mapping):
+        return False
+    metadata = row.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    if any(
+        is_hidden_from_generic_text_reads(metadata.get(key))
+        for key in ("predicate", "predicate_concept_id")
+    ):
+        return True
+
+    # Older concept embeddings aggregated arbitrary text relations into their
+    # searchable body without retaining per-relation metadata.  Until they are
+    # re-indexed, reject only Vontology-derived rows that visibly carry one of
+    # the dedicated predicate tokens; ordinary chat/file content is unaffected.
+    is_vontology_projection = (
+        metadata.get("type") in {"concept", "text_relation"}
+        or metadata.get("source") == "vontology_text_relation"
+        or str(row.get("id") or "").startswith(("concept:", "text_relation:"))
+    )
+    text = row.get("text")
+    return bool(
+        is_vontology_projection
+        and text_contains_hidden_generic_predicate(text)
+    )
+
+
 def _parse_namespace_actor_context(
     namespace: Any,
 ) -> tuple[str | None, str | None]:
@@ -21219,6 +21446,55 @@ def _search_knowledge_base(**kwargs):
 
     start = time.perf_counter()
 
+    from ...services.text_relation_read_policy import (
+        is_hidden_from_generic_text_reads,
+    )
+
+    requested_predicate = kwargs.get("predicate")
+    if is_hidden_from_generic_text_reads(requested_predicate):
+        retrieval_state = build_rag_retrieval_state(
+            "valid_empty",
+            result_count=0,
+            cause="generic_text_predicate_hidden",
+        )
+        return {
+            "results": [],
+            "count": 0,
+            "elapsed_ms": int((time.perf_counter() - start) * 1000),
+            "query": query_text,
+            "effective_namespace": ns,
+            "effective_namespace_source": ns_report.get("namespace_source"),
+            "retrieval_state": retrieval_state,
+            **ns_report,
+            "success": True,
+        }
+
+    requested_predicates = kwargs.get("predicates")
+    visible_requested_predicates = requested_predicates
+    if isinstance(requested_predicates, list):
+        visible_requested_predicates = [
+            predicate
+            for predicate in requested_predicates
+            if not is_hidden_from_generic_text_reads(predicate)
+        ]
+        if requested_predicates and not visible_requested_predicates:
+            retrieval_state = build_rag_retrieval_state(
+                "valid_empty",
+                result_count=0,
+                cause="generic_text_predicates_hidden",
+            )
+            return {
+                "results": [],
+                "count": 0,
+                "elapsed_ms": int((time.perf_counter() - start) * 1000),
+                "query": query_text,
+                "effective_namespace": ns,
+                "effective_namespace_source": ns_report.get("namespace_source"),
+                "retrieval_state": retrieval_state,
+                **ns_report,
+                "success": True,
+            }
+
     try:
         # The namespace resolver is the authority boundary for actor-private
         # RAG access.  Build row-level permissions from its accepted trusted
@@ -21303,13 +21579,12 @@ def _search_knowledge_base(**kwargs):
         if isinstance(requested_type, str) and requested_type.strip():
             permissions_context["type"] = requested_type.strip()
 
-        predicate = kwargs.get("predicate")
+        predicate = requested_predicate
         if isinstance(predicate, str) and predicate.strip():
             permissions_context["predicate"] = predicate.strip()
 
-        predicates = kwargs.get("predicates")
-        if isinstance(predicates, list):
-            permissions_context["predicates"] = predicates
+        if isinstance(visible_requested_predicates, list):
+            permissions_context["predicates"] = visible_requested_predicates
 
         service = get_rag_service()  # Default backend
         results = service.query(
@@ -21318,6 +21593,15 @@ def _search_knowledge_base(**kwargs):
             namespace=ns,
             permissions_context=permissions_context if permissions_context else None,
         )
+        hidden_result_count = 0
+        if isinstance(results, list):
+            visible_results = []
+            for row in results:
+                if _rag_row_contains_hidden_generic_text(row):
+                    hidden_result_count += 1
+                    continue
+                visible_results.append(row)
+            results = visible_results
         elapsed_ms = int((time.perf_counter() - start) * 1000)
 
         raw_retrieval_state = getattr(results, "retrieval_state", None)
@@ -21342,9 +21626,15 @@ def _search_knowledge_base(**kwargs):
                 result_count=result_count,
                 cause=(str(raw_retrieval_state.get("cause") or "").strip() or None),
                 detail=(str(raw_retrieval_state.get("detail") or "").strip() or None),
-                candidate_count=raw_retrieval_state.get("candidate_count"),
-                filtered_candidate_count=raw_retrieval_state.get(
-                    "filtered_candidate_count"
+                candidate_count=(
+                    result_count
+                    if hidden_result_count
+                    else raw_retrieval_state.get("candidate_count")
+                ),
+                filtered_candidate_count=(
+                    result_count
+                    if hidden_result_count
+                    else raw_retrieval_state.get("filtered_candidate_count")
                 ),
                 candidate_limit=raw_retrieval_state.get("candidate_limit"),
                 candidate_limit_reached=raw_retrieval_state.get(
@@ -24681,6 +24971,8 @@ def _get_related_concepts(**kwargs):
     filtered = []
     for row in results or []:
         if not isinstance(row, dict):
+            continue
+        if _rag_row_contains_hidden_generic_text(row):
             continue
         meta = row.get("metadata")
         if not isinstance(meta, dict):
@@ -39086,6 +39378,70 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "membership-management authority. Generic relationship tools remain "
                 "ineligible for memberOfVonOrg or hasVonOrgRole. Generic "
                 "memberOf and hasRole assertions are descriptive only."
+            ),
+        ),
+        MethodDefinition(
+            name="get_von_login_email_bindings",
+            handler=_get_von_login_email_bindings,
+            input_schema=_von_login_email_bindings_input_schema(),
+            output_schema=_von_login_email_bindings_output_schema(),
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "acting_actor_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+            },
+            hard_timeout_enabled=False,
+            description=(
+                "Read the canonical KB bindings used as one organisation member's "
+                "Von login email addresses. Use this admin-scoped identity tool "
+                "before email or generic concept search when asked what login "
+                "address a member has, or before trying to set one, so an already "
+                "bound address can be reported without a mutation. The server binds "
+                "the trusted actor and selected organisation, requires live "
+                "MANAGE_MEMBERS permission and exact target membership, and reads "
+                "only hasVonLoginEmail—not descriptive has_email facts."
+            ),
+        ),
+        MethodDefinition(
+            name="manage_von_login_email_binding",
+            handler=_manage_von_login_email_binding,
+            input_schema=_manage_von_login_email_binding_input_schema(),
+            output_schema=_manage_von_login_email_binding_output_schema(),
+            category="write",
+            ordinary_turn_trusted_argument_bindings={
+                "acting_actor_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "request_id": "turn_id",
+            },
+            ordinary_turn_effect=True,
+            write_guardrail={"ordinary_turn_explicit_request": True},
+            hard_timeout_enabled=False,
+            description=(
+                "Bind or remove one exact canonical Von login email address for a "
+                "member when the user explicitly requests that authentication "
+                "change. The server binds the trusted actor, current organisation, "
+                "and idempotency request; requires live organisation-admin or owner "
+                "authority plus exact target membership; treats an already bound "
+                "address as successful with changed=false; protects multi-organisation "
+                "identities; and returns a durable receipt with canonical KB "
+                "read-back. It never promotes a generic has_email contact fact. "
+                "Removing a binding prevents future OAuth resolution but does not "
+                "terminate an already active session."
+            ),
+        ),
+        MethodDefinition(
+            name="get_von_login_email_management_receipt",
+            handler=_get_von_login_email_management_receipt,
+            input_schema=_von_login_email_management_receipt_input_schema(),
+            output_schema=_von_login_email_management_receipt_output_schema(),
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "acting_actor_concept_id": "actor_user_concept_id",
+            },
+            hard_timeout_enabled=False,
+            description=(
+                "Read one durable Von login-email management receipt owned by the "
+                "trusted actor, including terminal outcome and canonical read-back."
             ),
         ),
         MethodDefinition(

--- a/src/backend/server/routes/predicate_routes.py
+++ b/src/backend/server/routes/predicate_routes.py
@@ -18,6 +18,9 @@ from ...services.concept_predicate_metadata_service import (
 from ...services.relationship_extent_index_service import (
     query_relationship_extent_index,
 )
+from ...services.text_relation_read_policy import (
+    is_hidden_from_generic_text_reads,
+)
 
 
 predicate_bp = Blueprint("predicates", __name__, url_prefix="/api/predicates")
@@ -115,6 +118,25 @@ def get_predicate_extent_data(
     concept_id = concept_id.strip()
     if sample_size is not None:
         sample_size = max(1, min(int(sample_size), 1000))
+
+    # Authentication identifiers are governed through the dedicated Von login
+    # lifecycle.  Predicate extent is a generic knowledge projection and must
+    # not reveal whether, where, or how often those bindings exist.
+    if is_hidden_from_generic_text_reads(concept_id):
+        return {
+            "concept_id": concept_id,
+            "extent": [],
+            "total_count": 0,
+            "limit": sample_size if sample_size is not None else limit,
+            "offset": 0 if sample_size is not None else offset,
+            "has_more": False,
+            "sampled": sample_size is not None,
+            **(
+                {"sample_size": sample_size}
+                if sample_size is not None
+                else {}
+            ),
+        }
 
     extent_items: List[Dict[str, Any]] = []
     total_count = 0
@@ -294,6 +316,8 @@ def _query_text_relations_extent(
     sort_order: str,
 ) -> tuple[List[Dict[str, Any]], int]:
     """Query text_relations collection for predicate extent."""
+    if is_hidden_from_generic_text_reads(predicate_concept_id):
+        return [], 0
     try:
         text_rel_coll = get_text_relations_collection()
         if text_rel_coll is None:
@@ -481,6 +505,8 @@ def _sample_text_relations_extent(
     sample_size: int,
 ) -> tuple[List[Dict[str, Any]], int]:
     """Sample text_relations extent for a predicate."""
+    if is_hidden_from_generic_text_reads(predicate_concept_id):
+        return [], 0
     try:
         text_rel_coll = get_text_relations_collection()
         if text_rel_coll is None:
@@ -873,6 +899,8 @@ def _find_custom_meta_properties(
 
 def _calculate_extent_statistics(predicate_id: str) -> Dict[str, int]:
     """Calculate statistics about predicate extent."""
+    if is_hidden_from_generic_text_reads(predicate_id):
+        return {"total_uses": 0, "unique_subjects": 0, "unique_objects": 0}
     try:
         text_rel_coll = get_text_relations_collection()
         concepts_coll = get_concepts_collection()

--- a/src/backend/services/concept_embedding_service.py
+++ b/src/backend/services/concept_embedding_service.py
@@ -29,6 +29,10 @@ from ..vontology.utils_vontology import (
     is_type,
     is_predicate,
 )
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +283,10 @@ def _get_individual_relations_sample(
     try:
         # Get text relations where this concept is the subject
         cursor = TextRelationsRepository.find(
-            {"subject_concept_id": concept_id},
+            {
+                "subject_concept_id": concept_id,
+                "predicate": generic_text_read_predicate_filter(),
+            },
             limit=limit,
         )
 
@@ -288,6 +295,8 @@ def _get_individual_relations_sample(
                 continue
 
             predicate = rel.get("predicate", "")
+            if is_hidden_from_generic_text_reads(predicate):
+                continue
             text_id = rel.get("object_text_id")
 
             if text_id:
@@ -321,6 +330,9 @@ def _get_predicate_extent_sample(
         List of dicts with subject_name, predicate, object_text
     """
     extent: List[Dict[str, str]] = []
+
+    if is_hidden_from_generic_text_reads(predicate_id):
+        return extent
 
     try:
         # Get text relations using this predicate

--- a/src/backend/services/concept_merge_service.py
+++ b/src/backend/services/concept_merge_service.py
@@ -461,7 +461,11 @@ def _raw_text_value(object_text_id: Any) -> dict[str, Any] | None:
     return dict(text_value) if isinstance(text_value, Mapping) else None
 
 
-def _text_assertion_precondition(relation: Mapping[str, Any]) -> dict[str, Any]:
+def _text_assertion_precondition(
+    relation: Mapping[str, Any],
+    *,
+    include_text_value: bool = True,
+) -> dict[str, Any]:
     relation_id = _relation_id(relation.get("_id"))
     text_value = _raw_text_value(relation.get("object_text_id"))
     if not relation_id or text_value is None:
@@ -471,13 +475,15 @@ def _text_assertion_precondition(relation: Mapping[str, Any]) -> dict[str, Any]:
         )
     relation_snapshot = _relation_snapshot(relation)
     text_value_snapshot = deepcopy(text_value)
-    return {
+    result = {
         "relation_id": relation_id,
         "relation": relation_snapshot,
         "relation_sha256": _sha256(relation_snapshot),
-        "text_value": text_value_snapshot,
         "text_value_sha256": _sha256(text_value_snapshot),
     }
+    if include_text_value:
+        result["text_value"] = text_value_snapshot
+    return result
 
 
 def _relation_id(value: Any) -> str:
@@ -640,7 +646,7 @@ def build_concept_merge_plan(source_id: str, target_id: str) -> dict[str, Any]:
             )
 
     target_preconditions = [
-        _text_assertion_precondition(relation)
+        _text_assertion_precondition(relation, include_text_value=False)
         for relation in sorted(
             target_relations,
             key=lambda row: _relation_id(row.get("_id")),

--- a/src/backend/services/concept_relation_service.py
+++ b/src/backend/services/concept_relation_service.py
@@ -44,6 +44,10 @@ from .relationship_extent_index_service import (
     incoming_dynamic_extent_rows_page_for_target,
     query_relationship_extent_index,
 )
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+)
 from .text_value_service import get_texts_for_concept, get_texts_for_concepts
 
 RelationValue = Dict[str, Any]
@@ -974,13 +978,18 @@ def find_relations_with_argument(
             text_by_id[text_id] = str(doc.get("text") or "")
         if text_ids:
             for rel in TextRelationsRepository.find(
-                {"object_text_id": {"$in": text_ids}}
+                {
+                    "object_text_id": {"$in": text_ids},
+                    "predicate": generic_text_read_predicate_filter(),
+                }
             ):
                 source_id = rel.get("subject_concept_id")
                 if not isinstance(source_id, str) or not source_id.strip():
                     continue
                 source_id = source_id.strip()
                 predicate_id = rel.get("predicate")
+                if is_hidden_from_generic_text_reads(predicate_id):
+                    continue
                 if not _predicate_matches_terms(predicate_id, predicate_terms):
                     continue
                 if not _argument_indexes_match(

--- a/src/backend/services/concept_search_service.py
+++ b/src/backend/services/concept_search_service.py
@@ -39,6 +39,7 @@ from ..db.repositories.text_value_repository import (
     TextValuesRepository,
 )
 from .text_value_service import get_preferred_texts_for_concepts
+from .text_relation_read_policy import text_contains_hidden_generic_predicate
 from ..vontology.utils_vontology import (
     get_vontology_node_and_descendant_ids,
     get_concept_display_name_with_names_fallback,
@@ -666,6 +667,12 @@ def _semantic_search(
         concept_ids = []
         score_map = {}
         for result in rag_results:
+            result_text = result.get("text") if isinstance(result, dict) else None
+            if text_contains_hidden_generic_predicate(result_text):
+                # Legacy concept embeddings could contain arbitrary relation
+                # text.  Drop such rows until the stale embedding is rebuilt
+                # under the current generic-read policy.
+                continue
             metadata = result.get("metadata", {})
             concept_id = metadata.get("concept_id")
             score = result.get("score", 0.0)
@@ -685,7 +692,7 @@ def _semantic_search(
         # Post-filter and build results
         for concept_doc in _consume_search_cursor(concepts_cursor):
             concept_id = concept_doc.get("concept_id")
-            if not concept_id:
+            if not concept_id or concept_id not in score_map:
                 continue
 
             # Apply kind filter

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -62,6 +62,10 @@ from .text_relation_predicate_validation_service import (
     TextRelationPredicateResolutionError,
     resolve_text_relation_predicate_for_write,
 )
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1927,8 +1931,15 @@ def _concept_read_back(concept_id: str) -> dict[str, Any]:
         if values:
             scope_edges[predicate_name] = values
     text_relations: list[dict[str, Any]] = []
-    for relation in TextRelationsRepository.find({"subject_concept_id": concept_id}):
+    for relation in TextRelationsRepository.find(
+        {
+            "subject_concept_id": concept_id,
+            "predicate": generic_text_read_predicate_filter(),
+        }
+    ):
         if not isinstance(relation, Mapping):
+            continue
+        if is_hidden_from_generic_text_reads(relation.get("predicate")):
             continue
         text_value = TextValuesRepository.find_one_by_id(
             relation.get("object_text_id")

--- a/src/backend/services/rag_text_relation_sync_service.py
+++ b/src/backend/services/rag_text_relation_sync_service.py
@@ -37,6 +37,9 @@ from src.backend.services.namespace_service import (
 from src.backend.services.text_relation_predicate_validation_service import (
     predicate_concept_id_for_storage,
 )
+from src.backend.services.text_relation_read_policy import (
+    is_hidden_from_generic_text_reads,
+)
 
 
 @dataclass(frozen=True)
@@ -142,6 +145,8 @@ def get_text_relation_preview(
         )
         if not isinstance(assertion, dict):
             return None
+        if is_hidden_from_generic_text_reads(assertion.get("predicate")):
+            return None
         concept_visibility: Dict[str, bool] = {}
         _populate_concept_visibility(
             [
@@ -188,6 +193,8 @@ def get_text_relation_preview(
     object_text_id = rel.get("object_text_id")
 
     if not isinstance(subject_concept_id, str) or not predicate or not object_text_id:
+        return None
+    if is_hidden_from_generic_text_reads(predicate):
         return None
 
     predicate_concept_id = predicate_concept_id_for_storage(predicate)
@@ -394,6 +401,8 @@ def _base_relation_to_rag_doc(
         or not predicate
     ):
         return None
+    if is_hidden_from_generic_text_reads(predicate):
+        return None
     if concept_allow is not None and subject_concept_id not in concept_allow:
         return None
 
@@ -474,6 +483,8 @@ def _scoped_assertion_to_rag_doc(
     concept_visibility: Dict[str, bool],
 ) -> TextRelationRagDoc | None:
     if not isinstance(assertion, dict):
+        return None
+    if is_hidden_from_generic_text_reads(assertion.get("predicate")):
         return None
     if assertion.get("assertion_form") == "standalone_text":
         try:
@@ -618,6 +629,8 @@ def _base_relation_should_prune(
     subject_id = str(relation.get("subject_concept_id") or "")
     if concept_allow is not None and subject_id not in concept_allow:
         return False
+    if is_hidden_from_generic_text_reads(relation.get("predicate")):
+        return True
     predicate_id = predicate_concept_id_for_storage(relation.get("predicate"))
     if (
         not subject_id

--- a/src/backend/services/scoped_assertion_service.py
+++ b/src/backend/services/scoped_assertion_service.py
@@ -32,6 +32,10 @@ from .text_relation_predicate_validation_service import (
     predicate_concept_id_for_storage,
     resolve_text_relation_predicate_for_write,
 )
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+)
 
 SCHEMA_VERSION = "scoped_knowledge_assertion.v1"
 TEXT_ASSERTION_SCHEMA_VERSION = "scoped_knowledge_assertion.v2"
@@ -923,6 +927,11 @@ def upsert_scoped_assertion(
                 )
             identity_object = {"concept_id": object_concept_id}
 
+        if is_hidden_from_generic_text_reads(storage_predicate):
+            raise PermissionError(
+                "dedicated Von login-email governance operation required"
+            )
+
     identity = {
         "scope_mode": scope["mode"],
         "audience_keys": scope["audience_keys"],
@@ -1166,6 +1175,7 @@ def promote_scoped_assertion_epistemic_status(
         "assertion_id": assertion_token,
         "provenance.asserted_by_user_concept_id": user_id,
         "status": "asserted",
+        "predicate": generic_text_read_predicate_filter(),
         "$or": scope_clauses,
     }
     collection = get_scoped_knowledge_assertions_collection()
@@ -1279,6 +1289,7 @@ def retract_scoped_assertion(
     authority_filter: dict[str, Any] = {
         "assertion_id": assertion_token,
         "provenance.asserted_by_user_concept_id": user_id,
+        "predicate": generic_text_read_predicate_filter(),
         "$or": scope_clauses,
     }
     now = datetime.now(timezone.utc)
@@ -1525,6 +1536,8 @@ def _visible_assertion_documents(
     required_concept_ids: set[str] = set()
     optional_link_concept_ids: set[str] = set()
     for document in documents:
+        if is_hidden_from_generic_text_reads(document.get("predicate")):
+            continue
         required_ids = _assertion_visibility_concept_ids(document)
         if required_ids is None:
             continue
@@ -1656,8 +1669,8 @@ def _build_assertion_query(
             query["assertion_form"] = STANDALONE_TEXT_ASSERTION_FORM
     if context_id:
         query["assertion_context.context_id"] = str(context_id).strip()
+    predicate_values: set[str] = set()
     if predicates:
-        predicate_values: set[str] = set()
         for item in predicates:
             if not isinstance(item, str) or not item.strip():
                 continue
@@ -1675,8 +1688,9 @@ def _build_assertion_query(
                     == predicate_value
                 ):
                     predicate_values.add(storage_candidate)
-        if predicate_values:
-            query["predicate"] = {"$in": sorted(predicate_values)}
+    query["predicate"] = generic_text_read_predicate_filter(
+        predicates=sorted(predicate_values) if predicates else None
+    )
     if object_kind is not None:
         if object_kind not in OBJECT_KINDS:
             raise ValueError("object_kind must be 'text' or 'concept'")
@@ -2091,6 +2105,7 @@ def get_visible_scoped_assertion_by_id(
         document = collection.find_one(
             {
                 "assertion_id": assertion_token,
+                "predicate": generic_text_read_predicate_filter(),
                 **audience_query,
             }
         )
@@ -2138,6 +2153,8 @@ def scoped_text_assertion_to_relation_row(
 ) -> dict[str, Any] | None:
     """Project a scoped text assertion into the generic text-read row shape."""
 
+    if is_hidden_from_generic_text_reads(assertion.get("predicate")):
+        return None
     if assertion.get("assertion_form") == STANDALONE_TEXT_ASSERTION_FORM:
         return None
     object_text = assertion.get("object_text")

--- a/src/backend/services/text_relation_read_policy.py
+++ b/src/backend/services/text_relation_read_policy.py
@@ -1,0 +1,104 @@
+"""Neutral visibility policy for generic text-relation reads.
+
+Authentication bindings are represented as text relations so the dedicated
+authentication and administration services can manage them canonically.  They
+are not ordinary ontology content, however, and must not be projected through
+generic knowledge-reading tools.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+GENERIC_TEXT_READ_HIDDEN_PREDICATES = frozenset({"#V#hasVonLoginEmail"})
+
+
+def _normalise_predicate(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _predicate_aliases(predicate: str) -> frozenset[str]:
+    if predicate.startswith("#V#"):
+        return frozenset({predicate, predicate[3:]})
+    return frozenset({predicate, f"#V#{predicate}"})
+
+
+_GENERIC_TEXT_READ_HIDDEN_QUERY_VALUES = frozenset(
+    alias
+    for predicate in GENERIC_TEXT_READ_HIDDEN_PREDICATES
+    for alias in _predicate_aliases(predicate)
+)
+
+
+def is_hidden_from_generic_text_reads(predicate: object) -> bool:
+    """Return whether ``predicate`` is reserved from generic text reads."""
+
+    value = _normalise_predicate(predicate)
+    if not value:
+        return False
+    return bool(_predicate_aliases(value) & GENERIC_TEXT_READ_HIDDEN_PREDICATES)
+
+
+def text_contains_hidden_generic_predicate(value: object) -> bool:
+    """Return whether text names a predicate reserved from generic reads."""
+
+    return isinstance(value, str) and any(
+        predicate in value for predicate in _GENERIC_TEXT_READ_HIDDEN_QUERY_VALUES
+    )
+
+
+def generic_text_read_predicate_filter(
+    *,
+    predicate: object = None,
+    predicates: Sequence[object] | None = None,
+) -> str | dict[str, list[str]]:
+    """Build a Mongo predicate condition that excludes reserved read rows.
+
+    A scalar request takes precedence, matching the existing generic text-read
+    contract.  An explicitly requested hidden predicate becomes an empty
+    ``$in`` query; an unfiltered read gets an explicit ``$nin`` constraint so
+    hidden rows cannot affect counts, limits, or truncation diagnostics.
+    """
+
+    scalar = _normalise_predicate(predicate)
+    if scalar:
+        if is_hidden_from_generic_text_reads(scalar):
+            return {"$in": []}
+        return scalar
+
+    requested = [
+        value
+        for raw_value in predicates or ()
+        if (value := _normalise_predicate(raw_value))
+    ]
+    if requested:
+        return {
+            "$in": [
+                value
+                for value in requested
+                if not is_hidden_from_generic_text_reads(value)
+            ]
+        }
+
+    return {"$nin": sorted(_GENERIC_TEXT_READ_HIDDEN_QUERY_VALUES)}
+
+
+def filter_generic_text_read_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Remove reserved predicates from an already materialised generic read."""
+
+    return [
+        row
+        for row in rows
+        if not is_hidden_from_generic_text_reads(row.get("predicate"))
+    ]
+
+
+__all__ = [
+    "GENERIC_TEXT_READ_HIDDEN_PREDICATES",
+    "filter_generic_text_read_rows",
+    "generic_text_read_predicate_filter",
+    "is_hidden_from_generic_text_reads",
+    "text_contains_hidden_generic_predicate",
+]

--- a/src/backend/services/text_relation_resolution_service.py
+++ b/src/backend/services/text_relation_resolution_service.py
@@ -13,6 +13,7 @@ from ..db.repositories.text_value_repository import (
 from ..security.access_control import filter_accessible_concept_ids
 from ..vontology.code_concepts_registry import is_code_concept_id
 from ..vontology.utils_vontology import get_vontology_node_and_descendant_ids
+from .text_relation_read_policy import is_hidden_from_generic_text_reads
 
 _MAX_RESULTS = 20
 _DEFAULT_MAX_RESULTS = 5
@@ -140,6 +141,18 @@ def resolve_concept_by_text_relation(
                 f"must be an integer from 1 to {_MAX_RESULTS}. Invalid: "
                 f"{', '.join(invalid_fields)}"
             ),
+        )
+
+    if is_hidden_from_generic_text_reads(exact_predicate):
+        return _result(
+            predicate=exact_predicate,
+            text=exact_text,
+            instance_of=type_filter,
+            status="not_found",
+            resolved_concept_id=None,
+            candidate_ids=[],
+            max_results=max_results,
+            resolution_complete=True,
         )
 
     text_rows_with_sentinel = _rows(

--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -7,6 +7,7 @@ text_relations repositories, with simple normalization and validation.
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from typing import (
     Any,
     Dict,
@@ -18,27 +19,31 @@ from typing import (
     Tuple,
     cast,
 )
-from datetime import datetime, timezone
+
 from bson import ObjectId
 from bson.errors import InvalidId
 from pymongo.errors import DuplicateKeyError
 
 from ..db.repositories.text_value_repository import (
-    TextValuesRepository,
     TextRelationsRepository,
+    TextValuesRepository,
 )
 from ..models.text_value_models import (
     RelationPredicate,
-    TextValueModel,
     TextRelationModel,
+    TextValueModel,
+)
+from ..security.access_control import (
+    can_access_concept,
+    filter_accessible_concept_ids,
 )
 from .feature_flags import (
     get_event_workflow_integration_enabled,
     get_workflow_discovery_cache_invalidation_enabled,
 )
-from ..security.access_control import (
-    can_access_concept,
-    filter_accessible_concept_ids,
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
 )
 
 _EVENT_TYPE_TEXT_RELATION_UPSERTED = "text_relation.upserted"
@@ -184,6 +189,13 @@ def _emit_text_relation_mutation_event(
     extra_payload: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Best-effort workflow event emission for text-relation mutations."""
+
+    # Authentication identifiers have a dedicated, actor-scoped governance
+    # lifecycle.  Generic workflow events persist their inputs for broader
+    # inspection, so neither the predicate nor its plaintext value belongs on
+    # that channel.
+    if is_hidden_from_generic_text_reads(predicate):
+        return
 
     if not get_event_workflow_integration_enabled(default=True):
         return
@@ -523,17 +535,13 @@ def get_texts_for_concepts(
             )
         return {}
 
-    rel_filter: Dict[str, Any] = {"subject_concept_id": {"$in": ordered_subject_ids}}
-    if predicate:
-        rel_filter["predicate"] = predicate
-    elif predicates:
-        predicate_values = [
-            str(item).strip()
-            for item in predicates
-            if isinstance(item, str) and str(item).strip()
-        ]
-        if predicate_values:
-            rel_filter["predicate"] = {"$in": predicate_values}
+    rel_filter: Dict[str, Any] = {
+        "subject_concept_id": {"$in": ordered_subject_ids},
+        "predicate": generic_text_read_predicate_filter(
+            predicate=predicate,
+            predicates=predicates,
+        ),
+    }
 
     sort = [("updated_at", -1), ("created_at", -1)] if recent_first else None
     per_concept_relation_limit = max(limit_per_concept, 1)
@@ -602,30 +610,37 @@ def get_texts_for_concepts(
                 MAX_PAGE_CANDIDATES // (scoped_per_concept_limit + 1),
             ),
         )
-        scoped_predicates = (
+        requested_scoped_predicates = (
             [predicate]
-            if predicate
+            if isinstance(predicate, str) and predicate.strip()
             else [
                 str(item).strip()
                 for item in predicates or ()
                 if isinstance(item, str) and str(item).strip()
             ]
-            or None
+        )
+        scoped_predicates = [
+            item
+            for item in requested_scoped_predicates
+            if not is_hidden_from_generic_text_reads(item)
+        ]
+        scoped_predicate_request_filtered_out = bool(
+            requested_scoped_predicates and not scoped_predicates
         )
         if requested_per_concept > scoped_per_concept_limit:
             scoped_query_truncated = True
             scoped_counts_are_lower_bounds = True
-        for batch_start in range(
-            0,
-            len(ordered_subject_ids),
-            max_subjects_per_query,
+        for batch_start in (
+            range(0, len(ordered_subject_ids), max_subjects_per_query)
+            if not scoped_predicate_request_filtered_out
+            else ()
         ):
             subject_batch = ordered_subject_ids[
                 batch_start : batch_start + max_subjects_per_query
             ]
             scoped_page = list_visible_scoped_assertions_page(
                 subject_concept_ids=subject_batch,
-                predicates=scoped_predicates,
+                predicates=scoped_predicates or None,
                 object_kind="text",
                 languages=[lang] if lang else None,
                 limit=min(
@@ -665,6 +680,8 @@ def get_texts_for_concepts(
                         ),
                     }
             for assertion in scoped_page.get("items") or ():
+                if is_hidden_from_generic_text_reads(assertion.get("predicate")):
+                    continue
                 scoped_row = scoped_text_assertion_to_relation_row(assertion)
                 if scoped_row is None:
                     continue
@@ -722,6 +739,8 @@ def _resolve_text_rows_from_relations(
     object_id_values: List[ObjectId] = []
     string_id_values: List[str] = []
     for relation in relations:
+        if is_hidden_from_generic_text_reads(relation.get("predicate")):
+            continue
         raw_id = relation.get("object_text_id")
         if not raw_id:
             continue
@@ -754,6 +773,8 @@ def _resolve_text_rows_from_relations(
 
     results: List[Dict[str, Any]] = []
     for r in relations:
+        if is_hidden_from_generic_text_reads(r.get("predicate")):
+            continue
         key = r.get("object_text_id")
         if isinstance(key, ObjectId):
             lookup_key = str(key)
@@ -1237,11 +1258,10 @@ def get_text_relations_summary(
     if not can_access_concept(subject_concept_id):
         raise PermissionError("User cannot view text for an inaccessible concept")
 
-    pred_filter: Dict[str, Any] = {"subject_concept_id": subject_concept_id}
-    if predicates:
-        pred_filter["predicate"] = {
-            "$in": [p for p in predicates if isinstance(p, str)]
-        }
+    pred_filter: Dict[str, Any] = {
+        "subject_concept_id": subject_concept_id,
+        "predicate": generic_text_read_predicate_filter(predicates=predicates),
+    }
 
     rels = list(
         TextRelationsRepository.find(
@@ -1339,21 +1359,38 @@ def get_text_relations_summary(
             list_visible_scoped_assertions_page,
         )
 
-        scoped_page = list_visible_scoped_assertions_page(
-            subject_concept_ids=[subject_concept_id],
-            predicates=predicates,
-            object_kind="text",
-            languages=languages,
-            limit=1000,
-        )
-        scoped_assertions = list(scoped_page.get("items") or ())
-        scoped_query_truncated = bool(scoped_page.get("truncated"))
-        scoped_visibility_filtered = bool(
-            scoped_page.get("visibility_filtered")
-        )
-        scoped_counts_are_lower_bounds = bool(
-            scoped_page.get("counts_are_lower_bounds")
-        )
+        requested_scoped_predicates = [
+            str(item).strip()
+            for item in predicates or ()
+            if isinstance(item, str) and str(item).strip()
+        ]
+        scoped_predicates = [
+            item
+            for item in requested_scoped_predicates
+            if not is_hidden_from_generic_text_reads(item)
+        ]
+        if not requested_scoped_predicates or scoped_predicates:
+            scoped_page = list_visible_scoped_assertions_page(
+                subject_concept_ids=[subject_concept_id],
+                predicates=scoped_predicates or None,
+                object_kind="text",
+                languages=languages,
+                limit=1000,
+            )
+            scoped_assertions = [
+                assertion
+                for assertion in scoped_page.get("items") or ()
+                if not is_hidden_from_generic_text_reads(
+                    assertion.get("predicate")
+                )
+            ]
+            scoped_query_truncated = bool(scoped_page.get("truncated"))
+            scoped_visibility_filtered = bool(
+                scoped_page.get("visibility_filtered")
+            )
+            scoped_counts_are_lower_bounds = bool(
+                scoped_page.get("counts_are_lower_bounds")
+            )
     for assertion in scoped_assertions:
         object_text = assertion.get("object_text")
         if not isinstance(object_text, dict):
@@ -1538,10 +1575,18 @@ def audit_concept_text_relations(
     # Query all text relations directly, bypassing normal access control
     rels = list(
         TextRelationsRepository.find(
-            {"subject_concept_id": concept_id},
+            {
+                "subject_concept_id": concept_id,
+                "predicate": generic_text_read_predicate_filter(),
+            },
             limit=1000,
         )
     )
+    rels = [
+        rel
+        for rel in rels
+        if not is_hidden_from_generic_text_reads(rel.get("predicate"))
+    ]
 
     if not rels:
         return {

--- a/src/backend/services/von_login_email_governance_service.py
+++ b/src/backend/services/von_login_email_governance_service.py
@@ -1,0 +1,1141 @@
+"""Governed organisation-administrator lifecycle for Von login emails.
+
+Login-email bindings authenticate a global Von person, so generic ontology
+tools must neither reveal nor mutate them.  This service exposes the smallest
+dedicated path: exact-organisation administrators can inspect a member's
+canonical bindings, while a bind request (including global uniqueness
+certification) or a removal that would change state additionally requires the
+actor to administer every organisation the target can enter (or to hold the
+separate global Von operational-administrator role).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from ..db.mongo_client import get_von_login_email_receipts_collection
+from ..security.access_control import (
+    LEGACY_IDENTITY_HEADER_ACTOR_SOURCE,
+    get_effective_user_concept_id_with_source,
+)
+from ..security.role_resolver import get_effective_permissions
+from .ontology_authority_membership_coordination_service import (
+    ontology_authority_membership_mutation_barrier,
+)
+from .ontology_publication_authority_service import OntologyMutationResourceBusy
+from .organisation_membership_service import (
+    get_user_memberships,
+    resolve_user_organisation_membership,
+)
+from .von_operational_administrator_service import (
+    is_live_von_operational_administrator,
+)
+from .von_user_authentication_service import (
+    LoginEmailBindingConflictError,
+    bind_von_login_email,
+    list_von_login_email_user_ids,
+    list_von_login_emails_for_user,
+    normalise_von_login_email,
+    remove_von_login_email,
+    von_login_email_binding_barrier,
+)
+
+READ_SCHEMA_VERSION = "von_login_email_bindings.v1"
+MUTATION_SCHEMA_VERSION = "von_login_email_management.v1"
+RECEIPT_SCHEMA_VERSION = "von_login_email_mutation_receipt.v1"
+_SUPPORTED_ACTIONS = {"bind", "remove"}
+_PENDING_RECONCILIATION_MIN_AGE = timedelta(seconds=35)
+_RECEIPT_PHASE_PRE_EFFECT = "pre_effect"
+_RECEIPT_PHASE_POSTCONDITION_PREEXISTING = "postcondition_preexisting"
+_RECEIPT_PHASE_EFFECT_MAY_HAVE_STARTED = "effect_may_have_started"
+_RECEIPT_PHASE_TERMINAL = "terminal"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalise_concept_id(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned.startswith("#V#") else f"#V#{cleaned.removeprefix('#')}"
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _sha256_json(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _error(
+    code: str,
+    message: str,
+    *,
+    schema_version: str = MUTATION_SCHEMA_VERSION,
+    effect_status: str = "not_started",
+    mutation_outcome: str = "not_started",
+    changed: bool | None = False,
+    **details: Any,
+) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "schema_version": schema_version,
+        "success": False,
+        "error_code": code,
+        "error": message,
+    }
+    if schema_version == MUTATION_SCHEMA_VERSION:
+        response.update(
+            {
+                "effect_status": effect_status,
+                "mutation_outcome": mutation_outcome,
+                "outcome_finality": (
+                    "terminal_not_started"
+                    if effect_status == "not_started"
+                    else "requires_canonical_reconciliation"
+                ),
+                "changed": changed,
+            }
+        )
+    response.update(details)
+    return response
+
+
+def _trusted_actor(
+    acting_actor_concept_id: object = None,
+) -> tuple[str | None, tuple[str, str] | None]:
+    try:
+        from ..integrations.internal_mcp.gateway import (
+            internal_mcp_actor_context_is_untrusted_payload_fallback,
+        )
+
+        payload_identity_only = (
+            internal_mcp_actor_context_is_untrusted_payload_fallback()
+        )
+    except Exception:  # noqa: BLE001 - optional transport provenance probe
+        payload_identity_only = False
+    actor_id, source = get_effective_user_concept_id_with_source()
+    actor_id = _normalise_concept_id(actor_id)
+    claimed_actor = _normalise_concept_id(acting_actor_concept_id)
+    if payload_identity_only:
+        return None, (
+            "client_supplied_identity_is_not_authority",
+            "Client or model supplied identity cannot authorise login-email access.",
+        )
+    if not actor_id or source == LEGACY_IDENTITY_HEADER_ACTOR_SOURCE:
+        return None, (
+            "authenticated_actor_context_required",
+            "Von login-email access requires trusted actor provenance.",
+        )
+    if claimed_actor is not None and claimed_actor != actor_id:
+        return None, (
+            "actor_context_mismatch",
+            "The supplied actor does not match the trusted server actor.",
+        )
+    return actor_id, None
+
+
+def _exact_organisation_authority(
+    *,
+    actor_id: str,
+    user_id: str,
+    organisation_id: str,
+) -> tuple[dict[str, Any], tuple[str, str] | None]:
+    operational_admin = is_live_von_operational_administrator(actor_id)
+    actor_membership = resolve_user_organisation_membership(actor_id, organisation_id)
+    actor_role = (
+        str(actor_membership.get("role") or "member")
+        if isinstance(actor_membership, Mapping)
+        else None
+    )
+    actor_permissions = get_effective_permissions(actor_role or "")
+    allowed = operational_admin or "MANAGE_MEMBERS" in actor_permissions
+    decision = {
+        "allowed": allowed,
+        "actor_concept_id": actor_id,
+        "organisation_concept_id": organisation_id,
+        "actor_role": actor_role,
+        "required_permissions": ["MANAGE_MEMBERS"],
+        "global_operational_administrator": operational_admin,
+        "authority_scope": "exact_organisation",
+    }
+    if not allowed:
+        return decision, (
+            "organisation_login_identity_management_authority_required",
+            "A live organisation admin or owner must manage this member's login email.",
+        )
+    try:
+        target_membership = resolve_user_organisation_membership(
+            user_id, organisation_id
+        )
+    except (LookupError, ValueError):
+        target_membership = None
+    if not isinstance(target_membership, Mapping):
+        return decision, (
+            "target_organisation_membership_required",
+            "The target must be a represented member of the selected organisation.",
+        )
+    return decision, None
+
+
+def _global_mutation_authority(
+    *,
+    actor_id: str,
+    user_id: str,
+    exact_decision: Mapping[str, Any],
+) -> tuple[dict[str, Any], tuple[str, str] | None]:
+    if exact_decision.get("global_operational_administrator") is True:
+        return {
+            **dict(exact_decision),
+            "allowed": True,
+            "authority_scope": "global_operational_administrator",
+        }, None
+
+    membership_inventory = get_user_memberships(user_id)
+    target_memberships = (
+        membership_inventory.get("memberships")
+        if isinstance(membership_inventory, Mapping)
+        else None
+    )
+    expected_org_id = _normalise_concept_id(
+        exact_decision.get("organisation_concept_id")
+    )
+    if not isinstance(target_memberships, list) or expected_org_id is None:
+        return {
+            **dict(exact_decision),
+            "allowed": False,
+            "authority_scope": "all_target_organisations",
+            "all_target_organisations_covered": False,
+            "membership_inventory_complete": False,
+        }, (
+            "cross_organisation_login_identity_authority_required",
+            "Changing this global login identity requires member-management authority in every organisation the target can enter.",
+        )
+
+    represented_target_orgs: set[str] = set()
+    for membership in target_memberships:
+        if not isinstance(membership, Mapping):
+            return {
+                **dict(exact_decision),
+                "allowed": False,
+                "authority_scope": "all_target_organisations",
+                "all_target_organisations_covered": False,
+                "membership_inventory_complete": False,
+            }, (
+                "cross_organisation_login_identity_authority_required",
+                "Changing this global login identity requires member-management authority in every organisation the target can enter.",
+            )
+        target_org_id = _normalise_concept_id(membership.get("organisation_concept_id"))
+        if target_org_id is None:
+            return {
+                **dict(exact_decision),
+                "allowed": False,
+                "authority_scope": "all_target_organisations",
+                "all_target_organisations_covered": False,
+                "membership_inventory_complete": False,
+            }, (
+                "cross_organisation_login_identity_authority_required",
+                "Changing this global login identity requires member-management authority in every organisation the target can enter.",
+            )
+        represented_target_orgs.add(target_org_id)
+        actor_membership = resolve_user_organisation_membership(actor_id, target_org_id)
+        actor_role = (
+            str(actor_membership.get("role") or "member")
+            if isinstance(actor_membership, Mapping)
+            else None
+        )
+        if "MANAGE_MEMBERS" not in get_effective_permissions(actor_role or ""):
+            return {
+                **dict(exact_decision),
+                "allowed": False,
+                "authority_scope": "all_target_organisations",
+                "all_target_organisations_covered": False,
+                "membership_inventory_complete": True,
+            }, (
+                "cross_organisation_login_identity_authority_required",
+                "Changing this global login identity requires member-management authority in every organisation the target can enter.",
+            )
+    if expected_org_id not in represented_target_orgs:
+        return {
+            **dict(exact_decision),
+            "allowed": False,
+            "authority_scope": "all_target_organisations",
+            "all_target_organisations_covered": False,
+            "membership_inventory_complete": False,
+        }, (
+            "cross_organisation_login_identity_authority_required",
+            "Changing this global login identity requires member-management authority in every organisation the target can enter.",
+        )
+
+    return {
+        **dict(exact_decision),
+        "allowed": True,
+        "authority_scope": "all_target_organisations",
+        "all_target_organisations_covered": True,
+        "membership_inventory_complete": True,
+    }, None
+
+
+def get_von_login_email_bindings(
+    *,
+    user_concept_id: object,
+    organisation_concept_id: object,
+    acting_actor_concept_id: object = None,
+) -> dict[str, Any]:
+    """Read one organisation member's canonical login-email allow-list."""
+
+    actor_id, actor_error = _trusted_actor(acting_actor_concept_id)
+    if actor_error is not None:
+        return _error(*actor_error, schema_version=READ_SCHEMA_VERSION)
+    assert actor_id is not None
+    user_id = _normalise_concept_id(user_concept_id)
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    if user_id is None or organisation_id is None:
+        return _error(
+            "missing_parameter",
+            "user_concept_id and organisation_concept_id are required.",
+            schema_version=READ_SCHEMA_VERSION,
+        )
+    try:
+        with ontology_authority_membership_mutation_barrier():
+            authority_decision, denial = _exact_organisation_authority(
+                actor_id=actor_id,
+                user_id=user_id,
+                organisation_id=organisation_id,
+            )
+            if denial is not None:
+                return _error(
+                    *denial,
+                    schema_version=READ_SCHEMA_VERSION,
+                    authority_decision=authority_decision,
+                )
+            emails = list_von_login_emails_for_user(user_id)
+    except OntologyMutationResourceBusy:
+        return _error(
+            "ontology_mutation_resource_busy",
+            "Organisation authority is changing; retry the login-email read.",
+            schema_version=READ_SCHEMA_VERSION,
+        )
+    except (LookupError, ValueError):
+        return _error(
+            "target_organisation_membership_required",
+            "The target must be a represented member of the selected organisation.",
+            schema_version=READ_SCHEMA_VERSION,
+        )
+    canonical = {
+        "user_concept_id": user_id,
+        "organisation_concept_id": organisation_id,
+        "login_emails": emails,
+        "total_count": len(emails),
+    }
+    return {
+        "schema_version": READ_SCHEMA_VERSION,
+        "success": True,
+        "actor_concept_id": actor_id,
+        **canonical,
+        "authority_decision": authority_decision,
+        "canonical_read_back": canonical,
+    }
+
+
+def _receipt_collection():
+    collection = get_von_login_email_receipts_collection()
+    if collection is None:
+        raise RuntimeError("Von login-email receipt store unavailable")
+    return collection
+
+
+def _receipt_projection(document: Mapping[str, Any]) -> dict[str, Any]:
+    def serialise_time(value: object) -> object:
+        return value.isoformat() if isinstance(value, datetime) else value
+
+    return {
+        "schema_version": str(document.get("schema_version") or RECEIPT_SCHEMA_VERSION),
+        "receipt_id": document.get("receipt_id"),
+        "request_id": document.get("request_id"),
+        "actor_concept_id": document.get("actor_concept_id"),
+        "action": document.get("action"),
+        "user_concept_id": document.get("user_concept_id"),
+        "organisation_concept_id": document.get("organisation_concept_id"),
+        "email": document.get("email"),
+        "intent_fingerprint": document.get("intent_fingerprint"),
+        "status": document.get("status"),
+        "effect_phase": document.get("effect_phase"),
+        "mutation_outcome": document.get("mutation_outcome"),
+        "changed": document.get("changed"),
+        "error_code": document.get("error_code"),
+        "canonical_read_back": document.get("canonical_read_back"),
+        "canonical_read_back_sha256": document.get("canonical_read_back_sha256"),
+        "created_at": serialise_time(document.get("created_at")),
+        "updated_at": serialise_time(document.get("updated_at")),
+        "completed_at": serialise_time(document.get("completed_at")),
+    }
+
+
+def _begin_receipt(
+    *,
+    actor_id: str,
+    request_id: str,
+    action: str,
+    user_id: str,
+    organisation_id: str,
+    email: str,
+    reason: str | None,
+    intent_fingerprint: str,
+) -> tuple[dict[str, Any], bool]:
+    collection = _receipt_collection()
+    existing = collection.find_one(
+        {"actor_concept_id": actor_id, "request_id": request_id}
+    )
+    if isinstance(existing, Mapping):
+        return dict(existing), False
+    now = _now()
+    receipt_id = (
+        "vlr_" + hashlib.sha256(f"{actor_id}\x1f{request_id}".encode()).hexdigest()
+    )
+    document = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "actor_concept_id": actor_id,
+        "request_id": request_id,
+        "action": action,
+        "user_concept_id": user_id,
+        "organisation_concept_id": organisation_id,
+        "email": email,
+        "reason": reason,
+        "intent_fingerprint": intent_fingerprint,
+        "status": "pending",
+        "effect_phase": _RECEIPT_PHASE_PRE_EFFECT,
+        "mutation_outcome": "not_started",
+        "changed": False,
+        "created_at": now,
+        "updated_at": now,
+    }
+    try:
+        collection.insert_one(document)
+        return document, True
+    except DuplicateKeyError:
+        raced = collection.find_one(
+            {"actor_concept_id": actor_id, "request_id": request_id}
+        )
+        if not isinstance(raced, Mapping):
+            raise
+        return dict(raced), False
+
+
+def _finalise_receipt(
+    receipt_id: str,
+    *,
+    status: str,
+    mutation_outcome: str,
+    changed: bool | None,
+    canonical_read_back: Mapping[str, Any] | None,
+    authority_decision: Mapping[str, Any] | None,
+    response: Mapping[str, Any],
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    now = _now()
+    updated = _receipt_collection().find_one_and_update(
+        {"receipt_id": receipt_id, "status": "pending"},
+        {
+            "$set": {
+                "status": status,
+                "effect_phase": _RECEIPT_PHASE_TERMINAL,
+                "mutation_outcome": mutation_outcome,
+                "changed": changed,
+                "canonical_read_back": (
+                    dict(canonical_read_back)
+                    if isinstance(canonical_read_back, Mapping)
+                    else None
+                ),
+                "canonical_read_back_sha256": (
+                    _sha256_json(canonical_read_back)
+                    if isinstance(canonical_read_back, Mapping)
+                    else None
+                ),
+                "authority_decision": (
+                    dict(authority_decision)
+                    if isinstance(authority_decision, Mapping)
+                    else None
+                ),
+                "response_projection": dict(response),
+                "error_code": error_code,
+                "updated_at": now,
+                "completed_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(updated, Mapping):
+        updated = _receipt_collection().find_one({"receipt_id": receipt_id})
+    if not isinstance(updated, Mapping):
+        raise RuntimeError(  # noqa: TRY004 - missing receipt, not caller type
+            "Von login-email receipt finalisation failed"
+        )
+    return dict(updated)
+
+
+def _checkpoint_pending_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    effect_phase: str,
+    authority_decision: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Durably record the authority/effect phase before returning or writing."""
+
+    now = _now()
+    updated = _receipt_collection().find_one_and_update(
+        {
+            "receipt_id": receipt.get("receipt_id"),
+            "status": "pending",
+        },
+        {
+            "$set": {
+                "effect_phase": effect_phase,
+                "authority_decision": dict(authority_decision),
+                "effect_phase_updated_at": now,
+                "updated_at": now,
+            }
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not isinstance(updated, Mapping):
+        raise RuntimeError(  # noqa: TRY004 - missing receipt, not caller type
+            "Von login-email receipt checkpoint failed"
+        )
+    return dict(updated)
+
+
+def _response_with_receipt(
+    response: Mapping[str, Any], document: Mapping[str, Any]
+) -> dict[str, Any]:
+    return {**dict(response), "governance_receipt": _receipt_projection(document)}
+
+
+def _response_with_finalisation(
+    *,
+    initial_receipt: Mapping[str, Any],
+    response: Mapping[str, Any],
+    status: str,
+    mutation_outcome: str,
+    changed: bool | None,
+    canonical_read_back: Mapping[str, Any] | None,
+    authority_decision: Mapping[str, Any] | None,
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    try:
+        final = _finalise_receipt(
+            str(initial_receipt["receipt_id"]),
+            status=status,
+            mutation_outcome=mutation_outcome,
+            changed=changed,
+            canonical_read_back=canonical_read_back,
+            authority_decision=authority_decision,
+            response=response,
+            error_code=error_code,
+        )
+    except Exception as exc:  # noqa: BLE001 - canonical outcome still matters
+        pending_response = {
+            **dict(response),
+            "receipt_finalisation": "pending_reconciliation",
+            "receipt_finalisation_error": type(exc).__name__,
+            "outcome_finality": (
+                "canonical_effect_verified_receipt_pending"
+                if response.get("success") is True
+                else "requires_receipt_and_canonical_reconciliation"
+            ),
+        }
+        return _response_with_receipt(pending_response, initial_receipt)
+    return _response_with_receipt(response, final)
+
+
+def _pending_receipt_is_stale(receipt: Mapping[str, Any]) -> bool:
+    updated_at = receipt.get("updated_at") or receipt.get("created_at")
+    if not isinstance(updated_at, datetime):
+        return False
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=UTC)
+    else:
+        updated_at = updated_at.astimezone(UTC)
+    return _now() - updated_at >= _PENDING_RECONCILIATION_MIN_AGE
+
+
+def _reconcile_pending_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    if str(receipt.get("status") or "") != "pending":
+        return dict(receipt)
+    if not _pending_receipt_is_stale(receipt):
+        return dict(receipt)
+    effect_phase = str(receipt.get("effect_phase") or _RECEIPT_PHASE_PRE_EFFECT)
+    if effect_phase not in {
+        _RECEIPT_PHASE_POSTCONDITION_PREEXISTING,
+        _RECEIPT_PHASE_EFFECT_MAY_HAVE_STARTED,
+    }:
+        response = _error(
+            "von_login_email_mutation_not_started",
+            "The pending receipt did not cross a verified login-email effect boundary.",
+            reconciled_from_pending_receipt=True,
+        )
+        try:
+            return _finalise_receipt(
+                str(receipt["receipt_id"]),
+                status="failed",
+                mutation_outcome="not_started",
+                changed=False,
+                canonical_read_back=None,
+                authority_decision=None,
+                response=response,
+                error_code="von_login_email_mutation_not_started",
+            )
+        except Exception:  # noqa: BLE001 - preserve the durable pending record
+            return dict(receipt)
+
+    user_id = _normalise_concept_id(receipt.get("user_concept_id"))
+    organisation_id = _normalise_concept_id(receipt.get("organisation_concept_id"))
+    actor_id = _normalise_concept_id(receipt.get("actor_concept_id"))
+    action = _clean_text(receipt.get("action"))
+    recorded_authority = receipt.get("authority_decision")
+    try:
+        email = normalise_von_login_email(receipt.get("email"))
+    except ValueError:
+        return dict(receipt)
+    if (
+        user_id is None
+        or organisation_id is None
+        or actor_id is None
+        or action not in _SUPPORTED_ACTIONS
+        or not isinstance(recorded_authority, Mapping)
+        or recorded_authority.get("allowed") is not True
+    ):
+        return dict(receipt)
+    try:
+        with ontology_authority_membership_mutation_barrier():
+            reconciliation_authority, denial = _exact_organisation_authority(
+                actor_id=actor_id,
+                user_id=user_id,
+                organisation_id=organisation_id,
+            )
+            if denial is not None:
+                response = _error(
+                    "von_login_email_receipt_reconciliation_authority_required",
+                    "Current exact-organisation authority is required to reconcile this login-email receipt.",
+                    effect_status="indeterminate",
+                    mutation_outcome="indeterminate",
+                    changed=None,
+                    authority_decision=reconciliation_authority,
+                    canonical_read_back=None,
+                    reconciled_from_pending_receipt=True,
+                )
+                return _finalise_receipt(
+                    str(receipt["receipt_id"]),
+                    status="indeterminate",
+                    mutation_outcome="indeterminate",
+                    changed=None,
+                    canonical_read_back=None,
+                    authority_decision=dict(recorded_authority),
+                    response=response,
+                    error_code=(
+                        "von_login_email_receipt_reconciliation_authority_required"
+                    ),
+                )
+            with von_login_email_binding_barrier(email):
+                canonical, _ = _binding_observation(user_id, email)
+        postcondition_verified = _postcondition_holds(action, canonical)
+        response = {
+            "schema_version": MUTATION_SCHEMA_VERSION,
+            "success": postcondition_verified,
+            "effect_status": (
+                "succeeded" if postcondition_verified else "indeterminate"
+            ),
+            "mutation_outcome": (
+                "succeeded" if postcondition_verified else "indeterminate"
+            ),
+            "outcome_finality": (
+                "terminal_canonical_read_back"
+                if postcondition_verified
+                else "requires_canonical_reconciliation"
+            ),
+            "changed": None,
+            "action": action,
+            "actor_concept_id": actor_id,
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+            "email": email,
+            "canonical_read_back": canonical,
+            "reconciled_from_pending_receipt": True,
+            "reconciliation_authority_decision": reconciliation_authority,
+        }
+        return _finalise_receipt(
+            str(receipt["receipt_id"]),
+            status="succeeded" if postcondition_verified else "indeterminate",
+            mutation_outcome=(
+                "succeeded" if postcondition_verified else "indeterminate"
+            ),
+            changed=None,
+            canonical_read_back=canonical,
+            authority_decision=dict(recorded_authority),
+            response=response,
+            error_code=(
+                None
+                if postcondition_verified
+                else "von_login_email_postcondition_not_verified"
+            ),
+        )
+    except Exception:  # noqa: BLE001 - preserve the durable pending record
+        return dict(receipt)
+
+
+def _replay_or_conflict(
+    receipt: Mapping[str, Any], intent_fingerprint: str
+) -> dict[str, Any]:
+    if receipt.get("intent_fingerprint") != intent_fingerprint:
+        return _response_with_receipt(
+            _error(
+                "idempotency_request_conflict",
+                "This request_id is already bound to a different login-email intent.",
+            ),
+            receipt,
+        )
+    if receipt.get("status") == "pending":
+        receipt = _reconcile_pending_receipt(receipt)
+    if receipt.get("status") == "pending":
+        return _response_with_receipt(
+            _error(
+                "von_login_email_mutation_in_progress",
+                "The matching login-email effect is still in progress.",
+                effect_status="partial",
+                mutation_outcome="partial",
+                changed=None,
+            ),
+            receipt,
+        )
+    projection = receipt.get("response_projection")
+    if isinstance(projection, Mapping):
+        return _response_with_receipt(projection, receipt)
+    return _response_with_receipt(
+        _error(
+            "von_login_email_receipt_incomplete",
+            "The matching receipt exists but has no response projection.",
+            effect_status="indeterminate",
+            mutation_outcome="indeterminate",
+            changed=None,
+        ),
+        receipt,
+    )
+
+
+def _binding_observation(
+    user_id: str,
+    email: str,
+) -> tuple[dict[str, Any], bool]:
+    owners = list_von_login_email_user_ids(email)
+    binding_present = user_id in owners
+    canonical = {
+        "user_concept_id": user_id,
+        "email": email,
+        "binding_present": binding_present,
+    }
+    if binding_present:
+        canonical["binding_unambiguous"] = owners == [user_id]
+    return canonical, any(owner_id != user_id for owner_id in owners)
+
+
+def _postcondition_holds(action: str, canonical_state: Mapping[str, Any]) -> bool:
+    if action == "bind":
+        return (
+            canonical_state.get("binding_present") is True
+            and canonical_state.get("binding_unambiguous") is True
+        )
+    return canonical_state.get("binding_present") is False
+
+
+def _complete_failure(
+    *,
+    initial_receipt: Mapping[str, Any],
+    code: str,
+    message: str,
+    authority_decision: Mapping[str, Any] | None = None,
+    canonical_read_back: Mapping[str, Any] | None = None,
+    receipt_status: str = "failed",
+) -> dict[str, Any]:
+    response = _error(
+        code,
+        message,
+        authority_decision=authority_decision,
+        canonical_read_back=canonical_read_back,
+    )
+    return _response_with_finalisation(
+        initial_receipt=initial_receipt,
+        response=response,
+        status=receipt_status,
+        mutation_outcome="not_started",
+        changed=False,
+        canonical_read_back=canonical_read_back,
+        authority_decision=authority_decision,
+        error_code=code,
+    )
+
+
+def _successful_response(
+    *,
+    action: str,
+    actor_id: str,
+    user_id: str,
+    organisation_id: str,
+    email: str,
+    changed: bool,
+    authority_decision: Mapping[str, Any],
+    canonical_read_back: Mapping[str, Any],
+    reconciled_after_exception: str | None = None,
+) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "schema_version": MUTATION_SCHEMA_VERSION,
+        "success": True,
+        "effect_status": "succeeded",
+        "mutation_outcome": "succeeded",
+        "outcome_finality": "terminal_canonical_read_back",
+        "changed": changed,
+        "action": action,
+        "actor_concept_id": actor_id,
+        "user_concept_id": user_id,
+        "organisation_concept_id": organisation_id,
+        "email": email,
+        "authority_decision": dict(authority_decision),
+        "canonical_read_back": dict(canonical_read_back),
+    }
+    if not changed:
+        response["postcondition_preexisting"] = True
+    if reconciled_after_exception:
+        response["reconciled_after_exception"] = reconciled_after_exception
+    return response
+
+
+def manage_von_login_email(
+    *,
+    action: object,
+    user_concept_id: object,
+    organisation_concept_id: object,
+    email: object,
+    request_id: object,
+    reason: object = None,
+    acting_actor_concept_id: object = None,
+) -> dict[str, Any]:
+    """Bind or remove one member login email with authority and read-back."""
+
+    actor_id, actor_error = _trusted_actor(acting_actor_concept_id)
+    if actor_error is not None:
+        return _error(*actor_error)
+    assert actor_id is not None
+    action_value = _clean_text(action)
+    user_id = _normalise_concept_id(user_concept_id)
+    organisation_id = _normalise_concept_id(organisation_concept_id)
+    request_value = _clean_text(request_id)
+    reason_value = _clean_text(reason)
+    if action_value not in _SUPPORTED_ACTIONS:
+        return _error(
+            "invalid_von_login_email_action",
+            "action must be bind or remove.",
+        )
+    if user_id is None or organisation_id is None or request_value is None:
+        return _error(
+            "missing_parameter",
+            "user_concept_id, organisation_concept_id, and request_id are required.",
+        )
+    if len(request_value) > 256:
+        return _error(
+            "invalid_request_id",
+            "request_id must be at most 256 characters.",
+        )
+    if reason_value is not None and len(reason_value) > 1000:
+        return _error("invalid_reason", "reason must be at most 1000 characters.")
+    try:
+        email_value = normalise_von_login_email(email)
+    except ValueError:
+        return _error("login_email_invalid", "A valid login email is required.")
+
+    intent = {
+        "action": action_value,
+        "user_concept_id": user_id,
+        "organisation_concept_id": organisation_id,
+        "email": email_value,
+    }
+    intent_fingerprint = _sha256_json(intent)
+    receipt, created = _begin_receipt(
+        actor_id=actor_id,
+        request_id=request_value,
+        action=action_value,
+        user_id=user_id,
+        organisation_id=organisation_id,
+        email=email_value,
+        reason=reason_value,
+        intent_fingerprint=intent_fingerprint,
+    )
+    if not created:
+        return _replay_or_conflict(receipt, intent_fingerprint)
+
+    mutation_started = False
+    authority_decision: dict[str, Any] | None = None
+    before: dict[str, Any] | None = None
+    try:
+        with ontology_authority_membership_mutation_barrier():
+            authority_decision, denial = _exact_organisation_authority(
+                actor_id=actor_id,
+                user_id=user_id,
+                organisation_id=organisation_id,
+            )
+            if denial is not None:
+                return _complete_failure(
+                    initial_receipt=receipt,
+                    code=denial[0],
+                    message=denial[1],
+                    authority_decision=authority_decision,
+                    receipt_status="denied",
+                )
+
+            with von_login_email_binding_barrier(email_value):
+                target_bound = email_value in list_von_login_emails_for_user(user_id)
+                before = {
+                    "user_concept_id": user_id,
+                    "email": email_value,
+                    "binding_present": target_bound,
+                }
+                if action_value == "bind" or target_bound:
+                    authority_decision, cross_org_denial = _global_mutation_authority(
+                        actor_id=actor_id,
+                        user_id=user_id,
+                        exact_decision=authority_decision,
+                    )
+                    if cross_org_denial is not None:
+                        return _complete_failure(
+                            initial_receipt=receipt,
+                            code=cross_org_denial[0],
+                            message=cross_org_denial[1],
+                            authority_decision=authority_decision,
+                            canonical_read_back=before,
+                            receipt_status="denied",
+                        )
+
+                    before, other_binding = _binding_observation(user_id, email_value)
+                    if action_value == "bind" and other_binding:
+                        return _complete_failure(
+                            initial_receipt=receipt,
+                            code="von_login_email_binding_unavailable",
+                            message=(
+                                "The requested login-email binding cannot be applied."
+                            ),
+                            authority_decision=authority_decision,
+                            canonical_read_back=before,
+                            receipt_status="denied",
+                        )
+
+                requested_state_preexists = (
+                    action_value == "bind" and before["binding_present"] is True
+                ) or (action_value == "remove" and before["binding_present"] is False)
+                if requested_state_preexists:
+                    receipt = _checkpoint_pending_receipt(
+                        receipt,
+                        effect_phase=_RECEIPT_PHASE_POSTCONDITION_PREEXISTING,
+                        authority_decision=authority_decision,
+                    )
+                    response = _successful_response(
+                        action=action_value,
+                        actor_id=actor_id,
+                        user_id=user_id,
+                        organisation_id=organisation_id,
+                        email=email_value,
+                        changed=False,
+                        authority_decision=authority_decision,
+                        canonical_read_back=before,
+                    )
+                    return _response_with_finalisation(
+                        initial_receipt=receipt,
+                        response=response,
+                        status="succeeded",
+                        mutation_outcome="succeeded",
+                        changed=False,
+                        canonical_read_back=before,
+                        authority_decision=authority_decision,
+                    )
+
+                receipt = _checkpoint_pending_receipt(
+                    receipt,
+                    effect_phase=_RECEIPT_PHASE_EFFECT_MAY_HAVE_STARTED,
+                    authority_decision=authority_decision,
+                )
+                mutation_started = True
+                if action_value == "bind":
+                    write_result = bind_von_login_email(
+                        user_concept_id=user_id,
+                        email=email_value,
+                        provenance={
+                            "authorised_by_actor_concept_id": actor_id,
+                            "organisation_concept_id": organisation_id,
+                            "request_id": request_value,
+                            "reason": reason_value,
+                        },
+                    )
+                    changed = bool(write_result.get("relation_created"))
+                else:
+                    write_result = remove_von_login_email(
+                        user_concept_id=user_id,
+                        email=email_value,
+                    )
+                    changed = bool(write_result.get("removed"))
+                canonical, _ = _binding_observation(user_id, email_value)
+                if not _postcondition_holds(action_value, canonical):
+                    raise RuntimeError("von_login_email_postcondition_not_met")
+                response = _successful_response(
+                    action=action_value,
+                    actor_id=actor_id,
+                    user_id=user_id,
+                    organisation_id=organisation_id,
+                    email=email_value,
+                    changed=changed,
+                    authority_decision=authority_decision,
+                    canonical_read_back=canonical,
+                )
+                return _response_with_finalisation(
+                    initial_receipt=receipt,
+                    response=response,
+                    status="succeeded",
+                    mutation_outcome="succeeded",
+                    changed=changed,
+                    canonical_read_back=canonical,
+                    authority_decision=authority_decision,
+                )
+    except LoginEmailBindingConflictError:
+        return _complete_failure(
+            initial_receipt=receipt,
+            code="von_login_email_binding_unavailable",
+            message="The requested login-email binding cannot be applied.",
+            authority_decision=authority_decision,
+            canonical_read_back=before,
+        )
+    except Exception as exc:  # noqa: BLE001 - reconcile after possible effect
+        canonical = None
+        if mutation_started:
+            try:
+                canonical, _ = _binding_observation(user_id, email_value)
+            except Exception:  # noqa: BLE001 - receipt records uncertainty
+                canonical = None
+        if (
+            mutation_started
+            and isinstance(canonical, Mapping)
+            and _postcondition_holds(action_value, canonical)
+        ):
+            changed = canonical != before
+            response = _successful_response(
+                action=action_value,
+                actor_id=actor_id,
+                user_id=user_id,
+                organisation_id=organisation_id,
+                email=email_value,
+                changed=changed,
+                authority_decision=authority_decision or {},
+                canonical_read_back=canonical,
+                reconciled_after_exception=type(exc).__name__,
+            )
+            return _response_with_finalisation(
+                initial_receipt=receipt,
+                response=response,
+                status="succeeded",
+                mutation_outcome="succeeded",
+                changed=changed,
+                canonical_read_back=canonical,
+                authority_decision=authority_decision,
+            )
+
+        effect_may_have_crossed = mutation_started
+        error_code = (
+            "ontology_mutation_resource_busy"
+            if isinstance(exc, OntologyMutationResourceBusy)
+            else "von_login_email_mutation_failed"
+        )
+        response = _error(
+            error_code,
+            (
+                "The login-email resource is busy; retry with the same request."
+                if isinstance(exc, OntologyMutationResourceBusy)
+                else "The login-email effect could not be canonically verified."
+            ),
+            effect_status="indeterminate" if effect_may_have_crossed else "not_started",
+            mutation_outcome=(
+                "indeterminate" if effect_may_have_crossed else "not_started"
+            ),
+            changed=None if effect_may_have_crossed else False,
+            authority_decision=authority_decision,
+            canonical_read_back=canonical,
+        )
+        return _response_with_finalisation(
+            initial_receipt=receipt,
+            response=response,
+            status="indeterminate" if effect_may_have_crossed else "failed",
+            mutation_outcome=(
+                "indeterminate" if effect_may_have_crossed else "not_started"
+            ),
+            changed=None if effect_may_have_crossed else False,
+            canonical_read_back=canonical,
+            authority_decision=authority_decision,
+            error_code=error_code,
+        )
+
+
+def get_von_login_email_management_receipt(
+    *,
+    receipt_id: object,
+    acting_actor_concept_id: object = None,
+) -> dict[str, Any]:
+    """Read one actor-owned login-email management receipt."""
+
+    actor_id, actor_error = _trusted_actor(acting_actor_concept_id)
+    if actor_error is not None:
+        return _error(*actor_error)
+    assert actor_id is not None
+    receipt_value = _clean_text(receipt_id)
+    if receipt_value is None:
+        return _error("receipt_id_required", "receipt_id is required.")
+    document = _receipt_collection().find_one(
+        {"receipt_id": receipt_value, "actor_concept_id": actor_id}
+    )
+    if not isinstance(document, Mapping):
+        return _error(
+            "von_login_email_management_receipt_not_found",
+            "No matching actor-owned login-email receipt was found.",
+        )
+    if str(document.get("status") or "") == "pending":
+        document = _reconcile_pending_receipt(document)
+    response = document.get("response_projection")
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "success": True,
+        "governance_receipt": _receipt_projection(document),
+        "response_projection": (
+            dict(response) if isinstance(response, Mapping) else None
+        ),
+    }
+
+
+__all__ = [
+    "MUTATION_SCHEMA_VERSION",
+    "READ_SCHEMA_VERSION",
+    "RECEIPT_SCHEMA_VERSION",
+    "get_von_login_email_bindings",
+    "get_von_login_email_management_receipt",
+    "manage_von_login_email",
+]

--- a/src/backend/services/von_user_authentication_service.py
+++ b/src/backend/services/von_user_authentication_service.py
@@ -11,10 +11,12 @@ most one user; ambiguous or stale bindings fail closed.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from hashlib import sha256
 import logging
 import re
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from hashlib import sha256
 from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
@@ -24,6 +26,7 @@ from ..db.repositories.text_value_repository import (
 )
 from ..security.access_control import bypass_access_control
 from .exceptions import MultipleUsersForEmailError
+from .ontology_publication_authority_service import ontology_mutation_resource_lock
 from .text_value_service import (
     delete_text_relation_by_predicate_and_text,
     upsert_text_for_concept,
@@ -36,6 +39,11 @@ GENERIC_EMAIL_PREDICATE = "#V#has_email"
 PREDICATE_SPECIALISATION_PREDICATE = "#V#predicate_specialises_predicate"
 
 _LOGIN_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+$")
+_LOGIN_EMAIL_RESOURCE_PREFIX = "von-login-email-binding:v1:"
+_LOGIN_EMAIL_RESOURCE_STACK: ContextVar[tuple[str, ...]] = ContextVar(
+    "von_login_email_resource_stack",
+    default=(),
+)
 
 
 class LoginEmailBindingConflictError(RuntimeError):
@@ -66,11 +74,60 @@ def login_email_log_fingerprint(value: object) -> str:
     return sha256(normalised.encode("utf-8")).hexdigest()[:12]
 
 
+@contextmanager
+def von_login_email_binding_barrier(email: object) -> Iterator[None]:
+    """Serialise every writer of one normalised login identity.
+
+    The context-local stack makes the barrier re-entrant so a governed caller
+    can hold it across its authority/check/write/read-back boundary while the
+    low-level bind or remove primitive independently protects migration and
+    other trusted callers.
+    """
+
+    normalised_email = normalise_von_login_email(email)
+    resource_hash = sha256(normalised_email.encode("utf-8")).hexdigest()
+    resource_key = f"{_LOGIN_EMAIL_RESOURCE_PREFIX}{resource_hash}"
+    stack = _LOGIN_EMAIL_RESOURCE_STACK.get()
+    if resource_key in stack:
+        yield
+        return
+    token = _LOGIN_EMAIL_RESOURCE_STACK.set((*stack, resource_key))
+    try:
+        with ontology_mutation_resource_lock(resource_key):
+            yield
+    finally:
+        _LOGIN_EMAIL_RESOURCE_STACK.reset(token)
+
+
 def _normalise_concept_id(value: object) -> str | None:
     if not isinstance(value, str) or not value.strip():
         return None
     concept_id = value.strip()
     return concept_id if concept_id.startswith("#V#") else f"#V#{concept_id}"
+
+
+def _require_login_email_store() -> None:
+    if (
+        TextValuesRepository.collection() is None
+        or TextRelationsRepository.collection() is None
+    ):
+        raise RuntimeError("von_login_email_store_unavailable")
+
+
+def _mark_login_email_search_projections_stale(user_concept_id: str) -> None:
+    """Best-effort removal of login identities from legacy concept embeddings."""
+
+    try:
+        from .concept_embedding_service import mark_concept_embedding_stale
+
+        mark_concept_embedding_stale(user_concept_id)
+        mark_concept_embedding_stale(LOGIN_EMAIL_PREDICATE)
+    except Exception as exc:  # noqa: BLE001 - derived projection is best effort
+        logger.warning(
+            "Could not mark Von login-email search projections stale user=%s error=%s",
+            user_concept_id,
+            type(exc).__name__,
+        )
 
 
 def _login_email_text_value_ids(email: str) -> list[Any]:
@@ -93,6 +150,7 @@ def list_von_login_email_user_ids(email: object) -> list[str]:
     """Return every subject explicitly bound to the normalised login email."""
 
     normalised_email = normalise_von_login_email(email)
+    _require_login_email_store()
     text_value_ids = _login_email_text_value_ids(normalised_email)
     if not text_value_ids:
         return []
@@ -111,6 +169,45 @@ def list_von_login_email_user_ids(email: object) -> list[str]:
         is not None
     }
     return sorted(user_ids)
+
+
+def list_von_login_emails_for_user(user_concept_id: object) -> list[str]:
+    """Return the canonical login-email allow-list for one exact Von user.
+
+    This is a trusted identity-service read.  Callers must establish their own
+    authority before exposing the result; ordinary concept visibility is
+    deliberately not widened to reveal authentication identifiers.
+    """
+
+    normalised_user_id = _normalise_concept_id(user_concept_id)
+    if normalised_user_id is None:
+        raise ValueError("user_concept_id_required")
+    _require_login_email_store()
+    relations = TextRelationsRepository.find(
+        {
+            "subject_concept_id": normalised_user_id,
+            "predicate": LOGIN_EMAIL_PREDICATE,
+        },
+        projection={"_id": 0, "object_text_id": 1},
+    )
+    emails: set[str] = set()
+    for relation in relations:
+        if not isinstance(relation, Mapping):
+            continue
+        text_value = TextValuesRepository.find_one_by_id(
+            relation.get("object_text_id"),
+            projection={"_id": 0, "text": 1},
+        )
+        if not isinstance(text_value, Mapping):
+            continue
+        try:
+            emails.add(normalise_von_login_email(text_value.get("text")))
+        except ValueError:
+            logger.error(
+                "Ignoring invalid stored Von login-email binding user=%s",
+                normalised_user_id,
+            )
+    return sorted(emails)
 
 
 def find_user_concept_by_login_email(email: object) -> dict[str, Any] | None:
@@ -166,32 +263,34 @@ def bind_von_login_email(
     if not isinstance(user, Mapping):
         raise ValueError(f"user_concept_not_found:{normalised_user_id}")
 
-    existing_user_ids = list_von_login_email_user_ids(normalised_email)
-    conflicting_user_ids = [
-        concept_id
-        for concept_id in existing_user_ids
-        if concept_id != normalised_user_id
-    ]
-    if conflicting_user_ids:
-        raise LoginEmailBindingConflictError(
-            normalised_email,
-            conflicting_user_ids,
-        )
+    with von_login_email_binding_barrier(normalised_email):
+        existing_user_ids = list_von_login_email_user_ids(normalised_email)
+        conflicting_user_ids = [
+            concept_id
+            for concept_id in existing_user_ids
+            if concept_id != normalised_user_id
+        ]
+        if conflicting_user_ids:
+            raise LoginEmailBindingConflictError(
+                normalised_email,
+                conflicting_user_ids,
+            )
 
-    with bypass_access_control():
-        write_result = upsert_text_for_concept(
-            subject_concept_id=normalised_user_id,
-            predicate=LOGIN_EMAIL_PREDICATE,
-            text=normalised_email,
-            provenance={
-                "source": "von_login_email_binding",
-                **dict(provenance or {}),
-            },
-        )
+        with bypass_access_control():
+            write_result = upsert_text_for_concept(
+                subject_concept_id=normalised_user_id,
+                predicate=LOGIN_EMAIL_PREDICATE,
+                text=normalised_email,
+                provenance={
+                    "source": "von_login_email_binding",
+                    **dict(provenance or {}),
+                },
+            )
 
-    read_back_user_ids = list_von_login_email_user_ids(normalised_email)
-    if read_back_user_ids != [normalised_user_id]:
-        raise RuntimeError("von_login_email_binding_read_back_failed")
+        read_back_user_ids = list_von_login_email_user_ids(normalised_email)
+        if read_back_user_ids != [normalised_user_id]:
+            raise RuntimeError("von_login_email_binding_read_back_failed")
+    _mark_login_email_search_projections_stale(normalised_user_id)
     return {
         "success": True,
         "user_concept_id": normalised_user_id,
@@ -212,24 +311,26 @@ def remove_von_login_email(
     if normalised_user_id is None:
         raise ValueError("user_concept_id_required")
     normalised_email = normalise_von_login_email(email)
-    existing_user_ids = list_von_login_email_user_ids(normalised_email)
-    if normalised_user_id not in existing_user_ids:
-        return {
-            "success": True,
-            "user_concept_id": normalised_user_id,
-            "email": normalised_email,
-            "removed": False,
-        }
+    with von_login_email_binding_barrier(normalised_email):
+        existing_user_ids = list_von_login_email_user_ids(normalised_email)
+        if normalised_user_id not in existing_user_ids:
+            return {
+                "success": True,
+                "user_concept_id": normalised_user_id,
+                "email": normalised_email,
+                "removed": False,
+            }
 
-    with bypass_access_control():
-        delete_text_relation_by_predicate_and_text(
-            normalised_user_id,
-            LOGIN_EMAIL_PREDICATE,
-            normalised_email,
-            garbage_collect=False,
-        )
-    if normalised_user_id in list_von_login_email_user_ids(normalised_email):
-        raise RuntimeError("von_login_email_revocation_read_back_failed")
+        with bypass_access_control():
+            delete_text_relation_by_predicate_and_text(
+                normalised_user_id,
+                LOGIN_EMAIL_PREDICATE,
+                normalised_email,
+                garbage_collect=False,
+            )
+        if normalised_user_id in list_von_login_email_user_ids(normalised_email):
+            raise RuntimeError("von_login_email_revocation_read_back_failed")
+    _mark_login_email_search_projections_stale(normalised_user_id)
     return {
         "success": True,
         "user_concept_id": normalised_user_id,
@@ -241,12 +342,14 @@ def remove_von_login_email(
 __all__ = [
     "GENERIC_EMAIL_PREDICATE",
     "LOGIN_EMAIL_PREDICATE",
-    "LoginEmailBindingConflictError",
     "PREDICATE_SPECIALISATION_PREDICATE",
+    "LoginEmailBindingConflictError",
     "bind_von_login_email",
     "find_user_concept_by_login_email",
     "list_von_login_email_user_ids",
+    "list_von_login_emails_for_user",
     "login_email_log_fingerprint",
     "normalise_von_login_email",
     "remove_von_login_email",
+    "von_login_email_binding_barrier",
 ]

--- a/src/backend/services/vontology_concept_stats_service.py
+++ b/src/backend/services/vontology_concept_stats_service.py
@@ -19,13 +19,18 @@ import logging
 import threading
 import time
 from collections import defaultdict
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..db.repositories.concepts_repository import ConceptsRepository
 from ..db.repositories.text_value_repository import TextRelationsRepository
 from ..security.access_control import cache_scope_key
 from ..utils.time_utils import utc_iso_now
 from ..vontology.utils_vontology import is_predicate, is_pure_instance, is_type
+from .text_relation_read_policy import (
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +79,11 @@ def _scope_status(state: Mapping[str, Any], current_version: int) -> str:
         return STATS_STATUS_AVAILABLE
     if bool(state.get("is_rebuilding")):
         return STATS_STATUS_REBUILDING
-    if has_snapshot and isinstance(snapshot_version, int) and snapshot_version < current_version:
+    if (
+        has_snapshot
+        and isinstance(snapshot_version, int)
+        and snapshot_version < current_version
+    ):
         return STATS_STATUS_STALE
     return STATS_STATUS_FAILED
 
@@ -99,9 +108,7 @@ def _relationship_value_cardinality(raw: Any) -> int:
     if isinstance(raw, str):
         return 1 if raw.strip() else 0
     if isinstance(raw, list):
-        return sum(
-            1 for item in raw if isinstance(item, str) and bool(item.strip())
-        )
+        return sum(1 for item in raw if isinstance(item, str) and bool(item.strip()))
     return 0
 
 
@@ -153,9 +160,13 @@ def _compute_snapshot_for_scope() -> tuple[dict[str, dict[str, Any]], dict[str, 
     for concept_id, relationships in relationships_by_id.items():
         # Predicate extents from concept->concept relationship payloads.
         for predicate, value in relationships.items():
-            if isinstance(predicate, str) and predicate.startswith("#V#"):
-                relationship_extent_counts[predicate] += _relationship_value_cardinality(
-                    value
+            if (
+                isinstance(predicate, str)
+                and predicate.startswith("#V#")
+                and not is_hidden_from_generic_text_reads(predicate)
+            ):
+                relationship_extent_counts[predicate] += (
+                    _relationship_value_cardinality(value)
                 )
 
         # Type hierarchy for subtype/ancestor computations.
@@ -253,7 +264,14 @@ def _compute_snapshot_for_scope() -> tuple[dict[str, dict[str, Any]], dict[str, 
     else:
         try:
             pipeline = [
-                {"$match": {"predicate": {"$regex": r"^#V#"}}},
+                {
+                    "$match": {
+                        "predicate": {
+                            "$regex": r"^#V#",
+                            **generic_text_read_predicate_filter(),
+                        }
+                    }
+                },
                 {"$group": {"_id": "$predicate", "count": {"$sum": 1}}},
             ]
             for row in TextRelationsRepository.aggregate(pipeline):
@@ -261,7 +279,11 @@ def _compute_snapshot_for_scope() -> tuple[dict[str, dict[str, Any]], dict[str, 
                     continue
                 predicate = row.get("_id")
                 count_raw = row.get("count")
-                if isinstance(predicate, str) and isinstance(count_raw, (int, float)):
+                if (
+                    isinstance(predicate, str)
+                    and isinstance(count_raw, (int, float))
+                    and not is_hidden_from_generic_text_reads(predicate)
+                ):
                     text_extent_counts[predicate] = int(count_raw)
         except Exception as exc:  # pragma: no cover - defensive
             text_extent_available = False
@@ -272,7 +294,9 @@ def _compute_snapshot_for_scope() -> tuple[dict[str, dict[str, Any]], dict[str, 
         entry: dict[str, Any] = {"kind": kind}
 
         if kind == "type":
-            direct_instance_count = int(direct_instance_count_by_type.get(concept_id, 0))
+            direct_instance_count = int(
+                direct_instance_count_by_type.get(concept_id, 0)
+            )
             direct_pure_instance_count = int(
                 direct_pure_instance_count_by_type.get(concept_id, 0)
             )
@@ -452,7 +476,9 @@ def get_vontology_concept_stats(
             current_version = _MUTATION_VERSION
             status = _scope_status(state, current_version)
         if status != STATS_STATUS_AVAILABLE:
-            rebuild_vontology_concept_stats_snapshot(scope_key=scope, reason="on_demand")
+            rebuild_vontology_concept_stats_snapshot(
+                scope_key=scope, reason="on_demand"
+            )
 
     with _STATE_LOCK:
         state = _SCOPE_STATE.setdefault(scope, _new_scope_state())
@@ -569,4 +595,3 @@ def _reset_vontology_concept_stats_cache_for_tests() -> None:
     with _STATE_LOCK:
         _SCOPE_STATE.clear()
         _MUTATION_VERSION = 0
-

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -6825,6 +6825,139 @@ def test_possible_duplicate_review_intent_discovers_uncertain_assertion_lifecycl
         tool_metadata_service.invalidate_cache()
 
 
+def test_login_email_admin_intent_discovers_canonical_read_and_effect(
+    monkeypatch,
+) -> None:
+    from src.backend.integrations.internal_mcp import build_default_catalogue
+    from src.backend.services import tool_metadata_service
+
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(read_timeout_sec=1.0),
+        enabled=True,
+    )
+    trusted = {
+        "actor_user_concept_id": "#V#actor",
+        "actor_organisation_concept_id": "#V#organisation",
+        "turn_id": "login-email-turn",
+    }
+    monkeypatch.setattr(tool_metadata_service, "_load_from_vontology", dict)
+    tool_metadata_service.invalidate_cache()
+    try:
+        delegated = ordinary_turn_capability_delegation(
+            gateway,
+            user_concept_id="#V#actor",
+            trusted_argument_values=trusted,
+        )
+        assert "get_von_login_email_bindings" in delegated
+        assert "manage_von_login_email_binding" in delegated
+        assert "get_von_login_email_management_receipt" in delegated
+
+        without_organisation = ordinary_turn_capability_delegation(
+            gateway,
+            user_concept_id="#V#actor",
+            trusted_argument_values={
+                "actor_user_concept_id": "#V#actor",
+                "actor_organisation_concept_id": None,
+                "turn_id": "login-email-turn",
+            },
+        )
+        assert "get_von_login_email_bindings" not in without_organisation
+        assert "manage_von_login_email_binding" not in without_organisation
+
+        write_discovery = _capability_catalogue(
+            gateway,
+            delegated,
+            {"query": "set that as his Von login address", "limit": 50},
+        )
+        write_by_name = {
+            item["name"]: item for item in write_discovery["capabilities"]
+        }
+        assert write_by_name["manage_von_login_email_binding"]["query_match"] is True
+
+        read_discovery = _capability_catalogue(
+            gateway,
+            delegated,
+            {"query": "what is his Von login email address", "limit": 50},
+        )
+        read_by_name = {
+            item["name"]: item for item in read_discovery["capabilities"]
+        }
+        assert read_by_name["get_von_login_email_bindings"]["query_match"] is True
+
+        exact = _capability_catalogue(
+            gateway,
+            delegated,
+            {
+                "names": [
+                    "get_von_login_email_bindings",
+                    "manage_von_login_email_binding",
+                ]
+            },
+        )
+        exact_by_name = {item["name"]: item for item in exact["capabilities"]}
+        read = exact_by_name["get_von_login_email_bindings"]
+        mutation = exact_by_name["manage_von_login_email_binding"]
+        assert read["semantic_effect"] is False
+        assert mutation["semantic_effect"] is True
+        assert read["server_bound_arguments"] == [
+            "acting_actor_concept_id",
+            "organisation_concept_id",
+        ]
+        assert mutation["server_bound_arguments"] == [
+            "acting_actor_concept_id",
+            "organisation_concept_id",
+            "request_id",
+        ]
+        assert set(read["input_schema"]["properties"]) == {"user_concept_id"}
+        assert set(mutation["input_schema"]["properties"]) == {
+            "action",
+            "email",
+            "reason",
+            "user_concept_id",
+        }
+
+        read_payload = _trusted_tool_payload(
+            gateway=gateway,
+            tool_name="get_von_login_email_bindings",
+            model_payload={
+                "acting_actor_concept_id": "#V#attacker",
+                "organisation_concept_id": "#V#attacker_organisation",
+                "user_concept_id": "#V#target",
+            },
+            trusted_argument_values=trusted,
+        )
+        assert read_payload == {
+            "acting_actor_concept_id": "#V#actor",
+            "organisation_concept_id": "#V#organisation",
+            "user_concept_id": "#V#target",
+        }
+
+        mutation_payload = _trusted_tool_payload(
+            gateway=gateway,
+            tool_name="manage_von_login_email_binding",
+            model_payload={
+                "action": "bind",
+                "acting_actor_concept_id": "#V#attacker",
+                "email": "target@example.com",
+                "organisation_concept_id": "#V#attacker_organisation",
+                "request_id": "attacker-controlled-request",
+                "user_concept_id": "#V#target",
+            },
+            trusted_argument_values=trusted,
+        )
+        assert mutation_payload == {
+            "action": "bind",
+            "acting_actor_concept_id": "#V#actor",
+            "email": "target@example.com",
+            "organisation_concept_id": "#V#organisation",
+            "request_id": "login-email-turn",
+            "user_concept_id": "#V#target",
+        }
+    finally:
+        tool_metadata_service.invalidate_cache()
+
+
 def test_capability_metadata_failure_does_not_remove_delegated_reads(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_concept_embedding_service.py
+++ b/tests/backend/test_concept_embedding_service.py
@@ -116,6 +116,59 @@ class TestBuildConceptSearchableText:
         # The ID is always included
         assert "test concept" in text.lower()
 
+    def test_individual_relation_sample_excludes_login_identity(self, monkeypatch):
+        from src.backend.services import concept_embedding_service as service
+
+        captured = {}
+
+        def find_relations(query, **_kwargs):
+            captured["query"] = query
+            # Return a hidden row despite the query so output filtering is also
+            # exercised against imperfect repository doubles/backends.
+            return [
+                {
+                    "predicate": "#V#hasVonLoginEmail",
+                    "object_text_id": "secret-text",
+                },
+                {
+                    "predicate": "#V#hasNote",
+                    "object_text_id": "public-text",
+                },
+            ]
+
+        monkeypatch.setattr(service.TextRelationsRepository, "find", find_relations)
+        monkeypatch.setattr(
+            service.TextValuesRepository,
+            "find_one",
+            lambda query: {
+                "text": (
+                    "private@example.org"
+                    if query["_id"] == "secret-text"
+                    else "Visible note"
+                )
+            },
+        )
+
+        rows = service._get_individual_relations_sample("#V#person")
+
+        assert rows == [{"predicate": "#V#hasNote", "object_text": "Visible note"}]
+        assert "#V#hasVonLoginEmail" in captured["query"]["predicate"]["$nin"]
+
+    def test_login_identity_predicate_embedding_has_no_extent_sample(
+        self, monkeypatch
+    ):
+        from src.backend.services import concept_embedding_service as service
+
+        monkeypatch.setattr(
+            service.TextRelationsRepository,
+            "find",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("hidden predicate extent must not be queried")
+            ),
+        )
+
+        assert service._get_predicate_extent_sample("#V#hasVonLoginEmail") == []
+
     def test_includes_normalized_id(self):
         """Searchable text should include the normalized concept_id."""
         concept_doc = {

--- a/tests/backend/test_concept_merge_service_text_relations.py
+++ b/tests/backend/test_concept_merge_service_text_relations.py
@@ -488,6 +488,34 @@ def test_merge_plan_rejects_authority_role_transfer(merge_store) -> None:
     assert result["error_code"] == "identity_consolidation_authority_lifecycle_required"
 
 
+def test_server_merge_plan_does_not_embed_target_login_email_value(
+    merge_store,
+) -> None:
+    concepts, text_relations, text_values = merge_store
+    source_id = "#V#duplicate_person"
+    target_id = "#V#canonical_person"
+    concepts.insert_many([_concept(source_id), _concept(target_id)])
+    _insert_text_relation(
+        text_relations,
+        text_values,
+        relation_id="login-binding",
+        subject_id=target_id,
+        predicate="#V#hasVonLoginEmail",
+        text_id="login-text",
+        text="private-login@example.test",
+    )
+
+    plan = merge_service.build_concept_merge_plan(source_id, target_id)
+
+    assert "private-login@example.test" not in repr(plan)
+    assert len(plan["target_text_relation_preconditions"]) == 1
+    precondition = plan["target_text_relation_preconditions"][0]
+    assert precondition["relation_id"] == "login-binding"
+    assert precondition["relation"]["predicate"] == "#V#hasVonLoginEmail"
+    assert "text_value" not in precondition
+    assert precondition["text_value_sha256"]
+
+
 def test_merge_plan_fails_non_disclosing_when_hidden_reference_would_change(
     merge_store,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/backend/test_concept_relation_service_uncertainty.py
+++ b/tests/backend/test_concept_relation_service_uncertainty.py
@@ -149,6 +149,117 @@ def test_find_relations_with_argument_uncertain_only_returns_uncertain_hits() ->
     assert payload["uncertainty_diagnostics"]["mode"] == "uncertain_only"
 
 
+def test_generic_subject_text_reads_and_incidence_hide_login_email_binding() -> None:
+    from src.backend.db.repositories.concepts_repository import ConceptsRepository
+    from src.backend.security.access_control import bypass_access_control
+    from src.backend.services.concept_relation_service import (
+        find_relations_with_argument,
+        get_predicate_incidence,
+    )
+    from src.backend.services.text_value_service import upsert_text_for_concept
+
+    concept_id = "#V#generic_relation_login_email_guard"
+    ConceptsRepository.insert_one({"concept_id": concept_id, "relationships": {}})
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            text="Visible person name",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="#V#hasVonLoginEmail",
+            text="private-login@example.test",
+            lang="en-NZ",
+        )
+
+        unfiltered = find_relations_with_argument(
+            concept_id,
+            argument_index="subject",
+            relation_kind="text",
+            include_concept_preview=False,
+        )
+        explicit = find_relations_with_argument(
+            concept_id,
+            argument_index="subject",
+            predicate_filter=["#V#hasVonLoginEmail"],
+            relation_kind="text",
+            include_concept_preview=False,
+        )
+        incidence = get_predicate_incidence(
+            concept_id=concept_id,
+            argument_index="subject",
+            relation_kind="text",
+            include_concept_preview=False,
+        )
+
+    assert [hit["predicate_concept_id"] for hit in unfiltered["hits"]] == [
+        "hasName"
+    ]
+    assert explicit["hits"] == []
+    assert explicit["total_hits"] == 0
+    assert [
+        row["predicate_concept_id"] for row in incidence["predicates"]
+    ] == ["hasName"]
+    assert "private-login@example.test" not in repr(
+        {"unfiltered": unfiltered, "explicit": explicit, "incidence": incidence}
+    )
+
+
+def test_generic_text_object_lookup_filters_hidden_predicate_at_query_and_output(
+    monkeypatch,
+) -> None:
+    from bson import ObjectId
+
+    from src.backend.services import concept_relation_service as service
+
+    text_value_id = ObjectId()
+    captured_query = {}
+
+    monkeypatch.setattr(
+        service,
+        "_load_accessible_relation_subject_document",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find",
+        lambda *_args, **_kwargs: [
+            {"_id": text_value_id, "text": "private-login@example.test"}
+        ],
+    )
+
+    def find_relations(query, **_kwargs):
+        captured_query.update(query)
+        # Returning a forbidden row despite the query exercises the output-side
+        # defence as well as asserting the repository constraint below.
+        return [
+            {
+                "subject_concept_id": "#V#target_user",
+                "predicate": "#V#hasVonLoginEmail",
+                "object_text_id": str(text_value_id),
+            }
+        ]
+
+    monkeypatch.setattr(service.TextRelationsRepository, "find", find_relations)
+
+    payload = service.find_relations_with_argument(
+        "private-login@example.test",
+        argument_index="object",
+        predicate_filter=["#V#hasVonLoginEmail"],
+        relation_kind="text",
+        include_concept_preview=False,
+    )
+
+    assert captured_query == {
+        "object_text_id": {"$in": [str(text_value_id)]},
+        "predicate": {"$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]},
+    }
+    assert payload["hits"] == []
+    assert payload["total_hits"] == 0
+
+
 def test_get_predicate_incidence_entity_mode_groups_distinct_predicates() -> None:
     from src.backend.db.repositories.concepts_repository import ConceptsRepository
     from src.backend.services.concept_relation_service import get_predicate_incidence

--- a/tests/backend/test_concept_search_text_relations.py
+++ b/tests/backend/test_concept_search_text_relations.py
@@ -92,6 +92,39 @@ def test_search_concepts_exact_match_normalises_internal_whitespace():
     assert _has_concept(result["results"], concept_id)
 
 
+def test_search_concepts_does_not_treat_login_email_as_a_name_relation():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#login_email_search_guard"
+    login_email = "private-login-search@example.test"
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            text="Visible Search Name",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="#V#hasVonLoginEmail",
+            text=login_email,
+            lang="en-NZ",
+        )
+        email_result = search_concepts(query=login_email, match_type="exact")
+        name_result = search_concepts(
+            query="Visible Search Name",
+            match_type="exact",
+        )
+
+    assert _has_concept(email_result["results"], concept_id) is False
+    assert _has_concept(name_result["results"], concept_id) is True
+
+
 def test_search_concepts_substring_match_finds_has_description_relation():
     if TextValuesRepository.db() is None:
         pytest.skip("MongoDB not configured for this test run")

--- a/tests/backend/test_internal_mcp_catalogue_builds.py
+++ b/tests/backend/test_internal_mcp_catalogue_builds.py
@@ -398,6 +398,7 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "conversation_inspect_batch",
         "conversation_manage",
         "conversation_manage_batch",
+        "get_von_login_email_management_receipt",
     } <= actor_without_org
 
     # Capabilities that can persist state remain write-category even when
@@ -426,6 +427,7 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "conversation_manage",
         "conversation_manage_batch",
         "manage_organisation_membership",
+        "manage_von_login_email_binding",
         "task_create",
         "task_update_status",
         "task_add_comment",
@@ -439,6 +441,8 @@ def test_ordinary_turn_read_projection_follows_capability_authority_metadata():
         "conversation_transcript_page",
         "conversation_inspect_batch",
         "conversation_manage",
+        "get_von_login_email_bindings",
+        "get_von_login_email_management_receipt",
     } <= actor_mail_reads
 
     message_send_definition = catalogue.get("message_send_direct")

--- a/tests/backend/test_login_email_predicate_extent_containment.py
+++ b/tests/backend/test_login_email_predicate_extent_containment.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from src.backend.server.routes import predicate_routes
+
+
+def test_generic_predicate_extent_hides_login_identity_without_store_access(
+    monkeypatch,
+) -> None:
+    def unexpected_store_access(*_args, **_kwargs):
+        raise AssertionError("hidden predicate extent must not query storage")
+
+    monkeypatch.setattr(
+        predicate_routes,
+        "_query_text_relations_extent",
+        unexpected_store_access,
+    )
+    monkeypatch.setattr(
+        predicate_routes,
+        "_query_structured_relations_extent",
+        unexpected_store_access,
+    )
+
+    result = predicate_routes.get_predicate_extent_data(
+        concept_id="#V#hasVonLoginEmail",
+        limit=25,
+        offset=10,
+    )
+
+    assert result == {
+        "concept_id": "#V#hasVonLoginEmail",
+        "extent": [],
+        "total_count": 0,
+        "limit": 25,
+        "offset": 10,
+        "has_more": False,
+        "sampled": False,
+    }
+
+
+def test_generic_predicate_extent_hides_sample_and_statistics(monkeypatch) -> None:
+    def unexpected_store_access(*_args, **_kwargs):
+        raise AssertionError("hidden predicate statistics must not query storage")
+
+    monkeypatch.setattr(
+        predicate_routes,
+        "get_text_relations_collection",
+        unexpected_store_access,
+    )
+    monkeypatch.setattr(
+        predicate_routes,
+        "get_concepts_collection",
+        unexpected_store_access,
+    )
+
+    sampled = predicate_routes.get_predicate_extent_data(
+        concept_id="#V#hasVonLoginEmail",
+        sample_size=5,
+    )
+
+    assert sampled["extent"] == []
+    assert sampled["total_count"] == 0
+    assert sampled["sampled"] is True
+    assert sampled["sample_size"] == 5
+    assert predicate_routes._calculate_extent_statistics("#V#hasVonLoginEmail") == {
+        "total_uses": 0,
+        "unique_subjects": 0,
+        "unique_objects": 0,
+    }
+
+
+def test_non_sensitive_predicate_extent_keeps_existing_query_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        predicate_routes,
+        "_query_text_relations_extent",
+        lambda *_args, **_kwargs: ([{"predicate": "#V#hasName"}], 1),
+    )
+    monkeypatch.setattr(
+        predicate_routes,
+        "_query_structured_relations_extent",
+        lambda *_args, **_kwargs: ([], 0),
+    )
+
+    result = predicate_routes.get_predicate_extent_data(
+        concept_id="#V#hasName",
+        source_filter="text_relations",
+    )
+
+    assert result["extent"] == [{"predicate": "#V#hasName"}]
+    assert result["total_count"] == 1

--- a/tests/backend/test_rag_provenance_contract.py
+++ b/tests/backend/test_rag_provenance_contract.py
@@ -177,6 +177,74 @@ def test_search_knowledge_base_derives_permissions_context_from_namespace(monkey
     }
 
 
+def test_search_knowledge_base_filters_legacy_login_identity_projections(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    stub = _StubRAG(
+        results=[
+            {
+                "id": "text_relation:secret",
+                "score": 0.99,
+                "text": "private@example.org",
+                "metadata": {
+                    "type": "text_relation",
+                    "predicate": "#V#hasVonLoginEmail",
+                },
+            },
+            {
+                "id": "concept:#V#person",
+                "score": 0.98,
+                "text": (
+                    "Relations:\n"
+                    "  #V#hasVonLoginEmail: private@example.org"
+                ),
+                "metadata": {"type": "concept"},
+            },
+            {
+                "id": "concept:#V#public",
+                "score": 0.5,
+                "text": "Public represented knowledge",
+                "metadata": {"type": "concept"},
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: stub,
+    )
+
+    result = cat._search_knowledge_base(
+        query="private@example.org",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert [row["id"] for row in result["results"]] == ["concept:#V#public"]
+    assert "private@example.org" not in str(result["results"])
+
+
+def test_search_knowledge_base_does_not_query_hidden_predicate(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue as cat
+
+    def unexpected_backend_access(*_args, **_kwargs):
+        raise AssertionError("hidden generic predicate must not reach RAG")
+
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        unexpected_backend_access,
+    )
+
+    result = cat._search_knowledge_base(
+        query="private@example.org",
+        predicate="#V#hasVonLoginEmail",
+        namespace="#V#user@org",
+    )
+
+    assert result["success"] is True
+    assert result["results"] == []
+    assert result["count"] == 0
+
+
 def test_search_knowledge_base_rejects_conflicting_flask_actor(monkeypatch):
     from flask import Flask, session
 

--- a/tests/backend/test_rag_text_relation_sync_service.py
+++ b/tests/backend/test_rag_text_relation_sync_service.py
@@ -65,6 +65,89 @@ def test_text_relation_sync_requires_a_canonical_actor_namespace():
         svc._parse_namespace("user@org")
 
 
+def test_login_identity_relation_is_not_projected_or_previewed(monkeypatch):
+    from src.backend.services import rag_text_relation_sync_service as svc
+
+    relation_id = ObjectId()
+    hidden_relation = {
+        "_id": relation_id,
+        "subject_concept_id": "#V#person",
+        "predicate": "#V#hasVonLoginEmail",
+        "object_text_id": ObjectId(),
+    }
+    monkeypatch.setattr(
+        svc.TextRelationsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: hidden_relation,
+    )
+    monkeypatch.setattr(
+        svc.TextValuesRepository,
+        "find_one",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("hidden relation text must not be hydrated")
+        ),
+    )
+
+    assert (
+        svc._base_relation_to_rag_doc(
+            hidden_relation,
+            user_id="#V#user",
+            org_id="#V#org",
+            concept_allow=None,
+            language_allow=set(),
+            concept_visibility={},
+        )
+        is None
+    )
+    assert (
+        svc.get_text_relation_preview(
+            namespace="#V#user@org",
+            relation_id=str(relation_id),
+        )
+        is None
+    )
+
+
+def test_login_identity_relation_is_pruned_from_existing_rag_index(monkeypatch):
+    from src.backend.services import rag_text_relation_sync_service as svc
+
+    relation_id = ObjectId()
+    hidden_relation = {
+        "_id": relation_id,
+        "subject_concept_id": "#V#person",
+        "predicate": "#V#hasVonLoginEmail",
+        "object_text_id": ObjectId(),
+    }
+    monkeypatch.setattr(
+        svc.TextRelationsRepository,
+        "find",
+        lambda *_args, **_kwargs: iter([hidden_relation]),
+    )
+    monkeypatch.setattr(
+        svc.TextValuesRepository,
+        "find",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        svc,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        svc,
+        "_visible_concept_ids_in_namespace",
+        lambda concept_ids, **_kwargs: set(concept_ids),
+    )
+    rag = _StubRAG()
+    monkeypatch.setattr(svc, "get_rag_service", lambda: rag)
+
+    result = svc.sync_text_relations_to_rag(namespace="#V#user@org")
+
+    assert result["success"] is True
+    assert rag.upserts == []
+    assert rag.deletes == [f"text_relation:{relation_id}"]
+
+
 def test_one_pass_iterator_opens_each_store_once_and_batches_visibility(
     monkeypatch,
 ):

--- a/tests/backend/test_resolve_concept_by_text_relation.py
+++ b/tests/backend/test_resolve_concept_by_text_relation.py
@@ -78,6 +78,28 @@ def test_exact_predicate_and_text_resolve_one_visible_existing_concept(
     }
 
 
+def test_login_email_predicate_is_not_available_to_generic_text_resolution(
+    monkeypatch,
+) -> None:
+    def unexpected_query(*_args: Any, **_kwargs: Any):
+        raise AssertionError("hidden predicates must fail before repository lookup")
+
+    monkeypatch.setattr(service.TextValuesRepository, "find", unexpected_query)
+    monkeypatch.setattr(service.TextRelationsRepository, "find", unexpected_query)
+
+    result = service.resolve_concept_by_text_relation(
+        predicate="#V#hasVonLoginEmail",
+        text="private-login@example.test",
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "not_found"
+    assert result["resolved_concept_id"] is None
+    assert result["candidate_count"] == 0
+    assert result["candidates"] == []
+    assert result["resolution_complete"] is True
+
+
 def test_multiple_visible_matches_are_ambiguous_and_deterministic(
     monkeypatch,
 ) -> None:

--- a/tests/backend/test_scoped_assertion_service.py
+++ b/tests/backend/test_scoped_assertion_service.py
@@ -404,6 +404,72 @@ def test_visible_global_subject_accepts_user_scoped_text_assertion(monkeypatch):
     assert read_back["provenance"]["turn_id"] == "turn-1"
 
 
+def test_scoped_assertion_generic_write_rejects_login_identity_predicate(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from src.backend.services import scoped_assertion_service as service
+
+    monkeypatch.setattr(service, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        service,
+        "resolve_text_relation_predicate_for_write",
+        lambda _predicate: SimpleNamespace(
+            storage_predicate="#V#hasVonLoginEmail",
+            predicate_concept_id="#V#hasVonLoginEmail",
+        ),
+    )
+
+    with pytest.raises(PermissionError, match="dedicated Von login-email"):
+        service.upsert_scoped_assertion(
+            subject_concept_id="#V#person",
+            predicate="#V#hasVonLoginEmail",
+            target_text="private@example.test",
+            scope_mode="organisation",
+            acting_user_concept_id="#V#owner",
+            organisation_concept_id="#V#org",
+            namespace="#V#owner@org",
+        )
+
+
+def test_scoped_assertion_generic_reads_hide_stored_login_identity(monkeypatch):
+    from src.backend.services import scoped_assertion_service as service
+
+    collection = _collection()
+    hidden = _stored_text_assertion(
+        assertion_id="ska_hidden_login",
+        subject_concept_id="#V#person",
+    )
+    hidden["predicate"] = "#V#hasVonLoginEmail"
+    hidden["object_text"]["text"] = "private@example.test"
+    collection.insert_one(hidden)
+    monkeypatch.setattr(
+        service,
+        "get_scoped_knowledge_assertions_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+
+    assert service.list_visible_scoped_assertions(
+        user_concept_id="#V#author",
+        organisation_concept_id="#V#trusted_org",
+    ) == []
+    assert (
+        service.get_visible_scoped_assertion_by_id(
+            "ska_hidden_login",
+            user_concept_id="#V#author",
+            organisation_concept_id="#V#trusted_org",
+        )
+        is None
+    )
+    assert service.scoped_text_assertion_to_relation_row(hidden) is None
+
+
 def test_scoped_assertion_mutations_emit_actor_bound_content_free_events(monkeypatch):
     from src.backend.services import scoped_assertion_service as service
     from src.backend.services import workflow_event_integration_service as events

--- a/tests/backend/test_semantic_search_integration.py
+++ b/tests/backend/test_semantic_search_integration.py
@@ -63,6 +63,54 @@ class TestSemanticSearchFunction:
         )
         assert isinstance(results, list)
 
+    def test_semantic_search_ignores_legacy_login_identity_embedding(
+        self, monkeypatch
+    ):
+        from src.backend.services import concept_search_service as service
+        from src.backend.services.rag_backends import llamaindex_backend
+
+        class StubRAG:
+            def query(self, **_kwargs):
+                return [
+                    {
+                        "text": (
+                            "Relations:\n"
+                            "  hasVonLoginEmail: private@example.test"
+                        ),
+                        "score": 1.0,
+                        "metadata": {"concept_id": "#V#private_person"},
+                    },
+                    {
+                        "text": "Visible concept text",
+                        "score": 0.5,
+                        "metadata": {"concept_id": "#V#visible_person"},
+                    },
+                ]
+
+        monkeypatch.setattr(
+            llamaindex_backend,
+            "LlamaIndexRAGService",
+            StubRAG,
+        )
+        monkeypatch.setattr(
+            service.ConceptsRepository,
+            "find",
+            lambda *_args, **_kwargs: [
+                {
+                    "concept_id": "#V#private_person",
+                    "relationships": {},
+                },
+                {
+                    "concept_id": "#V#visible_person",
+                    "relationships": {},
+                },
+            ],
+        )
+
+        results = service._semantic_search("private@example.test", limit=10)
+
+        assert [row[0] for row in results] == ["#V#visible_person"]
+
 
 class TestSearchConceptsSemanticMatchType:
     """Tests for search_concepts with match_type='semantic'."""

--- a/tests/backend/test_text_relation_read_policy.py
+++ b/tests/backend/test_text_relation_read_policy.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from bson import ObjectId
+
+from src.backend.services import text_value_service
+from src.backend.services.text_relation_read_policy import (
+    GENERIC_TEXT_READ_HIDDEN_PREDICATES,
+    filter_generic_text_read_rows,
+    generic_text_read_predicate_filter,
+    is_hidden_from_generic_text_reads,
+    text_contains_hidden_generic_predicate,
+)
+
+
+def test_login_email_predicate_and_storage_alias_are_hidden() -> None:
+    assert {"#V#hasVonLoginEmail"} == GENERIC_TEXT_READ_HIDDEN_PREDICATES
+    assert is_hidden_from_generic_text_reads("#V#hasVonLoginEmail") is True
+    assert is_hidden_from_generic_text_reads("hasVonLoginEmail") is True
+    assert (
+        text_contains_hidden_generic_predicate(
+            "Relations: hasVonLoginEmail: private@example.test"
+        )
+        is True
+    )
+    assert is_hidden_from_generic_text_reads("#V#has_email") is False
+
+
+def test_query_filter_excludes_hidden_predicates_without_counting_them() -> None:
+    assert generic_text_read_predicate_filter() == {
+        "$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]
+    }
+    assert generic_text_read_predicate_filter(predicate="#V#hasVonLoginEmail") == {
+        "$in": []
+    }
+    assert generic_text_read_predicate_filter(
+        predicates=["hasName", "#V#hasVonLoginEmail"]
+    ) == {"$in": ["hasName"]}
+
+
+def test_materialised_row_filter_is_a_defence_in_depth() -> None:
+    rows = filter_generic_text_read_rows(
+        [
+            {"predicate": "hasName", "text": "Visible name"},
+            {
+                "predicate": "#V#hasVonLoginEmail",
+                "text": "private-login@example.test",
+            },
+        ]
+    )
+
+    assert rows == [{"predicate": "hasName", "text": "Visible name"}]
+
+
+def test_login_identity_mutations_never_reach_generic_workflow_events(
+    monkeypatch,
+) -> None:
+    from src.backend.services import workflow_event_integration_service
+
+    launched: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        text_value_service,
+        "get_event_workflow_integration_enabled",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        workflow_event_integration_service,
+        "resolve_event_actor_context",
+        lambda: ("#V#actor", "#V#organisation"),
+    )
+    monkeypatch.setattr(
+        workflow_event_integration_service,
+        "maybe_launch_vontology_mutation_workflow",
+        lambda **kwargs: launched.append(kwargs),
+    )
+
+    for event_type in ("text_relation.upserted", "text_relation.deleted"):
+        text_value_service._emit_text_relation_mutation_event(
+            event_type=event_type,
+            subject_concept_id="#V#target",
+            relation_id="relation-1",
+            predicate="#V#hasVonLoginEmail",
+            text="private@example.test",
+            lang="en-NZ",
+        )
+
+    assert launched == []
+
+    text_value_service._emit_text_relation_mutation_event(
+        event_type="text_relation.upserted",
+        subject_concept_id="#V#target",
+        relation_id="relation-2",
+        predicate="hasName",
+        text="Visible name",
+        lang="en-NZ",
+    )
+    assert launched[0]["event_payload"]["text"] == "Visible name"
+
+
+def test_generic_mutation_read_back_hides_login_identity(monkeypatch) -> None:
+    from src.backend.services import ontology_mutation_command_service as command
+
+    captured_query = {}
+    monkeypatch.setattr(command, "can_access_concept", lambda _concept_id: True)
+    monkeypatch.setattr(
+        command.ConceptsRepository,
+        "find_one",
+        lambda *_args, **_kwargs: {
+            "concept_id": "#V#person",
+            "relationships": {},
+        },
+    )
+
+    def find_relations(query):
+        captured_query.update(query)
+        return [
+            {
+                "predicate": "#V#hasVonLoginEmail",
+                "object_text_id": "secret",
+            },
+            {"predicate": "hasName", "object_text_id": "visible"},
+        ]
+
+    monkeypatch.setattr(command.TextRelationsRepository, "find", find_relations)
+    monkeypatch.setattr(
+        command.TextValuesRepository,
+        "find_one_by_id",
+        lambda text_id: {
+            "text": ("private@example.test" if text_id == "secret" else "Visible name"),
+            "lang": "en-NZ",
+        },
+    )
+    monkeypatch.setattr(
+        command,
+        "concept_publication_context",
+        lambda _concept_id: type(
+            "Context",
+            (),
+            {"to_mapping": lambda self: {"kind": "global"}},
+        )(),
+    )
+
+    result = command._concept_read_back("#V#person")
+
+    assert captured_query["predicate"] == {
+        "$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]
+    }
+    assert result["text_relations"] == [
+        {
+            "predicate": "hasName",
+            "text": "Visible name",
+            "language": "en-NZ",
+            "context": {},
+        }
+    ]
+    assert "private@example.test" not in repr(result)
+
+
+def test_generic_text_rows_and_summary_apply_hidden_query_constraint(
+    monkeypatch,
+) -> None:
+    concept_id = "#V#generic_read_policy_unit_target"
+    visible_text_id = ObjectId()
+    hidden_text_id = ObjectId()
+    relation_queries: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        text_value_service,
+        "filter_accessible_concept_ids",
+        lambda concept_ids: set(concept_ids),
+    )
+    monkeypatch.setattr(
+        text_value_service,
+        "can_access_concept",
+        lambda _concept_id: True,
+    )
+
+    def find_relations(query, **_kwargs):
+        relation_queries.append(query)
+        predicate_filter = query.get("predicate")
+        if predicate_filter == {"$in": []}:
+            return []
+        assert predicate_filter == {"$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]}
+        return [
+            {
+                "_id": ObjectId(),
+                "subject_concept_id": concept_id,
+                "predicate": "hasName",
+                "object_text_id": visible_text_id,
+            }
+        ]
+
+    monkeypatch.setattr(
+        text_value_service.TextRelationsRepository,
+        "find",
+        find_relations,
+    )
+
+    def find_text_values(query, **_kwargs):
+        requested_ids = query.get("_id", {}).get("$in", [])
+        assert hidden_text_id not in requested_ids
+        return [
+            {
+                "_id": visible_text_id,
+                "text": "Visible name",
+                "lang": "en-NZ",
+            }
+        ]
+
+    monkeypatch.setattr(
+        text_value_service.TextValuesRepository,
+        "find",
+        find_text_values,
+    )
+
+    metadata: dict[str, object] = {}
+    rows = text_value_service.get_texts_for_concepts(
+        [concept_id],
+        query_metadata=metadata,
+    )[concept_id]
+    explicit_hidden = text_value_service.get_texts_for_concept(
+        concept_id,
+        predicate="#V#hasVonLoginEmail",
+    )
+    summary = text_value_service.get_text_relations_summary(concept_id)
+    hidden_summary = text_value_service.get_text_relations_summary(
+        concept_id,
+        predicates=["#V#hasVonLoginEmail"],
+    )
+
+    assert [(row["predicate"], row["text"]) for row in rows] == [
+        ("hasName", "Visible name")
+    ]
+    assert metadata["raw_relation_count"] == 1
+    assert explicit_hidden == []
+    assert summary["groups_found"] == 1
+    assert summary["total_relations_scanned"] == 1
+    assert hidden_summary["groups"] == []
+    assert hidden_summary["total_relations_scanned"] == 0
+    assert [query["predicate"] for query in relation_queries] == [
+        {"$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]},
+        {"$in": []},
+        {"$nin": ["#V#hasVonLoginEmail", "hasVonLoginEmail"]},
+        {"$in": []},
+    ]

--- a/tests/backend/test_text_relations_summary_and_singleton.py
+++ b/tests/backend/test_text_relations_summary_and_singleton.py
@@ -9,7 +9,11 @@ from src.backend.db.repositories.text_value_repository import (
     TextValuesRepository,
 )
 from src.backend.security.access_control import bypass_access_control
+from src.backend.services.text_relation_read_policy import (
+    GENERIC_TEXT_READ_HIDDEN_PREDICATES,
+)
 from src.backend.services.text_value_service import (
+    audit_concept_text_relations,
     get_text_relations_summary,
     get_texts_for_concept,
     get_texts_for_concepts,
@@ -92,6 +96,74 @@ def test_get_text_relations_summary_groups_and_caps_relation_ids():
 
     assert len(en_group["relation_ids"]) <= 1
     assert len(fr_group["relation_ids"]) <= 1
+
+
+def test_generic_text_reads_and_summaries_hide_login_email_bindings():
+    if TextValuesRepository.db() is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concept_id = "#V#generic_text_read_login_email_guard"
+    login_predicate = next(iter(GENERIC_TEXT_READ_HIDDEN_PREDICATES))
+    login_email = "private-login@example.test"
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+    with bypass_access_control():
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasName",
+            text="Visible account name",
+            lang="en-NZ",
+        )
+        upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate=login_predicate,
+            text=login_email,
+            lang="en-NZ",
+        )
+
+        explicit_rows = get_texts_for_concept(
+            concept_id,
+            predicate=login_predicate,
+        )
+        query_metadata: dict[str, object] = {}
+        unfiltered_rows = get_texts_for_concepts(
+            [concept_id],
+            query_metadata=query_metadata,
+        )[concept_id]
+        unfiltered_summary = get_text_relations_summary(concept_id)
+        explicit_summary = get_text_relations_summary(
+            concept_id,
+            predicates=[login_predicate],
+        )
+        audit = audit_concept_text_relations(concept_id)
+
+    assert explicit_rows == []
+    assert [(row["predicate"], row["text"]) for row in unfiltered_rows] == [
+        ("hasName", "Visible account name")
+    ]
+    assert query_metadata["raw_relation_count"] == 1
+    assert query_metadata["relation_query_truncated"] is False
+    assert unfiltered_summary["groups_found"] == 1
+    assert unfiltered_summary["total_relations_scanned"] == 1
+    assert [group["predicate"] for group in unfiltered_summary["groups"]] == [
+        "hasName"
+    ]
+    assert explicit_summary["groups"] == []
+    assert explicit_summary["groups_found"] == 0
+    assert explicit_summary["total_relations_scanned"] == 0
+    assert [row["predicate"] for row in audit["relations"]] == ["hasName"]
+    assert audit["total_relations"] == 1
+    assert login_email not in repr(
+        {
+            "rows": unfiltered_rows,
+            "summary": unfiltered_summary,
+            "explicit_summary": explicit_summary,
+            "audit": audit,
+        }
+    )
 
 
 def test_upsert_singleton_text_relation_replaces_others_for_language():

--- a/tests/backend/test_von_login_email_governance_service.py
+++ b/tests/backend/test_von_login_email_governance_service.py
@@ -1,0 +1,835 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager, nullcontext
+from datetime import UTC, datetime, timedelta
+
+import mongomock
+import pytest
+
+from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import (
+    InternalMCPGateway,
+    InternalMCPTransport,
+)
+from src.backend.integrations.internal_mcp.tool_contract_registry import (
+    get_canonical_tool_registry,
+)
+from src.backend.services import von_login_email_governance_service as service
+
+
+@pytest.fixture()
+def governed_login_email(monkeypatch):
+    collection = mongomock.MongoClient()["test_von_db"][
+        "von_login_email_mutation_receipts"
+    ]
+    memberships: dict[tuple[str, str], str] = {
+        ("#V#actor", "#V#organisation"): "owner",
+        ("#V#target", "#V#organisation"): "member",
+    }
+    bindings: dict[str, set[str]] = {
+        "#V#target": {"existing@example.org"},
+    }
+    calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        service,
+        "get_von_login_email_receipts_collection",
+        lambda: collection,
+    )
+    monkeypatch.setattr(
+        service,
+        "get_effective_user_concept_id_with_source",
+        lambda: ("#V#actor", "trusted_in_process"),
+    )
+    monkeypatch.setattr(
+        service,
+        "ontology_authority_membership_mutation_barrier",
+        nullcontext,
+    )
+    monkeypatch.setattr(
+        service,
+        "von_login_email_binding_barrier",
+        lambda _email: nullcontext(),
+    )
+    monkeypatch.setattr(
+        service,
+        "is_live_von_operational_administrator",
+        lambda _actor_id: False,
+    )
+
+    def resolve_membership(user_id, organisation_id):
+        role = memberships.get((user_id, organisation_id))
+        if role is None:
+            return None
+        return {
+            "user_concept_id": user_id,
+            "organisation_concept_id": organisation_id,
+            "role": role,
+        }
+
+    def get_memberships(user_id):
+        return {
+            "memberships": [
+                {
+                    "user_concept_id": member_id,
+                    "organisation_concept_id": organisation_id,
+                    "role": role,
+                }
+                for (member_id, organisation_id), role in memberships.items()
+                if member_id == user_id
+            ]
+        }
+
+    def list_emails(user_concept_id):
+        return sorted(bindings.get(user_concept_id, set()))
+
+    def list_user_ids(email):
+        normalised_email = str(email).strip().casefold()
+        return sorted(
+            user_id
+            for user_id, user_bindings in bindings.items()
+            if normalised_email in user_bindings
+        )
+
+    def bind_email(*, user_concept_id, email, provenance=None):
+        del provenance
+        normalised_email = str(email).strip().casefold()
+        calls.append(("bind", user_concept_id, normalised_email))
+        user_bindings = bindings.setdefault(user_concept_id, set())
+        created = normalised_email not in user_bindings
+        user_bindings.add(normalised_email)
+        return {
+            "success": True,
+            "user_concept_id": user_concept_id,
+            "email": normalised_email,
+            "relation_created": created,
+            "read_back_user_concept_id": user_concept_id,
+        }
+
+    def remove_email(*, user_concept_id, email):
+        normalised_email = str(email).strip().casefold()
+        calls.append(("remove", user_concept_id, normalised_email))
+        user_bindings = bindings.setdefault(user_concept_id, set())
+        removed = normalised_email in user_bindings
+        user_bindings.discard(normalised_email)
+        return {
+            "success": True,
+            "user_concept_id": user_concept_id,
+            "email": normalised_email,
+            "removed": removed,
+        }
+
+    monkeypatch.setattr(
+        service, "resolve_user_organisation_membership", resolve_membership
+    )
+    monkeypatch.setattr(service, "get_user_memberships", get_memberships)
+    monkeypatch.setattr(service, "list_von_login_emails_for_user", list_emails)
+    monkeypatch.setattr(service, "list_von_login_email_user_ids", list_user_ids)
+    monkeypatch.setattr(service, "bind_von_login_email", bind_email)
+    monkeypatch.setattr(service, "remove_von_login_email", remove_email)
+
+    return {
+        "bindings": bindings,
+        "calls": calls,
+        "collection": collection,
+        "memberships": memberships,
+    }
+
+
+def _manage(**overrides):
+    arguments = {
+        "action": "bind",
+        "user_concept_id": "#V#target",
+        "organisation_concept_id": "#V#organisation",
+        "email": "new@example.org",
+        "request_id": "request-1",
+        "reason": "Manage an organisation member's login identity.",
+        "acting_actor_concept_id": "#V#actor",
+    }
+    arguments.update(overrides)
+    return service.manage_von_login_email(**arguments)
+
+
+@pytest.mark.parametrize("actor_role", ["owner", "admin"])
+def test_owner_and_admin_can_read_pre_existing_binding_in_exact_organisation(
+    governed_login_email,
+    actor_role,
+):
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = actor_role
+
+    result = service.get_von_login_email_bindings(
+        user_concept_id="#V#target",
+        organisation_concept_id="#V#organisation",
+        acting_actor_concept_id="#V#actor",
+    )
+
+    assert result["success"] is True
+    assert result["user_concept_id"] == "#V#target"
+    assert result["organisation_concept_id"] == "#V#organisation"
+    assert result["login_emails"] == ["existing@example.org"]
+    assert result["total_count"] == 1
+    assert result["authority_decision"]["allowed"] is True
+    assert result["authority_decision"]["actor_role"] == actor_role
+    assert result["authority_decision"]["required_permissions"] == ["MANAGE_MEMBERS"]
+    assert governed_login_email["calls"] == []
+
+
+def test_admin_read_holds_membership_barrier_through_authority_and_binding_read(
+    governed_login_email,
+    monkeypatch,
+):
+    barrier_state = {"held": False}
+    original_resolve = service.resolve_user_organisation_membership
+    original_list = service.list_von_login_emails_for_user
+
+    @contextmanager
+    def tracked_barrier():
+        assert barrier_state["held"] is False
+        barrier_state["held"] = True
+        try:
+            yield
+        finally:
+            barrier_state["held"] = False
+
+    def resolve_inside_barrier(user_id, organisation_id):
+        assert barrier_state["held"] is True
+        return original_resolve(user_id, organisation_id)
+
+    def list_inside_barrier(user_id):
+        assert barrier_state["held"] is True
+        return original_list(user_id)
+
+    monkeypatch.setattr(
+        service,
+        "ontology_authority_membership_mutation_barrier",
+        tracked_barrier,
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_user_organisation_membership",
+        resolve_inside_barrier,
+    )
+    monkeypatch.setattr(
+        service,
+        "list_von_login_emails_for_user",
+        list_inside_barrier,
+    )
+
+    result = service.get_von_login_email_bindings(
+        user_concept_id="#V#target",
+        organisation_concept_id="#V#organisation",
+        acting_actor_concept_id="#V#actor",
+    )
+
+    assert result["success"] is True
+    assert result["login_emails"] == ["existing@example.org"]
+    assert barrier_state["held"] is False
+
+
+def test_bind_is_receipted_canonically_read_back_and_idempotent(
+    governed_login_email,
+):
+    first = _manage()
+    second = _manage()
+
+    assert first["success"] is True
+    assert first["effect_status"] == "succeeded"
+    assert first["mutation_outcome"] == "succeeded"
+    assert first["outcome_finality"] == "terminal_canonical_read_back"
+    assert first["changed"] is True
+    assert first["canonical_read_back"]["user_concept_id"] == "#V#target"
+    assert first["canonical_read_back"]["email"] == "new@example.org"
+    assert first["canonical_read_back"]["binding_present"] is True
+    assert first["governance_receipt"]["status"] == "succeeded"
+    assert second == first
+    assert governed_login_email["calls"] == [("bind", "#V#target", "new@example.org")]
+
+
+def test_binding_that_already_exists_is_a_successful_no_op(governed_login_email):
+    result = _manage(email=" Existing@Example.ORG ")
+
+    assert result["success"] is True
+    assert result["effect_status"] == "succeeded"
+    assert result["changed"] is False
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert result["canonical_read_back"]["email"] == "existing@example.org"
+    assert result["governance_receipt"]["status"] == "succeeded"
+    assert governed_login_email["calls"] == []
+
+
+def test_remove_is_receipted_canonically_read_back_and_idempotent(
+    governed_login_email,
+):
+    first = _manage(
+        action="remove",
+        email="existing@example.org",
+        request_id="remove-1",
+    )
+    second = _manage(
+        action="remove",
+        email="existing@example.org",
+        request_id="remove-1",
+    )
+
+    assert first["success"] is True
+    assert first["effect_status"] == "succeeded"
+    assert first["changed"] is True
+    assert first["canonical_read_back"]["binding_present"] is False
+    assert first["governance_receipt"]["status"] == "succeeded"
+    assert second == first
+    assert governed_login_email["calls"] == [
+        ("remove", "#V#target", "existing@example.org")
+    ]
+
+
+def test_member_is_denied_without_leaking_existing_login_email(
+    governed_login_email,
+):
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = "member"
+
+    read = service.get_von_login_email_bindings(
+        user_concept_id="#V#target",
+        organisation_concept_id="#V#organisation",
+        acting_actor_concept_id="#V#actor",
+    )
+    mutation = _manage(email="candidate@example.org")
+
+    assert read["success"] is False
+    assert (
+        read["error_code"]
+        == "organisation_login_identity_management_authority_required"
+    )
+    assert "existing@example.org" not in json.dumps(read, sort_keys=True)
+    assert mutation["success"] is False
+    assert (
+        mutation["error_code"]
+        == "organisation_login_identity_management_authority_required"
+    )
+    assert "existing@example.org" not in json.dumps(mutation, sort_keys=True)
+    assert mutation["governance_receipt"]["status"] == "denied"
+    assert governed_login_email["calls"] == []
+
+
+def test_membership_barrier_contention_cannot_trigger_unauthorised_read(
+    governed_login_email,
+    monkeypatch,
+):
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = "member"
+
+    @contextmanager
+    def busy_membership_barrier():
+        raise service.OntologyMutationResourceBusy("busy")
+        yield
+
+    monkeypatch.setattr(
+        service,
+        "ontology_authority_membership_mutation_barrier",
+        busy_membership_barrier,
+    )
+    monkeypatch.setattr(
+        service,
+        "_binding_observation",
+        lambda *_args, **_kwargs: pytest.fail(
+            "authority failure must not trigger a binding read"
+        ),
+    )
+
+    result = _manage(email="existing@example.org", request_id="busy-membership")
+
+    assert result["success"] is False
+    assert result["error_code"] == "ontology_mutation_resource_busy"
+    assert result["effect_status"] == "not_started"
+    assert result["canonical_read_back"] is None
+    assert "existing@example.org" not in json.dumps(
+        result.get("canonical_read_back"), sort_keys=True
+    )
+
+
+def test_target_must_be_a_member_of_the_exact_organisation(governed_login_email):
+    governed_login_email["memberships"].pop(("#V#target", "#V#organisation"))
+
+    result = _manage()
+
+    assert result["success"] is False
+    assert result["error_code"] == "target_organisation_membership_required"
+    assert result["effect_status"] == "not_started"
+    assert result["governance_receipt"]["status"] == "denied"
+    assert governed_login_email["calls"] == []
+
+
+def test_actor_authority_is_exact_to_the_requested_organisation(
+    governed_login_email,
+):
+    governed_login_email["memberships"][("#V#target", "#V#other_org")] = "member"
+
+    result = _manage(organisation_concept_id="#V#other_org")
+
+    assert result["success"] is False
+    assert (
+        result["error_code"]
+        == "organisation_login_identity_management_authority_required"
+    )
+    assert result["authority_decision"]["organisation_concept_id"] == "#V#other_org"
+    assert result["governance_receipt"]["status"] == "denied"
+    assert governed_login_email["calls"] == []
+
+
+def test_cross_organisation_principal_mutation_requires_authority_in_every_org(
+    governed_login_email,
+):
+    governed_login_email["memberships"][("#V#target", "#V#other_org")] = "member"
+
+    result = _manage()
+
+    assert result["success"] is False
+    assert (
+        result["error_code"] == "cross_organisation_login_identity_authority_required"
+    )
+    assert result["effect_status"] == "not_started"
+    assert result["governance_receipt"]["status"] == "denied"
+    assert governed_login_email["calls"] == []
+
+
+def test_cross_org_denial_does_not_reveal_global_email_occupancy(
+    governed_login_email,
+):
+    governed_login_email["memberships"][("#V#target", "#V#other_org")] = "member"
+    governed_login_email["bindings"]["#V#outside_person"] = {"claimed@example.org"}
+
+    occupied = _manage(
+        email="claimed@example.org",
+        request_id="cross-org-occupied",
+    )
+    unoccupied = _manage(
+        email="unclaimed@example.org",
+        request_id="cross-org-unoccupied",
+    )
+
+    for result in (occupied, unoccupied):
+        assert result["success"] is False
+        assert (
+            result["error_code"]
+            == "cross_organisation_login_identity_authority_required"
+        )
+        assert result["canonical_read_back"]["binding_present"] is False
+        assert result["governance_receipt"]["status"] == "denied"
+    assert "#V#outside_person" not in json.dumps(occupied, sort_keys=True)
+    assert governed_login_email["calls"] == []
+
+
+@pytest.mark.parametrize(
+    "malformed_inventory",
+    [
+        {"memberships": "not-a-list"},
+        {"memberships": [None]},
+        {"memberships": [{"role": "member"}]},
+        {"memberships": []},
+    ],
+)
+def test_global_mutation_authority_fails_closed_on_malformed_inventory(
+    governed_login_email,
+    monkeypatch,
+    malformed_inventory,
+):
+    monkeypatch.setattr(
+        service,
+        "get_user_memberships",
+        lambda _user_id: malformed_inventory,
+    )
+
+    result = _manage(request_id="malformed-membership-inventory")
+
+    assert result["success"] is False
+    assert (
+        result["error_code"] == "cross_organisation_login_identity_authority_required"
+    )
+    assert result["effect_status"] == "not_started"
+    assert result["authority_decision"]["membership_inventory_complete"] is False
+    assert result["governance_receipt"]["status"] == "denied"
+    assert governed_login_email["calls"] == []
+
+
+def test_pre_existing_bind_requires_global_identity_authority_to_certify_no_op(
+    governed_login_email,
+):
+    governed_login_email["memberships"][("#V#target", "#V#other_org")] = "member"
+
+    result = _manage(email="existing@example.org")
+
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert (
+        result["error_code"] == "cross_organisation_login_identity_authority_required"
+    )
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert governed_login_email["calls"] == []
+
+
+def test_ambiguous_pre_existing_bind_is_not_certified_as_success(
+    governed_login_email,
+):
+    governed_login_email["bindings"]["#V#outside_person"] = {"existing@example.org"}
+
+    result = _manage(email="existing@example.org")
+
+    assert result["success"] is False
+    assert result["error_code"] == "von_login_email_binding_unavailable"
+    assert result["effect_status"] == "not_started"
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert result["canonical_read_back"]["binding_unambiguous"] is False
+    assert "#V#outside_person" not in json.dumps(result, sort_keys=True)
+    assert governed_login_email["calls"] == []
+
+
+def test_conflicting_binding_does_not_disclose_other_identity(
+    governed_login_email,
+):
+    governed_login_email["bindings"]["#V#outside_person"] = {"claimed@example.org"}
+
+    result = _manage(email="claimed@example.org")
+
+    assert result["success"] is False
+    assert result["error_code"] == "von_login_email_binding_unavailable"
+    assert "#V#outside_person" not in json.dumps(result, sort_keys=True)
+    assert result["canonical_read_back"] == {
+        "user_concept_id": "#V#target",
+        "email": "claimed@example.org",
+        "binding_present": False,
+    }
+    assert result["governance_receipt"]["status"] == "denied"
+    serialised = json.dumps(result, sort_keys=True)
+    assert "bound_user_count" not in serialised
+    assert "binding_unambiguous" not in serialised
+    assert governed_login_email["calls"] == []
+
+
+def test_foreign_bound_remove_no_op_does_not_reveal_account_occupancy(
+    governed_login_email,
+):
+    governed_login_email["bindings"]["#V#outside_person"] = {"claimed@example.org"}
+
+    result = _manage(
+        action="remove",
+        email="claimed@example.org",
+        request_id="remove-foreign",
+    )
+
+    assert result["success"] is True
+    assert result["changed"] is False
+    assert result["canonical_read_back"] == {
+        "user_concept_id": "#V#target",
+        "email": "claimed@example.org",
+        "binding_present": False,
+    }
+    serialised = json.dumps(result, sort_keys=True)
+    assert "#V#outside_person" not in serialised
+    assert "bound_user_count" not in serialised
+    assert "binding_unambiguous" not in serialised
+
+
+def test_cross_org_mutation_succeeds_when_actor_administers_every_target_org(
+    governed_login_email,
+):
+    governed_login_email["memberships"].update(
+        {
+            ("#V#target", "#V#other_org"): "member",
+            ("#V#actor", "#V#other_org"): "admin",
+        }
+    )
+
+    result = _manage()
+
+    assert result["success"] is True
+    assert result["changed"] is True
+    assert result["authority_decision"]["all_target_organisations_covered"] is True
+    assert governed_login_email["calls"] == [("bind", "#V#target", "new@example.org")]
+
+
+def test_global_operational_admin_can_manage_member_without_org_membership(
+    governed_login_email,
+    monkeypatch,
+):
+    governed_login_email["memberships"].pop(("#V#actor", "#V#organisation"))
+    monkeypatch.setattr(
+        service,
+        "is_live_von_operational_administrator",
+        lambda _actor_id: True,
+    )
+
+    result = _manage()
+
+    assert result["success"] is True
+    assert result["authority_decision"]["authority_scope"] == (
+        "global_operational_administrator"
+    )
+    assert governed_login_email["calls"] == [("bind", "#V#target", "new@example.org")]
+
+
+def test_gateway_payload_identity_cannot_authorise_login_email_mutation(
+    governed_login_email,
+):
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+    result = gateway.invoke(
+        "manage_von_login_email_binding",
+        {
+            "action": "bind",
+            "user_concept_id": "#V#target",
+            "organisation_concept_id": "#V#organisation",
+            "email": "new@example.org",
+            "request_id": "untrusted-payload-attempt",
+        },
+    ).payload
+
+    assert result["success"] is False
+    assert result["error_code"] == "client_supplied_identity_is_not_authority"
+    assert governed_login_email["calls"] == []
+    assert governed_login_email["collection"].count_documents({}) == 0
+
+
+def test_management_receipt_read_is_actor_bound(
+    governed_login_email,
+    monkeypatch,
+):
+    mutation = _manage()
+    receipt_id = mutation["governance_receipt"]["receipt_id"]
+
+    owned = service.get_von_login_email_management_receipt(
+        receipt_id=receipt_id,
+        acting_actor_concept_id="#V#actor",
+    )
+    assert owned["success"] is True
+    assert owned["governance_receipt"]["canonical_read_back"]["binding_present"] is True
+
+    monkeypatch.setattr(
+        service,
+        "get_effective_user_concept_id_with_source",
+        lambda: ("#V#other_actor", "trusted_in_process"),
+    )
+    hidden = service.get_von_login_email_management_receipt(
+        receipt_id=receipt_id,
+        acting_actor_concept_id="#V#other_actor",
+    )
+
+    assert hidden["success"] is False
+    assert hidden["error_code"] == "von_login_email_management_receipt_not_found"
+
+
+def test_exception_after_binding_is_reconciled_from_canonical_state(
+    governed_login_email,
+    monkeypatch,
+):
+    def bind_then_raise(*, user_concept_id, email, provenance=None):
+        del provenance
+        normalised_email = str(email).strip().casefold()
+        governed_login_email["bindings"].setdefault(user_concept_id, set()).add(
+            normalised_email
+        )
+        governed_login_email["calls"].append(
+            ("bind", user_concept_id, normalised_email)
+        )
+        raise RuntimeError("transport interrupted")
+
+    monkeypatch.setattr(service, "bind_von_login_email", bind_then_raise)
+
+    result = _manage()
+
+    assert result["success"] is True
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert result["reconciled_after_exception"] == "RuntimeError"
+    assert result["governance_receipt"]["status"] == "succeeded"
+
+
+def test_value_error_after_binding_is_reconciled_from_canonical_state(
+    governed_login_email,
+    monkeypatch,
+):
+    def bind_then_raise(*, user_concept_id, email, provenance=None):
+        del provenance
+        normalised_email = str(email).strip().casefold()
+        governed_login_email["bindings"].setdefault(user_concept_id, set()).add(
+            normalised_email
+        )
+        governed_login_email["calls"].append(
+            ("bind", user_concept_id, normalised_email)
+        )
+        raise ValueError("post-write response failed")
+
+    monkeypatch.setattr(service, "bind_von_login_email", bind_then_raise)
+
+    result = _manage()
+
+    assert result["success"] is True
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert result["reconciled_after_exception"] == "ValueError"
+    assert result["governance_receipt"]["status"] == "succeeded"
+
+
+def test_receipt_finalisation_outage_preserves_canonical_success_and_reconciles(
+    governed_login_email,
+    monkeypatch,
+):
+    original_finalise = service._finalise_receipt
+
+    def unavailable_finalisation(*_args, **_kwargs):
+        raise RuntimeError("receipt store update unavailable")
+
+    monkeypatch.setattr(service, "_finalise_receipt", unavailable_finalisation)
+
+    result = _manage()
+
+    assert result["success"] is True
+    assert result["canonical_read_back"]["binding_present"] is True
+    assert result["outcome_finality"] == "canonical_effect_verified_receipt_pending"
+    assert result["receipt_finalisation"] == "pending_reconciliation"
+    assert result["governance_receipt"]["status"] == "pending"
+    assert result["governance_receipt"]["effect_phase"] == "effect_may_have_started"
+
+    monkeypatch.setattr(service, "_finalise_receipt", original_finalise)
+    monkeypatch.setattr(service, "_pending_receipt_is_stale", lambda _receipt: True)
+    reconciled = service.get_von_login_email_management_receipt(
+        receipt_id=result["governance_receipt"]["receipt_id"],
+        acting_actor_concept_id="#V#actor",
+    )
+
+    assert reconciled["success"] is True
+    assert reconciled["governance_receipt"]["status"] == "succeeded"
+    assert reconciled["governance_receipt"]["effect_phase"] == "terminal"
+    assert reconciled["response_projection"]["success"] is True
+    assert reconciled["response_projection"]["reconciled_from_pending_receipt"] is True
+
+
+def test_stale_pre_effect_receipt_cannot_become_success_from_later_state(
+    governed_login_email,
+    monkeypatch,
+):
+    original_finalise = service._finalise_receipt
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = "member"
+
+    def unavailable_finalisation(*_args, **_kwargs):
+        raise RuntimeError("receipt store update unavailable")
+
+    monkeypatch.setattr(service, "_finalise_receipt", unavailable_finalisation)
+    denied = _manage(request_id="denied-finalisation-outage")
+
+    assert denied["success"] is False
+    assert denied["receipt_finalisation"] == "pending_reconciliation"
+    assert denied["governance_receipt"]["status"] == "pending"
+    assert denied["governance_receipt"]["effect_phase"] == "pre_effect"
+
+    # A later independent change matching the requested postcondition must not
+    # make a receipt for an effect that never crossed authority look successful.
+    governed_login_email["bindings"]["#V#target"].add("new@example.org")
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = "owner"
+    monkeypatch.setattr(service, "_finalise_receipt", original_finalise)
+    monkeypatch.setattr(service, "_pending_receipt_is_stale", lambda _receipt: True)
+
+    reconciled = service.get_von_login_email_management_receipt(
+        receipt_id=denied["governance_receipt"]["receipt_id"],
+        acting_actor_concept_id="#V#actor",
+    )
+
+    assert reconciled["success"] is True
+    assert reconciled["governance_receipt"]["status"] == "failed"
+    assert reconciled["governance_receipt"]["effect_phase"] == "terminal"
+    assert reconciled["governance_receipt"]["canonical_read_back"] is None
+    assert reconciled["response_projection"]["success"] is False
+    assert (
+        reconciled["response_projection"]["error_code"]
+        == "von_login_email_mutation_not_started"
+    )
+    assert reconciled["response_projection"].get("canonical_read_back") is None
+
+
+def test_pending_receipt_staleness_accepts_mongo_naive_utc_datetime(
+    governed_login_email,
+):
+    collection = governed_login_email["collection"]
+    collection.insert_one(
+        {
+            "receipt_id": "naive-time-receipt",
+            "updated_at": datetime.now(UTC) - timedelta(minutes=2),
+        }
+    )
+    stored = collection.find_one({"receipt_id": "naive-time-receipt"})
+
+    assert stored["updated_at"].tzinfo is None
+    assert service._pending_receipt_is_stale(stored) is True
+
+
+def test_pending_effect_reconciliation_requires_current_exact_org_authority(
+    governed_login_email,
+    monkeypatch,
+):
+    original_finalise = service._finalise_receipt
+
+    def unavailable_finalisation(*_args, **_kwargs):
+        raise RuntimeError("receipt store update unavailable")
+
+    monkeypatch.setattr(service, "_finalise_receipt", unavailable_finalisation)
+    result = _manage(request_id="effect-finalisation-outage")
+
+    assert result["success"] is True
+    assert result["governance_receipt"]["status"] == "pending"
+    assert result["governance_receipt"]["effect_phase"] == "effect_may_have_started"
+
+    governed_login_email["memberships"][("#V#actor", "#V#organisation")] = "member"
+    monkeypatch.setattr(service, "_finalise_receipt", original_finalise)
+    monkeypatch.setattr(service, "_pending_receipt_is_stale", lambda _receipt: True)
+
+    reconciled = service.get_von_login_email_management_receipt(
+        receipt_id=result["governance_receipt"]["receipt_id"],
+        acting_actor_concept_id="#V#actor",
+    )
+
+    assert reconciled["success"] is True
+    assert reconciled["governance_receipt"]["status"] == "indeterminate"
+    assert reconciled["governance_receipt"]["effect_phase"] == "terminal"
+    assert reconciled["governance_receipt"]["canonical_read_back"] is None
+    assert reconciled["response_projection"]["success"] is False
+    assert (
+        reconciled["response_projection"]["error_code"]
+        == "von_login_email_receipt_reconciliation_authority_required"
+    )
+    assert reconciled["response_projection"]["canonical_read_back"] is None
+    assert "binding_present" not in json.dumps(reconciled, sort_keys=True)
+
+
+def test_internal_catalogue_exposes_admin_login_email_lifecycle_only_internally():
+    catalogue = build_default_catalogue()
+
+    read = catalogue.get("get_von_login_email_bindings")
+    mutation = catalogue.get("manage_von_login_email_binding")
+    receipt = catalogue.get("get_von_login_email_management_receipt")
+
+    assert read is not None and read.category == "read"
+    assert mutation is not None and mutation.category == "write"
+    assert mutation.ordinary_turn_effect is True
+    assert mutation.write_guardrail == {"ordinary_turn_explicit_request": True}
+    assert receipt is not None and receipt.category == "read"
+    assert read.ordinary_turn_trusted_argument_bindings == {
+        "acting_actor_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+    }
+    assert mutation.ordinary_turn_trusted_argument_bindings == {
+        "acting_actor_concept_id": "actor_user_concept_id",
+        "organisation_concept_id": "actor_organisation_concept_id",
+        "request_id": "turn_id",
+    }
+
+    contracts = get_canonical_tool_registry()
+    for name in (
+        "get_von_login_email_bindings",
+        "manage_von_login_email_binding",
+        "get_von_login_email_management_receipt",
+    ):
+        exposure = contracts[name].exposure
+        assert exposure.expose_in_internal_catalogue is True
+        assert exposure.expose_in_vontology_stdio is False
+        assert exposure.expose_in_vonrag_stdio is False
+        assert exposure.expose_in_manifest is False

--- a/tests/backend/test_von_user_authentication_service.py
+++ b/tests/backend/test_von_user_authentication_service.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
+from contextlib import contextmanager, nullcontext
+
 import pytest
 from flask import Flask
 
 from src.backend.services import settings_service
 from src.backend.services import von_user_authentication_service as service
 from src.backend.services.exceptions import MultipleUsersForEmailError
+
+REAL_LOGIN_EMAIL_BINDING_BARRIER = service.von_login_email_binding_barrier
+
+
+@pytest.fixture(autouse=True)
+def available_login_email_store(monkeypatch):
+    monkeypatch.setattr(service, "_require_login_email_store", lambda: None)
+    monkeypatch.setattr(
+        service,
+        "_mark_login_email_search_projections_stale",
+        lambda _user_id: None,
+    )
+    monkeypatch.setattr(
+        service,
+        "von_login_email_binding_barrier",
+        lambda _email: nullcontext(),
+    )
 
 
 def test_login_lookup_uses_only_narrow_predicate_and_normalised_email(
@@ -131,8 +150,19 @@ def test_binding_writes_only_narrow_predicate_and_reads_back(monkeypatch):
         captured.update(kwargs)
         return {"relation_created": True}
 
+    @contextmanager
+    def binding_barrier(email):
+        captured["barrier_email"] = email
+        yield
+
     monkeypatch.setattr(service, "list_von_login_email_user_ids", list_bindings)
     monkeypatch.setattr(service, "upsert_text_for_concept", upsert)
+    monkeypatch.setattr(service, "von_login_email_binding_barrier", binding_barrier)
+    monkeypatch.setattr(
+        service,
+        "_mark_login_email_search_projections_stale",
+        lambda user_id: captured.update(stale_user_id=user_id),
+    )
 
     result = service.bind_von_login_email(
         user_concept_id="#V#alice",
@@ -142,6 +172,125 @@ def test_binding_writes_only_narrow_predicate_and_reads_back(monkeypatch):
     assert result["success"] is True
     assert captured["predicate"] == "#V#hasVonLoginEmail"
     assert captured["text"] == "alice@example.org"
+    assert captured["barrier_email"] == "alice@example.org"
+    assert captured["stale_user_id"] == "#V#alice"
+
+
+def test_login_email_binding_barrier_is_hashed_and_reentrant(monkeypatch):
+    acquired: list[str] = []
+
+    @contextmanager
+    def resource_lock(resource_key, **_kwargs):
+        acquired.append(resource_key)
+        yield
+
+    monkeypatch.setattr(service, "ontology_mutation_resource_lock", resource_lock)
+    with (
+        REAL_LOGIN_EMAIL_BINDING_BARRIER("Alice@Example.ORG"),
+        REAL_LOGIN_EMAIL_BINDING_BARRIER("alice@example.org"),
+    ):
+        pass
+
+    assert len(acquired) == 1
+    assert "alice@example.org" not in acquired[0]
+
+
+def test_user_login_email_list_reads_only_narrow_predicate(monkeypatch):
+    captured: dict[str, object] = {}
+    text_values = {
+        "email-a": {"text": "Alice@Example.ORG"},
+        "email-b": {"text": "second@example.org"},
+    }
+
+    def find_relations(query, projection=None):
+        captured["query"] = query
+        captured["projection"] = projection
+        return [
+            {"object_text_id": "email-b"},
+            {"object_text_id": "email-a"},
+        ]
+
+    monkeypatch.setattr(service.TextRelationsRepository, "find", find_relations)
+    monkeypatch.setattr(
+        service.TextValuesRepository,
+        "find_one_by_id",
+        lambda value, projection=None: text_values.get(value),
+    )
+
+    assert service.list_von_login_emails_for_user("alice") == [
+        "alice@example.org",
+        "second@example.org",
+    ]
+    assert captured["query"] == {
+        "subject_concept_id": "#V#alice",
+        "predicate": "#V#hasVonLoginEmail",
+    }
+    assert captured["projection"] == {"_id": 0, "object_text_id": 1}
+
+
+def test_removal_deletes_only_narrow_binding_and_reads_back(monkeypatch):
+    lookups = iter([["#V#alice"], []])
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        service,
+        "list_von_login_email_user_ids",
+        lambda _email: next(lookups),
+    )
+
+    def delete(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        service,
+        "delete_text_relation_by_predicate_and_text",
+        delete,
+    )
+    monkeypatch.setattr(
+        service,
+        "_mark_login_email_search_projections_stale",
+        lambda user_id: captured.update(stale_user_id=user_id),
+    )
+
+    result = service.remove_von_login_email(
+        user_concept_id="#V#alice",
+        email=" Alice@Example.ORG ",
+    )
+
+    assert result["success"] is True
+    assert result["removed"] is True
+    assert captured["args"] == (
+        "#V#alice",
+        "#V#hasVonLoginEmail",
+        "alice@example.org",
+    )
+    assert captured["kwargs"] == {"garbage_collect": False}
+    assert captured["stale_user_id"] == "#V#alice"
+
+
+def test_login_email_readers_fail_closed_when_store_is_unavailable(monkeypatch):
+    def unavailable():
+        raise RuntimeError("von_login_email_store_unavailable")
+
+    monkeypatch.setattr(service, "_require_login_email_store", unavailable)
+
+    with pytest.raises(RuntimeError, match="von_login_email_store_unavailable"):
+        service.list_von_login_email_user_ids("alice@example.org")
+    with pytest.raises(RuntimeError, match="von_login_email_store_unavailable"):
+        service.list_von_login_emails_for_user("#V#alice")
+
+
+def test_remove_cannot_claim_no_op_when_store_is_unavailable(monkeypatch):
+    def unavailable():
+        raise RuntimeError("von_login_email_store_unavailable")
+
+    monkeypatch.setattr(service, "_require_login_email_store", unavailable)
+
+    with pytest.raises(RuntimeError, match="von_login_email_store_unavailable"):
+        service.remove_von_login_email(
+            user_concept_id="#V#alice",
+            email="alice@example.org",
+        )
 
 
 def test_settings_login_does_not_link_or_create_from_session_hint(monkeypatch):

--- a/tests/backend/test_vontology_concept_stats_service.py
+++ b/tests/backend/test_vontology_concept_stats_service.py
@@ -108,6 +108,62 @@ def test_stats_snapshot_counts_types_and_predicate_extent(monkeypatch):
     assert predicate["direct_pure_instance_count"] == 1
 
 
+def test_stats_snapshot_conceals_login_identity_predicate_extent(monkeypatch):
+    stats_service._reset_vontology_concept_stats_cache_for_tests()
+    docs = [
+        *_seed_docs(),
+        _concept_doc(
+            "#V#hasVonLoginEmail",
+            is_an_instance_of=["#V#predicate"],
+        ),
+        _concept_doc(
+            "#V#target",
+            extra_relationships={"#V#hasVonLoginEmail": "#V#email_value"},
+        ),
+    ]
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        stats_service.ConceptsRepository,
+        "find",
+        lambda *_args, **_kwargs: docs,
+    )
+    monkeypatch.setattr(
+        stats_service.TextRelationsRepository,
+        "collection",
+        lambda: object(),
+    )
+
+    def aggregate(pipeline):
+        captured["pipeline"] = pipeline
+        # Defence in depth: even a backend returning an out-of-policy row must
+        # not let its real count reach the generic stats snapshot.
+        return [{"_id": "#V#hasVonLoginEmail", "count": 7}]
+
+    monkeypatch.setattr(
+        stats_service.TextRelationsRepository,
+        "aggregate",
+        aggregate,
+    )
+
+    rebuilt = stats_service.rebuild_vontology_concept_stats_snapshot(
+        scope_key="hidden-predicate-scope",
+        reason="unit-test",
+    )
+    payload = stats_service.get_vontology_concept_stats(
+        ["#V#hasVonLoginEmail"],
+        scope_key="hidden-predicate-scope",
+    )
+
+    assert rebuilt["success"] is True
+    hidden_stats = payload["concept_stats"]["#V#hasVonLoginEmail"]
+    assert hidden_stats["kind"] == "predicate"
+    assert hidden_stats["extent_count"] == 0
+    assert hidden_stats["extent_count_is_exact"] is True
+    assert hidden_stats["extent_count_unavailable"] is False
+    match = captured["pipeline"][0]["$match"]["predicate"]
+    assert match["$nin"] == ["#V#hasVonLoginEmail", "hasVonLoginEmail"]
+
+
 def test_stats_invalidation_marks_snapshot_stale_until_rebuilt(monkeypatch):
     stats_service._reset_vontology_concept_stats_cache_for_tests()
     monkeypatch.setattr(
@@ -134,9 +190,7 @@ def test_stats_invalidation_marks_snapshot_stale_until_rebuilt(monkeypatch):
     )
     assert stale_payload["stats_status"] == stats_service.STATS_STATUS_STALE
     assert stale_payload["concept_stats"]["#V#mammal"]["stats_unavailable"] is True
-    assert (
-        stale_payload["concept_stats"]["#V#mammal"]["stats_reason"] == "cache_stale"
-    )
+    assert stale_payload["concept_stats"]["#V#mammal"]["stats_reason"] == "cache_stale"
 
     refreshed_payload = stats_service.get_vontology_concept_stats(
         ["#V#mammal"],


### PR DESCRIPTION
## Summary

- add dedicated organisation-owner/admin tools to read, bind, remove, and reconcile canonical Von login-email bindings
- server-bind actor, selected organisation, and idempotency identity; require exact target membership and all-target-organisation authority for global identity effects
- return durable receipts and canonical read-back, including honest indeterminate outcomes
- keep the authentication predicate out of generic KB reads, RAG and semantic projections, extent/statistics views, merge telemetry, scoped assertions, and workflow mutation events

## Validation

- 101 passed: login governance, authentication, migration, catalogue, and trusted-binding discovery
- 231 passed, 34 skipped: affected generic-read, RAG, scoped assertion, merge, search, and relation regression suite
- 46 passed: post-review derived stats, event, and predicate-route suite
- 45 passed: final adversarial focused regression
- Python compilation, undefined-name lint, strict lint on new modules, formatting, and staged diff checks passed