### PR TITLE
JVNAUTOSCI-2721: start prospective readiness programme with real-path evidence

### DIFF
--- a/docs/engineering/jvnautosci_2721_prospective_readiness_2026-09-05.md
+++ b/docs/engineering/jvnautosci_2721_prospective_readiness_2026-09-05.md
@@ -1,0 +1,273 @@
+# First prospective replay-readiness responsibility
+
+- **Kind:** Dated execution and evidence record
+- **Lifecycle:** Frozen evidence record
+- **Authority:** Observations and interpretation; not runtime policy or certification
+- **Owner:** Michael Witbrock through [JVNAUTOSCI-2721](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2721)
+- **Evidence date:** 5 September 2026 UTC
+- **Live selection:** 2721 and [the bounded programme](role_convergence_test_programme.md)
+
+## Scope and prior state
+
+Michael authorised refining the programme and beginning execution. The real
+responsibility is maintaining readiness of Von's replay and reliability work
+for Michael. Codex selected the initial sources, issued the encounters through
+Michael's normal authenticated Chrome session, and independently reviewed the
+results. That facilitation is not autonomous Von initiative or beneficiary
+adoption.
+
+The existing runtime at port 5001 was clean release
+`38afefd252071274a497bdc9b9be41982c4ca9e1`, including 2722's owner-bound Jira reads.
+Health and worker readiness were checked. No production code or represented
+prompt was changed for these encounters. Luna is the principal model; Sol is
+excluded. Private diagnostic envelopes remain outside the repository.
+
+The frozen portfolio review supplied sequencing advice. The programme and
+live Jira were refined around an initial brief, unchanged fresh encounter,
+the complete 2568 family, its actual published outcome, and one scheduled
+maintenance checkpoint. Later learned efficacy and transfer remain separate
+claims. 2720's rejected candidate is not reactivated.
+
+## Encounter A: establish the responsibility
+
+The prompt supplied the job, exact proposed product name, seven Jira issue
+identities (2721, 2722, 2720, 2568, 2577, 2578 and 2590), and authority to
+maintain one internal product. It did not supply an answer or prescribed
+recommendation. Jira and other products were to remain unchanged; scheduling
+was explicitly excluded from this encounter. Source and outcome expectations
+were retained before submission. Jira refinement was a rolling acquisition:
+2568's updated description was saved just after submission, before source reads.
+
+Von created `#V#von_replay_and_reliability_readiness_michael_2721`, a
+`#V#work_document` with Michael as owner and user-specific visibility. The
+creation, owner relation and `hasContent` write have successful effect receipts;
+the turn fetched the concept and text again. An independent actor-scoped
+canonical service read recovered the exact 5,492-character text and matching
+write-receipt SHA-256:
+`2cee7f3f7c6691660cae0819deb80d25c6017370d17b34edfe26ad69df18556f`.
+The canonical text relation is `6a9c167cb312f5fd99b0ceab`.
+
+The brief links its sources, distinguishes 2722's delivered read path from
+unproved broader capabilities, and selects the four-turn Jira family. However,
+it imports the real critic, durable worker and independent-case requirements
+from broader certification work into that ordinary conversational replay. It
+also describes 2720 as a completed learning-cycle dossier without preserving
+the material fact that the candidate was rejected. These are judgement and
+knowledge-maintenance deficits; a persisted, source-linked brief alone does
+not pass the intended programme-management claim.
+
+The UI elapsed time was 7 minutes 20 seconds. Canonical turn timing records
+405.241 seconds, so the UI and recorded execution spans are reported separately.
+There were 136 tool invocations: 14 Jira reads, 100 `turn_read_evidence` calls,
+and 22 discovery, creation, relationship, text and read-back calls. All 100
+evidence reads returned `ok`; they included repeated field and keyword
+projections of the acquired issue/comment payloads. This is observed retrieval
+burden, not evidence that all those reads were redundant or that Atlas alone
+caused the latency. The recorded totals include 156.908 seconds in tools and
+198.339 seconds in model calls; overlapping totals are not added.
+
+Nineteen model calls were recorded. The UI reported 1,060,153 input tokens,
+15,458 output tokens and a known cost subtotal of US$0.119615, with partial
+coverage. Missing auxiliary usage is not zero cost. No Jira write, import,
+reconciliation, schedule creation or mutation of another work product appears
+in the executed-tool record.
+
+Locator: session `a1fb157e-a4b2-4bd7-b45b-ddb21acff5fd`, request
+`ea086bbd-a3d8-4f50-bd2f-520a7deb942f`, assistant history index 137.
+
+**Merge decision does not change:** the programme and honest initial evidence
+can be published; competence, efficient routine maintenance and beneficial
+learning remain unproved. Do not add a semantic code restriction merely to
+make this brief match an authored answer.
+
+## Encounter B: recover in a fresh conversation
+
+The second prompt named the continuing responsibility, asked Von to recover
+the saved product and check current evidence, and permitted only that product's
+maintenance. It supplied neither A's transcript nor an authored correction.
+The A receipt and persisted trace were retained before B; the separate full
+canonical text read, made while B was underway, matched A's write hash.
+
+Von recovered the same product and read current Jira sources. The source set
+was not unchanged: 2577's canonical `updated` timestamp is
+`2026-09-06T01:13:34.521+1200` (5 September 13:13 UTC, during A), and its current
+status is SUPERSEDED. B recognised that supersession and acquired its successor
+2579. It also found newer 2578 evidence which predated both encounters but had
+been missed in A. Thus this is useful recovery and source reconciliation, not
+a clean no-change control or proof of autonomous noticing. B retained the
+over-broad recommended replay prerequisites.
+
+B reported an update and successful read-back. Independent canonical reads
+found **two** active `hasContent` relations: A's text remained alongside B's
+6,411-character revision, relation `6a9c1aacb312f5fd99b0ceda`, SHA-256
+`b2bf391e1bd214d64c8ef4fceab269914bff28dd5d6134e50b9211b0d12e0edb`.
+The normal adaptive turn used `upsert_text_relation`, whose text-specific
+upsert does not replace a prior different text. The existing digest workflow
+instead selects `upsert_singleton_text_relation`. Whether subsequent consumers
+receive an unambiguous current brief must be checked; the two rows are not
+silently described as a completed replacement.
+
+UI elapsed time was 3 minutes 39 seconds; recorded elapsed time was 209.403
+seconds. There were 27 tool calls and 14 model calls: 13 provider-observed Luna
+calls plus one Luna-requested auxiliary call with missing observed identity
+and usage. Known cost subtotal was US$0.042780 with partial coverage. A likewise
+had 18 provider-observed Luna calls and one partially observed auxiliary call.
+The two encounters were sequential. They are not a matched architectural or
+model comparison: setup and maintenance have different jobs and evidence.
+
+Locator: session `b9e97d77-32aa-4f3f-aae0-f3d67c3026a0`, request
+`2fd4ccbc-4cb6-4a3b-bb1c-56ab9e3ed6f6`, assistant history index 28.
+
+## Four-turn Jira family
+
+The exact four prompts came from `jira_lookup_followup_family` in the existing
+prompt bank, SHA-256
+`601e8a729c9797553bc7f1f29dd3558315482115f61ca0e1217d9b9aec9a9ef6`.
+They ask for the newest Task, its represented concept, full direct Jira details,
+and separate summaries of that issue and its predecessor. Normal owner-issued
+browser turns were used; no fixture identity or imported browser credential
+substituted for the supported owner binding.
+
+Canonical Jira queries before and during the family identified 2722 (Done)
+and predecessor 2721 (In Progress). Issue contents remained live; the user was
+also editing Jira and explicitly confirmed that concurrent work. The two model
+arms are sequential operational observations with the same actor, prompts and
+deployed code, not a frozen-source, randomised model benchmark.
+
+### Luna
+
+The persisted answers carry the correct issue identity across all four turns,
+give Michael as assignee and the full 2722 description, and separately describe
+2721 and 2722. Turn 3 used an exact Jira search with the requested fields; a
+particular tool name is not necessary for the direct-source outcome.
+Turn 2 performed exact key and full-title lookups with zero matches, plus name
+resolution and a broader partial search. Its retained answer says a represented
+concept was not found and is not currently verified, rather than claiming an
+exhaustive proof of absence. No import or other semantic effect was executed.
+
+However, **turn 2 failed visibly**: the browser displayed “The final response
+did not return from Von.” The exact server record subsequently contained a
+completed 424-character answer, no effects and `turn_output_health.status=ok`.
+The copied browser diagnostic instead had `status=error` at 110.741 seconds.
+This is an answer-delivery/recovery discrepancy, not evidence that Luna failed
+to answer internally. The later prompts continued in the same conversation
+after the failure was retained; no retry was disguised as the original turn.
+
+Current `chatTab.js` catches a failed generate transport, reports an error, and
+then stops foreground result polling in `finally`. That is a reachable reason
+why the existing alternate result route may not recover a late persisted
+answer. The precise underlying transport exception was not captured. The
+observed discrepancy justifies a focused recovery investigation; it does not
+justify blaming model capability or changing semantic reasoning policy.
+
+The existing evaluator reports four canonical-record passes, including its
+legacy obligation checks. Those checks do not verify browser delivery and
+accept empty legacy obligation fields. They are supporting diagnostics only:
+**the user-visible Luna family does not pass**. No model promotion or ordinary
+four-turn reliability claim follows from its four machine passes.
+
+| Turn | Request | History index | Recorded elapsed | UI elapsed/outcome |
+| --- | --- | ---: | ---: | --- |
+| 1 | `5ed2c659-a6db-4744-964c-4163e42304dc` | 4 | 50.585 s | 54 s; answer delivered |
+| 2 | `359677d2-07d7-4d7c-a258-7d1dc7eb7937` | 13 | 109.236 s | 110.741 s; error displayed |
+| 3 | `97b20653-95b6-4e63-ba7e-1073b81193de` | 20 | 133.071 s | 155 s; answer delivered |
+| 4 | `23701987-5211-4440-8f07-39f4188fd3a6` | 27 | 75.434 s | 80 s; answer delivered |
+
+Session: `1aa92c43-14c9-4b4d-9232-4e2a441ea5d9`. All 21 fully observed calls were
+Luna; four auxiliary calls requested/selected Luna with missing observed
+identity and usage. The known family cost subtotal is partial. There was a
+substantial wall-clock gap between turns 2 and 3; elapsed measurements describe
+individual turns, not a continuous unattended family or clean latency ranking.
+
+### Terra and the bounded comparison
+
+Terra delivered all four answers and retained the same issue reference. Exact
+key/title searches supported its qualified not-found answer. Turn 3 retrieved
+2722's full description and assignee directly from Jira; turn 4 returned the
+two actual target issues separately. No semantic writes occurred. The complete
+Terra family passes this bounded observed case; it does not establish a
+population reliability rate, an architectural advantage or a routing rule.
+
+| Turn | Request | History index | Recorded elapsed | UI elapsed |
+| --- | --- | ---: | ---: | ---: |
+| 1 | `bd03d86f-4f5f-44ab-a007-07eb5eb5d236` | 4 | 54.517 s | 58 s |
+| 2 | `3b2409a8-4526-453d-94d9-541db3a8b481` | 10 | 52.730 s | 56 s |
+| 3 | `a1902362-5d25-456a-bf16-c88bcd8ad0c3` | 14 | 43.599 s | 47 s |
+| 4 | `0319faa4-857c-48d9-84a0-4d7a0212c9d2` | 20 | 48.172 s | 62 s |
+
+Session: `9b69af39-2a26-4a1e-9f9e-38cfbb7aeb08`. Sixteen provider-observed calls
+were Terra; four auxiliary calls requested/selected Terra but lacked observed
+identity and usage. The existing canonical evaluator again gave four passes,
+supplemented here by source, effect and delivered-answer review.
+
+Known family cost subtotals were **US$0.040571 for Luna** and **US$0.2804134 for
+Terra**, both partial telemetry estimates. Terra used two representation lookup
+calls to Luna's four, and its answer arrived. Luna also produced a supported
+answer internally. This sample does not identify an inadequate Luna reasoning
+capability or justify replacing the principal model. The browser preference
+was restored to Luna after the pair. All observed calls used the intended
+non-Sol model; unobserved auxiliary identity remains explicitly unavailable.
+
+## Checkpoint attempt after publishing the actual result
+
+The complete family result was written into 2568's description and read back
+at its canonical update timestamp `2026-09-06T02:48:17.943+1200`. It explicitly
+retains In Progress for Luna's visible delivery failure and records Terra's
+bounded pass. This was the actual changed source for the planned checkpoint,
+not a fabricated successful lesson.
+
+Before the attempt, the authoritative registry returned Vontology workflow
+`#V#lab_project_status_digest_workflow` with 11 states and definition hash
+`e34c44ab88224020ebcca9524a3325131e3dfe6035198286f87074faa6587445`.
+The live continuity prompt text had SHA-256
+`a39941a5bae51044298308ee5be9e675b68faa0da4f937a2e680fd18101dfbc5` and matched
+the release seed after trimming boundary whitespace. No seed was activated or
+overwritten for this test.
+
+The attached Von MCP `workflow_create_schedule` request selected one `once`
+occurrence, Michael's intended scope, the existing digest workflow, this exact
+work-product ID, current source locators and Luna. The prompt asked to maintain
+the responsibility; it did not supply the expected revised text. The tool
+rejected the request with **`workflow_actor_authority_required`**, reporting
+that launch scope conflicted with ambient authority (`mismatch_fields=[]`).
+The handler returns this error before schedule construction/persistence.
+No schedule ID or worker occurrence was created and no scheduled model ran.
+
+This establishes a missing usable actor binding on the attached scheduling
+route. It does not establish that every trusted operator route or the scheduler
+itself is broken. Separately, the catalogue and live
+[2698](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2698) confirm that
+ordinary-chat schedule creation remains unavailable. Comment 37303 records this
+new pilot consumer and failed attempt on that existing task. The checkpoint
+claim remains blocked at launch; revision through the digest's singleton writer
+was not exercised. The two foreground text relations remain retained evidence.
+
+## Delivery decision and limits
+
+**Merge decision does not change:** publish the refined programme and this
+bounded execution record. It establishes a real owned work product, fresh
+recovery and actual source reconciliation, a full paired Jira-family observation,
+and two discriminating integration failures. It does not establish dependable
+routine programme management, a completed scheduled checkpoint, low human
+burden, beneficial learning or transfer.
+
+The current decisions remain in 2721, 2568 and 2698. Repair of answer recovery
+must reconcile the exact persisted request and delivered UI outcome; supported
+schedule issuance must precede a positive checkpoint claim. These observed
+connections, and the ambiguous foreground text revision, matter before adding
+a general role, theory or learning mechanism. Neither a universal certification
+campaign nor a model switch is supported as the next remedy by these results.
+
+Facilitation included source selection, ten foreground prompt submissions,
+model selection/restoration, evidence inspection, Jira planning/result updates,
+and one unsuccessful schedule-creation request. No corrective answer was fed
+to Von. Michael's later use or feedback on the brief remains unobserved.
+The concurrent portfolio reconciliation was checked against live Jira and
+incorporated into the programme; its local audit files were preserved.
+
+The [selected evidence](../generated/jvnautosci_2721_prospective_readiness_2026-09-05.json)
+retains locators, response/source hashes, effect summaries, model identities,
+cost coverage and the rejected checkpoint receipt. Full actor-scoped traces,
+canonical text snapshots and diagnostic envelopes remain in the private local
+execution archive. No application code, credentials or running model policy
+was changed by this delivery, and no deployment is required for these documents.

--- a/docs/engineering/role_convergence_test_programme.md
+++ b/docs/engineering/role_convergence_test_programme.md
@@ -27,6 +27,63 @@ development baseline and known failures, not prospective adoption.
 The [first deployment/witness record](jvnautosci_2721_replay_programme_2026-09-05.md)
 contains the initial observations and their limitations. Current repair selection
 remains in Jira.
+The [prospective readiness record](jvnautosci_2721_prospective_readiness_2026-09-05.md)
+retains the real first encounters and subsequent replay observations.
+
+### Selected operational tranche
+
+Michael authorised refinement and execution of this programme after delivery
+of 2722. Michael is the beneficiary and operator for this first real work
+package; Codex facilitates execution and independently inspects the evidence.
+Facilitation is recorded rather than attributed to Von. The 5 September
+portfolio review recommends this sequence; it remains a frozen audit, not
+the live delivery plan.
+
+The tranche now starts with one real actor-owned brief **before** the new
+2568 result, then an unchanged fresh encounter, the four-turn Jira family,
+publication of its actual outcome, and a bounded scheduled checkpoint. This
+makes a new result a genuine changed premise. The task is not to manufacture
+a successful lesson or to turn every existing replay into a release gate.
+
+| Delivery | Minimum useful result | Boundary |
+| --- | --- | --- |
+| Programme and first encounter | Current Jira decision, one discoverable brief with source identities and a useful next-action recommendation, exact read-back | Can publish with later encounters pending; author assistance and partial coverage remain visible |
+| Fresh encounter and first replay | Prior responsibility recovered without its transcript; complete 2568 answers reconciled with canonical sources and effects | Luna principal, one matched Terra family; repeat only a material disagreement or unresolved delivery question |
+| Changed-evidence checkpoint | The existing scheduler/worker reads the maintained responsibility and updates affected conclusions from the newly published evidence | One explicitly bounded occurrence; no unattended recurring service is claimed or enabled by default |
+| Follow-on repair | One observed material gap improved on the affected path and a relevant neighbour | Use existing repair issues; latency, authority, transport and context are distinguished from model judgement |
+| Learning and transfer | A fitting source-derived practice earns a later-use disposition; a different setting supplies local facts and authority | Separate later claim; preserve 2720's rejected candidate |
+
+The prospective product is named **Von replay and reliability readiness —
+Michael — 2721**. Resolve or create it through the authenticated actor's
+canonical tools and record its actual ID on 2721 before the scheduled checkpoint. Do not
+overwrite the existing operational default digest. Its text should retain
+the purpose, source references, unresolved commitments, evidence dates,
+decision-relevant unknowns, present recommendation and next attention
+condition. Jira remains the commitment/status authority; the brief is a
+revisable projection. A separate controlled experiment uses a separate product.
+
+Standing task scope covers source reads, this internal brief's bounded updates,
+recording execution evidence on the selected Jira issues, and one checkpoint.
+It does not create authority for mail, expenditure, submission, access changes,
+or unrelated task mutations. Creation of a schedule is recorded with its actor,
+inputs, model selection, occurrence and terminal state. A facilitator-selected
+checkpoint proves scheduled execution and source-driven revision, not that Von
+autonomously chose when to pay attention.
+The ordinary-conversation creation gap remains in
+[2698](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2698). Until its
+supported entry point is delivered, use the existing authorised operator
+schedule surface and count that setup; do not manufacture an ordinary-turn
+authority witness or replace the checkpoint with a passive task.
+
+Before encounter A, retain the source scope and outcome expectations outside
+Von's acting context. Give Von the job and accessible sources, not an authored
+brief or required recommendation. Before B, retain A's exact canonical text.
+Before the replay, retain both current Jira targets and the prompt bank version.
+Publish actual results, including failures, before C; do not seed C with the
+desired revised conclusion. Count setup, source selection, corrections and
+supervision even when the final answer is useful. Human adoption is established
+only by the beneficiary's actual use or feedback, not by Codex grading its own
+facilitated run.
 
 ## 2. Use the existing work
 
@@ -36,7 +93,7 @@ are a dated routing map; re-read the relevant issue before another cycle.
 | Existing task/surface | Use in this programme | Claim it does not supply |
 |---|---|---|
 | [2371](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2371), `run_replay_suite_report.py` | Discover available replays and report collection/adapter failures | A discovered or executed case is not a verified outcome |
-| [2577](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2577), `run_operational_certification.py` | Existing stateful adapters, canonical observations, represented evaluators and negative controls | The whole programme remains Not Certified; its historical all-family gates do not gate this bounded slice |
+| [2577](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2577), superseded into [2579](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2579); `run_operational_certification.py` | Reuse stateful adapters, canonical observations, represented evaluators and negative controls | Historical campaign remains Not Certified; its retired all-family programme does not gate this bounded slice |
 | [2568](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2568), multi-turn Jira family | Check current-source access, carried referents, changed intent and two-target separation on `/von/generate` | Same-chat continuity is not cross-encounter responsibility |
 | [2590](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2590), digest replay | Exercise the existing foreground digest capability and repeated update | Two prompted updates do not establish noticing or usefulness |
 | [2532](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2532) | Bounded stronger-model comparisons when model adequacy is a live causal question | Historical local/premium labels and timeout results are not current routing evidence |
@@ -45,13 +102,14 @@ are a dated routing map; re-read the relevant issue before another cycle.
 
 Use the existing experiment and benchmark surfaces when they consume the
 selected evidence. Do not construct another runner, dashboard, mandatory
-schema, theory store or certification gate to execute this plan. A full 2577
-campaign still uses its actual represented contract; a narrower collection
-must be labelled non-certifying, rather than weakening that contract to turn it
-green. Existing JSON banks remain development inputs/exports. Durable
+schema, theory store or certification gate to execute this plan. Any newly
+selected certification claim uses its actual represented contract; a narrower
+collection must be labelled non-certifying, rather than weakening that contract
+to turn it green. Do not restart the retired 2577 campaign by inheritance.
+Existing JSON banks remain development inputs/exports. Durable
 independently governed evaluation policy belongs on its represented surface.
 
-## 3. Establish a trustworthy first witness
+## 3. Establish a trustworthy replay witness
 
 Deploy the reviewed release through `./run.sh deploy-main` from clean primary
 `main`, then read `/health`, runtime commit/dirty state, startup-seed receipts
@@ -61,20 +119,31 @@ Record the previous runtime, selected commit and resulting state for recovery.
 Never force overwrite divergent live prompt/workflow authority merely to obtain
 a green preflight. Inspect its meaning and choose the bounded migration.
 
-Run the existing Jira family once on the selected real server. Use normal
-authenticated test-session issuance, an allowed model and the actual namespace.
-This checks a prerequisite without modifying a real lab commitment:
+2722's [owner-read evidence](jira_authorised_read_replay_2026-09-05.md) establishes
+the bounded direct-read path. It does not pass the four-turn family. Run that
+family after the initial brief and unchanged encounter, using the existing
+prompt bank and evaluator. The normal authenticated account owner must acquire
+the Jira binding; the browser-test fixture actor is not that owner.
+
+Discover the existing replay inputs with:
 
 ```sh
 pdm run python scripts/run_replay_suite_report.py --list
-pdm run python scripts/run_live_multi_turn_followup_replay.py \
-  --case jira_lookup_followup_family --model gpt-5.6-luna \
-  --base-url http://127.0.0.1:5001 --allow-non-agent-test-server \
-  --output-json tmp/role-programme-jira-witness.json
 ```
 
+Use the four exact `jira_lookup_followup_family` prompts from
+`scripts/live_multi_turn_followup_prompt_bank.json` in one fresh normal-owner
+conversation. Repeat in a different fresh conversation for Terra. The current
+CLI runner establishes a browser-test session; its user/organisation parameters
+do not themselves confer the owner's authority. Do not reuse that default as
+an authorised positive witness or copy browser credentials into a runner.
+When that runner has a supported authenticated entry for the selected actor,
+it can automate the same family. Meanwhile, browser-issued turns and canonical
+persisted records support the bounded witness; reuse its existing evaluation
+functions rather than adding another execution platform.
+
 Use GPT-5.6 Luna as the principal model, matching Michael's ordinary Von use.
-Verify the exact scoped model pool before reusing the command. Provider
+Verify the exact scoped model pool before submitting the trials. Provider
 availability alone does not establish actor eligibility. Pair the first witness
 and selected ordinary role cases with Terra using the same prompts, sources,
 tools, actor and fresh conversation state. Michael specifically wants to know
@@ -82,8 +151,8 @@ where Terra succeeds and Luna does not; retain the reverse differences too.
 Do not replace the principal workload with whichever model happened to pass an
 earlier rehearsal. Other models are diagnostic arms for a specific unresolved
 question, not an automatic matrix expansion.
-The explicit non-AgentTest flag is for the authorised local deployment. An
-isolated AgentTest run may instead use the default 5010 server. Inspect actual
+An isolated AgentTest run may use the default 5010 server for development, with
+its actual actor and authority limitations labelled. Inspect actual
 provider/model identities, including auxiliary calls; Sol remains prohibited.
 If the preflight fails, reconcile its exact typed failure before rerunning.
 Do not treat an observer deadline as cancellation or resubmit unfinished work.
@@ -165,11 +234,13 @@ Record separately:
   material to the claim, source versions, request/instance IDs, canonical
   read-back locators and any facilitator intervention.
 
-Start with one A–F development sequence and the real Jira witness, not every
-historical replay. Once runnable, use three fresh repetitions of the smallest
-ordinary family whose reliability could change the delivery decision. Five
-trials are for the represented certification claim or an unresolved decision
-that warrants them, not an automatic expansion. Report actual denominators and
+Start with the selected operational tranche and reuse the existing fictional
+A–C evidence. Exercise D–F when a real observation or a named uncertainty needs
+them; they are not all prerequisites to publishing the first useful brief.
+Repeat the smallest ordinary family only where another observation could
+change the delivery decision. Three or five trials may support a particular
+reliability or represented-certification claim, not an automatic expansion.
+Report actual denominators and
 joint successes; do not describe one perfect sequence as a reliability rate or
 derive a population pass^k claim from it. Broader corpus, multilingual and
 multi-model sweeps remain optional until a concrete question needs them.
@@ -200,9 +271,19 @@ unrelated repair or a new universal guardrail. Wrong-target effects, lost real
 commitments, invented approvals or an unqualified stale decision after the
 exercised change block the affected capability claim.
 
-The human programme decision belongs in 2721; infrastructure defects use 2577
-or an existing concrete repair issue. Briefs and dated evidence link back to
+The human programme decision belongs in 2721; defects use an existing concrete
+repair issue, and broader scientific comparison belongs in 2579. Briefs and dated evidence link back to
 that decision rather than becoming competing live repair plans.
+
+Keep portfolio housekeeping bounded alongside the operational cycle. Update
+obsolete next-action statements after verified deliveries. The concurrent
+5 September reconciliation superseded 2600/2602 into 2595 and left 2603's H4
+decision open, as verified from live Jira. Do not repeat those retirements.
+Reconcile any remaining 2595/2603 question against actual decisions and merged behaviour;
+prepare any unresolved decision for Michael without treating implementation,
+silence or this programme instruction as his historical gate decision. Do not
+restart a cutover, mass-close old tasks, or expand the pilot's release criteria
+merely to make the portfolio appear consistent.
 
 ## 7. Learned benefit and transfer: the following decision
 

--- a/docs/generated/jvnautosci_2721_prospective_readiness_2026-09-05.json
+++ b/docs/generated/jvnautosci_2721_prospective_readiness_2026-09-05.json
@@ -1,0 +1,2126 @@
+{
+  "record_kind": "dated_operational_evidence",
+  "evidence_date_utc": "2026-09-05",
+  "runtime_commit": "38afefd252071274a497bdc9b9be41982c4ca9e1",
+  "prompt_bank_sha256": "601e8a729c9797553bc7f1f29dd3558315482115f61ca0e1217d9b9aec9a9ef6",
+  "trials": [
+    {
+      "label": "encounter-a",
+      "turn": 1,
+      "session_id": "a1fb157e-a4b2-4bd7-b45b-ddb21acff5fd",
+      "request_id": "ea086bbd-a3d8-4f50-bd2f-520a7deb942f",
+      "history_index": 137,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "partial_judgement",
+      "ui_elapsed_seconds": 440,
+      "recorded_timing": {
+        "elapsed_ms": 405241,
+        "llm_call_count": 19,
+        "llm_elapsed_ms": 198339,
+        "observed_timeline_ms": 404111,
+        "operation_elapsed_ms": 393763,
+        "phase_elapsed_ms": 404152,
+        "tool_elapsed_ms": 156908
+      },
+      "response_sha256": "6dced19923ecbf44a967d3dab03f66c7829897818bb4218ce15920d081ca602f",
+      "tool_counts": {
+        "turn_capabilities": 4,
+        "resolve_concept_by_name": 4,
+        "jira_get_issue": 7,
+        "jira_get_comments": 7,
+        "turn_read_evidence": 100,
+        "search_concepts": 8,
+        "create_concepts": 1,
+        "add_relationship": 1,
+        "upsert_text_relation": 1,
+        "fetch_concept": 1,
+        "fetch_concept_content": 1,
+        "get_text_relations": 1
+      },
+      "model_identities": [
+        {
+          "call_count": 18,
+          "connection_id": "#V#openai_provider",
+          "effective_model": "gpt-5.6-luna",
+          "effective_service_tier": "default",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "provider_request_sent": true,
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna"
+        },
+        {
+          "call_count": 1,
+          "connection_id": null,
+          "effective_model": null,
+          "effective_service_tier": null,
+          "model_identity_source": null,
+          "provider": "openai",
+          "provider_request_sent": true,
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna"
+        }
+      ],
+      "usage": {
+        "cache_write_input_tokens": null,
+        "cached_input_tokens": null,
+        "input_tokens": null,
+        "known_cache_write_input_tokens": 347187,
+        "known_cached_input_tokens": 712912,
+        "known_input_tokens": 1060153,
+        "known_output_tokens": 15458,
+        "known_total_tokens": 1075611,
+        "output_tokens": null,
+        "partial_call_count": 0,
+        "reported_call_count": 18,
+        "status": "partial",
+        "total_tokens": null,
+        "unavailable_call_count": 1
+      },
+      "estimated_cost": {
+        "amount": null,
+        "currency": "USD",
+        "known_amount": 0.11961539,
+        "partial_call_count": 0,
+        "priced_call_count": 18,
+        "pricing": {
+          "effective_at_utc": "2026-08-05T00:00:00Z",
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05"
+        },
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "status": "partial",
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ],
+        "unpriced_call_count": 1
+      },
+      "effects": [
+        {
+          "tool": "create_concepts",
+          "effect_id": "effect_a498a75b172b26836c329b59",
+          "effect_status": "succeeded",
+          "changed": true
+        },
+        {
+          "tool": "add_relationship",
+          "effect_id": "effect_893639a5d85f41fdd949c722",
+          "effect_status": "succeeded",
+          "changed": true
+        },
+        {
+          "tool": "upsert_text_relation",
+          "effect_id": "effect_0a4ff3e40612a73ec1524eca",
+          "effect_status": "succeeded",
+          "changed": true
+        }
+      ],
+      "source_receipts": [
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "dbc7581a92c322c96511d734138f9f906f69612490b609b0c0dc0d319b5afdef",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "Von replay and reliability readiness — Michael — 2721",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "d94ae4bac2f6d013c0e079b7fd7743cb7388c7ce6cb5eb187901441dd29bfdd5",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2721",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "edff5f261cf5e1f1f3f93979fa57e302de6d5bdbe3fbe91688f39cad5106821a",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2722",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "c437e2fc0cf8d4a51852acfbac3b56111c40983ad88c6e9184e0597d5071b603",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2720",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "1019447fe1e55b620d24c6ae3422c7bd07aff235eb4c3f887db0f0f8f0193200",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2568",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "e55330f2ea72963b804b196cf9f76e71d368ba034482ea83b292d9b13647fe9b",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2577",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "5dffe1aab53803d1d1622ed1072060a1b1b0a4d445cf071fa0e7ca72a81b412b",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2578",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "623648a5791bc085fbd85c1601eefe145623f22f63c7960103e70d45d7a5d6a5",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2590",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "comment",
+              "issuelinks",
+              "subtasks",
+              "parent",
+              "labels",
+              "components",
+              "fixVersions",
+              "priority",
+              "assignee",
+              "reporter",
+              "updated",
+              "created"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "4eb3d4aef397e3762badd03829a54349af941a00d68cde522d10ae88b605fb26",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2721"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "d0dfc5c3a07a20eaceb9bdb6b246c0d2ec77fc6ed6eb068b8b7127612d49831e",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2722"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "9acf783e29ead70370bfaebbabffd694e6b7a6c86a9258fcaa85082d4441dbfb",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2720"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "9a6cd29ed38f5407ed35e0317074621c780a8c954b917c97bd3bfd1f0cbcd507",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2568"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "9e233c7b40f60769e309e4f7c7012ece15dfaa86fc46c06b00bbf6d8525d73ec",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2577"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "e9771b6f23a10c546c71121c5c339d8bf115af6a655a549eb212e62bb3d1d3c8",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2578"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "daa1547c968570ccc22d68db2d10ed0632df01814dc5627425dd635447d2168a",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2590"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "56754280ddf03a8c5ab40729323d133075fabdee991ee4a664bc2926cd3feefe",
+          "target_ids": [
+            "#V#administering_a_drug",
+            "#V#call_for_workshop_proposals",
+            "#V#conceptual_work",
+            "#V#criterion",
+            "#V#crop_plant",
+            "#V#document_describing_a_transient_state_of_the_world",
+            "#V#non_natural_inanimate_thing",
+            "#V#norm",
+            "#V#omnivore",
+            "#V#organic_matter",
+            "#V#practice",
+            "#V#professional",
+            "#V#professional_activity",
+            "#V#sail_group_ph_d_project_meeting",
+            "#V#scholarly_article",
+            "#V#scholarly_work",
+            "#V#self_administrationofdrug",
+            "#V#the_union_of_consumer_durables_service_products",
+            "#V#the_union_of_types_of_information_bearing_thing_classified_by_content_information_structures_of_a_conceptual_work_works",
+            "#V#work_activity"
+          ],
+          "selected_arguments": {
+            "query": "work product",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "159532ba3f9f252a1cb7eb286fc242460a0a7d58a9787e5d6efd756626aeafa7",
+          "target_ids": [
+            "#V#department_of_internal_affairs",
+            "#V#human_rights_watch_international_award",
+            "#V#iconip",
+            "#V#internal_model_evaluation",
+            "#V#propositional_logic"
+          ],
+          "selected_arguments": {
+            "query": "internal work product",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "929a743f89205f147ecea5322db3bc8ff094aab7f095c0a7035afba326513458",
+          "target_ids": [
+            "#V#task",
+            "#V#task_specification",
+            "#V#task_description_document",
+            "#V#programming_task"
+          ],
+          "selected_arguments": {
+            "query": "task",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "b55209881f565fc698690e57d91b47ffc8f76ba5b1ac970216d270df18c78802",
+          "target_ids": [
+            "#V#document",
+            "#V#document_contianing_a_list",
+            "#V#document_describing_a_transient_state_of_the_world",
+            "#V#work_document",
+            "#V#online_document",
+            "#V#sub_document",
+            "#V#reading_a_document",
+            "#V#system_design_document",
+            "#V#task_description_document",
+            "#V#work_description_document",
+            "#V#von_system_design_document",
+            "#V#sail_system_design_document",
+            "#V#workflow_description_document",
+            "#V#von_agentic_system_overview_document",
+            "#V#von_agentic_component_design_document",
+            "#V#ai_produced_document",
+            "#V#journalistic_document",
+            "#V#best_documentary_feature",
+            "#V#submission_to_governmentdocument",
+            "#V#best_documentary_short_subject_motion_picture"
+          ],
+          "selected_arguments": {
+            "query": "document",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "563447be4d6bb7892a1f4de2c75ca56838fd309d85b725a98af3f00f9416653c",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "owned by",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "0c915ca425a10769adc573a77d4004f2835ef07bdee275206208bebd9f1a1005",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "has owner",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "ad93558dd5a4d6f45543e17d2423dbd74d26db1ac6521da0beb0cfaeb5ed5ed5",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "work document",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "2d48c93846f2e40408238d161b274888491a8f8c0eb3a2aa286421f7103071a4",
+          "target_ids": [
+            "#V#hasowner"
+          ],
+          "selected_arguments": {
+            "query": "owner",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "d93167d6f4f8698bbdd2953209757d28665525eb0e0348f72563d4b0d4532ef1",
+          "target_ids": [],
+          "selected_arguments": {
+            "query": "responsible",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "dea6513028aba0632e807525d9c0e1943d088a7da322d9b70d9bc01e2c093acb",
+          "target_ids": [
+            "#V#has_author"
+          ],
+          "selected_arguments": {
+            "query": "has author",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "59249211f31ea343ca0c51ce9ba4b136d1bdbf20ea94a0303679435a258a0166",
+          "target_ids": [
+            "#V#assigned_supervisor"
+          ],
+          "selected_arguments": {
+            "query": "assigned",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "create_concepts",
+          "status": "ok",
+          "sha256": "d2d5a5bd7a1d3b1f1af24b9419a6b19820b9c17252569bdf15e4594408f9084e",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {}
+        },
+        {
+          "tool": "add_relationship",
+          "status": "ok",
+          "sha256": "422a3dc5dcd07be1e6ef94706e9c5675dc6e97143719e7db782267ee193db80d",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "predicate": "#V#hasowner"
+          }
+        },
+        {
+          "tool": "upsert_text_relation",
+          "status": "ok",
+          "sha256": "1e5b8778d1e94fbb61e9dc168d78065b9391a079626795ba97244fe95742af53",
+          "target_ids": [
+            "6a9c167cb312f5fd99b0ceab"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+            "predicate": "hasContent"
+          }
+        },
+        {
+          "tool": "fetch_concept",
+          "status": "ok",
+          "sha256": "f0dcb8fcd02fdd0429f6811e00f60c9945d8a32e6cacc4799c5dd378ac35091f",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        },
+        {
+          "tool": "fetch_concept_content",
+          "status": "ok",
+          "sha256": "a33d883cb1c7b98c247dfc724104b9f6420fec61fb3b78da5f69870baa492a2a",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        },
+        {
+          "tool": "get_text_relations",
+          "status": "ok",
+          "sha256": "80df78d9fe65e9916501635be44a22f7b2b307faaf5d57a293fc5f0873529847",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+            "predicate": "hasContent"
+          }
+        }
+      ]
+    },
+    {
+      "label": "encounter-b",
+      "turn": 1,
+      "session_id": "b9e97d77-32aa-4f3f-aae0-f3d67c3026a0",
+      "request_id": "2fd4ccbc-4cb6-4a3b-bb1c-56ab9e3ed6f6",
+      "history_index": 28,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "recovered_and_revised_with_multiple_content_rows",
+      "ui_elapsed_seconds": 219,
+      "recorded_timing": {
+        "elapsed_ms": 209403,
+        "llm_call_count": 14,
+        "llm_elapsed_ms": 79812,
+        "observed_timeline_ms": 208284,
+        "operation_elapsed_ms": 118754,
+        "phase_elapsed_ms": 208312,
+        "tool_elapsed_ms": 28124
+      },
+      "response_sha256": "14ee314ac5602a1ab4d51c1fbab5d77edd114c4789a3d21a526bdcb20c60fb79",
+      "tool_counts": {
+        "turn_capabilities": 3,
+        "resolve_concept_by_name": 1,
+        "jira_search": 2,
+        "turn_read_evidence": 9,
+        "fetch_concept": 1,
+        "fetch_concept_content": 2,
+        "get_text_relations": 2,
+        "jira_get_comments": 5,
+        "jira_get_issue": 1,
+        "upsert_text_relation": 1
+      },
+      "model_identities": [
+        {
+          "call_count": 13,
+          "connection_id": "#V#openai_provider",
+          "effective_model": "gpt-5.6-luna",
+          "effective_service_tier": "default",
+          "model_identity_source": "provider_response",
+          "provider": "openai",
+          "provider_request_sent": true,
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna"
+        },
+        {
+          "call_count": 1,
+          "connection_id": null,
+          "effective_model": null,
+          "effective_service_tier": null,
+          "model_identity_source": null,
+          "provider": "openai",
+          "provider_request_sent": true,
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna"
+        }
+      ],
+      "usage": {
+        "cache_write_input_tokens": null,
+        "cached_input_tokens": null,
+        "input_tokens": null,
+        "known_cache_write_input_tokens": 105778,
+        "known_cached_input_tokens": 305290,
+        "known_input_tokens": 411107,
+        "known_output_tokens": 8518,
+        "known_total_tokens": 419625,
+        "output_tokens": null,
+        "partial_call_count": 0,
+        "reported_call_count": 13,
+        "status": "partial",
+        "total_tokens": null,
+        "unavailable_call_count": 1
+      },
+      "estimated_cost": {
+        "amount": null,
+        "currency": "USD",
+        "known_amount": 0.0427797,
+        "partial_call_count": 0,
+        "priced_call_count": 13,
+        "pricing": {
+          "effective_at_utc": "2026-08-05T00:00:00Z",
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05"
+        },
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "status": "partial",
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ],
+        "unpriced_call_count": 1
+      },
+      "effects": [
+        {
+          "tool": "upsert_text_relation",
+          "effect_id": "effect_b12236d224a9ccb01bb6ee2d",
+          "effect_status": "succeeded",
+          "changed": true
+        }
+      ],
+      "source_receipts": [
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "62eb0f6770ad8dc8456c2337378a1adf43e23455b6a964a15f97e44e5e8b6092",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "Von replay and reliability readiness — Michael — 2721",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "f5dff8f74b76cfdb6e8dd5855b48348270bd1c05c9361ebea6b2d4ead35187b6",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "text ~ \"Von replay and reliability readiness\" OR summary ~ \"replay\" OR summary ~ \"reliability\"",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "updated",
+              "assignee",
+              "priority",
+              "issuetype",
+              "parent",
+              "labels",
+              "comment"
+            ]
+          }
+        },
+        {
+          "tool": "fetch_concept",
+          "status": "ok",
+          "sha256": "7403ffb65ee236617eca7039fd81b3db203af52bf8247202beb452546a31896b",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        },
+        {
+          "tool": "fetch_concept_content",
+          "status": "ok",
+          "sha256": "a33d883cb1c7b98c247dfc724104b9f6420fec61fb3b78da5f69870baa492a2a",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        },
+        {
+          "tool": "get_text_relations",
+          "status": "ok",
+          "sha256": "a7892cc562f027dd58bbf7c3d806c2852ae5b4b0fbc59fd23268b5051d60c940",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        },
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "134eb2275d68e6552e3360a84183e0f727153a643891a16770ac000f18cbd83c",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "issuekey in (JVNAUTOSCI-2721, JVNAUTOSCI-2722, JVNAUTOSCI-2720, JVNAUTOSCI-2568, JVNAUTOSCI-2577, JVNAUTOSCI-2578, JVNAUTOSCI-2590)",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "updated",
+              "assignee",
+              "priority",
+              "issuetype",
+              "parent",
+              "labels"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "236c257377f9e746e225e19c07ce99a6b83098c57611042e234e6abb056bfbcf",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2577"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "e45f713591b1c4576491ec774262411ff9b8f82ca528f07a80e1586a256dabb1",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2721"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "d926b9e35b1d25913fe12552df18fc06d99f5bad3ed6c003d3d47f67966d4785",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2578"
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "21283e2e6e71af77da68758cd363ec37102834ff72403faee7176cfc135c2123",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2568"
+          }
+        },
+        {
+          "tool": "jira_get_issue",
+          "status": "ok",
+          "sha256": "c1722bdf5a1fe6791836f1ed5464632dc79aab3408407455f5ffaa52e7fd0e5e",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2579",
+            "fields": [
+              "summary",
+              "description",
+              "status",
+              "updated",
+              "assignee",
+              "priority",
+              "issuetype",
+              "parent",
+              "labels"
+            ]
+          }
+        },
+        {
+          "tool": "jira_get_comments",
+          "status": "ok",
+          "sha256": "4bad923e152e05d39b052acd25fd25f80b92d265e4b2271891ead45244ea33fe",
+          "target_ids": [],
+          "selected_arguments": {
+            "issue_key": "JVNAUTOSCI-2579"
+          }
+        },
+        {
+          "tool": "upsert_text_relation",
+          "status": "ok",
+          "sha256": "c12d1ee24a2b30732093095ef27c0f059f1a575fe093d22d6c5d3c08e4c547d9",
+          "target_ids": [
+            "6a9c1aacb312f5fd99b0ceda"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+            "predicate": "hasContent"
+          }
+        },
+        {
+          "tool": "get_text_relations",
+          "status": "ok",
+          "sha256": "57a4e9587b06dc1894b366a3334d1ae7a02dbb8730ca4bb7513fecf697aef36b",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+            "predicate": "hasContent"
+          }
+        },
+        {
+          "tool": "fetch_concept_content",
+          "status": "ok",
+          "sha256": "1cee3f811a89202f46b9875f2cb274006d8cc2aac71286bb9304ae600f86081f",
+          "target_ids": [
+            "#V#von_replay_and_reliability_readiness_michael_2721"
+          ],
+          "selected_arguments": {
+            "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721"
+          }
+        }
+      ]
+    },
+    {
+      "label": "jira-luna",
+      "turn": 1,
+      "session_id": "1aa92c43-14c9-4b4d-9232-4e2a441ea5d9",
+      "request_id": "5ed2c659-a6db-4744-964c-4163e42304dc",
+      "history_index": 4,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 54,
+      "recorded_timing": {
+        "elapsed_ms": 50585,
+        "observed_timeline_ms": 49488,
+        "phase_elapsed_ms": 49498,
+        "llm_elapsed_ms": 11395,
+        "llm_call_count": 5,
+        "operation_elapsed_ms": 16638,
+        "tool_elapsed_ms": 1737
+      },
+      "response_sha256": "d99c2e7013c2794da85f3b408d49547baa1a7d78e2507eec308277cec37e96ed",
+      "tool_counts": {
+        "turn_capabilities": 2,
+        "jira_search": 1
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 4
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 4,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 39095,
+        "input_tokens": null,
+        "known_cached_input_tokens": 21335,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 17748,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 391,
+        "output_tokens": null,
+        "known_total_tokens": 39486,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.0053353,
+        "currency": "USD",
+        "priced_call_count": 4,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "eadbd3d7790ac661888232d2bd762cea5890ca20644bad523f73888dddeef496",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "project = JVNAUTOSCI AND issuetype = Task ORDER BY created DESC",
+            "fields": [
+              "key",
+              "summary",
+              "status",
+              "created"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_any",
+            "outcome": "pass",
+            "expected": [
+              "JVNAUTOSCI-"
+            ],
+            "observed": "JVNAUTOSCI-"
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-luna",
+      "turn": 2,
+      "session_id": "1aa92c43-14c9-4b4d-9232-4e2a441ea5d9",
+      "request_id": "359677d2-07d7-4d7c-a258-7d1dc7eb7937",
+      "history_index": 13,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivery_failed_despite_persisted_answer",
+      "ui_elapsed_seconds": 110.741,
+      "recorded_timing": {
+        "elapsed_ms": 109236,
+        "observed_timeline_ms": 108110,
+        "phase_elapsed_ms": 108127,
+        "llm_elapsed_ms": 35054,
+        "llm_call_count": 9,
+        "operation_elapsed_ms": 68085,
+        "tool_elapsed_ms": 25477
+      },
+      "response_sha256": "d0b2064e2e2c72a37bce099a55215abe8acb38ebea1246bbf6a25d51eaff06b6",
+      "tool_counts": {
+        "turn_capabilities": 2,
+        "search_concepts": 3,
+        "turn_read_evidence": 1,
+        "resolve_concept_by_name": 1
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 8
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 8,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 142682,
+        "input_tokens": null,
+        "known_cached_input_tokens": 112732,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 29926,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 1915,
+        "output_tokens": null,
+        "known_total_tokens": 144597,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.01203894,
+        "currency": "USD",
+        "priced_call_count": 8,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "6a5683ceecc0e1beb41a52e3d436e33c58735866df6ec8e208421a1b39ec4e36",
+          "target_ids": [],
+          "selected_arguments": {
+            "query": "JVNAUTOSCI-2722",
+            "match_type": "exact"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "763d7aa4a8d18ebd98e244982fc9bc59ba0ba0080e34fd7ca25e0b7c72d469ad",
+          "target_ids": [
+            "#V#arxiv_pdf_file_46934c89efa546be9fc5fa535a562064",
+            "#V#arxiv_pdf_file_ebb7708267514045856d0e87a5c1934a",
+            "#V#arxiv_pdf_file_de5f9fe3ab184965baab0512ba951b8e",
+            "#V#computer_file_copy_444e112b2db145bda9feffe248d29333",
+            "#V#arxiv_pdf_file_2c214e49afd64ca991405b41ebb299bc",
+            "#V#arxiv_pdf_file_bb7073fa894744eb8c34fb0962afcb6f",
+            "#V#arxiv_pdf_file_e3099f892ca245fd8ecb68d026daad7a",
+            "#V#action",
+            "#V#add_affiliation_workflow",
+            "#V#anesthesia",
+            "#V#arxiv_2408_02603_a_four_step_bayesian_workflow_for_improving_ecological_science",
+            "#V#arxiv_2506_03346_negligible_effects_of_environmental_fluctuations_on_the_maintenance_of_coral_biodiversity_a_test_of_five_storage_effects",
+            "#V#arxiv_2506_03346_negligible_effects_of_environmental_fluctuations_on_the_maintenance_of_coral_biodiversity",
+            "#V#bloom_designing_for_llm_augmented_behavior_change_interactions",
+            "#V#concept_page_conversation_renderer",
+            "#V#conversation_turn_execution_workflow",
+            "#V#effective_supervisory_load_(uoa_scs)",
+            "#V#exploring_gaps_in_the_apsdirect_minimal_pair_analysis_in_llm_syntactic_assessments",
+            "#V#general_von_chat_prompt_for_witbrock",
+            "#V#external_identity_arxiv_336307fc17fd8cde_scope_cb6af932c9"
+          ],
+          "selected_arguments": {
+            "query": "Restore authorised Jira reads without import side effects",
+            "match_type": "substring"
+          }
+        },
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "3120c359ef7f27ef44b97c11106ed6fd9d70367694cac89b56de333c29946b45",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "JVNAUTOSCI-2722",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "e60dc9d5f9c42fcaceffdad9290e26559c7139fe1bcc3c64af4221c96f11ba65",
+          "target_ids": [],
+          "selected_arguments": {
+            "query": "Restore authorised Jira reads on ordinary turns without import side effects",
+            "match_type": "exact"
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "forbid_decisions",
+            "outcome": "pass",
+            "expected": "not in ['escalation_required']",
+            "observed": ""
+          },
+          {
+            "check": "forbid_unsatisfied_obligation_sources",
+            "outcome": "pass",
+            "expected": "no unsatisfied obligation sourced from ['turn_expected_outcome_conditional_required_tools']",
+            "observed": []
+          },
+          {
+            "check": "require_prior_obligation_suppression",
+            "outcome": "pass",
+            "expected": "suppression telemetry present or no inherited unsatisfied obligations",
+            "observed": {
+              "suppressed_prior_obligations": [],
+              "inherited_unsatisfied_count": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-luna",
+      "turn": 3,
+      "session_id": "1aa92c43-14c9-4b4d-9232-4e2a441ea5d9",
+      "request_id": "97b20653-95b6-4e63-ba7e-1073b81193de",
+      "history_index": 20,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 155,
+      "recorded_timing": {
+        "elapsed_ms": 133071,
+        "observed_timeline_ms": 130403,
+        "phase_elapsed_ms": 145775,
+        "llm_elapsed_ms": 43570,
+        "llm_call_count": 5,
+        "operation_elapsed_ms": 53217,
+        "tool_elapsed_ms": 3708
+      },
+      "response_sha256": "550fad10250fa39922c656485fff3c294ef780bedc2310788697719a41c7d523",
+      "tool_counts": {
+        "jira_search": 1,
+        "turn_read_evidence": 4
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 4
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 4,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 62278,
+        "input_tokens": null,
+        "known_cached_input_tokens": 41229,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 21037,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 4005,
+        "output_tokens": null,
+        "known_total_tokens": 66283,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.01089223,
+        "currency": "USD",
+        "priced_call_count": 4,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "021e04a63b0635523023d605a0dc7c7a7df513b5a73f2821ae68d24216273291",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "key = JVNAUTOSCI-2722",
+            "fields": [
+              "summary",
+              "description",
+              "assignee",
+              "status",
+              "project",
+              "issuetype",
+              "key",
+              "created",
+              "updated",
+              "reporter",
+              "priority",
+              "labels",
+              "components"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_any",
+            "outcome": "pass",
+            "expected": [
+              "JVNAUTOSCI-"
+            ],
+            "observed": "JVNAUTOSCI-"
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-luna",
+      "turn": 4,
+      "session_id": "1aa92c43-14c9-4b4d-9232-4e2a441ea5d9",
+      "request_id": "23701987-5211-4440-8f07-39f4188fd3a6",
+      "history_index": 27,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 80,
+      "recorded_timing": {
+        "elapsed_ms": 75434,
+        "observed_timeline_ms": 74397,
+        "phase_elapsed_ms": 74406,
+        "llm_elapsed_ms": 40145,
+        "llm_call_count": 6,
+        "operation_elapsed_ms": 56879,
+        "tool_elapsed_ms": 10674
+      },
+      "response_sha256": "b92e859b8406568ba4d2e92d2d634e0c651443b9637c720c69f2d67b41c62d2e",
+      "tool_counts": {
+        "jira_search": 3,
+        "turn_read_evidence": 2
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": "gpt-5.6-luna",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 5
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-luna",
+          "selected_model": "gpt-5.6-luna",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 5,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 113921,
+        "input_tokens": null,
+        "known_cached_input_tokens": 84559,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 29347,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 2728,
+        "output_tokens": null,
+        "known_total_tokens": 116649,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.01230453,
+        "currency": "USD",
+        "priced_call_count": 5,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "aa8ad208cd92defdb3e5146abeb692f280042b60d1c98778ef512f1d110c4f66",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "key = JVNAUTOSCI-2722",
+            "fields": [
+              "summary",
+              "description",
+              "assignee",
+              "status",
+              "issuetype",
+              "project",
+              "priority",
+              "created",
+              "updated",
+              "reporter",
+              "labels",
+              "components",
+              "comment"
+            ]
+          }
+        },
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "12a406ba1ec9f55d9254217e0301f7fa7b85397efdb3d4e0b487c49323602f42",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "project = JVNAUTOSCI AND created < \"2026-09-05 15:34\" ORDER BY created DESC",
+            "fields": [
+              "summary",
+              "description",
+              "assignee",
+              "status",
+              "issuetype",
+              "project",
+              "priority",
+              "created",
+              "updated",
+              "reporter",
+              "labels",
+              "components",
+              "comment"
+            ]
+          }
+        },
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "8e1ef2e9e4cbb321904db9cee987eca1482be0cd2a42cc009458507c3f5730e4",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "key = JVNAUTOSCI-2721",
+            "fields": [
+              "summary",
+              "description",
+              "assignee",
+              "status",
+              "issuetype",
+              "project",
+              "priority",
+              "created",
+              "updated",
+              "reporter",
+              "labels",
+              "components",
+              "comment"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_all_groups",
+            "outcome": "pass",
+            "expected": [
+              [
+                "JVNAUTOSCI-"
+              ]
+            ],
+            "observed": [
+              {
+                "group": [
+                  "JVNAUTOSCI-"
+                ],
+                "hit": "JVNAUTOSCI-"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-terra",
+      "turn": 1,
+      "session_id": "9b69af39-2a26-4a1e-9f9e-38cfbb7aeb08",
+      "request_id": "bd03d86f-4f5f-44ab-a007-07eb5eb5d236",
+      "history_index": 4,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 58,
+      "recorded_timing": {
+        "elapsed_ms": 54517,
+        "observed_timeline_ms": 53457,
+        "phase_elapsed_ms": 53466,
+        "llm_elapsed_ms": 9321,
+        "llm_call_count": 5,
+        "operation_elapsed_ms": 16150,
+        "tool_elapsed_ms": 3370
+      },
+      "response_sha256": "4873deda98319126ac8364965642ed1ec37de38ca8b06e44689b0e4fc7d8db90",
+      "tool_counts": {
+        "turn_capabilities": 2,
+        "jira_search": 1
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 4
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 4,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 38809,
+        "input_tokens": null,
+        "known_cached_input_tokens": 21179,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 17618,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 287,
+        "output_tokens": null,
+        "known_total_tokens": 39096,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.0517488,
+        "currency": "USD",
+        "priced_call_count": 4,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "740cb6d4a90434a85cf229a54f750217bc5e0e369a82e06917330351af952c55",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "project = JVNAUTOSCI ORDER BY created DESC",
+            "fields": [
+              "key",
+              "summary",
+              "status",
+              "created"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_any",
+            "outcome": "pass",
+            "expected": [
+              "JVNAUTOSCI-"
+            ],
+            "observed": "JVNAUTOSCI-"
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-terra",
+      "turn": 2,
+      "session_id": "9b69af39-2a26-4a1e-9f9e-38cfbb7aeb08",
+      "request_id": "3b2409a8-4526-453d-94d9-541db3a8b481",
+      "history_index": 10,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 56,
+      "recorded_timing": {
+        "elapsed_ms": 52730,
+        "observed_timeline_ms": 51685,
+        "phase_elapsed_ms": 51696,
+        "llm_elapsed_ms": 13392,
+        "llm_call_count": 6,
+        "operation_elapsed_ms": 25985,
+        "tool_elapsed_ms": 8823
+      },
+      "response_sha256": "237faa8dc31af457bf245029336725306693bd5256be44cce0251b409a1daf23",
+      "tool_counts": {
+        "turn_capabilities": 2,
+        "resolve_concept_by_name": 1,
+        "search_concepts": 1
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 5
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 5,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 70361,
+        "input_tokens": null,
+        "known_cached_input_tokens": 45471,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 24875,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 483,
+        "output_tokens": null,
+        "known_total_tokens": 70844,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.0771077,
+        "currency": "USD",
+        "priced_call_count": 5,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "resolve_concept_by_name",
+          "status": "ok",
+          "sha256": "3120c359ef7f27ef44b97c11106ed6fd9d70367694cac89b56de333c29946b45",
+          "target_ids": [],
+          "selected_arguments": {
+            "name": "JVNAUTOSCI-2722",
+            "normalisation_level": "exact"
+          }
+        },
+        {
+          "tool": "search_concepts",
+          "status": "ok",
+          "sha256": "6e4954b72d6ed87e1727e35d83592bffdc665d87697db270be5756b827882491",
+          "target_ids": [],
+          "selected_arguments": {
+            "query": "Restore authorised Jira reads on ordinary turns without import side effects",
+            "match_type": "exact"
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "forbid_decisions",
+            "outcome": "pass",
+            "expected": "not in ['escalation_required']",
+            "observed": ""
+          },
+          {
+            "check": "forbid_unsatisfied_obligation_sources",
+            "outcome": "pass",
+            "expected": "no unsatisfied obligation sourced from ['turn_expected_outcome_conditional_required_tools']",
+            "observed": []
+          },
+          {
+            "check": "require_prior_obligation_suppression",
+            "outcome": "pass",
+            "expected": "suppression telemetry present or no inherited unsatisfied obligations",
+            "observed": {
+              "suppressed_prior_obligations": [],
+              "inherited_unsatisfied_count": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-terra",
+      "turn": 3,
+      "session_id": "9b69af39-2a26-4a1e-9f9e-38cfbb7aeb08",
+      "request_id": "a1902362-5d25-456a-bf16-c88bcd8ad0c3",
+      "history_index": 14,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 47,
+      "recorded_timing": {
+        "elapsed_ms": 43599,
+        "observed_timeline_ms": 42552,
+        "phase_elapsed_ms": 42562,
+        "llm_elapsed_ms": 17425,
+        "llm_call_count": 4,
+        "operation_elapsed_ms": 23815,
+        "tool_elapsed_ms": 3090
+      },
+      "response_sha256": "f3cac6e55e3437427ecbc9e92495aa29895971958c127ad105b63b7c40561da2",
+      "tool_counts": {
+        "jira_search": 1,
+        "turn_read_evidence": 1
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 3
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 3,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 37889,
+        "input_tokens": null,
+        "known_cached_input_tokens": 22451,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 15429,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 1840,
+        "output_tokens": null,
+        "known_total_tokens": 39729,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.0651607,
+        "currency": "USD",
+        "priced_call_count": 3,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "ec2c93b8c0645cf7d5bf2ab4b3e10155bca5a1730adaaa904ae37f87835b8f9f",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "key = JVNAUTOSCI-2722",
+            "fields": [
+              "key",
+              "summary",
+              "status",
+              "description",
+              "assignee",
+              "reporter",
+              "priority",
+              "issuetype",
+              "project",
+              "created",
+              "updated",
+              "resolution",
+              "labels",
+              "components",
+              "fixVersions",
+              "versions",
+              "duedate"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_any",
+            "outcome": "pass",
+            "expected": [
+              "JVNAUTOSCI-"
+            ],
+            "observed": "JVNAUTOSCI-"
+          }
+        ]
+      }
+    },
+    {
+      "label": "jira-terra",
+      "turn": 4,
+      "session_id": "9b69af39-2a26-4a1e-9f9e-38cfbb7aeb08",
+      "request_id": "0319faa4-857c-48d9-84a0-4d7a0212c9d2",
+      "history_index": 20,
+      "canonical_terminal_status": "completed",
+      "visible_outcome": "delivered",
+      "ui_elapsed_seconds": 62,
+      "recorded_timing": {
+        "elapsed_ms": 48172,
+        "observed_timeline_ms": 47121,
+        "phase_elapsed_ms": 56986,
+        "llm_elapsed_ms": 21288,
+        "llm_call_count": 5,
+        "operation_elapsed_ms": 29667,
+        "tool_elapsed_ms": 3480
+      },
+      "response_sha256": "6cc456d3a9c12ce01db727564c9141dc9df3e8f05ad880b2257a322c949fc2a6",
+      "tool_counts": {
+        "jira_search": 1,
+        "turn_read_evidence": 3
+      },
+      "model_identities": [
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": "gpt-5.6-terra",
+          "model_identity_source": "provider_response",
+          "provider_request_sent": true,
+          "effective_service_tier": "default",
+          "connection_id": "#V#openai_provider",
+          "call_count": 4
+        },
+        {
+          "provider": "openai",
+          "requested_model": "gpt-5.6-terra",
+          "selected_model": "gpt-5.6-terra",
+          "effective_model": null,
+          "model_identity_source": null,
+          "provider_request_sent": true,
+          "effective_service_tier": null,
+          "connection_id": null,
+          "call_count": 1
+        }
+      ],
+      "usage": {
+        "status": "partial",
+        "reported_call_count": 4,
+        "partial_call_count": 0,
+        "unavailable_call_count": 1,
+        "known_input_tokens": 74005,
+        "input_tokens": null,
+        "known_cached_input_tokens": 50961,
+        "cached_input_tokens": null,
+        "known_cache_write_input_tokens": 23032,
+        "cache_write_input_tokens": null,
+        "known_output_tokens": 1550,
+        "output_tokens": null,
+        "known_total_tokens": 75555,
+        "total_tokens": null
+      },
+      "estimated_cost": {
+        "status": "partial",
+        "amount": null,
+        "known_amount": 0.0863962,
+        "currency": "USD",
+        "priced_call_count": 4,
+        "partial_call_count": 0,
+        "unpriced_call_count": 1,
+        "pricing_versions": [
+          "openai-standard-observed-2026-08-05"
+        ],
+        "pricing": {
+          "source": "https://developers.openai.com/api/docs/pricing",
+          "version": "openai-standard-observed-2026-08-05",
+          "effective_at_utc": "2026-08-05T00:00:00Z"
+        },
+        "unavailable_reasons": [
+          "effective_model_unavailable"
+        ]
+      },
+      "effects": [],
+      "source_receipts": [
+        {
+          "tool": "jira_search",
+          "status": "ok",
+          "sha256": "ba8b61fe22f8fd8b52c7504fa93acb231834ceaf75b54e840d24143fa2025631",
+          "target_ids": [],
+          "selected_arguments": {
+            "jql": "project = JVNAUTOSCI ORDER BY created DESC",
+            "fields": [
+              "summary",
+              "status",
+              "description",
+              "assignee",
+              "reporter",
+              "priority",
+              "issuetype",
+              "created",
+              "updated",
+              "resolution"
+            ]
+          }
+        }
+      ],
+      "canonical_machine_evaluation": {
+        "verdict": "pass",
+        "checks": [
+          {
+            "check": "require_completed",
+            "outcome": "pass",
+            "expected": "completed",
+            "observed": "completed"
+          },
+          {
+            "check": "response_must_mention_all_groups",
+            "outcome": "pass",
+            "expected": [
+              [
+                "JVNAUTOSCI-"
+              ]
+            ],
+            "observed": [
+              {
+                "group": [
+                  "JVNAUTOSCI-"
+                ],
+                "hit": "JVNAUTOSCI-"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "work_product": {
+    "concept_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+    "snapshots": {
+      "encounter-a": [
+        {
+          "relation_id": "6a9c167cb312f5fd99b0ceab",
+          "characters": 5492,
+          "sha256": "2cee7f3f7c6691660cae0819deb80d25c6017370d17b34edfe26ad69df18556f"
+        }
+      ],
+      "encounter-b": [
+        {
+          "relation_id": "6a9c167cb312f5fd99b0ceab",
+          "characters": 5492,
+          "sha256": "2cee7f3f7c6691660cae0819deb80d25c6017370d17b34edfe26ad69df18556f"
+        },
+        {
+          "relation_id": "6a9c1aacb312f5fd99b0ceda",
+          "characters": 6411,
+          "sha256": "b2bf391e1bd214d64c8ef4fceab269914bff28dd5d6134e50b9211b0d12e0edb"
+        }
+      ]
+    }
+  },
+  "checkpoint_attempt": {
+    "inputs": {
+      "workflow_id": "#V#lab_project_status_digest_workflow",
+      "schedule_type": "once",
+      "run_at": "2026-09-05T14:50:21.000Z",
+      "user_id": "#V#michael_witbrock",
+      "org_id": "#V#university_of_auckland_strong_ai_lab",
+      "namespace": "#V#michael_witbrock@university_of_auckland_strong_ai_lab",
+      "description": "2721 prospective readiness checkpoint: one operator-facilitated occurrence, 5 September 2026",
+      "default_inputs": {
+        "prompt": "Maintain the continuing responsibility 'Von replay and reliability readiness — Michael — 2721' at this checkpoint. Recover the saved brief and inspect current material sources. Revise affected conclusions, outstanding commitments, consequential unknowns and the next useful action from actual evidence, preserving unaffected context. Keep Jira as task authority and qualify unavailable evidence. Maintain only this selected internal work product; leave Jira and all other products unchanged. This is one scheduled maintenance occurrence, not a certification or authority to create further schedules.",
+        "work_product_id": "#V#von_replay_and_reliability_readiness_michael_2721",
+        "jira_jql": "key in (JVNAUTOSCI-2721, JVNAUTOSCI-2722, JVNAUTOSCI-2720, JVNAUTOSCI-2568, JVNAUTOSCI-2577, JVNAUTOSCI-2578, JVNAUTOSCI-2579, JVNAUTOSCI-2590) ORDER BY updated DESC",
+        "evidence_sources": [
+          "JVNAUTOSCI-2721",
+          "JVNAUTOSCI-2722",
+          "JVNAUTOSCI-2720",
+          "JVNAUTOSCI-2568",
+          "JVNAUTOSCI-2577",
+          "JVNAUTOSCI-2578",
+          "JVNAUTOSCI-2579",
+          "JVNAUTOSCI-2590"
+        ],
+        "requested_model": "gpt-5.6-luna",
+        "requested_client_type": "openai",
+        "prefer_default_model": true,
+        "requested_model_parameters": {
+          "reasoning_effort": "high"
+        }
+      }
+    },
+    "receipt": {
+      "success": false,
+      "error": "Workflow launch actor scope conflicts with ambient authority.",
+      "error_code": "workflow_actor_authority_required",
+      "error_details": {
+        "mismatch_fields": []
+      }
+    },
+    "schedule_created": false,
+    "scheduled_model_requests": 0
+  },
+  "limitations": [
+    "Ten foreground turns with facilitator-selected sources and prompts; not beneficiary adoption.",
+    "Live Jira changed during acquisition and the model pair; not a frozen-source randomised benchmark.",
+    "Canonical evaluator passes do not establish delivered answers; Luna turn 2 visibly failed.",
+    "The precise transport exception was not retained.",
+    "Auxiliary observed model identity and usage are unavailable; known costs are partial.",
+    "Two foreground content rows remain; scheduled replacement was not exercised.",
+    "The scheduling rejection is attached-route actor binding evidence, not global scheduler failure."
+  ]
+}


### PR DESCRIPTION
Refines the continuing-role programme around one real readiness brief for Michael, incorporating the concurrent Jira portfolio reconciliation. Records ten normal-owner browser turns on the deployed release: creation, fresh recovery/revision, and the complete four-turn Jira family on Luna and Terra.

Terra delivered all four family answers. Luna retained four grounded answers but one did not reach the UI; the record preserves that failure despite passing canonical machine checks. It also records ambiguous foreground text replacement and a rejected checkpoint launch, with the next work retained on 2568/2698. 2721 remains open for dependable maintenance, beneficiary use, learned benefit and transfer.

Validation: exact source/effect/answer review, canonical product read-back and hashes, existing replay evaluator, model identity and usage coverage, Markdown links, JSON consistency and `git diff --check`. Selected evidence omits private traces and diagnostic credentials. No application code, prompt activation or deployment change is included.
