### PR TITLE
Preserve retrieval status and repair backend regression test isolation

### DIFF
--- a/docs/engineering/backend_test_drift_diagnosis_2026-09-05.md
+++ b/docs/engineering/backend_test_drift_diagnosis_2026-09-05.md
@@ -1,0 +1,71 @@
+# Backend test drift diagnosis — 5 September 2026
+
+## Scope and evidence
+
+Source: [4 September full backend run](https://github.com/Strong-AI-Lab/Von/actions/runs/33902795573), commit `edf6f2b7be67610a760fed7e0ecb4d9704d81e77`: 134 failures, of which 30 were outside the 106-entry backlog; two backlog entries passed.
+
+Replayed those exact 30 node IDs on code based on `5b2f8b976069` using the project PDM environment (macOS, Python 3.14), with the workflow's deliberately unavailable Mongo endpoints and invalid external-service credentials. Result: **17 failed, 13 passed in 135.83 seconds**. These are selected-test results, not a Linux/full-suite recovery claim. No production database, live model calls, or runtime deployment was used.
+
+A matched control supplied only an isolated mongomock database (`VON_USE_MOCK_DB=1`, `VON_DB_NAME=drift_diagnosis_isolated`) for the access-control, session-organisation, multi-window, and model-registry cases: **13 passed in 1.10 seconds**, including all 11 that failed in the no-database replay. The same 13 cases consumed 121.839 seconds of test time in that replay.
+
+## Findings
+
+1. **Eleven failures are missing database fixtures, not demonstrated production defects.** Ten access/session/multi-window cases now require durable window bindings or ontology mutation coordination receipts, but their older fixtures leave these on real Mongo access while the CI environment supplies no database. The model-registry test mocks legacy graph getters; the newer batch loader first reads the actual concept collection and raises before reaching the mocked compatibility loader. The isolated mock database resolves all eleven without a production-code change. Keep the faithful durable behaviour; repair fixture coverage and isolation.
+
+2. **Two failures expose a retrieval-state loss in production support code.** In `catalogue._search_knowledge_base`, the filtering loop replaces a `RAGQueryResults` list subclass with a plain list, then attempts to read `retrieval_state` from that replacement. A backend that supplies state on the result but has no `get_last_retrieval_state` method loses both valid-empty and embedding-mismatch semantics. A real backend exposing the secondary getter can recover state, so this does not establish that every deployed retrieval is affected. Preserve the original typed state before filtering, then retain the existing visibility-aware adjustment.
+
+3. **Three history failures are strict expectations that omit added metadata.** The differences are additional provenance/focal-concept fields and lightweight concept-Q&A projection keys. The supplied history and optional situation remain present. Update expected contracts while retaining the assertions that history is not loaded unnecessarily or overwritten.
+
+4. **One seed-authority failure is an omitted bootstrap allowlist entry.** `academic_roster_workflow_vontology_service.py` is explicitly bootstrap support and is called as a startup bootstrap function; its repo seed reference is not evidence of a runtime workflow choosing repo text over represented authority. Add this support module to the appropriate checked allowlist after retaining the bootstrap/runtime distinction.
+
+5. **Thirteen original failures pass in the selected replay; that is not evidence they are fixed in the full suite.** Running the service-export eviction test before previously passing cases reproduced failures in scope-coordination contention, chat-session restoration, and temperature handling. That baseline control was interrupted after 239.50 seconds because module eviction also bypassed the intended mocks and caused repeated unavailable-database work; it was not a completed suite. The original temperature, membership-recovery, and mocked task failures are consistent with service-module identity pollution rather than provider behaviour.
+
+## Repairs and delivery evidence
+
+The user subsequently authorised carrying out the repairs in an isolated worktree. The retrieval tool now captures attempt-specific state before converting/filtering its list. A neighbouring test verifies that private login-identity rows stay filtered and that a mutable getter describing another request cannot override the current result's state.
+
+The service-export check now runs in a fresh subprocess, leaving collected test modules and mock targets intact. Session test modules use an opt-in fresh mock database and reset/restore window bindings. The legacy model-registry test explicitly selects its mocked compatibility loader and isolates its snapshot caches. History assertions include the added metadata while retaining exact history/projection checks. The academic-roster bootstrap support path is included in the seed-authority allowlist; no production authority logic changed.
+
+- Exact 30 reported cases with the service-export test deliberately first: **31 passed in 14.14 seconds** in the no-database CI-style environment.
+- Impacted and neighbouring retrieval/privacy, history, registry, session, durable-recovery, seed-authority, and mail-profile files: **125 passed in 10.67 seconds** in the same environment.
+- Ruff comparison against the base: no new findings; unrelated existing lint debt is preserved.
+- No full backend suite has been rerun, so these results do not prune the historical failure backlog or establish that all original full-suite interactions have been removed.
+
+The cadence change was delivered separately as [PR 557](https://github.com/Strong-AI-Lab/Von/pull/557), merged at `7b6df954a804b13625f0ec0b6ecede6c419be1e4`. Sixteen local targeted checks and a [successful Linux diagnostic workflow](https://github.com/Strong-AI-Lab/Von/actions/runs/33976707819) support the configuration change. Real scheduled notification delivery remains to be observed. The accepted-failure backlog has not been changed by this task.
+
+Other active worktrees modify different catalogue functions; this repair is confined to `_search_knowledge_base`. The primary checkout's documentation and backlog changes were preserved. Jira read access returned `authenticated_actor_context_required`; this evidence is retained here instead of claiming a Jira update. No production runtime deployment or live model evaluation was performed.
+
+## Exact selected replay results
+
+| No-database result | Test node ID |
+|---|---|
+| Fail | `tests/backend/test_access_control_identity_resolution.py::test_window_session_organisation_context_controls_visibility` |
+| Fail | `tests/backend/test_chat_history_conversation_situation.py::test_malformed_optional_situation_does_not_hide_history_or_get_overwritten` |
+| Fail | `tests/backend/test_chat_history_conversation_situation.py::test_session_state_can_read_carrier_metadata_without_loading_history` |
+| Fail | `tests/backend/test_chat_history_conversation_situation.py::test_session_state_returns_history_and_optional_situation_without_changing_history_contract` |
+| Pass | `tests/backend/test_mail_profile_resource_vontology_service.py::test_bootstrap_materialises_mail_profile_resource_vocabulary` |
+| Fail | `tests/backend/test_model_registry_service.py::test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints` |
+| Fail | `tests/backend/test_rag_retrieval_state.py::test_search_knowledge_base_does_not_report_index_mismatch_as_success` |
+| Fail | `tests/backend/test_rag_retrieval_state.py::test_search_knowledge_base_preserves_valid_empty_as_success` |
+| Fail | `tests/backend/test_repo_seed_authority_guardrails.py::test_repo_seed_authority_is_restricted_to_seed_support_paths` |
+| Fail | `tests/backend/test_session_org_routes.py::test_legacy_session_user_id_owns_durable_window_binding_canonically` |
+| Fail | `tests/backend/test_session_org_routes.py::test_set_organisation_rejects_non_member_without_changing_session` |
+| Pass | `tests/backend/test_session_org_routes.py::test_set_organisation_reports_scope_coordination_contention_as_retryable` |
+| Fail | `tests/backend/test_session_org_routes.py::test_set_organisation_updates_session_and_namespace` |
+| Fail | `tests/backend/test_session_org_routes.py::test_set_user_concept_preserves_window_scoped_org_namespace` |
+| Pass | `tests/backend/test_set_chat_session_endpoint.py::test_set_chat_session_projects_terminal_concept_q_and_a_state` |
+| Pass | `tests/backend/test_structured_tool_calling_client.py::TestTemperatureGuards::test_openai_provider_omits_temperature_for_gpt5_mini` |
+| Pass | `tests/backend/test_structured_tool_calling_client.py::TestTemperatureGuards::test_resolve_safe_temperature_for_model[gpt-5-mini-0.7-None]` |
+| Pass | `tests/backend/test_structured_tool_calling_client.py::TestTemperatureGuards::test_resolve_safe_temperature_for_model[gpt-5-mini-2026-03-01-0.7-None]` |
+| Pass | `tests/backend/test_task_management_service.py::TestTaskParityDatesAndEpic::test_update_task_fields_rejects_destination_without_membership` |
+| Pass | `tests/backend/test_window_session_context_persistence.py::test_old_tab_recovers_from_exact_owned_conversation_metadata` |
+| Pass | `tests/backend/test_window_session_context_persistence.py::test_recovery_cannot_rebind_between_membership_invalidation_and_commit` |
+| Pass | `tests/backend/test_window_session_context_persistence.py::test_restart_preserves_two_org_tabs_and_authoritative_personal_tab` |
+| Pass | `tests/backend/test_window_session_context_persistence.py::test_restart_recovers_org_and_revalidates_current_role` |
+| Pass | `tests/backend/test_window_session_context_persistence.py::test_restart_recovery_fails_closed_and_deletes_revoked_membership` |
+| Pass | `tests/backend/test_window_session_multi_org_isolation.py::TestCreateChatSessionUsesWindowContext::test_create_session_keeps_explicit_personal_window_context` |
+| Fail | `tests/backend/test_window_session_multi_org_isolation.py::TestWindowSessionContextIsolation::test_two_windows_can_have_different_orgs` |
+| Fail | `tests/backend/test_window_session_multi_org_isolation.py::TestWindowSessionStoreIsolation::test_get_effective_context_prefers_window_session` |
+| Fail | `tests/backend/test_window_session_multi_org_isolation.py::TestWindowSessionStoreIsolation::test_get_effective_context_treats_another_users_window_as_unknown` |
+| Fail | `tests/backend/test_window_session_multi_org_isolation.py::test_get_effective_context_ignores_partial_window_scope_in_compatibility_mode` |
+| Fail | `tests/backend/test_window_session_multi_org_isolation.py::test_get_effective_context_unknown_window_falls_back_in_compatibility_mode` |

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -21819,6 +21819,10 @@ def _search_knowledge_base(**kwargs):
             namespace=ns,
             permissions_context=permissions_context if permissions_context else None,
         )
+        # Keep the state attached to this exact query before list filtering
+        # discards the RAGQueryResults subclass. A mutable last-query getter is
+        # only a compatibility fallback, not the authority for this attempt.
+        raw_retrieval_state = getattr(results, "retrieval_state", None)
         hidden_result_count = 0
         if isinstance(results, list):
             visible_results = []
@@ -21830,7 +21834,6 @@ def _search_knowledge_base(**kwargs):
             results = visible_results
         elapsed_ms = int((time.perf_counter() - start) * 1000)
 
-        raw_retrieval_state = getattr(results, "retrieval_state", None)
         if not isinstance(raw_retrieval_state, Mapping):
             get_last_retrieval_state = getattr(
                 service,

--- a/src/backend/workflows/workflow_purity_report.py
+++ b/src/backend/workflows/workflow_purity_report.py
@@ -499,6 +499,7 @@ CORE_SUPPORT_POLICY_CONTRACTS = (
 REPO_SEED_AUTHORITY_SCAN_GLOBS = ("src/backend/**/*.py",)
 REPO_SEED_AUTHORITY_ALLOWED_PATHS = frozenset(
     {
+        "src/backend/services/academic_roster_workflow_vontology_service.py",
         "src/backend/services/concept_search_instance_retrieval_workflow_vontology_service.py",
         "src/backend/services/conversation_turn_workflow_vontology_service.py",
         "src/backend/services/email_source_representation_convergence_workflow_vontology_service.py",

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -38,3 +38,22 @@ def workspace_tmp_path(request) -> Generator[Path, None, None]:
     path.mkdir(parents=True, exist_ok=True)
     yield path
     shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def isolated_window_session_db(monkeypatch):
+    """Exercise durable bindings and mutation receipts against a fresh mock DB."""
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DB_NAME", "test_isolated_window_sessions")
+    from src.backend.db.mongo_client import close_connection
+    from src.backend.services import window_session_context_service as windows
+
+    close_connection()
+    monkeypatch.setattr(windows, "_window_session_store", None)
+    monkeypatch.setattr(windows, "_window_session_binding_repository", None)
+    try:
+        yield
+    finally:
+        if windows._window_session_store is not None:
+            windows._window_session_store.stop_cleanup_thread()
+        close_connection()

--- a/tests/backend/test_access_control_identity_resolution.py
+++ b/tests/backend/test_access_control_identity_resolution.py
@@ -505,7 +505,9 @@ def test_access_controlled_cursor_resolves_actor_scope_once_per_batch(
     assert calls == {"user": 3, "organisation": 3}
 
 
-def test_window_session_organisation_context_controls_visibility(monkeypatch) -> None:
+def test_window_session_organisation_context_controls_visibility(
+    monkeypatch, isolated_window_session_db
+) -> None:
     mongomock = pytest.importorskip("mongomock")
     from flask import session
 

--- a/tests/backend/test_chat_history_conversation_situation.py
+++ b/tests/backend/test_chat_history_conversation_situation.py
@@ -153,6 +153,15 @@ def test_session_state_returns_history_and_optional_situation_without_changing_h
     )
 
     assert state == {
+        "mode": None,
+        "origin_kind": None,
+        "created_by_actor_concept_id": None,
+        "created_by_actor_type": None,
+        "is_agent_created": False,
+        "test_artifact_kind": None,
+        "focal_concept_ids": [],
+        "focal_concept_ids_source": None,
+        "focal_concept_ids_updated_at": None,
         "session_id": "session-1",
         "history": history,
         "conversation_situation": {
@@ -174,15 +183,21 @@ def test_session_state_returns_history_and_optional_situation_without_changing_h
         },
     }
     assert collection.find_calls[0][1] == {
+        "mode": 1,
+        "origin_kind": 1,
+        "concept_q_and_a.schema_version": 1,
+        "concept_q_and_a.concept": 1,
+        "concept_q_and_a.lifecycle": 1,
+        "concept_q_and_a.initial_question": 1,
         "_id": 0,
         "session_id": 1,
         "history": 1,
-            "conversation_situation": 1,
-            "conversation_observations": 1,
-            "conversation_observation_total": 1,
-            "focal_concept_ids": 1,
-            "focal_concept_ids_source": 1,
-            "focal_concept_ids_updated_at": 1,
+        "conversation_situation": 1,
+        "conversation_observations": 1,
+        "conversation_observation_total": 1,
+        "focal_concept_ids": 1,
+        "focal_concept_ids_source": 1,
+        "focal_concept_ids_updated_at": 1,
     }
 
     legacy_history = chat_history_service.get_chat_history(
@@ -228,18 +243,22 @@ def test_session_state_can_read_carrier_metadata_without_loading_history(
     assert state is not None
     assert state["history"] == []
     assert state["conversation_situation"]["revision"] == 2
-    assert state["conversation_observations"][0]["observation_id"] == (
-        "observation-1"
-    )
+    assert state["conversation_observations"][0]["observation_id"] == ("observation-1")
     assert collection.find_calls[0][1] == {
+        "mode": 1,
+        "origin_kind": 1,
+        "concept_q_and_a.schema_version": 1,
+        "concept_q_and_a.concept": 1,
+        "concept_q_and_a.lifecycle": 1,
+        "concept_q_and_a.initial_question": 1,
         "_id": 0,
         "session_id": 1,
-            "conversation_situation": 1,
-            "conversation_observations": 1,
-            "conversation_observation_total": 1,
-            "focal_concept_ids": 1,
-            "focal_concept_ids_source": 1,
-            "focal_concept_ids_updated_at": 1,
+        "conversation_situation": 1,
+        "conversation_observations": 1,
+        "conversation_observation_total": 1,
+        "focal_concept_ids": 1,
+        "focal_concept_ids_source": 1,
+        "focal_concept_ids_updated_at": 1,
     }
 
 
@@ -379,6 +398,15 @@ def test_malformed_optional_situation_does_not_hide_history_or_get_overwritten(
     )
 
     assert state == {
+        "mode": None,
+        "origin_kind": None,
+        "created_by_actor_concept_id": None,
+        "created_by_actor_type": None,
+        "is_agent_created": False,
+        "test_artifact_kind": None,
+        "focal_concept_ids": [],
+        "focal_concept_ids_source": None,
+        "focal_concept_ids_updated_at": None,
         "session_id": "session-1",
         "history": [{"role": "user", "content": "Still available"}],
         "conversation_situation": None,
@@ -440,10 +468,9 @@ def test_malformed_optional_observation_does_not_hide_transcript(
 
     assert state is not None
     assert state["history"] == history
-    assert [
-        item["observation_id"]
-        for item in state["conversation_observations"]
-    ] == ["valid-observation"]
+    assert [item["observation_id"] for item in state["conversation_observations"]] == [
+        "valid-observation"
+    ]
     assert state["conversation_observation_state"]["total_count"] == 2
     assert state["conversation_observation_state"]["omitted_count"] == 1
 
@@ -605,16 +632,10 @@ def test_conversation_observations_are_bounded_and_resettable(
     assert "error_step" not in observations[-1]
     assert state["conversation_observation_state"] == {
         "schema_version": "conversation_observation_state.v1",
-        "retained_count": (
-            chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS
-        ),
-        "total_count": (
-            chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS + 3
-        ),
+        "retained_count": (chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS),
+        "total_count": (chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS + 3),
         "omitted_count": 3,
-        "retention_limit": (
-            chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS
-        ),
+        "retention_limit": (chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS),
     }
 
     cleared = chat_history_service.clear_chat_history_conversation_observations(
@@ -648,9 +669,7 @@ def test_observation_append_self_heals_legacy_or_malformed_total(
                 "observation_id": f"legacy-{index}",
                 "kind": "durable_workflow_terminal",
             }
-            for index in range(
-                chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS
-            )
+            for index in range(chat_history_service.CONVERSATION_OBSERVATION_MAX_ITEMS)
         ],
     }
     if stored_total is not _MISSING:
@@ -687,9 +706,7 @@ def test_observation_append_self_heals_legacy_or_malformed_total(
     )
     assert state["conversation_observation_state"]["omitted_count"] == 1
     assert state["conversation_observations"][0]["observation_id"] == "legacy-1"
-    assert state["conversation_observations"][-1]["observation_id"] == (
-        "new-terminal"
-    )
+    assert state["conversation_observations"][-1]["observation_id"] == ("new-terminal")
 
 
 def test_session_state_tail_projection_avoids_loading_unrequested_history(
@@ -703,8 +720,7 @@ def test_session_state_tail_projection_avoids_loading_unrequested_history(
             "user_id": "#V#user",
             "session_id": "session-1",
             "history": [
-                {"role": "user", "content": f"message-{index}"}
-                for index in range(20)
+                {"role": "user", "content": f"message-{index}"} for index in range(20)
             ],
             "conversation_situation": {
                 "text": "The conversation continues.",

--- a/tests/backend/test_model_registry_service.py
+++ b/tests/backend/test_model_registry_service.py
@@ -129,9 +129,9 @@ def test_batched_graph_loader_preserves_registry_semantics_with_bounded_reads(
     del concept_docs["#V#test_registry_entry"]["relationships"][
         mod.PRED_HAS_MODEL_API_PROFILE
     ]
-    text_map[
-        ("#V#test_registry_entry", mod.PRED_HAS_MODEL_API_PROFILE)
-    ] = ["#V#test_profile"]
+    text_map[("#V#test_registry_entry", mod.PRED_HAS_MODEL_API_PROFILE)] = [
+        "#V#test_profile"
+    ]
 
     assert mod._load_registry_from_vontology_graph_batched() is None
 
@@ -140,6 +140,19 @@ def test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints(
     monkeypatch,
 ) -> None:
     import src.backend.services.model_registry_service as mod
+
+    # This case exercises legacy graph encoding; the batch loader has its own
+    # bounded-read test above. Do not let its real DB read bypass these stubs.
+    monkeypatch.setattr(
+        mod, "_load_registry_from_vontology_graph_batched", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(mod, "_MODEL_REGISTRY_SNAPSHOT_CACHE", {})
+    monkeypatch.setattr(
+        mod, "_load_registry_snapshot_from_disk", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        mod, "_persist_registry_snapshot_to_disk", lambda **_kwargs: None
+    )
 
     resolution_map = {
         "default_model_registry": "#V#default_model_registry",
@@ -253,9 +266,7 @@ def test_get_model_registry_snapshot_prefers_graph_and_exposes_constraints(
         "llm_model_capabilities.v1"
     )
     assert model_entry["capabilities"]["input_token_limit"] == 400000
-    assert model_entry["capabilities"]["features"]["function_calling"] == (
-        "supported"
-    )
+    assert model_entry["capabilities"]["features"]["function_calling"] == ("supported")
 
     profile = model_entry["api_profiles"][0]
     assert profile["api_surface"] == "chat_completions"

--- a/tests/backend/test_rag_retrieval_state.py
+++ b/tests/backend/test_rag_retrieval_state.py
@@ -193,9 +193,7 @@ def test_filtered_saturated_window_preserves_rows_but_reports_partial_recovery(
         SimpleNamespace(
             node=SimpleNamespace(
                 metadata={
-                    "user_id": (
-                        "#V#target_user" if index == 49 else "#V#other_user"
-                    )
+                    "user_id": ("#V#target_user" if index == 49 else "#V#other_user")
                 },
                 ref_doc_id=f"doc-{index}",
                 node_id=f"node-{index}",
@@ -270,10 +268,10 @@ def test_hidden_scoped_candidates_are_absent_from_retrieval_diagnostics(
         ),
         SimpleNamespace(
             node=SimpleNamespace(
-                    metadata={
-                        "type": "text_relation",
-                        "relation_id": "visible",
-                        "user_id": "#V#target_user",
+                metadata={
+                    "type": "text_relation",
+                    "relation_id": "visible",
+                    "user_id": "#V#target_user",
                     "organisation_concept_id": "#V#org",
                 },
                 ref_doc_id="text_relation:visible",
@@ -284,10 +282,10 @@ def test_hidden_scoped_candidates_are_absent_from_retrieval_diagnostics(
         ),
         SimpleNamespace(
             node=SimpleNamespace(
-                    metadata={
-                        "type": "text_relation",
-                        "relation_id": "filtered",
-                        "user_id": "#V#other_user",
+                metadata={
+                    "type": "text_relation",
+                    "relation_id": "filtered",
+                    "user_id": "#V#other_user",
                     "organisation_concept_id": "#V#org",
                 },
                 ref_doc_id="text_relation:filtered",
@@ -590,3 +588,49 @@ def test_llm_projection_keeps_typed_state_when_no_rows_are_returned() -> None:
 
     assert payload["retrieval_state"] == state
     assert "authoritative" in payload["retrieval_diagnostics"]["note"]
+
+
+def test_search_knowledge_base_keeps_attempt_state_while_filtering_private_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _StatefulRAG:
+        last_state_reads = 0
+
+        def query(self, **_kwargs: Any) -> RAGQueryResults:
+            return RAGQueryResults(
+                [
+                    {"id": "public", "text": "Visible research result"},
+                    {
+                        "id": "private",
+                        "text": "Private login identity",
+                        "metadata": {"predicate": "#V#hasVonLoginEmail"},
+                    },
+                ],
+                retrieval_state=build_rag_retrieval_state(
+                    "results_available",
+                    result_count=2,
+                    candidate_count=2,
+                ),
+            )
+
+        def get_last_retrieval_state(self, _namespace):
+            self.last_state_reads += 1
+            # This mutable getter may describe a different concurrent request.
+            return build_rag_retrieval_state("embedding_signature_mismatch")
+
+    service = _StatefulRAG()
+    monkeypatch.setattr(
+        "src.backend.services.rag_service.get_rag_service",
+        lambda *_args, **_kwargs: service,
+    )
+    payload = catalogue._search_knowledge_base(
+        query="synthetic query",
+        namespace="#V#test_user@org",
+    )
+
+    assert payload["success"] is True
+    assert [row["id"] for row in payload["results"]] == ["public"]
+    assert payload["retrieval_state"]["status"] == "results_available"
+    assert payload["retrieval_state"]["result_count"] == 1
+    assert payload["retrieval_state"]["candidate_count"] == 1
+    assert service.last_state_reads == 0

--- a/tests/backend/test_services_package_exports.py
+++ b/tests/backend/test_services_package_exports.py
@@ -1,26 +1,34 @@
 from __future__ import annotations
 
-import importlib
+import subprocess
 import sys
+from pathlib import Path
 
 
 def test_services_package_exports_are_lazy() -> None:
-    for module_name in list(sys.modules):
-        if module_name == "src.backend.services" or module_name.startswith(
-            "src.backend.services."
-        ):
-            sys.modules.pop(module_name, None)
+    # A fresh interpreter observes lazy imports without evicting service modules
+    # still referenced by other collected tests or their monkeypatch fixtures.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib
+import sys
 
-    services_pkg = importlib.import_module("src.backend.services")
-
-    assert "src.backend.services.concept_service" not in sys.modules
-    assert "src.backend.services.testing_workflow_vontology_service" not in sys.modules
-
-    concept_service = services_pkg.concept_service
-    testing_workflow_vontology_service = services_pkg.testing_workflow_vontology_service
-
-    assert concept_service.__name__ == "src.backend.services.concept_service"
-    assert (
-        testing_workflow_vontology_service.__name__
-        == "src.backend.services.testing_workflow_vontology_service"
+services_pkg = importlib.import_module("src.backend.services")
+assert "src.backend.services.concept_service" not in sys.modules
+assert "src.backend.services.testing_workflow_vontology_service" not in sys.modules
+assert services_pkg.concept_service.__name__ == "src.backend.services.concept_service"
+assert services_pkg.testing_workflow_vontology_service.__name__ == (
+    "src.backend.services.testing_workflow_vontology_service"
+)
+""",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/backend/test_session_org_routes.py
+++ b/tests/backend/test_session_org_routes.py
@@ -11,6 +11,8 @@ from contextlib import contextmanager
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("isolated_window_session_db")
+
 
 @pytest.fixture
 def app_client(monkeypatch):
@@ -98,8 +100,7 @@ def app_client(monkeypatch):
             "organisation_concept_id": organisation_concept_id,
             "role": (
                 "admin"
-                if organisation_concept_id
-                == "#V#university_of_auckland_strong_ai_lab"
+                if organisation_concept_id == "#V#university_of_auckland_strong_ai_lab"
                 else "member"
             ),
         },
@@ -124,9 +125,7 @@ def app_client(monkeypatch):
         lambda user_concept_id: {
             "user_concept_id": user_concept_id,
             "memberships": represented_memberships.get(user_concept_id, []),
-            "total_memberships": len(
-                represented_memberships.get(user_concept_id, [])
-            ),
+            "total_memberships": len(represented_memberships.get(user_concept_id, [])),
         },
     )
 
@@ -493,8 +492,7 @@ def test_set_user_concept_preserves_window_scoped_org_namespace(app_client):
     assert data["organisation_id"] == "#V#university_of_auckland_strong_ai_lab"
     assert data["role"] == "admin"
     assert (
-        data["namespace"]
-        == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
+        data["namespace"] == "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
     )
 
     ctx = client.get(

--- a/tests/backend/test_window_session_multi_org_isolation.py
+++ b/tests/backend/test_window_session_multi_org_isolation.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import types
 import pytest
 
+pytestmark = pytest.mark.usefixtures("isolated_window_session_db")
+
 
 @pytest.fixture
 def app_client(monkeypatch):
@@ -529,9 +531,7 @@ class TestCreateChatSessionUsesWindowContext:
             sess["namespace"] = (
                 "#V#michael_witbrock@university_of_auckland_strong_ai_lab"
             )
-            sess["organisation_concept_id"] = (
-                "university_of_auckland_strong_ai_lab"
-            )
+            sess["organisation_concept_id"] = "university_of_auckland_strong_ai_lab"
             sess["role_in_org"] = "owner"
 
         resp = client.post(


### PR DESCRIPTION
Merge decision: ready — the targeted Linux retrieval replay and CI passed, as did the 31-test exact replay and 125-test neighbouring suite. No candidate-caused material regression remains on the affected path.

## User outcome

Knowledge retrieval retains valid-empty and index-mismatch status attached to its exact result, instead of losing it when private rows are filtered. Backend tests no longer lose their service mocks after the lazy-import check or fail solely because durable session storage was omitted from fixtures.

## Material changes

Capture query-specific retrieval state before list filtering; retain privacy filtering and use the mutable last-query getter only for legacy results. Run the lazy-import test in a fresh process, add opt-in isolated session persistence fixtures, isolate the legacy registry test, update history metadata expectations, and recognise the academic-roster bootstrap path in the seed-authority allowlist.

[Diagnosis and exact original test results](docs/engineering/backend_test_drift_diagnosis_2026-09-05.md) document the causal evidence. The previously authorised cadence change is already merged in #557. Other active catalogue edits concern different functions and have been preserved.

## Evidence

- All 30 reported failures plus the formerly disruptive import test first: 31 passed in 14.14 seconds.
- Relevant retrieval/privacy, session, durable recovery, history, registry, seed-authority and mail-profile files: 125 passed in 10.67 seconds.
- No new Ruff findings against the base; syntax and diff checks pass.
- [Linux/Python 3.11 retrieval replay](https://github.com/Strong-AI-Lab/Von/actions/runs/33977417797) passed; Python compatibility and secret scanning CI passed.

## Ship boundary

Minimum: exact reported cases and relevant neighbours pass; private rows remain filtered; current retrieval state outranks a different request's mutable last-state getter; targeted Linux replay and relevant CI pass.

Stop-ship: data exposure, fabricated authoritative-empty results, a broken supported session path caused by this candidate, or disturbance of unrelated work.

Non-blocking limitation: this is bounded acceptance, not a full-suite or production-health claim. The historical backlog is untouched. No runtime deployment is requested or performed.
