### PR TITLE
fix(digest): preserve prior content and Jira evidence through synthesis

### DIFF
--- a/src/backend/services/jira_tool_evidence_contract_vontology_service.py
+++ b/src/backend/services/jira_tool_evidence_contract_vontology_service.py
@@ -374,6 +374,9 @@ _PAYLOAD_PATH_SPECS: tuple[JiraConceptSpec, ...] = (
     _payload_path(
         "#V#jira_payload_path_issues_fields_updated", "issues[].fields.updated"
     ),
+    _payload_path(
+        "#V#jira_payload_path_issues_fields_description", "issues[].fields.description"
+    ),
     _payload_path("#V#jira_payload_path_next_page_token", "nextPageToken"),
     _payload_path("#V#jira_payload_path_is_last", "isLast"),
 )
@@ -459,7 +462,10 @@ def _field_payload_path_relationships() -> tuple[JiraRelationshipSpec, ...]:
             "#V#jira_payload_path_fields_updated",
             "#V#jira_payload_path_issues_fields_updated",
         ),
-        JIRA_DESCRIPTION_FIELD_ID: ("#V#jira_payload_path_fields_description",),
+        JIRA_DESCRIPTION_FIELD_ID: (
+            "#V#jira_payload_path_fields_description",
+            "#V#jira_payload_path_issues_fields_description",
+        ),
         JIRA_NEXT_PAGE_TOKEN_FIELD_ID: ("#V#jira_payload_path_next_page_token",),
         JIRA_IS_LAST_FIELD_ID: ("#V#jira_payload_path_is_last",),
     }
@@ -537,6 +543,7 @@ def _tool_field_relationships() -> tuple[JiraRelationshipSpec, ...]:
         JIRA_PARENT_FIELD_ID,
         JIRA_CREATED_FIELD_ID,
         JIRA_UPDATED_FIELD_ID,
+        JIRA_DESCRIPTION_FIELD_ID,
         JIRA_TOTAL_FIELD_ID,
         JIRA_JQL_FIELD_ID,
         JIRA_NEXT_PAGE_TOKEN_FIELD_ID,
@@ -587,6 +594,7 @@ def _evidence_view_relationships() -> tuple[JiraRelationshipSpec, ...]:
         JIRA_PARENT_FIELD_ID,
         JIRA_CREATED_FIELD_ID,
         JIRA_UPDATED_FIELD_ID,
+        JIRA_DESCRIPTION_FIELD_ID,
         JIRA_TOTAL_FIELD_ID,
         JIRA_JQL_FIELD_ID,
         JIRA_NEXT_PAGE_TOKEN_FIELD_ID,

--- a/src/backend/workflows/repo_seed_bundles/lab_status_digest_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/lab_status_digest_workflow_seed_bundle.json
@@ -2,7 +2,7 @@
   "family_id": "lab_status_digest_workflow_seed_bundle",
   "managed_by": "lab_status_digest_workflow_vontology_service",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "8",
+  "seed_version": "9",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#lab_project_status_digest_workflow": {
       "6": [
@@ -10,6 +10,9 @@
       ],
       "7": [
         "bbd325a04a2974799e03a769f9a4acb6fd8f1124465fd8c0ff23a9ecb9553b4a"
+      ],
+      "8": [
+        "17b2b9d9156c0f3d3f5a96b819e62584315d4394de89f3c498d33e06fc765460"
       ]
     }
   },
@@ -112,7 +115,7 @@
         },
         {
           "predicate": "#V#hasWorkflowRequiredEffectsContractJson",
-          "text": "{\"schema_version\":\"workflow_required_effects_contract.v1\",\"contract_id\":\"evidence_backed_lab_status_digest\",\"required_effects\":[{\"effect_id\":\"current_cross_source_status_evidence\",\"effect_type\":\"grounded_evidence\",\"description\":\"The workflow must inspect current Jira and repository evidence plus the prior represented digest before synthesis.\",\"required_tools\":[\"jira_search\",\"repo_dossier_git_metadata\",\"fetch_concept_content\"],\"required_tools_match\":\"all\",\"missing_failure_code\":\"status_digest_source_evidence_missing\",\"failed_failure_code\":\"status_digest_source_evidence_failed\"},{\"effect_id\":\"digest_persistence_and_readback\",\"effect_type\":\"grounded_evidence\",\"description\":\"The workflow must update the stable represented digest and read back both content and text-relation evidence before success.\",\"required_tools\":[\"upsert_singleton_text_relation\",\"fetch_concept_content\",\"get_text_relations_summary\"],\"required_tools_match\":\"all\",\"missing_failure_code\":\"status_digest_readback_missing\",\"failed_failure_code\":\"status_digest_readback_failed\"}]}",
+          "text": "{\"schema_version\":\"workflow_required_effects_contract.v1\",\"contract_id\":\"evidence_backed_lab_status_digest\",\"required_effects\":[{\"effect_id\":\"current_cross_source_status_evidence\",\"effect_type\":\"grounded_evidence\",\"description\":\"The workflow must inspect current Jira and repository evidence plus the prior represented digest before synthesis.\",\"required_tools\":[\"jira_search\",\"repo_dossier_git_metadata\",\"get_text_relations\"],\"required_tools_match\":\"all\",\"missing_failure_code\":\"status_digest_source_evidence_missing\",\"failed_failure_code\":\"status_digest_source_evidence_failed\"},{\"effect_id\":\"digest_persistence_and_readback\",\"effect_type\":\"grounded_evidence\",\"description\":\"The workflow must update the stable represented digest and read back both content and text-relation evidence before success.\",\"required_tools\":[\"upsert_singleton_text_relation\",\"fetch_concept_content\",\"get_text_relations_summary\"],\"required_tools_match\":\"all\",\"missing_failure_code\":\"status_digest_readback_missing\",\"failed_failure_code\":\"status_digest_readback_failed\"}]}",
           "lang": "en-NZ"
         }
       ],
@@ -154,10 +157,22 @@
             "static_input_bindings": [
               {
                 "key": "tool_name",
-                "value": "fetch_concept_content"
+                "value": "get_text_relations"
               },
               {
-                "key": "reconstruct_md",
+                "key": "predicate",
+                "value": "hasContent"
+              },
+              {
+                "key": "language",
+                "value": "en-NZ"
+              },
+              {
+                "key": "limit",
+                "value": 10
+              },
+              {
+                "key": "recent_first",
                 "value": true
               }
             ],
@@ -202,6 +217,7 @@
                 "key": "fields",
                 "value": [
                   "summary",
+                  "description",
                   "status",
                   "assignee",
                   "updated",

--- a/tests/backend/test_jira_tool_evidence_contract_vontology_service.py
+++ b/tests/backend/test_jira_tool_evidence_contract_vontology_service.py
@@ -217,7 +217,7 @@ def test_jira_get_issue_projection_preserves_required_answer_fields_and_omits_ra
     assert telemetry["missing_required_fields"] == []
 
 
-def test_jira_search_projection_preserves_required_rows_and_omits_detail_only_fields(
+def test_jira_search_projection_preserves_returned_descriptions_and_omits_raw_fields(
     _reset_mock_db: Any,
 ) -> None:
     service.bootstrap_jira_tool_evidence_contract()
@@ -237,7 +237,7 @@ def test_jira_search_projection_preserves_required_rows_and_omits_detail_only_fi
                         "issuetype": {"name": "Task"},
                         "created": "2026-06-20T00:00:00.000+0000",
                         "updated": "2026-06-21T00:00:00.000+0000",
-                        "description": "Detail-only field must not leak into search rows.",
+                        "description": "Candidate rejected despite issue completion.",
                     },
                     "raw": "not selected by the represented view",
                 }
@@ -261,9 +261,10 @@ def test_jira_search_projection_preserves_required_rows_and_omits_detail_only_fi
             "issue_type": "Task",
             "created": "2026-06-20T00:00:00.000+0000",
             "updated": "2026-06-21T00:00:00.000+0000",
+            "description": "Candidate rejected despite issue completion.",
         }
     ]
-    assert "description" not in projected["issues"][0]
+    assert "raw" not in projected["issues"][0]
     assert "raw" not in projected
 
     telemetry = projected["_tool_evidence_projection"]

--- a/tests/backend/test_lab_status_digest_continuity.py
+++ b/tests/backend/test_lab_status_digest_continuity.py
@@ -37,7 +37,9 @@ from src.backend.workflows.vontology_loader import (
 from src.backend.workflows.workflow_mcp_tool_actions import (
     register_workflow_mcp_tool_actions,
 )
-from test_lab_status_digest_workflow_vontology_service import _reset_mock_db  # noqa: F401
+from test_lab_status_digest_workflow_vontology_service import (
+    _reset_mock_db,
+)  # noqa: F401
 
 ACTOR = "#V#continuity_test_operator"
 PRODUCT = "#V#continuity_test_kestrel"
@@ -69,7 +71,17 @@ class DigestWorld:
                 self.calls.append((_name, dict(kwargs)))
                 if _name == "jira_search":
                     return {
-                        "issues": self.jira_rows,
+                        "issues": [
+                            {
+                                **row,
+                                "fields": {
+                                    key: value
+                                    for key, value in row.get("fields", {}).items()
+                                    if key in kwargs["fields"]
+                                },
+                            }
+                            for row in self.jira_rows
+                        ],
                         "isLast": False,
                         "nextPageToken": "more",
                     }
@@ -205,6 +217,51 @@ def test_stale_nonempty_readback_does_not_complete(world):
     )
 
 
+def test_synthesis_receives_stored_brief_and_jira_acceptance_evidence(world):
+    # A descriptive concept header is not the maintained document. The live
+    # scheduled failure had both, unlike the earlier content-only fixture.
+    prior = "Previous checkpoint.\n" + ("Evidence and unresolved commitments.\n" * 160)
+    prior += "TASK-1 remains unaccepted; TASK-2 awaits the replication result."
+    with override_current_actor(ACTOR):
+        for predicate, text in (
+            ("hasDescription", "A source-linked readiness brief for this project."),
+            ("hasContent", prior),
+        ):
+            upsert_singleton_text_relation(
+                subject_concept_id=PRODUCT,
+                predicate=predicate,
+                text=text,
+                lang="en-NZ",
+            )
+    description = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "Candidate REJECTED despite issue Done."}
+                ],
+            }
+        ],
+    }
+    world.jira_rows = [
+        {
+            "key": "TASK-1",
+            "fields": {"status": {"name": "Done"}, "description": description},
+        }
+    ]
+    result = world.run(PRODUCT, "Updated checkpoint.", jira_jql="key = TASK-1")
+    assert result.completed, (result.error, result.data)
+    synthesis = world.syntheses[-1]
+    assert prior in [
+        row["text"] for row in synthesis["prior_digest_evidence"]["relations"]
+    ]
+    assert (
+        synthesis["jira_evidence"]["issues"][0]["fields"]["description"] == description
+    )
+
+
 def test_supplied_product_id_does_not_grant_another_actors_write_authority(world):
     private = "#V#continuity_other_actor_product"
     concept_service.create_concept(
@@ -214,7 +271,11 @@ def test_supplied_product_id_does_not_grant_another_actors_write_authority(world
     )
     result = world.run(private, "Should not be written")
     assert not result.completed
-    assert not any(tool == "upsert_singleton_text_relation" for tool, _ in world.calls)
+    # Text retrieval may return no visible rows rather than a concept lookup
+    # error. The canonical write boundary still denies the foreign product.
+    assert world.syntheses[-1]["prior_digest_evidence"]["relations"] == []
+    with override_current_actor("#V#another_actor"):
+        assert get_texts_for_concept(private, predicate="hasContent") == []
 
 
 def test_due_schedule_runs_same_capability_with_continuity_inputs(world, monkeypatch):

--- a/tests/backend/test_lab_status_digest_continuity.py
+++ b/tests/backend/test_lab_status_digest_continuity.py
@@ -218,6 +218,12 @@ def test_stale_nonempty_readback_does_not_complete(world):
 
 
 def test_synthesis_receives_stored_brief_and_jira_acceptance_evidence(world):
+    from src.backend.services.jira_tool_evidence_contract_vontology_service import (
+        bootstrap_jira_tool_evidence_contract,
+    )
+
+    # Production also applies this represented projection in the MCP bridge.
+    bootstrap_jira_tool_evidence_contract()
     # A descriptive concept header is not the maintained document. The live
     # scheduled failure had both, unlike the earlier content-only fixture.
     prior = "Previous checkpoint.\n" + ("Evidence and unresolved commitments.\n" * 160)
@@ -257,9 +263,8 @@ def test_synthesis_receives_stored_brief_and_jira_acceptance_evidence(world):
     assert prior in [
         row["text"] for row in synthesis["prior_digest_evidence"]["relations"]
     ]
-    assert (
-        synthesis["jira_evidence"]["issues"][0]["fields"]["description"] == description
-    )
+    assert synthesis["jira_evidence"]["_llm_view"] == "tool_evidence_projection.v1"
+    assert synthesis["jira_evidence"]["issues"][0]["description"] == description
 
 
 def test_supplied_product_id_does_not_grant_another_actors_write_authority(world):

--- a/tests/backend/test_lab_status_digest_workflow_vontology_service.py
+++ b/tests/backend/test_lab_status_digest_workflow_vontology_service.py
@@ -97,7 +97,7 @@ def test_bootstrap_materialises_lab_status_digest_authority(
     assert required_effects[0]["required_tools"] == [
         "jira_search",
         "repo_dossier_git_metadata",
-        "fetch_concept_content",
+        "get_text_relations",
     ]
     assert required_effects[1]["required_tools"] == [
         "upsert_singleton_text_relation",


### PR DESCRIPTION
Scheduled digests could read a concept description while overlooking its maintained hasContent brief. The initial Jira query omitted descriptions, and the represented search projection discarded them even when fetched. The release now reads bounded canonical content rows, requests descriptions in the existing 12-issue query, and preserves returned descriptions through the represented Jira search view.

The synthesis prompt, Luna routing, actor access boundaries and exact persistence path remain unchanged. The known version-8 authority is identified for normal migration; unknown live authority is not overwritten.

Validation: two regressions reproduced the content-loss and projection-loss paths before repair. All 46 focused digest continuity, materialisation and Jira/generic evidence projection tests pass, including scheduler execution, exact read-back, foreign-owner write denial and omission of unrelated raw data. Live actor-owned checkpoints exposed both failures; the final Luna checkpoint is running against explicitly activated represented release inputs. This is an evidence-input integration repair, not a learning or certification claim.

JVNAUTOSCI-2721.
