### PR TITLE
Restore authorised ordinary-turn Jira reads (JVNAUTOSCI-2722)

### DIFF
--- a/docs/engineering/jira_authorised_read_replay_2026-09-05.md
+++ b/docs/engineering/jira_authorised_read_replay_2026-09-05.md
@@ -1,0 +1,109 @@
+# Authorised Jira read replay — 5 September 2026
+
+- **Kind:** Bounded acceptance evidence
+- **Lifecycle:** Dated record
+- **Decision surface:** [JVNAUTOSCI-2722](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2722)
+- **Programme:** [JVNAUTOSCI-2721](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2721)
+- **Machine-readable observations:** [selected receipts](../generated/jira_authorised_read_2026-09-05.json)
+
+## Claim and baseline
+
+The configured Jira account's authenticated Von owner can obtain a current
+issue and the newest project Task through ordinary chat without importing
+tasks or rewriting a digest. Other users cannot borrow that account merely
+by supplying the owner's identifier, namespace or account selector.
+
+The preceding deployed baseline, `16e4fc79089e8480237e22bc3021874ced5f2cd4`,
+excluded ordinary Jira reads as `deployment_global_account`. The earlier
+Terra trial returned a non-answer. A Luna caller reached Jira through a
+Terra digest child that replaced an existing text relation. Those observations
+and exact identities remain on the linked issue. Successful operator reads
+distinguished that capability/authority mismatch from expired credentials.
+
+The candidate makes the three existing read tools available to the unique
+owner resolved through the configured account's protected Von login-email
+binding. The ordinary model chooses its query. The actual Jira proxy checks
+the actor and account again, including direct workflow calls. This uses the
+existing identity surface; it adds no workflow, semantic routing rule, token
+ceremony or broad user grant. The explicit operator migration CLI binds its
+operator provenance at its entry point, leaving its shared runner actor-bound.
+The current authority rule lives in the [security guide](security_considerations.md).
+
+## Normal authenticated path
+
+Four fresh Chrome conversations used Michael's existing normal login and
+SAIL organisation on candidate port 5002. No browser-test login, manually
+injected credential or test actor supplied the positive path. The candidate
+used the normal Atlas data, authentication and Jira services. Its isolated
+runtime marker and disabled background consumers prevented duplicate shared
+maintenance; those settings did not replace the turn's binding or retrieval.
+
+The candidate base was `7dd93457695f97deb64369c04aa10cc7a1ddfe40`, with the
+three runtime source hashes retained in the selected receipts. Runtime start
+was `2026-09-05T11:58:27.550179Z`. Luna remained the saved primary; Terra used
+the allowed browser model override. No Sol request was issued.
+
+The exact prompts were:
+
+1. “Look up JVNAUTOSCI-2722 in Jira and give its current summary and status.”
+2. “What is the most recently created Task in the JVNAUTOSCI Jira project?
+   Give its key, summary and status.”
+
+| Model | Case | Source read | Visible completion | Recorded turn time | Estimated USD |
+| --- | --- | --- | --- | --- | --- |
+| Luna | Exact issue | `jira_get_issue` | Correct, 58 s | 53.970 s | 0.005123 |
+| Luna | Newest Task | `jira_search` | Correct, 45 s | 40.868 s | 0.005296 |
+| Terra | Exact issue | `jira_get_issue` | Correct, 53 s | 48.883 s | 0.049255 |
+| Terra | Newest Task | `jira_search` | Correct, 42 s | 38.308 s | 0.052629 |
+
+Every answer identified `JVNAUTOSCI-2722`, its current summary and `In Progress`.
+The recency queries constrained issue type to Task and sorted Jira `created`
+descending, with one result. Canonical persisted Jira responses agreed with
+the visible answers. Each record had four provider-observed calls to its
+requested model, two capability-discovery calls and one Jira read. Each Jira
+response carried the authenticated owner's `governed_login_email_owner`
+receipt. Terminal state was `completed`. There was no workflow launch,
+import, reconciliation or Jira mutation invocation in these turns; ordinary
+conversation persistence still occurred.
+
+The record includes request/session identifiers, history positions, source
+response hashes, effective queries, model identities and selected receipts.
+Full private traces and expiring telemetry access envelopes are not published.
+The UI duration includes work outside the recorded turn interval. Costs are
+Von's estimates from reported usage, not invoices; order and caching were not
+randomised. These cases show no Terra-only success and support no general
+model ranking. Latency remains substantial for these small requests.
+
+## Boundary and regression evidence
+
+The live governed identity resolved an owner binding for Michael and none
+for the second actor. With the real configured proxy and identity lookup,
+forged owner/namespace/selector input from that actor returned
+`jira_resource_not_authorised`; missing trusted actor context returned
+`authenticated_actor_context_required`. A direct proxy call in the second
+actor's workflow context was also denied. An RPC sentinel recorded zero
+external calls in those negative probes. This proves the selected live
+binding boundary, not a second positive login route.
+
+Targeted tests cover all three ordinary read tools, server-only projection,
+forged request fields, owner and non-owner workflow calls, changed account
+configuration, missing/reassigned/ambiguous identity, separate Jira 401
+results and explicit operator CLI compatibility. The final run was:
+
+```sh
+pdm run pytest tests/backend/test_jira_read_authority.py \
+  tests/backend/test_internal_mcp_jira_tools.py \
+  tests/backend/test_von_generate_workflow_instances.py \
+  tests/backend/test_internal_mcp_catalogue_builds.py -q \
+  -k 'not canonical_outcome_report_uses_natural_fact_grounded_projection'
+```
+
+Result: **124 passed, 1 deselected**. The deselected narration-report test
+failed in the broader run and independently on unchanged main `7dd93457`
+(`turn_not_deliverable` versus expected `not_required`). It does not exercise
+Jira and was not repaired or relabelled as passing. Diff checks passed.
+
+The evidence supports this owner-read capability. It does not establish
+multi-user Jira delegation, the complete four-turn follow-up family, broader
+role competence or learned transfer. The continuing programme and release
+decision remain on the linked Jira issues.

--- a/docs/engineering/security_considerations.md
+++ b/docs/engineering/security_considerations.md
@@ -325,6 +325,19 @@ selected profile against trusted invocation provenance and current represented
 authority. Revalidate the catalogue and adaptive-turn service before relying
 on this dated candidate implementation claim.
 
+The Jira account-owner read path uses the authenticated actor and the configured
+Atlassian account's unique, governed `#V#hasVonLoginEmail` identity binding.
+Ordinary contact email, imported Jira person data and organisation membership
+do not supply that binding. The server projects `jira_search`, `jira_get_issue`
+and `jira_get_comments` with a hidden account selector only for that owner.
+Jira retrieval rechecks the actual proxy account and current binding, including
+direct workflow calls; a model-supplied selector or identity is not authority.
+The account's Jira permissions determine its issue visibility. This bounded
+owner path does not delegate the deployment account to other Von users or
+release Jira writes. Explicit trusted-local operator access remains separate.
+Missing or ambiguous identity binding fails closed, and a changed credential
+configuration cannot silently reuse the previous account's proxy.
+
 **Protection**:
 - The ordinary-turn projection excludes undelegated effects; an operation's
   catalogue category alone does not establish authority

--- a/docs/generated/jira_authorised_read_2026-09-05.json
+++ b/docs/generated/jira_authorised_read_2026-09-05.json
@@ -1,0 +1,261 @@
+{
+  "issue": "JVNAUTOSCI-2722",
+  "observed_date": "2026-09-05",
+  "base_commit": "7dd93457695f97deb64369c04aa10cc7a1ddfe40",
+  "runtime_port": 5002,
+  "runtime_started_at_utc": "2026-09-05T11:58:27.550179Z",
+  "positive_path": "normal authenticated Chrome /von/generate, fresh session for every case",
+  "isolation": "normal shared Atlas data and authentication; isolated runtime marker and background consumers disabled",
+  "trials": [
+    {
+      "case": "luna-exact",
+      "request_id": "5f6a53b5-f2e9-4dc2-be10-9ae5727277f1",
+      "session_id": "0ed3aa38-4c22-4325-8035-11fe5068f6d0",
+      "history_index": 4,
+      "terminal_status": "completed",
+      "requested_selected_provider_observed_model": "gpt-5.6-luna",
+      "provider_call_count": 4,
+      "tools": [
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "jira_get_issue",
+          "status": "ok"
+        }
+      ],
+      "jira_arguments": {
+        "issue_key": "JVNAUTOSCI-2722",
+        "fields": [
+          "summary",
+          "status"
+        ]
+      },
+      "jira_evidence_sha256": "0f000bd9024fc6b0061c281b41f59b5b73d4c35bed092e0468cdf7952ff8beb3",
+      "authority": {
+        "access": "read_only",
+        "actor_concept_id": "#V#michael_witbrock",
+        "grant_source": "governed_login_email_owner",
+        "principal_kind": "authenticated_actor"
+      },
+      "answer_issue": "JVNAUTOSCI-2722",
+      "answer_status": "In Progress",
+      "answer_summary": "Restore authorised Jira reads on ordinary turns without import side effects",
+      "recency_basis": null,
+      "import_reconciliation_or_jira_write_invocations": 0,
+      "ui_elapsed_seconds": 58,
+      "recorded_elapsed_ms": 53970,
+      "llm_elapsed_ms": 12268,
+      "input_tokens": 38263,
+      "output_tokens": 356,
+      "estimated_cost_usd": 0.00512256,
+      "pricing_version": [
+        "openai-standard-observed-2026-08-05"
+      ]
+    },
+    {
+      "case": "luna-newest",
+      "request_id": "1a1ab383-86a4-44c5-a21c-853d13dc9d5e",
+      "session_id": "e5262bf6-41a7-4f38-8628-1e3a54640a21",
+      "history_index": 4,
+      "terminal_status": "completed",
+      "requested_selected_provider_observed_model": "gpt-5.6-luna",
+      "provider_call_count": 4,
+      "tools": [
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "jira_search",
+          "status": "ok"
+        }
+      ],
+      "jira_arguments": {
+        "jql": "project = JVNAUTOSCI AND issuetype = Task ORDER BY created DESC",
+        "max_results": 1,
+        "fields": [
+          "key",
+          "summary",
+          "status",
+          "created",
+          "issuetype"
+        ]
+      },
+      "jira_evidence_sha256": "b772c80fce39d5f96554c08a085239ba3e02e86503512c773c5ff3e1f9da4d2b",
+      "authority": {
+        "access": "read_only",
+        "actor_concept_id": "#V#michael_witbrock",
+        "grant_source": "governed_login_email_owner",
+        "principal_kind": "authenticated_actor"
+      },
+      "answer_issue": "JVNAUTOSCI-2722",
+      "answer_status": "In Progress",
+      "answer_summary": "Restore authorised Jira reads on ordinary turns without import side effects",
+      "recency_basis": "Jira created DESC with issuetype Task",
+      "import_reconciliation_or_jira_write_invocations": 0,
+      "ui_elapsed_seconds": 45,
+      "recorded_elapsed_ms": 40868,
+      "llm_elapsed_ms": 9792,
+      "input_tokens": 38950,
+      "output_tokens": 376,
+      "estimated_cost_usd": 0.00529554,
+      "pricing_version": [
+        "openai-standard-observed-2026-08-05"
+      ]
+    },
+    {
+      "case": "terra-exact",
+      "request_id": "313a8a98-6c2d-45c1-b6a0-f7d4fbbe0fb0",
+      "session_id": "fd577fe7-fdd6-4808-bc99-f99c2f1a12b5",
+      "history_index": 4,
+      "terminal_status": "completed",
+      "requested_selected_provider_observed_model": "gpt-5.6-terra",
+      "provider_call_count": 4,
+      "tools": [
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "jira_get_issue",
+          "status": "ok"
+        }
+      ],
+      "jira_arguments": {
+        "issue_key": "JVNAUTOSCI-2722",
+        "fields": [
+          "summary",
+          "status"
+        ]
+      },
+      "jira_evidence_sha256": "0f000bd9024fc6b0061c281b41f59b5b73d4c35bed092e0468cdf7952ff8beb3",
+      "authority": {
+        "access": "read_only",
+        "actor_concept_id": "#V#michael_witbrock",
+        "grant_source": "governed_login_email_owner",
+        "principal_kind": "authenticated_actor"
+      },
+      "answer_issue": "JVNAUTOSCI-2722",
+      "answer_status": "In Progress",
+      "answer_summary": "Restore authorised Jira reads on ordinary turns without import side effects",
+      "recency_basis": null,
+      "import_reconciliation_or_jira_write_invocations": 0,
+      "ui_elapsed_seconds": 53,
+      "recorded_elapsed_ms": 48883,
+      "llm_elapsed_ms": 8530,
+      "input_tokens": 38208,
+      "output_tokens": 200,
+      "estimated_cost_usd": 0.0492552,
+      "pricing_version": [
+        "openai-standard-observed-2026-08-05"
+      ]
+    },
+    {
+      "case": "terra-newest",
+      "request_id": "de2118a6-678e-4c66-aa5d-bda91f627248",
+      "session_id": "965d5e1c-b070-4415-9857-b779af65bbea",
+      "history_index": 4,
+      "terminal_status": "completed",
+      "requested_selected_provider_observed_model": "gpt-5.6-terra",
+      "provider_call_count": 4,
+      "tools": [
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "turn_capabilities",
+          "status": "ok"
+        },
+        {
+          "name": "jira_search",
+          "status": "ok"
+        }
+      ],
+      "jira_arguments": {
+        "jql": "project = JVNAUTOSCI ORDER BY created DESC",
+        "max_results": 1,
+        "fields": [
+          "summary",
+          "status",
+          "created"
+        ]
+      },
+      "jira_evidence_sha256": "bd0b2045ef2bfc645c745e2682aebf415dd2ee21acfd208cf9e6e05f6887f84e",
+      "authority": {
+        "access": "read_only",
+        "actor_concept_id": "#V#michael_witbrock",
+        "grant_source": "governed_login_email_owner",
+        "principal_kind": "authenticated_actor"
+      },
+      "answer_issue": "JVNAUTOSCI-2722",
+      "answer_status": "In Progress",
+      "answer_summary": "Restore authorised Jira reads on ordinary turns without import side effects",
+      "recency_basis": "Jira created DESC with issuetype Task",
+      "import_reconciliation_or_jira_write_invocations": 0,
+      "ui_elapsed_seconds": 42,
+      "recorded_elapsed_ms": 38308,
+      "llm_elapsed_ms": 7819,
+      "input_tokens": 39827,
+      "output_tokens": 250,
+      "estimated_cost_usd": 0.0526285,
+      "pricing_version": [
+        "openai-standard-observed-2026-08-05"
+      ]
+    }
+  ],
+  "code_sha256": {
+    "src/backend/integrations/internal_mcp/jira_proxy_mcp.py": "8c705f4f51cc660682b23c09566acb69ede6bf8bd09bbf0400931d1a9865f730",
+    "src/backend/integrations/internal_mcp/catalogue.py": "1c539d27ff567c86fe0085c71a974cd498f38122f4ab818c437547136858f712",
+    "src/backend/server/routes/von_routes.py": "3756c5e9667b255b1efc51cce699ddfa4762d9e6e46d65cf2f49379ff9aa6341"
+  },
+  "negative_probe": {
+    "binding_source": "live_governed_login_identity",
+    "owner_binding_present": true,
+    "other_actor_binding_present": false,
+    "rpc_calls": 0,
+    "results": [
+      {
+        "route": "gateway_forged_payload",
+        "actor": "#V#zhan_von_witbrock",
+        "error_code": "jira_resource_not_authorised"
+      },
+      {
+        "route": "gateway_forged_payload",
+        "actor": null,
+        "error_code": "authenticated_actor_context_required"
+      },
+      {
+        "route": "direct_workflow_proxy",
+        "actor": "#V#zhan_von_witbrock",
+        "error_code": "jira_resource_not_authorised"
+      }
+    ]
+  },
+  "test_evidence": {
+    "passed": 124,
+    "deselected": 1,
+    "baseline_failure": "test_canonical_outcome_report_uses_natural_fact_grounded_projection also fails on unchanged main7dd93457"
+  },
+  "limits": [
+    "One fresh trial per model and prompt; no stochastic reliability or general model-ranking claim.",
+    "Cost is Von telemetry estimate, not an invoice; caching and trial order are not randomised.",
+    "Other actors do not gain Jira access; no multi-user delegation added.",
+    "No complete multi-turn family, role certification, or Jira write release.",
+    "Negative live binding probe substituted an RPC sentinel; positive trials used real Jira."
+  ]
+}

--- a/scripts/run_jira_task_migration.py
+++ b/scripts/run_jira_task_migration.py
@@ -103,8 +103,18 @@ def _parse_args() -> JiraTaskMigrationOptions:
 
 
 def main() -> None:
+    from src.backend.integrations.internal_mcp.gateway import (
+        INTERNAL_MCP_TRUSTED_LOCAL_OPERATOR_SOURCE,
+        bind_internal_mcp_actor_context_source,
+    )
+
     options = _parse_args()
-    report = run_jira_task_migration_sync(options)
+    # This explicit local CLI is an operator entry point. Keep this authority
+    # here, not in the runner also called by actor-bound durable workflows.
+    with bind_internal_mcp_actor_context_source(
+        INTERNAL_MCP_TRUSTED_LOCAL_OPERATOR_SOURCE
+    ):
+        report = run_jira_task_migration_sync(options)
     print(json.dumps({"report_path": str(options.report_path), "summary": report}, indent=2))
 
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -25712,6 +25712,7 @@ def _jira_search_input_schema() -> Schema:
     return Schema(
         required={"jql": str},
         optional={
+            "resource_id": (str,),
             "max_results": (int,),
             "start_at": (int,),
             "next_page_token": (str,),
@@ -25730,7 +25731,7 @@ def _jira_search_input_schema() -> Schema:
 def _jira_get_issue_input_schema() -> Schema:
     return Schema(
         required={"issue_key": str},
-        optional={"fields": (list,), "expand": (list,)},
+        optional={"fields": (list,), "expand": (list,), "resource_id": (str,)},
         allow_unknown=True,
         comma_separated_list_fields=("fields", "expand"),
         description=(
@@ -25745,6 +25746,7 @@ def _jira_get_comments_input_schema() -> Schema:
     return Schema(
         required={"issue_key": str},
         optional={
+            "resource_id": (str,),
             "start_at": (int,),
             "max_results": (int,),
             "order_by": (str,),
@@ -32553,13 +32555,14 @@ def _jira_search(**kwargs):
             start_at=kwargs.get("start_at"),
             next_page_token=kwargs.get("next_page_token"),
             fields=kwargs.get("fields"),
+            **({"resource_id": kwargs["resource_id"]} if "resource_id" in kwargs else {}),
         )
 
     try:
         return _run_async_compat(_async_search)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -32584,13 +32587,14 @@ def _jira_get_issue(**kwargs):
             issue_key=issue_key,
             fields=kwargs.get("fields"),
             expand=kwargs.get("expand"),
+            **({"resource_id": kwargs["resource_id"]} if "resource_id" in kwargs else {}),
         )
 
     try:
         return _run_async_compat(_async_get_issue)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -32635,13 +32639,14 @@ def _jira_get_comments(**kwargs):
             max_results=kwargs.get("max_results"),
             order_by=order_by,
             body_format=body_format,
+            **({"resource_id": kwargs["resource_id"]} if "resource_id" in kwargs else {}),
         )
 
     try:
         return _run_async_compat(_async_get_comments)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -32670,7 +32675,7 @@ def _jira_get_project_issue_types(**kwargs):
         return _run_async_compat(_async_get_project_issue_types)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={
                 "exception_type": "JiraProxyError",
@@ -32704,7 +32709,7 @@ def _jira_get_bulk_operation_progress(**kwargs):
         result = _run_async_compat(_async_get_progress)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={
                 "exception_type": "JiraProxyError",
@@ -32752,7 +32757,7 @@ def _jira_get_transitions(**kwargs):
         return _run_async_compat(_async_get_transitions)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -32908,7 +32913,7 @@ def _jira_add_attachment(**kwargs):
         raw_result = _run_async_compat(_async_add_attachment)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -34304,7 +34309,7 @@ def _jira_get_myself(**kwargs):
         return _run_async_compat(_async_get_myself)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -36276,7 +36281,7 @@ def _task_import_jira_issues(**kwargs):
         fetch_payload = _run_async_compat(_fetch_jira_issues)
     except JiraProxyError as exc:
         return make_error_response(
-            "jira_proxy_error",
+            getattr(exc, "reason_code", "jira_proxy_error"),
             str(exc),
             details={"exception_type": "JiraProxyError"},
             suggestions=["Check Jira connectivity and authentication"],
@@ -42055,7 +42060,7 @@ def _build_default_catalogue_external_integration_definitions() -> List[
             input_schema=_jira_search_input_schema(),
             output_schema=jira_search_output_schema,
             category="read",
-            ordinary_turn_excluded_reason="deployment_global_account",
+            ordinary_turn_trusted_argument_bindings={"resource_id": "jira_resource_id"},
             timeout_sec=20.0,
             description="Run a JQL query against Jira. Use when you need to find issues by status, assignee, project, or other fields. Requires valid ATLASSIAN_BASE_URL, ATLASSIAN_EMAIL, and ATLASSIAN_API_TOKEN in the environment. Returns the Jira search response including issues array.",
         ),
@@ -42065,7 +42070,7 @@ def _build_default_catalogue_external_integration_definitions() -> List[
             input_schema=_jira_get_issue_input_schema(),
             output_schema=jira_get_issue_output_schema,
             category="read",
-            ordinary_turn_excluded_reason="deployment_global_account",
+            ordinary_turn_trusted_argument_bindings={"resource_id": "jira_resource_id"},
             timeout_sec=15.0,
             description=(
                 "Fetch full details for a Jira issue by key (e.g., JVNAUTOSCI-123). "
@@ -42079,7 +42084,7 @@ def _build_default_catalogue_external_integration_definitions() -> List[
             input_schema=_jira_get_comments_input_schema(),
             output_schema=jira_get_comments_output_schema,
             category="read",
-            ordinary_turn_excluded_reason="deployment_global_account",
+            ordinary_turn_trusted_argument_bindings={"resource_id": "jira_resource_id"},
             timeout_sec=15.0,
             description=(
                 "Read comments on a Jira issue one page at a time, with "

--- a/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
+++ b/src/backend/integrations/internal_mcp/jira_proxy_mcp.py
@@ -12,6 +12,7 @@ import os
 import sys
 import threading
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, cast
 
@@ -31,6 +32,106 @@ JIRA_PROXY_ENV_OVERRIDE_KEYS: tuple[str, ...] = (
 
 class JiraProxyError(Exception):
     """Raised when Jira proxy operations fail."""
+
+
+class JiraInvocationAuthorityError(JiraProxyError):
+    """Non-enumerating denial before the configured account is queried."""
+
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _jira_resource_id(auth: Mapping[str, Any]) -> str:
+    identity = f"{auth.get('base_url', '')}\n{str(auth.get('email') or '').casefold()}"
+    return "jira_account_" + sha256(identity.encode("utf-8")).hexdigest()[:24]
+
+
+def _jira_account_owner(auth: Mapping[str, Any]) -> str | None:
+    from ...services.von_user_authentication_service import (
+        find_user_concept_by_login_email,
+    )
+
+    if not all(auth.get(key) for key in ("base_url", "email", "token_present")):
+        raise JiraInvocationAuthorityError(
+            "jira_configuration_unavailable",
+            "Jira account configuration is unavailable.",
+        )
+    try:
+        # This governed authentication binding is deliberately stronger than
+        # contact email, imported Jira person data or organisation membership.
+        owner = find_user_concept_by_login_email(auth["email"])
+    except Exception as exc:
+        raise JiraInvocationAuthorityError(
+            "jira_account_binding_unavailable",
+            "The Jira account's governed owner binding could not be verified.",
+        ) from exc
+    return owner.get("concept_id") if owner else None
+
+
+def jira_resource_binding_for_user(user_concept_id: str | None) -> str | None:
+    """Project this deployment's Jira account only for its authenticated owner."""
+
+    if not user_concept_id:
+        return None
+    auth = inspect_jira_auth_config()
+    try:
+        owner = _jira_account_owner(auth)
+    except JiraInvocationAuthorityError:
+        return None
+    return _jira_resource_id(auth) if owner == user_concept_id else None
+
+
+def resolve_jira_read_authority(
+    auth: Mapping[str, Any], *, resource_id: str | None = None
+) -> dict[str, Any]:
+    """Recheck the actual proxy account for direct and workflow retrieval."""
+
+    from .gateway import (
+        get_internal_mcp_actor_context_source,
+        get_internal_mcp_preexisting_actor_context,
+        internal_mcp_actor_context_is_trusted_local_operator,
+        internal_mcp_actor_context_is_untrusted_payload_fallback,
+    )
+    from ...security.access_control import get_effective_user_concept_id
+
+    actual_resource_id = _jira_resource_id(auth)
+    if resource_id is not None and resource_id != actual_resource_id:
+        raise JiraInvocationAuthorityError(
+            "jira_resource_not_authorised", "The Jira account binding has changed."
+        )
+    operator = internal_mcp_actor_context_is_trusted_local_operator()
+    actor_id = None
+    if not operator:
+        preexisting = get_internal_mcp_preexisting_actor_context()
+        if not internal_mcp_actor_context_is_untrusted_payload_fallback():
+            if preexisting is not None:
+                actor_id = preexisting[0]
+            elif get_internal_mcp_actor_context_source() is None:
+                # A durable worker may call the proxy directly inside its
+                # server-bound actor context. An unscoped call is not an operator.
+                actor_id = get_effective_user_concept_id()
+        if not actor_id:
+            raise JiraInvocationAuthorityError(
+                "authenticated_actor_context_required",
+                "Jira reads require an authenticated actor or the trusted local operator route.",
+            )
+        if _jira_account_owner(auth) != actor_id:
+            raise JiraInvocationAuthorityError(
+                "jira_resource_not_authorised",
+                "The configured Jira account is not authorised for this actor.",
+            )
+    return {
+        "principal_kind": (
+            "trusted_local_operator" if operator else "authenticated_actor"
+        ),
+        "actor_concept_id": actor_id,
+        "resource_id": actual_resource_id,
+        "grant_source": (
+            "trusted_local_operator" if operator else "governed_login_email_owner"
+        ),
+        "access": "read_only",
+    }
 
 
 def _resolve_jira_auth(
@@ -67,11 +168,16 @@ def _resolve_jira_auth(
     if base_url:
         base_url = base_url.rstrip("/")
 
-    return base_url, email, token, {
-        "base_url": base_url_key,
-        "email": email_key,
-        "token": token_key,
-    }
+    return (
+        base_url,
+        email,
+        token,
+        {
+            "base_url": base_url_key,
+            "email": email_key,
+            "token": token_key,
+        },
+    )
 
 
 @dataclass
@@ -88,6 +194,7 @@ class JiraMCPProxy:
     """Manages external Jira MCP server subprocess using MCP SDK client."""
 
     def __init__(self, config: JiraProxyConfig):
+        self._auth_identity = _resolve_jira_auth(config.env)[:3]
         client_config = MCPServerConfig(
             command=config.command,
             args=config.args,
@@ -97,9 +204,25 @@ class JiraMCPProxy:
         )
         self._client = MCPStdIOClient(client_config)
 
-    async def _call(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+    async def _call(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        *,
+        resource_id: str | None = None,
+    ) -> Any:
+        authority = None
+        if tool_name == "jira_search" or tool_name.startswith("jira_get_"):
+            base_url, email, token = self._auth_identity
+            authority = resolve_jira_read_authority(
+                {"base_url": base_url, "email": email, "token_present": bool(token)},
+                resource_id=resource_id,
+            )
         try:
-            return await self._client.call_tool(tool_name, arguments)
+            result = await self._client.call_tool(tool_name, arguments)
+            if authority is not None and isinstance(result, dict):
+                result = {**result, "authority": authority}
+            return result
         except MCPToolClientError as exc:
             raise JiraProxyError(str(exc)) from exc
 
@@ -111,6 +234,7 @@ class JiraMCPProxy:
         start_at: Optional[int] = None,
         next_page_token: Optional[str] = None,
         fields: Optional[list[str]] = None,
+        resource_id: str | None = None,
     ) -> Dict[str, Any]:
         arguments: Dict[str, Any] = {"jql": jql}
         if isinstance(max_results, int):
@@ -121,7 +245,7 @@ class JiraMCPProxy:
             arguments["next_page_token"] = next_page_token.strip()
         if fields:
             arguments["fields"] = fields
-        return await self._call("jira_search", arguments)
+        return await self._call("jira_search", arguments, resource_id=resource_id)
 
     async def get_issue(
         self,
@@ -129,13 +253,14 @@ class JiraMCPProxy:
         issue_key: str,
         fields: Optional[list[str]] = None,
         expand: Optional[list[str]] = None,
+        resource_id: str | None = None,
     ) -> Dict[str, Any]:
         arguments: Dict[str, Any] = {"issue_key": issue_key}
         if fields:
             arguments["fields"] = fields
         if expand:
             arguments["expand"] = expand
-        return await self._call("jira_get_issue", arguments)
+        return await self._call("jira_get_issue", arguments, resource_id=resource_id)
 
     async def get_comments(
         self,
@@ -145,6 +270,7 @@ class JiraMCPProxy:
         max_results: Optional[int] = None,
         order_by: Optional[str] = None,
         body_format: Optional[str] = None,
+        resource_id: str | None = None,
     ) -> Dict[str, Any]:
         arguments: Dict[str, Any] = {"issue_key": issue_key}
         if isinstance(start_at, int):
@@ -155,7 +281,7 @@ class JiraMCPProxy:
             arguments["order_by"] = order_by.strip()
         if isinstance(body_format, str) and body_format.strip():
             arguments["body_format"] = body_format.strip()
-        return await self._call("jira_get_comments", arguments)
+        return await self._call("jira_get_comments", arguments, resource_id=resource_id)
 
     async def get_watchers(self, *, issue_key: str) -> Dict[str, Any]:
         return await self._call("jira_get_watchers", {"issue_key": issue_key})
@@ -347,8 +473,13 @@ async def get_jira_proxy() -> JiraMCPProxy:
     global _proxy_instance
 
     with _proxy_lock:
-        if _proxy_instance is None:
-            config = _build_jira_config()
+        config = _build_jira_config()
+        # Never authorise a freshly configured account and then send the read
+        # through a process still authenticated as the previous account.
+        if (
+            _proxy_instance is None
+            or _proxy_instance._auth_identity != _resolve_jira_auth(config.env)[:3]
+        ):
             _proxy_instance = JiraMCPProxy(config)
             logger.info("%s Initialised Jira MCP proxy via %s", _LOG_TAG, config.args)
         return _proxy_instance

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -12299,6 +12299,14 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
 
     _check_background_cancellation("authentication context")
 
+    from ...integrations.internal_mcp.jira_proxy_mcp import (
+        jira_resource_binding_for_user,
+    )
+
+    # Only the authenticated actor can acquire this selector. Jira retrieval
+    # rechecks the actual proxy account and governed identity at invocation.
+    jira_resource_trusted_binding = jira_resource_binding_for_user(user_concept_id)
+
     linkedin_resource_trusted_binding: str | None = None
     if user_concept_id:
         from ...integrations.internal_mcp.linkedin_proxy_mcp import (
@@ -13694,6 +13702,10 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
         adaptive_turn_started = time.perf_counter()
         adaptive_input_context = enhanced_context
         trusted_turn_argument_values: dict[str, Any] = {}
+        if jira_resource_trusted_binding is not None:
+            trusted_turn_argument_values["jira_resource_id"] = (
+                jira_resource_trusted_binding
+            )
         if linkedin_resource_trusted_binding is not None:
             trusted_turn_argument_values["linkedin_resource_id"] = (
                 linkedin_resource_trusted_binding

--- a/tests/backend/test_jira_read_authority.py
+++ b/tests/backend/test_jira_read_authority.py
@@ -1,0 +1,260 @@
+"""Exercise account ownership at discovery and at the actual Jira RPC boundary."""
+
+import asyncio
+
+import pytest
+
+from src.backend.integrations.internal_mcp import jira_proxy_mcp as jira
+from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.security.access_control import override_current_actor
+from src.backend.services import von_user_authentication_service as identity
+from src.backend.services.adaptive_turn_service import (
+    _model_visible_input_schema,
+    ordinary_turn_capability_delegation,
+)
+
+OWNER = "#V#jira_owner"
+OTHER = "#V#other_actor"
+AUTH = {
+    "base_url": "https://example.atlassian.net",
+    "email": "owner@example.com",
+    "token_present": True,
+}
+READS = (
+    ("jira_search", {"jql": "project = PROJ ORDER BY created DESC"}),
+    ("jira_get_issue", {"issue_key": "PROJ-1"}),
+    ("jira_get_comments", {"issue_key": "PROJ-1"}),
+)
+
+
+@pytest.fixture
+def account(monkeypatch):
+    state = {"owner": OWNER, "calls": []}
+    monkeypatch.setattr(jira, "inspect_jira_auth_config", lambda: dict(AUTH))
+
+    def lookup(email):
+        assert email == AUTH["email"]
+        return {"concept_id": state["owner"]} if state["owner"] else None
+
+    monkeypatch.setattr(identity, "find_user_concept_by_login_email", lookup)
+    proxy = jira.JiraMCPProxy(
+        jira.JiraProxyConfig(
+            command="unused",
+            args=[],
+            env={
+                "ATLASSIAN_BASE_URL": AUTH["base_url"],
+                "ATLASSIAN_EMAIL": AUTH["email"],
+                "ATLASSIAN_API_TOKEN": "test-token",
+            },
+        )
+    )
+
+    async def call(tool, arguments):
+        state["calls"].append((tool, arguments))
+        return {"issues": [], "key": "PROJ-1", "comments": []}
+
+    monkeypatch.setattr(proxy._client, "call_tool", call)
+
+    async def get_proxy():
+        return proxy
+
+    monkeypatch.setattr(jira, "get_jira_proxy", get_proxy)
+    state["proxy"] = proxy
+    return state
+
+
+def gateway(*, operator=False):
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+        trusted_actor_payload_fallback=operator,
+    )
+
+
+def test_governed_owner_binding_projects_only_the_three_read_capabilities(account):
+    resource = jira.jira_resource_binding_for_user(OWNER)
+    assert resource
+    assert jira.jira_resource_binding_for_user(OTHER) is None
+    assert jira.jira_resource_binding_for_user(None) is None
+    g = gateway()
+    names = ordinary_turn_capability_delegation(
+        g, user_concept_id=OWNER, trusted_argument_values={"jira_resource_id": resource}
+    )
+    assert all(name in names for name, _ in READS)
+    assert "jira_create_issue" not in names
+    assert "jira_get_auth_config" not in names
+    without = ordinary_turn_capability_delegation(g, user_concept_id=OTHER)
+    assert all(name not in without for name, _ in READS)
+    for name, _ in READS:
+        schema = _model_visible_input_schema(
+            g.get_method_definition(name), {"jira_resource_id": resource}
+        )
+        assert "resource_id" not in schema["properties"]
+
+
+@pytest.mark.parametrize("name,arguments", READS)
+@pytest.mark.parametrize("with_selector", [True, False])
+def test_owner_read_through_gateway_or_workflow_keeps_exact_query(
+    account, name, arguments, with_selector
+):
+    payload = dict(arguments)
+    if with_selector:
+        payload["resource_id"] = jira.jira_resource_binding_for_user(OWNER)
+    with override_current_actor(OWNER, None):
+        result = gateway().invoke(name, payload).payload
+    assert result["authority"]["actor_concept_id"] == OWNER
+    assert account["calls"] == [(name, arguments)]
+
+
+@pytest.mark.parametrize("name,arguments", READS)
+@pytest.mark.parametrize("actor", [OTHER, None])
+def test_other_actor_and_payload_impersonation_denied_before_rpc(
+    account, name, arguments, actor
+):
+    with override_current_actor(actor, None):
+        result = (
+            gateway()
+            .invoke(
+                name,
+                {
+                    **arguments,
+                    "user_concept_id": OWNER,
+                    "namespace": "jira_owner",
+                    "resource_id": jira.jira_resource_binding_for_user(OWNER),
+                },
+            )
+            .payload
+        )
+    assert result["error_code"] == (
+        "jira_resource_not_authorised"
+        if actor
+        else "authenticated_actor_context_required"
+    )
+    assert account["calls"] == []
+
+
+def test_direct_durable_proxy_call_rechecks_actor_without_gateway(account):
+    with (
+        override_current_actor(OTHER, None),
+        pytest.raises(jira.JiraInvocationAuthorityError),
+    ):
+        asyncio.run(account["proxy"].search(jql="project = PROJ"))
+    assert account["calls"] == []
+    with override_current_actor(OWNER, None):
+        result = asyncio.run(account["proxy"].search(jql="project = PROJ"))
+    assert result["authority"]["actor_concept_id"] == OWNER
+
+
+@pytest.mark.parametrize("new_owner", [None, OTHER])
+def test_revoked_or_reassigned_binding_cannot_use_previous_selector(account, new_owner):
+    resource = jira.jira_resource_binding_for_user(OWNER)
+    account["owner"] = new_owner
+    with override_current_actor(OWNER, None):
+        result = (
+            gateway()
+            .invoke("jira_get_issue", {"issue_key": "PROJ-1", "resource_id": resource})
+            .payload
+        )
+    assert result["error_code"] == "jira_resource_not_authorised"
+    assert account["calls"] == []
+
+
+def test_ambiguous_or_unavailable_identity_fails_closed(account, monkeypatch):
+    def unavailable(_email):
+        raise RuntimeError("private identity detail must not be returned")
+
+    monkeypatch.setattr(identity, "find_user_concept_by_login_email", unavailable)
+    assert jira.jira_resource_binding_for_user(OWNER) is None
+    with override_current_actor(OWNER, None):
+        result = gateway().invoke("jira_get_issue", {"issue_key": "PROJ-1"}).payload
+    assert result["error_code"] == "jira_account_binding_unavailable"
+    assert "private identity detail" not in str(result)
+    assert account["calls"] == []
+
+
+def test_stale_account_selector_denied(account):
+    with override_current_actor(OWNER, None):
+        result = (
+            gateway()
+            .invoke(
+                "jira_get_issue", {"issue_key": "PROJ-1", "resource_id": "old-account"}
+            )
+            .payload
+        )
+    assert result["error_code"] == "jira_resource_not_authorised"
+    assert account["calls"] == []
+
+
+def test_explicit_local_operator_remains_available_without_login_binding(account):
+    account["owner"] = None
+    with override_current_actor(None, None):
+        result = (
+            gateway(operator=True)
+            .invoke("jira_get_issue", {"issue_key": "PROJ-1"})
+            .payload
+        )
+    assert result["authority"]["principal_kind"] == "trusted_local_operator"
+
+
+def test_jira_authentication_failure_is_not_relabelled_as_actor_denial(
+    account, monkeypatch
+):
+    async def denied(*_args):
+        return {"success": False, "status_code": 401, "error": "Unauthorised"}
+
+    monkeypatch.setattr(account["proxy"]._client, "call_tool", denied)
+    with override_current_actor(OWNER, None):
+        result = gateway().invoke("jira_get_issue", {"issue_key": "PROJ-1"}).payload
+    assert result["status_code"] == 401
+    assert result["success"] is False
+
+
+def test_proxy_cache_tracks_actual_account_and_credential_configuration(monkeypatch):
+    env = {
+        "ATLASSIAN_BASE_URL": AUTH["base_url"],
+        "ATLASSIAN_EMAIL": AUTH["email"],
+        "ATLASSIAN_API_TOKEN": "first",
+    }
+    monkeypatch.setattr(jira, "_proxy_instance", None)
+    monkeypatch.setattr(
+        jira,
+        "_build_jira_config",
+        lambda: jira.JiraProxyConfig(command="unused", args=[], env=dict(env)),
+    )
+    first = asyncio.run(jira.get_jira_proxy())
+    assert asyncio.run(jira.get_jira_proxy()) is first
+    env["ATLASSIAN_EMAIL"] = "changed@example.com"
+    changed = asyncio.run(jira.get_jira_proxy())
+    assert changed is not first
+    env["ATLASSIAN_API_TOKEN"] = "rotated"
+    assert asyncio.run(jira.get_jira_proxy()) is not changed
+
+
+def test_operator_migration_cli_binds_authority_only_around_its_runner(
+    monkeypatch, capsys
+):
+    from pathlib import Path
+    from types import SimpleNamespace
+    from scripts import run_jira_task_migration as cli
+    from src.backend.integrations.internal_mcp.gateway import (
+        internal_mcp_actor_context_is_trusted_local_operator,
+    )
+
+    monkeypatch.setattr(
+        cli, "_parse_args", lambda: SimpleNamespace(report_path=Path("unused.json"))
+    )
+    calls = []
+
+    def run(_options):
+        assert internal_mcp_actor_context_is_trusted_local_operator()
+        calls.append(True)
+        return {"dry_run": True}
+
+    monkeypatch.setattr(cli, "run_jira_task_migration_sync", run)
+    cli.main()
+    assert calls == [True]
+    assert not internal_mcp_actor_context_is_trusted_local_operator()
+    assert '"dry_run": true' in capsys.readouterr().out

--- a/tests/backend/test_von_generate_workflow_instances.py
+++ b/tests/backend/test_von_generate_workflow_instances.py
@@ -630,6 +630,32 @@ def test_generate_passes_authorised_workflow_inputs_to_adaptive_capabilities(
     }
 
 
+@pytest.mark.parametrize("account_owner", ["#V#michael_witbrock", "#V#someone_else"])
+def test_generate_binds_jira_from_authenticated_identity_not_body(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, account_owner: str,
+) -> None:
+    from src.backend.integrations.internal_mcp import jira_proxy_mcp as jira
+    from src.backend.services import von_user_authentication_service as identity
+
+    monkeypatch.setattr(jira, "inspect_jira_auth_config", lambda: {
+        "base_url": "https://example.atlassian.net", "email": "owner@example.com",
+        "token_present": True,
+    })
+    monkeypatch.setattr(identity, "find_user_concept_by_login_email", lambda email: {
+        "concept_id": account_owner,
+    })
+    response = app.test_client().post("/von/generate", json={
+        "prompt": "Look up the current Jira issue.",
+        "user_id": "#V#someone_else", "jira_resource_id": "forged",
+        "trusted_argument_values": {"jira_resource_id": "forged"},
+    })
+    assert response.status_code == 200
+    call = app.config["_ADAPTIVE_TURN_CALLS"][-1]
+    binding = (call["trusted_argument_values"] or {}).get("jira_resource_id")
+    assert binding == jira.jira_resource_binding_for_user("#V#michael_witbrock")
+    assert bool(binding) == (account_owner == "#V#michael_witbrock")
+
+
 def test_body_identity_cannot_override_actor_scope_passed_to_adaptive_turn(
     app: Flask,
 ) -> None:


### PR DESCRIPTION
Merge decision: ready — the authenticated owner of the configured Jira account can obtain current issue details and the newest project Task through ordinary chat without importing tasks or rewriting a digest.

## User outcome

[JVNAUTOSCI-2722](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2722) removes the capability/authority mismatch that blocked the 2721 pilot. The prior ordinary catalogue hid Jira reads even from the account owner; an available digest workflow could retrieve Jira while making an unrequested durable write.

## Material changes

- Project the three existing Jira read tools using the configured account's unique protected Von login-email binding and authenticated server actor. Keep the account selector hidden from the model.
- Recheck actual account ownership at the Jira proxy, including direct workflow calls. Refresh cached proxy configuration when the account or credential changes; preserve typed authority and connection failures.
- Retain explicit local-operator migration CLI access at its entry point. Other actors and ordinary Jira writes gain no access.

The guard prevents a demonstrated cross-user path: a separately acting workflow must not consume deployment Jira credentials under an unrelated actor. A hidden selector alone does not enforce that boundary. No workflow, query interpretation rule, new token or grant schema is added.

## Evidence

- 124 targeted tests passed. One narration-report test was excluded after its failure reproduced on unchanged main; it does not exercise Jira.
- Four fresh normal-authenticated Chrome turns: Luna and Terra each passed exact-issue and newest-Task queries. Persisted records show matching requested/selected/provider-observed models, two capability discoveries and one Jira read each, correct source data and owner receipts, with no workflow launch/import/reconciliation/Jira mutation.
- Live identity negative probes: other actor, missing actor and forged owner fields denied before RPC; direct workflow proxy denied too.
- [Dated evidence](docs/engineering/jira_authorised_read_replay_2026-09-05.md) and [selected receipts](docs/generated/jira_authorised_read_2026-09-05.json) retain runtime/source hashes and exact locators without publishing private traces or access envelopes.

## Ship boundary

- **Minimum ship criteria:** Normal authorised owner path, current source-grounded answers and preserved negative actor boundary. Tier 3 for authority release; satisfied by the bounded evidence above.
- **Stop-ship:** Cross-user disclosure, fabricated current data, normal owner blockage or an unintended import/write on the read cases.
- **Non-blocking observations:** Visible completion took 42–58 seconds. Luna estimates were approximately USD 0.005 per turn and Terra USD 0.05; four ordered trials are not a general model/cost benchmark. The unrelated baseline test failure remains.
- **Non-goals:** Other-user delegation, Jira writes, the full multi-turn follow-up family and role certification. Local runtime deployment and read-back are authorised separately and will be recorded on Jira after merge.


[JVNAUTOSCI-2722]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ