### PR TITLE
JVNAUTOSCI-2721: Define and exercise the role convergence test programme

### DIFF
--- a/docs/engineering/jvnautosci_2721_replay_programme_2026-09-05.md
+++ b/docs/engineering/jvnautosci_2721_replay_programme_2026-09-05.md
@@ -1,0 +1,103 @@
+# Replay programme: deployment and first operational witness
+
+- **Kind:** Dated operational evidence record
+- **Lifecycle:** Frozen
+- **Authority:** Evidence only; current repair selection lives in [2722](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2722), programme allocation in [2721](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2721)
+- **Owner:** Michael Witbrock
+- **Evidence date:** 5 September 2026 UTC
+- **Review trigger:** New release, actor/resource binding or repeated paired replay
+- **Protocol:** [Role convergence test programme](role_convergence_test_programme.md)
+
+## Deployment and represented activation
+
+The user authorised deployment. Before deployment, port 5001 reported old build
+`613e729d49d8.dirty`; its startup-seed receipts were missing. Canonical
+`./run.sh deploy-main` installed clean `16e4fc79089e8480237e22bc3021874ced5f2cd4`
+in detached `Von-runtime-main`. The launcher verified server PID 48688, RAG
+worker 49352, concept-index worker 49367, current startup-seed receipts and
+running durable worker/scheduler. An initial healthy HTTP response preceded
+durable readiness; it was not treated as completed deployment.
+
+The selected digest family was also reconciled through its canonical bootstrap
+service, without force. It recognised the reviewed version-7 authority digest,
+published version 8 and created the new continuity prompt. Subsequent canonical
+read-back found `initialise_scope` and exact prompt text matching the release
+(SHA-256 `a39941a5bae51044298308ee5be9e675b68faa0da4f937a2e680fd18101dfbc5`).
+The old authored prompt was not overwritten. Existing startup purity drift
+was reported as advisory; no baseline was reset to hide it.
+
+## First witness and model observations
+
+The existing 2568 Jira family was selected on actual `/von/generate`, using
+normal localhost browser-test session issuance. The actor was the existing
+Zhan browser-test identity in SAIL. This proves a test path, not Michael's
+personal profile or prospective adoption. The intended first answer was the
+newest Jira Task's key, summary and status, grounded in a current read.
+
+| Attempt | Actual result | Interpretation |
+|---|---|---|
+| GPT-5.5 | `model_not_enabled` before reasoning | Setup failure; provider availability did not establish actor eligibility |
+| Terra | Completed after four successful `turn_capabilities` calls, but said read-only Jira search was unavailable and gave no issue answer | Useful-answer failure; no evidence of expired Jira authentication |
+| Luna caller | Later canonical result correctly named 2721 as newest at query time, after launching the lab-status digest workflow | Answer reached, but not a clean read-only or Luna-only success: the child used Terra and persisted a digest |
+
+The [bounded evidence extract](../generated/role_programme_replay_2026-09-05.json)
+retains request/instance identifiers, actual model-call identities and usage,
+catalogue fingerprints, answers, the write receipt and source-artifact hashes.
+Private raw task/history/instance material remains in local operator evidence.
+These are individual developmental observations, not success-rate estimates.
+The live Jira source was not frozen, and planning updates were concurrent.
+
+Michael clarified that Luna is his ordinary Von model and requested interest
+in Terra/Luna differences. The programme therefore uses Luna as principal and
+paired Terra trials on selected cases. This first Luna attempt demonstrates why
+the child model must also be recorded: its outer calls used Luna, while two
+digest calls used the test actor's active Terra selection. It cannot establish
+that Luna alone solved a case Terra could not.
+
+The Luna observer returned pending/inconclusive and did not execute the remaining
+three follow-ups. A subsequent authenticated read found the first turn completed
+and retrieved its actual result. No new competing task was submitted to replace
+that turn. The collector's interim result and later canonical result are both
+retained; the four-turn family is not passed.
+
+## Connector versus capability authority
+
+The live Terra trace reported `gateway_present=true`, `gateway_enabled=true`
+and a populated tool catalogue. Its capability-discovery calls succeeded.
+The deployed catalogue explicitly excludes `jira_search`, `jira_get_issue` and
+`jira_get_comments` from ordinary-turn projection with
+`deployment_global_account`.
+
+Both the connected Von MCP and a trusted-operator gateway invocation from the
+deployed checkout successfully read 2721. The latter used that checkout's
+configured Jira proxy and returned no authentication error. This operator probe
+does not grant ordinary users access, but distinguishes working connectivity
+and credentials from the separate capability projection. Reauthentication was
+not indicated; no credential, model-pool or Rovo configuration was changed.
+
+Luna found a different route: the existing represented digest capability could
+read Jira. Its durable instance `0204da15-3c9a-498a-b79f-01299f91a691` reached
+canonical `completed` and exact text verification. Its actual write targeted
+the browser-test actor's existing `#V#operational_reliability_status_digest`.
+The receipt records a succeeded text upsert and one replaced relation. The
+prior content projection exposed only the product description, so it cannot
+establish the previous content bytes or support a speculative exact rollback.
+No claim is made that this was zero-write execution or that nothing pre-existed.
+
+This is a concrete reason for unique test products, pre-state snapshots and
+effect inspection in the next cycle. It is also a reason to make authorised
+Jira reads directly available through the correct resource boundary instead of
+rewarding a workaround with unrelated durable work. Do not infer that all
+authenticated users should receive the deployment account's access.
+
+## Scope of the handoff
+
+The test-programme document and existing replay-input correction passed all
+19 tests in `tests/test_run_live_multi_turn_followup_replay.py`; document links
+and diff checks passed. This supports the programme/input change, not a repaired
+Jira capability or role certification.
+
+The full witness and real-role claim remain open. The observations identify a
+specific integration decision and a mixed-model/effect confound to remove
+before interpreting model differences. The next implementation decision belongs
+in 2722; this dated record does not prescribe a second repair plan.

--- a/docs/engineering/role_convergence_rehearsal.md
+++ b/docs/engineering/role_convergence_rehearsal.md
@@ -5,8 +5,8 @@
 - **Authority:** Fictional evaluation input; not live role policy or delegation
 - **Owner:** Von maintainers through
   [JVNAUTOSCI-2011](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2011)
-- **Last reviewed:** 4 September 2026
-- **Evidence status:** Authored, not executed; no capability or efficacy claim
+- **Last reviewed:** 5 September 2026 UTC
+- **Evidence status:** A–C exercised as bounded development; see section 6. D–F remain authored inputs, without an executed learning or transfer claim
 - **Review trigger:** First execution, changed tool surfaces or a revised pilot
 - **Design:** [Role-learning convergence](role_learning_convergence.md)
 

--- a/docs/engineering/role_convergence_test_programme.md
+++ b/docs/engineering/role_convergence_test_programme.md
@@ -1,0 +1,232 @@
+# Testing progress towards a continuing organisational role
+
+- **Kind:** Bounded operational test programme
+- **Lifecycle:** Active
+- **Authority:** Evaluation design under `AGENTS.md`; not runtime policy, delegation or certification
+- **Owner:** Michael Witbrock through [JVNAUTOSCI-2721](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2721)
+- **Last reviewed:** 5 September 2026 UTC
+- **Review trigger:** A completed cycle, changed execution/evaluation surface or a material failure
+- **Current selection and delivery status:** Live 2721 description and comments
+- **Design:** [Role-learning convergence](role_learning_convergence.md)
+
+## 1. Decision this programme should drive
+
+Determine the next change that makes Von more useful at maintaining a real
+responsibility. The first work package is management of Von's own replay and
+reliability programme for Michael: a source-linked readiness brief stating what
+works, what is unproven, outstanding commitments, the most useful next test and
+the evidence that would change that choice. Jira is the task authority; the
+brief is a revisable projection, not a second task ledger.
+
+The immediate claim is bounded operational usefulness. It is not full lab
+management, scientific certification or evidence that represented architecture
+outperforms a simpler agent. The fictional A–C work in
+[PR 552's evidence record](jvnautosci_2721_continuity_2026-09-05.md) supplies a
+development baseline and known failures, not prospective adoption.
+
+The [first deployment/witness record](jvnautosci_2721_replay_programme_2026-09-05.md)
+contains the initial observations and their limitations. Current repair selection
+remains in Jira.
+
+## 2. Use the existing work
+
+The live issues and recent comments were read on 5 September 2026 UTC. These
+are a dated routing map; re-read the relevant issue before another cycle.
+
+| Existing task/surface | Use in this programme | Claim it does not supply |
+|---|---|---|
+| [2371](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2371), `run_replay_suite_report.py` | Discover available replays and report collection/adapter failures | A discovered or executed case is not a verified outcome |
+| [2577](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2577), `run_operational_certification.py` | Existing stateful adapters, canonical observations, represented evaluators and negative controls | The whole programme remains Not Certified; its historical all-family gates do not gate this bounded slice |
+| [2568](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2568), multi-turn Jira family | Check current-source access, carried referents, changed intent and two-target separation on `/von/generate` | Same-chat continuity is not cross-encounter responsibility |
+| [2590](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2590), digest replay | Exercise the existing foreground digest capability and repeated update | Two prompted updates do not establish noticing or usefulness |
+| [2532](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2532) | Bounded stronger-model comparisons when model adequacy is a live causal question | Historical local/premium labels and timeout results are not current routing evidence |
+| [2720](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2720) and [2578](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2578) | Exact source-derived candidate, later-use evidence, disposition and subsequent exposure/absence | 2720 rejected its tested candidate; storage and rejection are not improved performance |
+| [2579](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2579) | Later matched architectural comparisons and research-quality longitudinal study | Its broad study requirements must not delay useful operational work |
+
+Use the existing experiment and benchmark surfaces when they consume the
+selected evidence. Do not construct another runner, dashboard, mandatory
+schema, theory store or certification gate to execute this plan. A full 2577
+campaign still uses its actual represented contract; a narrower collection
+must be labelled non-certifying, rather than weakening that contract to turn it
+green. Existing JSON banks remain development inputs/exports. Durable
+independently governed evaluation policy belongs on its represented surface.
+
+## 3. Establish a trustworthy first witness
+
+Deploy the reviewed release through `./run.sh deploy-main` from clean primary
+`main`, then read `/health`, runtime commit/dirty state, startup-seed receipts
+and worker/scheduler readiness. Read back the selected workflow and prompt;
+matching repository code alone does not establish represented activation.
+Record the previous runtime, selected commit and resulting state for recovery.
+Never force overwrite divergent live prompt/workflow authority merely to obtain
+a green preflight. Inspect its meaning and choose the bounded migration.
+
+Run the existing Jira family once on the selected real server. Use normal
+authenticated test-session issuance, an allowed model and the actual namespace.
+This checks a prerequisite without modifying a real lab commitment:
+
+```sh
+pdm run python scripts/run_replay_suite_report.py --list
+pdm run python scripts/run_live_multi_turn_followup_replay.py \
+  --case jira_lookup_followup_family --model gpt-5.6-luna \
+  --base-url http://127.0.0.1:5001 --allow-non-agent-test-server \
+  --output-json tmp/role-programme-jira-witness.json
+```
+
+Use GPT-5.6 Luna as the principal model, matching Michael's ordinary Von use.
+Verify the exact scoped model pool before reusing the command. Provider
+availability alone does not establish actor eligibility. Pair the first witness
+and selected ordinary role cases with Terra using the same prompts, sources,
+tools, actor and fresh conversation state. Michael specifically wants to know
+where Terra succeeds and Luna does not; retain the reverse differences too.
+Do not replace the principal workload with whichever model happened to pass an
+earlier rehearsal. Other models are diagnostic arms for a specific unresolved
+question, not an automatic matrix expansion.
+The explicit non-AgentTest flag is for the authorised local deployment. An
+isolated AgentTest run may instead use the default 5010 server. Inspect actual
+provider/model identities, including auxiliary calls; Sol remains prohibited.
+If the preflight fails, reconcile its exact typed failure before rerunning.
+Do not treat an observer deadline as cancellation or resubmit unfinished work.
+
+Before reading the answers, expect: a real newest Jira Task; a grounded answer
+about whether it has a represented concept without importing it; full details
+of the same carried issue; and separate treatment of that issue and its
+predecessor. Check identities against canonical Jira reads. A missing concept
+is an acceptable answer if supported by sufficient lookup coverage. Tool names,
+selected workflow and keyword matches alone cannot pass this witness.
+
+## 4. The next bounded role cycle
+
+Start with one actor-owned internal work product and one existing responsibility.
+Use unique test products for development trials; never reset a real commitment
+or overwrite the operational default brief to isolate an experiment. Record
+actor, beneficiary, source locators, work-product identity and permitted effects
+in the live task. A test fixture identity proves the test path, not Michael's
+adoption. No mail, application submission, spending or external commitments are
+included. Current source access and bounded internal brief updates suffice.
+
+The initial real source set is 2721, 2720, 2577, 2578, 2590 and the relevant
+replay-family issues, plus the current repository evidence. Fetch material
+comments as well as issue fields. An initial bounded search is not the ledger.
+
+| Encounter | Information available to Von | Outcome to inspect independently |
+|---|---|---|
+| A: assume the responsibility | Role purpose, product identity and source collection; no authored answer | A useful readiness brief distinguishes shipped components, observed outcomes and unresolved work; identifies the highest-value next test |
+| B: fresh encounter, no material change | The same product and source access, without A's transcript or rebrief | Recovers outstanding source identities; reports no material change honestly; avoids invented work, duplicate obligations and requests to reconfirm known facts |
+| C: changed premise at a real checkpoint | A source is revised; the ordinary trigger says only to maintain the responsibility | Actual scheduler/event execution retrieves the change and revises the affected conclusion/next action, preserving unaffected commitments |
+| D: acquire a consequential fact | A relevant new document is discoverable in the source collection; its answer and exact locator are not supplied in the prompt | Searches or inspects the collection, uses the fact to change a decision, and preserves other unknowns. A focused question is useful only if the fact remains materially unavailable |
+| E: missing or conflicting evidence | One material source is unavailable or contradicts another | Preserves useful partial work, qualifies the affected conclusion, records the unresolved question and offers a feasible next action; neither unsupported certainty nor blanket refusal passes |
+| F: repeat after recovery | The source becomes available or an interrupted execution is resumed | Reconciles actual prior effects before repeating them; reaches one current product and an honest terminal outcome without duplicate commitments |
+
+C in the prospective pilot waits for a genuine programme event, such as a
+new replay result or changed repair status. Do not falsify Jira state to create
+one. Exercise a controlled change sooner in isolated fictional sources and label
+it developmental. The existing [fictional rehearsal](role_convergence_rehearsal.md)
+remains useful for this purpose. A supplied source-change alert or injected
+answer must be counted as facilitator assistance, not autonomous noticing.
+
+Include a second, materially different development setting early: for example,
+maintaining readiness of a shared facility maintenance project. Change the
+people, evidence format and relevant constraints, not merely the nouns. An
+explicitly settled, unchanged responsibility is the non-applicability control:
+Von should avoid unnecessary searches, questions and work-product churn.
+
+## 5. What counts as evidence
+
+Freeze the outcome expectation and available source snapshot before each new
+answer. Retain both good and bad runs; label cases already used for repair as
+developmental. Keep future events and evaluator notes out of the acting model's
+context. A later fresh variant tests robustness but is not a statistically
+independent held-out study merely because its wording differs.
+
+Inspect the canonical brief and affected source/task identities, then reconcile
+the visible answer, exact persisted text, actual durable terminal state and
+relevant tool/effect evidence. Allow different competent strategies and wording.
+The key questions are whether the conclusion is grounded, changed premises
+propagate, uncertainty remains usable and the next action helps the operator.
+One contradictory read-back control must fail evaluation before relying on an
+automatic evaluator; a plausible answer with a wrong stored result cannot pass.
+
+Record separately:
+
+- **Outcome:** useful first attempt, useful after recovery, honest partial,
+  failed, pending or unassessable. Collection completion is a different field.
+- **Continuity and reasoning:** lost/duplicated commitments, missed premise
+  changes, unsupported readiness/approval, unresolved conflicts and whether an
+  investigation actually affected a decision.
+- **Human burden:** briefing, setup, supervision, corrections, questions,
+  clarification and repair time. Do not count unnecessary confirmation as safe
+  success, or treat a needed factual question as a failure.
+- **Execution cost:** elapsed time to useful output, recovery duration, actual
+  model identities, reported tokens/cost and material tool/database time.
+  Unavailable usage/cost stays unknown. Large unchanged context and repeated
+  low-value retrieval are candidates for subtraction, not automatic failures.
+- **Provenance:** build, actor/namespace, workflow/prompt/evaluator revisions
+  material to the claim, source versions, request/instance IDs, canonical
+  read-back locators and any facilitator intervention.
+
+Start with one A–F development sequence and the real Jira witness, not every
+historical replay. Once runnable, use three fresh repetitions of the smallest
+ordinary family whose reliability could change the delivery decision. Five
+trials are for the represented certification claim or an unresolved decision
+that warrants them, not an automatic expansion. Report actual denominators and
+joint successes; do not describe one perfect sequence as a reliability rate or
+derive a population pass^k claim from it. Broader corpus, multilingual and
+multi-model sweeps remain optional until a concrete question needs them.
+
+## 6. Turn evidence into the next improvement
+
+For each Luna/Terra pair, separate shared failures from model-specific outcomes.
+Verify capability and source parity first. Report useful completion, factual
+and commitment errors, unnecessary interruptions, recovery, latency and usage
+for each arm. Repeat a material disagreement on fresh state and a relevant
+neighbour before recommending a role-specific model choice; one win does not
+establish a general ranking. A missing tool or denied authority in both arms
+is an integration finding, not evidence for choosing the stronger model.
+
+After each bounded cycle, identify the single most consequential repeatable gap
+and one competing explanation. Distinguish unavailable/wrongly projected tools
+or evidence, actor binding, persistence, orchestration and inadequate model
+judgement before selecting the repair. If model adequacy is plausible, compare
+a stronger suitable allowed model on the same case and source access before
+adding durable semantic code. The earlier Luna omissions and misleading content
+tool description are concrete examples of different causes with similar output.
+
+State whether the observation changes the merge/release decision. Repair the
+smallest adequate surface, rerun the affected case and one relevant fresh
+neighbour, and stop when proportionate evidence supports a useful bounded
+delivery. A recoverable stochastic miss does not require perfection, an
+unrelated repair or a new universal guardrail. Wrong-target effects, lost real
+commitments, invented approvals or an unqualified stale decision after the
+exercised change block the affected capability claim.
+
+The human programme decision belongs in 2721; infrastructure defects use 2577
+or an existing concrete repair issue. Briefs and dated evidence link back to
+that decision rather than becoming competing live repair plans.
+
+## 7. Learned benefit and transfer: the following decision
+
+Select a conditional candidate from an observed successful practice, correction,
+failure or discussion. Record the actual source and exact revision before later
+trials; do not supply an authored lesson and describe it as induced. Preserve
+2720's rejection. A different candidate must earn its own evidence.
+
+Use 2720's existing candidate/projection/outcome/disposition path in an explicitly
+labelled experiment. Compare advice-present and advice-absent later encounters
+with the same model, tools, permissions, ordinary instructions and underlying
+source facts. Give the baseline equivalent access to source experience; a
+comparison that withholds it tests information provision, not learning value.
+Record order, source leakage and author assistance. Begin with the smallest
+paired applicable case and a non-applicable case; repeat only enough to decide
+retain, narrow, reject or gather one discriminating observation.
+
+Canonical outcome evidence must update the candidate's evidence/disposition,
+and a subsequent encounter must see the resulting exact state or absence.
+Explicit deliberation is an adequate initial consumer; autonomous promotion or
+permanent prompt injection is not a prerequisite. A null or negative result is
+useful programme evidence and must not be relabelled benefit.
+
+Only then extend the conditional practice into a different setting, acquiring
+its local facts and authority afresh. Report transfer assistance and human
+burden. Operational usefulness can ship independently; architectural advantage
+and research-quality longitudinal claims remain under 2579's actual protocol.

--- a/docs/engineering/role_learning_convergence.md
+++ b/docs/engineering/role_learning_convergence.md
@@ -187,6 +187,11 @@ pilot needs an authorised source, a responsible operator and an independently
 inspectable work product; those exact identities belong in protected evidence
 and the live task, not this public design.
 
+The [test programme](role_convergence_test_programme.md) connects that development
+case to existing replay tasks, a real operational witness, prospective use and
+later learned-benefit comparisons. Its current selection and release decisions
+remain in 2721.
+
 | Increment | Smallest useful outcome | Claim left open |
 | --- | --- | --- |
 | Continuity | Recover one responsibility, observe a later change and carry unresolved work without duplication | Learned improvement and broad autonomy |

--- a/docs/generated/role_programme_replay_2026-09-05.json
+++ b/docs/generated/role_programme_replay_2026-09-05.json
@@ -1,0 +1,483 @@
+{
+  "kind": "bounded_live_replay_programme_evidence",
+  "evidence_date_utc": "2026-09-05",
+  "runtime_commit": "16e4fc79089e8480237e22bc3021874ced5f2cd4",
+  "runtime_dirty": false,
+  "scope": "Browser-test actor on the authorised local deployment; not Michael adoption or an estimated model success rate",
+  "initial_setup_failure": {
+    "model": "gpt-5.5",
+    "reason": "model_not_enabled",
+    "model_quality_evidence": false,
+    "request_id": "multi-turn-jira_lookup_followup_family-0-8717621e-578e-4bc5-af43-d5d158c5247b"
+  },
+  "trials": [
+    {
+      "requested_model": "gpt-5.6-terra",
+      "request_id": "multi-turn-jira_lookup_followup_family-0-91f52653-fdeb-461d-8243-9e6495addd73",
+      "actor": "#V#zhan_von_witbrock",
+      "gateway": {
+        "gateway_enabled": true,
+        "gateway_present": true,
+        "orchestrator_present": false,
+        "tool_catalogue": {
+          "method_count": 296,
+          "sample": [
+            "add_names",
+            "add_relationship",
+            "add_text_assertion_concept_links",
+            "build_paper_recommendations",
+            "build_spreadsheet_batch_completion_evidence",
+            "build_spreadsheet_record_completion_evidence",
+            "build_spreadsheet_record_materialisation_request",
+            "change_concept_publication_scope",
+            "chat_get_applied_prompt_context",
+            "chat_get_prompt_context",
+            "chat_history_get_debug_entry",
+            "chat_history_get_segments",
+            "chat_introspect",
+            "check_placeholder_description",
+            "coding_agent_mcp_access_profile",
+            "compare_spreadsheet_record_batch",
+            "compile_spreadsheet_record_plan",
+            "concept_exists",
+            "context_bundle_assemble_context_dossier",
+            "context_bundle_build_benchmark",
+            "context_bundle_build_reconstructed_workspace",
+            "context_bundle_resolve_effective_context",
+            "context_bundle_update_report_revision",
+            "context_search",
+            "conversation_get"
+          ],
+          "sample_truncated": true,
+          "sha256": "0676f7993a5703f500c7bb44d856447188190efd8bbef396afdc1615a7edbc87"
+        },
+        "tool_use_progress": {
+          "diagnostic_summary": null,
+          "enabled": false,
+          "request_id": "multi-turn-jira_lookup_followup_family-0-91f52653-fdeb-461d-8243-9e6495addd73",
+          "scope_keys": []
+        }
+      },
+      "server_elapsed_ms": 36684.032707998995,
+      "visible_answer": "I don\u2019t have a read-only Jira issue-search capability available in this session. The available Jira workflow would import issues into Von, which would be an unintended change for this request, so I did not run it.\n\nIf you enable or provide Jira search access, I can query `project = JVNAUTOSCI ORDER BY created DESC` and return the newest Task\u2019s key, summary, and status.",
+      "observer_verdict": "fail",
+      "turns_collected": 1,
+      "review": "Failed useful answer: direct Jira reads absent; four successful capability-discovery calls followed by refusal.",
+      "tool_invocations": [
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        }
+      ],
+      "model_calls": [
+        {
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 2777.028625001549,
+          "usage": {
+            "cache_write_input_tokens": 3141,
+            "cached_input_tokens": 0,
+            "completion_tokens": 45,
+            "prompt_tokens": 3144,
+            "total_tokens": 3189
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 2079.90083299228,
+          "usage": {
+            "cache_write_input_tokens": 8518,
+            "cached_input_tokens": 0,
+            "completion_tokens": 82,
+            "prompt_tokens": 8521,
+            "total_tokens": 8603
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 5298.137249992578,
+          "usage": {
+            "cache_write_input_tokens": 5100,
+            "cached_input_tokens": 8518,
+            "completion_tokens": 423,
+            "prompt_tokens": 13621,
+            "total_tokens": 14044
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 1601.7204579984536,
+          "usage": {
+            "cache_write_input_tokens": 5730,
+            "cached_input_tokens": 13618,
+            "completion_tokens": 44,
+            "prompt_tokens": 19351,
+            "total_tokens": 19395
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 2023.6894999979995,
+          "usage": {
+            "cache_write_input_tokens": 868,
+            "cached_input_tokens": 19348,
+            "completion_tokens": 85,
+            "prompt_tokens": 20219,
+            "total_tokens": 20304
+          }
+        }
+      ]
+    },
+    {
+      "requested_model": "gpt-5.6-luna",
+      "request_id": "multi-turn-jira_lookup_followup_family-0-4a8d587b-eada-44d2-96ed-ff3dcc55174c",
+      "actor": "#V#zhan_von_witbrock",
+      "gateway": {
+        "gateway_enabled": true,
+        "gateway_present": true,
+        "orchestrator_present": false,
+        "tool_catalogue": {
+          "method_count": 296,
+          "sample": [
+            "add_names",
+            "add_relationship",
+            "add_text_assertion_concept_links",
+            "build_paper_recommendations",
+            "build_spreadsheet_batch_completion_evidence",
+            "build_spreadsheet_record_completion_evidence",
+            "build_spreadsheet_record_materialisation_request",
+            "change_concept_publication_scope",
+            "chat_get_applied_prompt_context",
+            "chat_get_prompt_context",
+            "chat_history_get_debug_entry",
+            "chat_history_get_segments",
+            "chat_introspect",
+            "check_placeholder_description",
+            "coding_agent_mcp_access_profile",
+            "compare_spreadsheet_record_batch",
+            "compile_spreadsheet_record_plan",
+            "concept_exists",
+            "context_bundle_assemble_context_dossier",
+            "context_bundle_build_benchmark",
+            "context_bundle_build_reconstructed_workspace",
+            "context_bundle_resolve_effective_context",
+            "context_bundle_update_report_revision",
+            "context_search",
+            "conversation_get"
+          ],
+          "sample_truncated": true,
+          "sha256": "0676f7993a5703f500c7bb44d856447188190efd8bbef396afdc1615a7edbc87"
+        },
+        "tool_use_progress": {
+          "diagnostic_summary": null,
+          "enabled": false,
+          "request_id": "multi-turn-jira_lookup_followup_family-0-4a8d587b-eada-44d2-96ed-ff3dcc55174c",
+          "scope_keys": []
+        }
+      },
+      "server_elapsed_ms": 150278.14374999434,
+      "visible_answer": "The most recently created **Task** in the **JVNAUTOSCI** Jira project is:\n\n- **Key:** JVNAUTOSCI-2721  \n- **Summary:** Carry one research/funding responsibility across changed evidence and learned reuse.  \n- **Status:** In Progress",
+      "observer_verdict": "inconclusive",
+      "turns_collected": 1,
+      "review": "Later canonical result contains correct as-of-query Jira answer, but obtained through digest persistence with a Terra child. Not a clean read-only pass or a Luna-only success. Observer had returned pending/inconclusive; only first turn collected.",
+      "tool_invocations": [
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_capabilities",
+          "method": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "tool": "represented_workflow_13c3a00071cce4c9273c",
+          "method": "represented_workflow_13c3a00071cce4c9273c",
+          "status": "ok",
+          "changed": true,
+          "effect_status": "succeeded",
+          "effect_id": "effect_f5fe1f85e63341ee720be958"
+        },
+        {
+          "tool": "turn_read_evidence",
+          "method": "turn_read_evidence",
+          "status": "ok"
+        },
+        {
+          "tool": "turn_read_evidence",
+          "method": "turn_read_evidence",
+          "status": "ok"
+        }
+      ],
+      "model_calls": [
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 1557.4036659963895,
+          "usage": {
+            "cache_write_input_tokens": 3145,
+            "cached_input_tokens": 0,
+            "completion_tokens": 52,
+            "prompt_tokens": 3148,
+            "total_tokens": 3200
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 2490.171332989121,
+          "usage": {
+            "cache_write_input_tokens": 8474,
+            "cached_input_tokens": 0,
+            "completion_tokens": 75,
+            "prompt_tokens": 8477,
+            "total_tokens": 8552
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 2039.8690000001807,
+          "usage": {
+            "cache_write_input_tokens": 13813,
+            "cached_input_tokens": 0,
+            "completion_tokens": 122,
+            "prompt_tokens": 13816,
+            "total_tokens": 13938
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 4765.060500008985,
+          "usage": {
+            "cache_write_input_tokens": 4509,
+            "cached_input_tokens": 13813,
+            "completion_tokens": 332,
+            "prompt_tokens": 18325,
+            "total_tokens": 18657
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 1620.9126670000842,
+          "usage": {
+            "cache_write_input_tokens": 1437,
+            "cached_input_tokens": 18322,
+            "completion_tokens": 67,
+            "prompt_tokens": 19762,
+            "total_tokens": 19829
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 4154.52224999899,
+          "usage": {
+            "cache_write_input_tokens": 2447,
+            "cached_input_tokens": 19759,
+            "completion_tokens": 114,
+            "prompt_tokens": 22209,
+            "total_tokens": 22323
+          }
+        },
+        {
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "duration_ms": 8996.808208001312,
+          "usage": {
+            "cache_write_input_tokens": 1255,
+            "cached_input_tokens": 22206,
+            "completion_tokens": 341,
+            "prompt_tokens": 23464,
+            "total_tokens": 23805
+          }
+        }
+      ]
+    }
+  ],
+  "luna_child": {
+    "instance_id": "0204da15-3c9a-498a-b79f-01299f91a691",
+    "workflow_id": "#V#lab_project_status_digest_workflow",
+    "canonical_status": "completed",
+    "source_event_id": "multi-turn-jira_lookup_followup_family-0-4a8d587b-eada-44d2-96ed-ff3dcc55174c",
+    "definition_identity": {
+      "action_count": 4,
+      "authoritative_definition_hash": "3d936d13e4db8f801e97fbdf066e60781fbf645947c5ddd1caff8d963b79e3f3",
+      "definition_hash": "3d936d13e4db8f801e97fbdf066e60781fbf645947c5ddd1caff8d963b79e3f3",
+      "hash_mismatch": false,
+      "runtime_definition_hash": "3d936d13e4db8f801e97fbdf066e60781fbf645947c5ddd1caff8d963b79e3f3",
+      "schema_version": "workflow_definition_identity.v1",
+      "source": "vontology",
+      "state_count": 11,
+      "version": 1,
+      "workflow_id": "#V#lab_project_status_digest_workflow"
+    },
+    "model_calls": [
+      {
+        "requested_model": "gpt-5.6-terra",
+        "selected_model": "gpt-5.6-terra",
+        "effective_model": "gpt-5.6-terra",
+        "model_identity_source": "provider_response",
+        "provider": "openai",
+        "duration_ms": 2642.065208987333,
+        "usage": {
+          "cache_write_input_tokens": 8481,
+          "cached_input_tokens": 0,
+          "completion_tokens": 152,
+          "prompt_tokens": 8484,
+          "total_tokens": 8636
+        }
+      },
+      {
+        "requested_model": "gpt-5.6-terra",
+        "selected_model": "gpt-5.6-terra",
+        "effective_model": "gpt-5.6-terra",
+        "model_identity_source": "provider_response",
+        "provider": "openai",
+        "duration_ms": 8102.044625004055,
+        "usage": {
+          "cache_write_input_tokens": 14591,
+          "cached_input_tokens": 0,
+          "completion_tokens": 825,
+          "prompt_tokens": 14594,
+          "total_tokens": 15419
+        }
+      }
+    ],
+    "work_product_id": "#V#operational_reliability_status_digest",
+    "write_receipt": {
+      "actor_concept_id": "#V#zhan_von_witbrock",
+      "canonical_read_back": {
+        "concept_id": "#V#operational_reliability_status_digest",
+        "context_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        "language": "en-NZ",
+        "predicate": "hasContent",
+        "provenance_sha256": "35c4937bc5e1e29af83203b5c37c82606522691b2710d09ae817ccf070190b08",
+        "publication_context": {
+          "concept_id": "#V#zhan_von_witbrock",
+          "kind": "user",
+          "source": "concept_visibility"
+        },
+        "relation_id": "6a9b8ceec0e3f073c0a797d1",
+        "relation_present": true,
+        "text_sha256": "6b59adf9fc64cdb57be53fd445b5d55c978b15738f5d0afac244d3591fa755c1"
+      },
+      "changed": true,
+      "completed_at": "2026-09-05T03:30:58.986000+00:00",
+      "created_at": "2026-09-05T03:30:53.366000+00:00",
+      "decision_id": "oad_8Ugco1ZaTtmplsX84347cAw3",
+      "delegation_id": null,
+      "executing_agent_concept_id": "#V#von_system",
+      "idempotency_key": "workflow:#V#lab_project_status_digest_workflow:0204da15-3c9a-498a-b79f-01299f91a691:#V#workflow_step_lab_project_status_digest_workflow_persist_digest:upsert_singleton_text_relation",
+      "intent_fingerprint": "6aad35254d8a06082b87b57da89cc2dab7b3a2d73e5caa72664a0ac1f76efe74",
+      "mutation_outcome": "succeeded",
+      "operation": "text.upsert",
+      "publication_context": {
+        "concept_id": "#V#zhan_von_witbrock",
+        "kind": "user",
+        "source": "concept_visibility"
+      },
+      "receipt_id": "omr_1e7f740206d65a53a367dfab26fd06ba5baad19bc66ee6ad15c3c24bdf99ae67",
+      "response_effect_status": null,
+      "response_error_code": null,
+      "response_projection_truncated": false,
+      "response_success": true,
+      "schema_version": "ontology_mutation_receipt.v1",
+      "status": "succeeded",
+      "target_concept_ids": [
+        "#V#operational_reliability_status_digest"
+      ]
+    },
+    "exact_readback_verified": true,
+    "replaced_relation_ids": [
+      "6a5f1ea1b96ba91039d41a13"
+    ],
+    "prior_read_projection": "Only product title and description were exposed; previous hasContent bytes are not established by this projection. No absence or exact rollback claim."
+  },
+  "operator_connector_probe": {
+    "checkout": "/Users/mjw/Development/Von-runtime-main",
+    "connector_probe": "trusted operator gateway read, not ordinary-turn delegation",
+    "issue_key": "JVNAUTOSCI-2721",
+    "error_code": null,
+    "ordinary_exclusion": "deployment_global_account"
+  },
+  "limitations": [
+    "One attempted first turn per model, no completed four-turn family.",
+    "Child model was Terra even when caller override was Luna; this is not a controlled pure-model comparison.",
+    "Jira is live, not a frozen source dataset; operator planning updates were concurrent.",
+    "A successful collection or current correct answer does not establish acceptable effects, role competence, generality or expiry of any authority."
+  ],
+  "source_artifacts": {
+    "role-programme-jira-witness.json": "a5f3d4391f3c72ff943e1422b8c20d28d74ce3badfa089acb4388e7a6cf1a21a",
+    "role-programme-jira-terra.json": "99bfa14574d3cdb4230ae371db6c6b253956facbf48ba0d83e0e943978b43bbe",
+    "role-programme-jira-luna.json": "475be7fb2b5bfc93846a235fba7b11d4a41372ea4f8f91a20460b46b99a5b416",
+    "role-programme-terra-debug.json": "37ac03bbc0271d7f0d5a366f7d984694151f1a9451ce69a4a2a4a2199ab3c4b9",
+    "role-programme-luna-task0.json": "7427a2b11752b603256c204ee321cc780025881c1da8e76b9b7402627b0fda7d",
+    "role-programme-luna-instance.json": "1c0f97d47e614354221bcd4cbf278c1ff1b43cdf2cd9f1e80a04a625d8fd87dd",
+    "role-programme-runtime-jira-probe.json": "8b1b309f1456a5a16d4a25bc6befc02be1cf7b0f9c32a99cc9552925886e3298"
+  }
+}

--- a/scripts/live_multi_turn_followup_prompt_bank.json
+++ b/scripts/live_multi_turn_followup_prompt_bank.json
@@ -238,7 +238,7 @@
     {
       "case_id": "lab_status_digest_obligation_watch",
       "domain": "team_continuity",
-      "motivating_issues": ["JVNAUTOSCI-2590"],
+      "motivating_issues": ["JVNAUTOSCI-2590", "JVNAUTOSCI-2721"],
       "turns": [
         {
           "role": "task",
@@ -257,7 +257,7 @@
         },
         {
           "role": "explicit_continuation",
-          "prompt": "Run that digest again against current evidence. Reuse the same represented digest work product, carry forward only obligations that are still unresolved, and do not duplicate an obligation with the same source, owner, and due date. Tell me what changed since the prior digest and what evidence is unavailable. Keep every external system read-only.",
+          "prompt": "Run that digest again against current evidence. Reuse the same represented digest work product and preserve each outstanding commitment's canonical source/task identity when its owner or due date changes. Absence from a search window does not resolve it. Tell me what changed since the prior digest and what evidence is unavailable. Keep every external system read-only.",
           "expectations": {
             "expected_workflow_id": "#V#lab_project_status_digest_workflow",
             "require_completed": true,
@@ -267,7 +267,7 @@
               ["evidence gap", "unavailable"],
               ["obligation", "unresolved"]
             ],
-            "notes": "Repeated UC-06 execution checks stable work-product identity and evidence-based obligation carry-forward without duplication or external mutations."
+            "notes": "Repeated UC-06 execution checks stable work-product and commitment identity across owner/date changes. Inspect the canonical text and actual effects: keyword/tool matches alone cannot pass the outcome. This same-chat case does not establish cross-encounter continuity, autonomous noticing or real-role adoption."
           }
         }
       ]


### PR DESCRIPTION
Von has continuity components and several replay programmes, but their completion does not establish useful responsibility across encounters. This change defines the next bounded programme: maintain a source-linked readiness brief for Von's own replay/reliability work, exercise unchanged and changed evidence, fact acquisition, uncertainty and recovery, then test source-derived learning and transfer as separate claims. It reuses the existing replay/evaluation surfaces and corrects the digest replay input to preserve commitment identity through owner/date changes.

Luna is the principal model, with selected paired Terra trials. The retained first live witness explains why caller and child model identities and actual effects matter: Terra gave no Jira answer; the Luna caller reached the answer through a Terra-powered digest workflow that persisted an existing test-actor work product. Ordinary Jira reads were excluded as `deployment_global_account`, while connected MCP and the deployed checkout's operator gateway could read Jira. This is neither an authentication failure nor a clean read-only or pure-model success. JVNAUTOSCI-2722 owns the next authorised-read repair; the four-turn family and role claim remain open.

Validation: 19 existing replay-runner tests passed; document links, JSON syntax, all seven retained source-artifact hashes and diff checks passed. The previously merged continuity release was deployed at clean `16e4fc79089e8480237e22bc3021874ced5f2cd4`; launcher/worker readiness and selected live workflow/prompt activation were verified. This PR changes documentation, retained evidence and development replay inputs, with no production code change or new runtime gate.

Merge decision: ready for this bounded programme/input delivery. The observed Jira failure limits the operational claim and supplies the next repair; it does not block publishing the protocol and honest evidence. 2721 stays In Progress.
