### PR TITLE
Recover saved chat answers after connection loss

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -14996,7 +14996,7 @@ function stopForegroundTaskResultPolling(request) {
     request.foregroundTaskResultPoll = null;
 }
 
-function startForegroundTaskResultPolling(request, handlers = {}) {
+function startForegroundTaskResultPolling(request, handlers = {}, { immediate = false } = {}) {
     if (!request || request.aborted || !request.clientRequestId) {
         return;
     }
@@ -15011,18 +15011,22 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
         // A server-dispatched retry is already running by the time the browser
         // adopts it, so check promptly instead of imposing the foreground
         // generate path's initial grace period.
-        nextDelayMs: request.observingServerDispatch === true
+        nextDelayMs: immediate || request.observingServerDispatch === true
             ? 250
             : FOREGROUND_TASK_RESULT_POLL_INITIAL_DELAY_MS,
         delivering: false
     };
+    const isCurrent = () => (
+        request.foregroundTaskResultPoll === poll
+        && !poll.abortController.signal.aborted
+        && !request.aborted
+        && !request.foregroundDeliveryCompleted
+        && isLiveChatRequest(request)
+        && isChatOrganisationRequestCurrent(request.organisationGeneration)
+    );
 
     const scheduleNextPoll = (delayMs) => {
-        if (
-            request.aborted
-            || request.foregroundDeliveryCompleted
-            || !isLiveChatRequest(request)
-        ) {
+        if (!isCurrent()) {
             return;
         }
         poll.timeoutId = setTimeout(() => {
@@ -15062,12 +15066,7 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
     };
 
     const pollOnce = async () => {
-        if (
-            poll.delivering
-            || request.aborted
-            || request.foregroundDeliveryCompleted
-            || !isLiveChatRequest(request)
-        ) {
+        if (poll.delivering || !isCurrent()) {
             return;
         }
 
@@ -15075,6 +15074,9 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
             const { resp: statusResp, payload: statusPayload } = await fetchJson(
                 `/von/api/task/status/${encodeURIComponent(requestId)}`
             );
+            if (!isCurrent()) {
+                return;
+            }
             if (await repairWindowContextIfNeeded(statusResp, statusPayload)) {
                 return;
             }
@@ -15105,6 +15107,9 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
             const { resp: resultResp, payload: resultPayload } = await fetchJson(
                 `/von/api/task/result/${encodeURIComponent(requestId)}`
             );
+            if (!isCurrent()) {
+                return;
+            }
             if (await repairWindowContextIfNeeded(resultResp, resultPayload)) {
                 return;
             }
@@ -15150,7 +15155,7 @@ function startForegroundTaskResultPolling(request, handlers = {}) {
     };
 
     request.foregroundTaskResultPoll = poll;
-    if (request.observingServerDispatch === true) {
+    if (immediate || request.observingServerDispatch === true) {
         void pollOnce();
     } else {
         scheduleNextPoll(poll.nextDelayMs);
@@ -37785,6 +37790,38 @@ async function handleSendPrompt(options = {}) {
         }
     };
 
+    // Observation owns this lifetime once the generate connection is gone.
+    // Reuse the same actor-scoped result reader for server dispatch and lost
+    // responses; neither path resubmits the user's prompt.
+    const waitForForegroundTaskResult = () => new Promise((resolve) => {
+        const signal = request.abortController.signal;
+        const settle = () => {
+            signal.removeEventListener('abort', settle);
+            resolve();
+        };
+        signal.addEventListener('abort', settle, { once: true });
+        if (signal.aborted || !isLiveChatRequest(request) || !isRequestCurrentOrganisation()) {
+            settle();
+            return;
+        }
+        startForegroundTaskResultPolling(request, {
+            onCompleted: async (...args) => {
+                try {
+                    await foregroundTaskResultHandlers.onCompleted(...args);
+                } finally {
+                    settle();
+                }
+            },
+            onFailed: async (...args) => {
+                try {
+                    await foregroundTaskResultHandlers.onFailed(...args);
+                } finally {
+                    settle();
+                }
+            }
+        }, { immediate: true });
+    });
+
     if (!fromQueue) {
         // Clear input only for direct sends; queued execution should preserve current draft text.
         if (promptText) {
@@ -37793,6 +37830,7 @@ async function handleSendPrompt(options = {}) {
         setPromptComposerValue('', { promptInput });
     }
 
+    let generateTransportInterrupted = false;
     try {
         setLoadingIndicatorTooltip(formatToolUseHistoryTooltip(request));
 
@@ -37807,19 +37845,7 @@ async function handleSendPrompt(options = {}) {
                 return;
             }
             startToolUseProgressPolling(request);
-            await new Promise((resolve) => {
-                let settled = false;
-                const settle = () => {
-                    if (settled) {
-                        return;
-                    }
-                    settled = true;
-                    request.abortController.signal.removeEventListener('abort', settle);
-                    resolve();
-                };
-                request.abortController.signal.addEventListener('abort', settle, { once: true });
-                startForegroundTaskResultPolling(request, foregroundTaskResultHandlers);
-            });
+            await waitForForegroundTaskResult();
             return;
         }
 
@@ -37884,7 +37910,10 @@ async function handleSendPrompt(options = {}) {
         // before an immediate generate response tears down the active card.
         await Promise.resolve();
         await Promise.resolve();
-        const response = await responsePromise;
+        const response = await responsePromise.catch((error) => {
+            generateTransportInterrupted = true;
+            throw error;
+        });
         if (response?.ok) {
             request.attachmentBindingAccepted = true;
         }
@@ -37907,6 +37936,10 @@ async function handleSendPrompt(options = {}) {
             data = await response.json();
         } catch (parseError) {
             console.warn('[chatTab] Unable to parse /von/generate response JSON:', parseError);
+            if (response.ok) {
+                generateTransportInterrupted = true;
+                throw parseError;
+            }
             data = {
                 error: response.ok
                     ? 'Server returned an unreadable response.'
@@ -37989,7 +38022,15 @@ async function handleSendPrompt(options = {}) {
         if (request?.foregroundDeliveryCompleted) {
             return;
         }
-        if (request && (request.aborted || (error && error.name === 'AbortError'))) {
+        if (request.aborted || request.abortController.signal.aborted) {
+            return;
+        }
+        if (generateTransportInterrupted && !isThinkingFailureProgress(request.latestProgress)) {
+            console.warn('[chatTab] Response connection interrupted; observing the original task:', error);
+            if (isRequestVisible()) {
+                showToast('The answer connection was interrupted. Checking the original request for its result.', 'info');
+            }
+            await waitForForegroundTaskResult();
             return;
         }
         const failureSummary = resolveGenerateCatchFailureSummary(request, error);

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -9175,6 +9175,100 @@ describe('thinking card toggle accessibility', () => {
         }
     });
 
+    test.each(['connection', 'body', 'cancel', 'organisation'])(
+        'reconciles an interrupted answer without resubmission: %s', async (scenario) => {
+            const { getUserContext } = require('../apiService.js');
+            const {
+                __testOnly_getLiveChatRequestForSession,
+                __testOnly_startOrganisationSwitchForChatTab,
+                __testOnly_handleOrgSwitchFailureForChatTab
+            } = require('../chatTab.js');
+            getUserContext.mockReturnValue({ user_id: 'user', org_id: 'org' });
+            const sessionId = 'session-interrupted-answer';
+            __testOnly_setActiveChatSession(sessionId, 'Interrupted answer');
+            document.getElementById('promptInput').value = 'Read the issue details';
+            let finishResult;
+            let resultRequested = false;
+            let statusReads = 0;
+            global.fetch = jest.fn(async (url, options = {}) => {
+                const reply = (payload, status = 200) => ({
+                    ok: status === 200, status, json: async () => payload
+                });
+                if (url === '/von/generate') {
+                    if (scenario === 'body') {
+                        return { ok: true, json: async () => { throw new TypeError('Load failed'); } };
+                    }
+                    throw new TypeError('Failed to fetch');
+                }
+                if (String(url).startsWith('/von/api/task/status/')) {
+                    statusReads += 1;
+                    if (scenario === 'connection' && statusReads === 1) {
+                        return reply({ error: 'Task not found' }, 404);
+                    }
+                    return reply({ status: 'completed', has_result: true });
+                }
+                if (String(url).startsWith('/von/api/task/result/')) {
+                    resultRequested = true;
+                    // Deliberately ignore abort here: a late read must not deliver
+                    // after Stop or an organisation change, even if transport races.
+                    return new Promise(resolve => {
+                        finishResult = () => resolve(reply({ result: {
+                            response: 'Saved answer for the original request',
+                            llm_debug: { model: 'test-model' }
+                        } }));
+                    });
+                }
+                if (String(url).startsWith('/von/progress/')) {
+                    return reply({ status: 'working', phase: 'response_finalising' });
+                }
+                if (String(url).startsWith('/von/api/render_markdown')) {
+                    return reply({ html: JSON.parse(options.body).text });
+                }
+                return reply({});
+            });
+            jest.useFakeTimers();
+            try {
+                const sendPromise = sendMessage();
+                for (let i = 0; i < 50; i += 1) await Promise.resolve();
+                expect(document.querySelector('.error-turn')).toBeNull();
+                if (scenario === 'connection') {
+                    expect(resultRequested).toBe(false);
+                    await jest.advanceTimersByTimeAsync(400);
+                }
+                expect(resultRequested).toBe(true);
+                const request = __testOnly_getLiveChatRequestForSession(sessionId);
+                expect(request).toBeTruthy();
+                if (scenario === 'cancel') {
+                    __testOnly_bindThinkingCardControls();
+                    document.getElementById('abortButton').click();
+                } else if (scenario === 'organisation') {
+                    __testOnly_startOrganisationSwitchForChatTab({});
+                }
+                finishResult();
+                for (let i = 0; i < 60; i += 1) await Promise.resolve();
+                await sendPromise;
+                const answers = document.querySelectorAll('.assistant-turn .chat-message-text');
+                if (scenario === 'cancel' || scenario === 'organisation') {
+                    expect(answers).toHaveLength(0);
+                } else {
+                    expect(answers).toHaveLength(1);
+                    expect(answers[0].dataset.originalText).toBe('Saved answer for the original request');
+                    expect(request.turnOutcome.status).toBe('completed');
+                }
+                expect(global.fetch.mock.calls.filter(([url]) => url === '/von/generate')).toHaveLength(1);
+                const originalId = JSON.parse(global.fetch.mock.calls.find(([url]) => url === '/von/generate')[1].body).client_request_id;
+                expect(global.fetch.mock.calls.filter(([url]) => String(url).startsWith('/von/api/task/result/')))
+                    .toEqual([[`/von/api/task/result/${originalId}`, expect.objectContaining({ credentials: 'same-origin' })]]);
+            } finally {
+                if (scenario === 'organisation') {
+                    await __testOnly_handleOrgSwitchFailureForChatTab({});
+                }
+                __testOnly_resetChatRequestState();
+                jest.useRealTimers();
+            }
+        }
+    );
+
     test('retains a failed card inline when the last live progress remains non-terminal', async () => {
         const { getUserContext } = require('../apiService.js');
         getUserContext.mockReturnValue({


### PR DESCRIPTION
When the generate connection drops after Von has accepted or completed a turn, the chat currently reports a failed answer and stops its task-result observer. Keep that observer alive for the original request, including interrupted successful response bodies, and deliver the saved answer without resubmitting the prompt. Stop and organisation changes invalidate late result reads. Explicit server failures retain their existing handling.

Validation: all 329 tests in the affected chat, prompt-queue and cancellation suites pass; four new regressions fail on the baseline. Changed-file static lint and diff checks pass. Normal-owner Luna four-turn Jira replay follows deployment before closing [JVNAUTOSCI-2568](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2568). Indefinite server/network outages remain pending rather than being misreported as completed or failed work.


[JVNAUTOSCI-2568]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ