### PR TITLE
Schedule CodeQL scans every eight hours

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  schedule:
+    # Run against the latest default-branch commit every eight hours. Minute 17
+    # avoids the higher congestion GitHub reports at the start of each hour.
+    - cron: "17 0,8,16 * * *"
+      timezone: "Pacific/Auckland"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- add an advanced CodeQL workflow for Python and JavaScript/TypeScript
- run the security-and-quality query suite every eight hours in Pacific/Auckland time
- retain manual workflow dispatch while removing push and pull-request triggers

## Validation
- parsed the workflow as YAML
- `git diff --check`

After this workflow is merged and manually validated, the repository-managed GitHub Code Quality workflow will be disabled so it no longer runs on each pull request and subsequent push to `main`.