### PR TITLE
Reduce backend drift runs and repeated failure alerts

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,24 +1,15 @@
-name: Nightly Backend Tests
+name: Scheduled Backend Tests
 
-# JVNAUTOSCI-2656. Backend pytest has never run in CI, so red tests accumulate
-# on main unnoticed: test_mcp_manifest_parity was failing for an unknown period
-# and was found by accident.
-#
-# This reports rather than gates. main has no branch protection, so a failing
-# check blocks nothing, and a per-pull-request gate would have cost several
-# thirty-minute jobs on every PR while being unable to prevent anything.
-# Promoting this to a required check is a small change if that is introduced.
-#
-# It runs without a database. Of 3776 cost_normal tests, 3561 pass with no
-# database in 13m48s locally; the rest are recorded in
-# ci/known_test_failures.txt along with the genuinely broken ones. Provisioning
-# a database would shrink that list by roughly half and is tracked separately.
+# Full cost_normal regression reporting, twice weekly and on demand.
+# Completed evidence is reused for unchanged scheduled commits. Notification
+# state is separate from ci/known_test_failures.txt: failures are never accepted
+# merely to silence an email. State loss safely causes another full run.
+# No live database or external-service credentials are supplied to the suite.
 
 on:
   schedule:
-    # 15:00 UTC daily, which is early morning in Pacific/Auckland, so drift
-    # introduced during the working day is reported before the next one.
-    - cron: "0 15 * * *"
+    # Monday and Thursday. Manual dispatch remains available after repairs.
+    - cron: "0 15 * * 1,4"
   workflow_dispatch:
     inputs:
       test_notification:
@@ -30,6 +21,10 @@ on:
         type: string
         default: ""
 
+concurrency:
+  group: backend-drift-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   drift-report:
     name: Backend test drift
@@ -40,6 +35,7 @@ jobs:
     timeout-minutes: 350
     permissions:
       contents: read
+      actions: read
 
     env:
       # No database is provisioned. The default 5000ms Mongo timeouts are kept
@@ -58,18 +54,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Plan full-suite execution
+        id: plan
+        if: ${{ !inputs.test_notification && inputs.pytest_path == '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python scripts/backend_test_drift_schedule.py plan
+
       - name: Setup Python
+        if: ${{ inputs.test_notification || inputs.pytest_path != '' || steps.plan.outputs.run_suite == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Setup PDM
+        if: ${{ inputs.test_notification || inputs.pytest_path != '' || steps.plan.outputs.run_suite == 'true' }}
         uses: pdm-project/setup-pdm@v4
         with:
           version: "2.29.0"
           cache: true
 
       - name: Install dependencies
+        if: ${{ inputs.test_notification || inputs.pytest_path != '' || steps.plan.outputs.run_suite == 'true' }}
         run: |
           pdm lock --check
           pdm sync --clean -G dev
@@ -86,7 +93,7 @@ jobs:
           pdm run python scripts/notify_backend_test_drift.py test /tmp/drift.txt
 
       - name: Report drift against the recorded backlog
-        if: ${{ !inputs.test_notification }}
+        if: ${{ !inputs.test_notification && (inputs.pytest_path != '' || steps.plan.outputs.run_suite == 'true') }}
         id: drift
         env:
           BACKEND_TEST_PATH: ${{ inputs.pytest_path }}
@@ -103,7 +110,7 @@ jobs:
 
       - name: Retain the complete drift evidence
         id: evidence
-        if: ${{ !inputs.test_notification && always() }}
+        if: ${{ !inputs.test_notification && steps.drift.outcome != 'skipped' && always() }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
@@ -112,24 +119,26 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-      - name: Notify on new failures
-        if: ${{ always() && inputs.pytest_path == '' && steps.drift.outputs.status == '1' }}
+      - name: Notify on changed failures or weekly reminder
+        if: ${{ always() && !inputs.test_notification && inputs.pytest_path == '' && github.ref_name == github.event.repository.default_branch }}
         env:
+          RAN_SUITE: ${{ steps.plan.outputs.run_suite }}
           NIGHTLY_SMTP_USERNAME: ${{ secrets.NIGHTLY_SMTP_USERNAME }}
           NIGHTLY_SMTP_APP_PASSWORD: ${{ secrets.NIGHTLY_SMTP_APP_PASSWORD }}
           NIGHTLY_DRIFT_ARTIFACT_AVAILABLE: ${{ steps.evidence.outcome == 'success' }}
-        run: pdm run python scripts/notify_backend_test_drift.py new_failures /tmp/drift.txt
+        run: python scripts/backend_test_drift_schedule.py finish
 
-      - name: Notify when the run itself broke
-        if: ${{ always() && inputs.pytest_path == '' && steps.drift.outputs.status == '2' }}
-        env:
-          NIGHTLY_SMTP_USERNAME: ${{ secrets.NIGHTLY_SMTP_USERNAME }}
-          NIGHTLY_SMTP_APP_PASSWORD: ${{ secrets.NIGHTLY_SMTP_APP_PASSWORD }}
-          NIGHTLY_DRIFT_ARTIFACT_AVAILABLE: ${{ steps.evidence.outcome == 'success' }}
-        run: pdm run python scripts/notify_backend_test_drift.py broken /tmp/drift.txt
+      - name: Retain schedule and notification state
+        if: ${{ always() && !inputs.test_notification && inputs.pytest_path == '' && github.ref_name == github.event.repository.default_branch }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-drift-state
+          path: /tmp/backend-drift-state.json
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Fail the run when there is drift
-        if: ${{ always() && !inputs.test_notification && (steps.drift.outputs.status != '0' || steps.evidence.outcome != 'success') }}
+        if: ${{ always() && !inputs.test_notification && steps.drift.outcome != 'skipped' && (steps.drift.outputs.status != '0' || steps.evidence.outcome != 'success') }}
         run: |
           echo "drift report exited ${{ steps.drift.outputs.status }}"
           echo "evidence upload outcome was ${{ steps.evidence.outcome }}"

--- a/scripts/backend_test_drift_schedule.py
+++ b/scripts/backend_test_drift_schedule.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Reuse completed scheduled evidence and pace backend drift notifications.
+
+State is an Actions artefact, not the accepted-failure backlog. Missing or
+unreadable state causes a fresh run. Manual runs always execute; diagnostic
+slices and runs off the default branch never publish shared schedule state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+STATE_NAME = "backend-drift-state"
+STATE_FILE = "backend-drift-state.json"
+
+
+def restore_state(repo: str, branch: str) -> dict:
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/actions/artifacts?name={STATE_NAME}&per_page=100",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
+        artifacts = json.loads(result.stdout)["artifacts"]
+        for artifact in artifacts:
+            if (
+                artifact["expired"]
+                or artifact.get("workflow_run", {}).get("head_branch") != branch
+            ):
+                continue
+            archive = subprocess.run(
+                ["gh", "api", f"repos/{repo}/actions/artifacts/{artifact['id']}/zip"],
+                check=True,
+                capture_output=True,
+                timeout=60,
+            )
+            with zipfile.ZipFile(io.BytesIO(archive.stdout)) as zipped:
+                state = json.loads(zipped.read(STATE_FILE))
+            if state.get("schema_version") == "backend_drift_schedule.v1":
+                return state
+    except (
+        OSError,
+        subprocess.SubprocessError,
+        ValueError,
+        KeyError,
+        zipfile.BadZipFile,
+    ):
+        print("Previous schedule state unavailable; running the suite.")
+    return {}
+
+
+def complete(report: dict) -> bool:
+    return (
+        report.get("full_run") is True
+        and report.get("status") in {"new_failures", "no_new_failures"}
+        and report.get("pytest_exit_code") in {0, 1}
+        and isinstance(report.get("observed_failures"), list)
+    )
+
+
+def should_run(event: str, sha: str, state: dict) -> bool:
+    return not (
+        event == "schedule"
+        and state.get("tested_sha") == sha
+        and complete(state.get("report", {}))
+    )
+
+
+def notification(report: dict, state: dict, now: datetime) -> str:
+    if not complete(report):
+        return "broken"
+    previous = state.get("notified_report", {})
+    # Compare with the last successfully sent report: a failed send must retry.
+    if not complete(previous):
+        return "changed" if report.get("new_failures") else ""
+    if any(
+        set(report.get(key, [])) != set(previous.get(key, []))
+        for key in ("observed_failures", "new_failures")
+    ):
+        return "changed"
+    if report.get("new_failures"):
+        try:
+            last = datetime.fromisoformat(state["last_notified_at"])
+            if now - last < timedelta(days=7):
+                return ""
+        except (KeyError, ValueError, TypeError):
+            pass
+        return "reminder"
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("phase", choices=["plan", "finish"])
+    parser.add_argument("--directory", default="/tmp")
+    args = parser.parse_args()
+    directory = Path(args.directory)
+    state_path = directory / STATE_FILE
+    if args.phase == "plan":
+        state = restore_state(
+            os.environ["GITHUB_REPOSITORY"], os.environ["DEFAULT_BRANCH"]
+        )
+        run = should_run(
+            os.environ["GITHUB_EVENT_NAME"], os.environ["GITHUB_SHA"], state
+        )
+        state_path.write_text(json.dumps(state))
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+            output.write(f"run_suite={str(run).lower()}\n")
+        print(
+            "Run full suite."
+            if run
+            else "Unchanged commit; reusing completed full-suite evidence."
+        )
+        return 0
+
+    state = json.loads(state_path.read_text()) if state_path.exists() else {}
+    report_path = directory / "backend-test-drift.json"
+    ran = os.environ.get("RAN_SUITE") == "true"
+    if ran:
+        try:
+            report = json.loads(report_path.read_text())
+        except (OSError, ValueError):
+            report = {
+                "status": "run_broken",
+                "output_tail": "The suite did not produce a readable report. Inspect the run logs.",
+            }
+    else:
+        report = state.get("report", {})
+    now = datetime.now(UTC)
+    kind = notification(report, state, now)
+    current_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    if ran and complete(report):
+        state.update(
+            tested_sha=os.environ["GITHUB_SHA"],
+            report=report,
+            report_run_url=current_url,
+        )
+    if ran and not complete(report):
+        state.pop("tested_sha", None)
+    state["schema_version"] = "backend_drift_schedule.v1"
+    summary = (
+        f"{'Executed' if ran else 'Reused'} full-suite evidence: {current_url if ran else state.get('report_run_url', current_url)}\n"
+        f"Notification: {kind or 'unchanged; suppressed'}\n"
+    )
+    if kind:
+        body = directory / "drift-notification.txt"
+        body.write_text(
+            summary
+            + "\nFailures outside the accepted backlog: "
+            + str(len(report.get("new_failures", [])))
+            + "\n"
+            + "\n".join(report.get("new_failures", []))
+            + "\n\n"
+            + report.get("output_tail", "")
+        )
+        receipt = directory / "drift-notification-sent"
+        receipt.unlink(missing_ok=True)
+        env = dict(os.environ, NIGHTLY_NOTIFICATION_RECEIPT=str(receipt))
+        subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("notify_backend_test_drift.py")),
+                kind,
+                str(body),
+            ],
+            env=env,
+            check=False,
+        )
+        if receipt.exists():
+            state.update(last_notified_at=now.isoformat(), notified_report=report)
+        else:
+            summary += "Notification not delivered; next run will retry.\n"
+    state_path.write_text(json.dumps(state, indent=2) + "\n")
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as output:
+        output.write("\n" + summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notify_backend_test_drift.py
+++ b/scripts/notify_backend_test_drift.py
@@ -53,7 +53,7 @@ def build_message(status: str, body: str) -> EmailMessage:
         f"backend-test-drift-{run_id}"
         if (
             run_id
-            and status in {"new_failures", "broken"}
+            and status in {"new_failures", "broken", "changed", "reminder"}
             and os.environ.get("NIGHTLY_DRIFT_ARTIFACT_AVAILABLE", "true").lower()
             == "true"
         )
@@ -61,6 +61,8 @@ def build_message(status: str, body: str) -> EmailMessage:
     )
 
     subject = {
+        "changed": f"[{repo}] Backend tests: failure set changed",
+        "reminder": f"[{repo}] Backend tests: weekly unresolved-failure reminder",
         "new_failures": f"[{repo}] Nightly backend tests: new failures",
         "broken": f"[{repo}] Nightly backend tests: the run itself failed",
         "test": f"[{repo}] Nightly backend tests: notification path test",
@@ -123,6 +125,8 @@ def main() -> int:
         return 1
 
     recipients = message["To"] + (f", cc {message['Cc']}" if message["Cc"] else "")
+    if receipt := os.environ.get("NIGHTLY_NOTIFICATION_RECEIPT"):
+        Path(receipt).write_text("sent\n", encoding="utf-8")
     print(f"notified {recipients}")
     return 0
 

--- a/tests/backend/test_backend_test_drift_schedule.py
+++ b/tests/backend/test_backend_test_drift_schedule.py
@@ -1,0 +1,194 @@
+from datetime import UTC, datetime, timedelta
+
+from scripts.backend_test_drift_schedule import notification, should_run
+
+
+def report(*failures):
+    return {
+        "full_run": True,
+        "status": "new_failures" if failures else "no_new_failures",
+        "pytest_exit_code": 1 if failures else 0,
+        "observed_failures": list(failures),
+        "new_failures": list(failures),
+    }
+
+
+def test_unchanged_completed_commit_skips_only_scheduled_runs():
+    state = {"tested_sha": "abc", "report": report("failure")}
+    assert not should_run("schedule", "abc", state)
+    assert should_run("workflow_dispatch", "abc", state)
+    assert should_run("schedule", "def", state)
+    assert should_run("schedule", "abc", {})
+    state["report"]["status"] = "run_broken"
+    assert should_run("schedule", "abc", state)
+
+
+def test_slice_does_not_establish_full_suite_completion():
+    result = report("failure")
+    result["full_run"] = False
+    assert should_run("schedule", "abc", {"tested_sha": "abc", "report": result})
+
+
+def test_changed_failure_identity_not_just_count_alerts_and_recovery_alerts():
+    now = datetime.now(UTC)
+    state = {"notified_report": report("old"), "last_notified_at": now.isoformat()}
+    assert notification(report("new"), state, now) == "changed"
+    assert notification(report(), state, now) == "changed"
+    assert notification(report("old"), state, now) == ""
+
+
+def test_weekly_reminder_can_use_reused_report_without_rerunning_suite():
+    now = datetime.now(UTC)
+    state = {
+        "notified_report": report("old"),
+        "last_notified_at": (now - timedelta(days=7)).isoformat(),
+    }
+    assert notification(report("old"), state, now) == "reminder"
+    state["last_notified_at"] = (now - timedelta(days=6)).isoformat()
+    assert notification(report("old"), state, now) == ""
+
+
+def test_missing_notification_receipt_retries_and_broken_run_always_alerts():
+    now = datetime.now(UTC)
+    state = {"report": report("new")}
+    assert notification(report("new"), state, now) == "changed"
+    assert notification({"status": "run_broken"}, state, now) == "broken"
+    assert notification(report(), {}, now) == ""
+
+
+def test_state_restore_ignores_other_branches_and_expired_artifacts(monkeypatch):
+    import io
+    import json
+    import zipfile
+    from types import SimpleNamespace
+
+    from scripts import backend_test_drift_schedule as mod
+
+    archive = io.BytesIO()
+    state = {
+        "schema_version": "backend_drift_schedule.v1",
+        "tested_sha": "abc",
+        "report": report("old"),
+    }
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr(mod.STATE_FILE, json.dumps(state))
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if command[-1].endswith("/zip"):
+            return SimpleNamespace(stdout=archive.getvalue())
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "artifacts": [
+                        {
+                            "id": 3,
+                            "expired": False,
+                            "workflow_run": {"head_branch": "experiment"},
+                        },
+                        {
+                            "id": 2,
+                            "expired": True,
+                            "workflow_run": {"head_branch": "main"},
+                        },
+                        {
+                            "id": 1,
+                            "expired": False,
+                            "workflow_run": {"head_branch": "main"},
+                        },
+                    ]
+                }
+            ).encode()
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", run)
+    assert mod.restore_state("owner/repo", "main") == state
+    assert len(calls) == 2
+    assert calls[-1][-1].endswith("/1/zip")
+
+
+def test_unreadable_state_runs_again(monkeypatch):
+    from scripts import backend_test_drift_schedule as mod
+
+    def unavailable(*args, **kwargs):
+        raise OSError("unavailable")
+
+    monkeypatch.setattr(mod.subprocess, "run", unavailable)
+    assert mod.restore_state("owner/repo", "main") == {}
+
+
+def test_finish_reuses_report_and_records_only_successful_notification(
+    monkeypatch, tmp_path
+):
+    import json
+
+    from scripts import backend_test_drift_schedule as mod
+
+    state = {
+        "tested_sha": "abc",
+        "report": report("old"),
+        "notified_report": report("old"),
+        "last_notified_at": "2020-01-01T00:00:00+00:00",
+        "report_run_url": "https://example.test/original",
+    }
+    (tmp_path / mod.STATE_FILE).write_text(json.dumps(state))
+    monkeypatch.setattr(
+        mod.sys, "argv", ["schedule", "finish", "--directory", str(tmp_path)]
+    )
+    for key, value in {
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_RUN_ID": "2",
+        "GITHUB_SHA": "abc",
+        "RAN_SUITE": "false",
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "summary"),
+    }.items():
+        monkeypatch.setenv(key, value)
+    calls = []
+
+    def not_sent(command, **kwargs):
+        calls.append(command)
+
+    monkeypatch.setattr(mod.subprocess, "run", not_sent)
+    assert mod.main() == 0
+    assert (
+        json.loads((tmp_path / mod.STATE_FILE).read_text())["last_notified_at"]
+        == state["last_notified_at"]
+    )
+    assert calls[0][2] == "reminder"
+
+    def sent(command, **kwargs):
+        from pathlib import Path
+
+        Path(kwargs["env"]["NIGHTLY_NOTIFICATION_RECEIPT"]).write_text("sent")
+
+    monkeypatch.setattr(mod.subprocess, "run", sent)
+    assert mod.main() == 0
+    saved = json.loads((tmp_path / mod.STATE_FILE).read_text())
+    assert saved["last_notified_at"] != state["last_notified_at"]
+    assert saved["tested_sha"] == "abc"
+
+
+def test_broken_manual_rerun_invalidates_previous_skip_evidence(monkeypatch, tmp_path):
+    import json
+
+    from scripts import backend_test_drift_schedule as mod
+
+    (tmp_path / mod.STATE_FILE).write_text(
+        json.dumps({"tested_sha": "abc", "report": report("old")})
+    )
+    monkeypatch.setattr(
+        mod.sys, "argv", ["schedule", "finish", "--directory", str(tmp_path)]
+    )
+    for key, value in {
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_RUN_ID": "2",
+        "GITHUB_SHA": "abc",
+        "RAN_SUITE": "true",
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "summary"),
+    }.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: None)
+    assert mod.main() == 0
+    saved = json.loads((tmp_path / mod.STATE_FILE).read_text())
+    assert should_run("schedule", "abc", saved)


### PR DESCRIPTION
Merge decision: ready for CI — targeted tests and workflow lint support the cadence and notification change; the existing backend failures are a separate diagnosis.

## User outcome

Full backend regression runs happen on Monday and Thursday, skip already-completed unchanged scheduled commits, and remain available on demand. Repeated failures no longer generate an email every run: notifications report changes, broken runs, or a weekly reminder for unresolved failures outside the backlog.

## Material changes

Retain completion and successful-notification evidence in a default-branch Actions artefact. Missing state causes a fresh run; incomplete runs are retried; diagnostic slices cannot update shared state. Preserve the accepted-failure backlog and existing targeted checks. Failed email delivery does not advance the notification checkpoint.

## Evidence

- 16 targeted schedule, notification, and drift-reporter tests pass.
- Ruff, diff checks, and actionlint pass.
- The 30 tests in the 4 September email were replayed on current code: 17 fail and 13 pass locally. These results do not establish full-suite recovery or production health.

## Ship boundary

Minimum criteria: validate scheduled skipping, manual execution, incomplete-run retry, failure-set changes, weekly reminder, and failed-send retry; pass relevant CI.

Stop-ship: skipping untested changes, losing changed-failure alerts, or allowing diagnostic runs to overwrite shared evidence.

Non-goals: repairing the existing product/test failures, changing the accepted backlog, or restarting Von. First actual scheduled execution will establish the end-to-end scheduling and email effect.
