### PR TITLE
fix(studio): make workflow selection and topology readable

### DIFF
--- a/src/frontend/web/von_interface/static/js/test/workflowStudioPage.test.js
+++ b/src/frontend/web/von_interface/static/js/test/workflowStudioPage.test.js
@@ -52,7 +52,7 @@ describe('workflowStudioPage helpers', () => {
     expect(layout.edges).toHaveLength(2);
     expect(layout.nodes[0].stepId).toBe('start');
     expect(layout.width).toBeGreaterThan(700);
-    expect(layout.height).toBeGreaterThan(300);
+    expect(layout.height).toBeGreaterThanOrEqual(Math.max(...layout.nodes.map(node => node.y + node.height)));
   });
 
   test('summarises preview diffs compactly', () => {
@@ -114,19 +114,21 @@ describe('actor schedule operations', () => {
     const api = require('../apiService.js');
     jest.spyOn(api, 'ensureUniqueWindowSessionId').mockResolvedValue(undefined);
     document.body.innerHTML = `
-      <div id="workflowStudioCatalogue"></div>
+      <div id="workflowStudioTitle"></div><div id="workflowStudioSummary"></div><div id="workflowStudioSummaryChips"></div><div id="workflowStudioCatalogue"></div>
       <div id="workflowStudioCanvas"></div>
       <div id="workflowStudioStatusBanner"></div>
       <button class="workflow-studio-view-tab" data-view="operations">Operations</button>`;
     let schedule = null;
     let firstCreate = true;
     let resolveOther;
+    const otherRequests = [];
     const creations = [];
     global.fetch = jest.fn(async (url, options = {}) => {
       const reply = data => ({ ok: true, json: async () => data });
-      if (String(url).startsWith('/api/workflow-studio/catalogue')) return reply({ items: [{ workflow_id: '#V#schedule_ui_test', is_executable: true }, { workflow_id: '#V#other_workflow', is_executable: true }] });
+      if (String(url).startsWith('/api/workflow-studio/catalogue')) return reply({ items: [{ workflow_id: '#V#schedule_ui_test', is_executable: true }, { workflow_id: '#V#other_workflow', is_executable: false, executability_reason: 'inspection_summary_pending' }] });
       if (String(url).endsWith(encodeURIComponent('#V#other_workflow'))) return new Promise(resolve => {
-        resolveOther = () => resolve(reply({ summary: { is_executable: true }, operations: { schedules: { items: [] } } }));
+        resolveOther = (summary = { is_executable: true, executability_reason: 'executable', description: 'Loaded description' }) => resolve(reply({ summary, operations: { schedules: { items: [] } } }));
+        otherRequests.push(resolveOther);
       });
       if (String(url).startsWith('/api/workflow-studio/workflows/')) return reply({
         summary: { is_executable: true }, operations: { schedules: { items: schedule ? [schedule] : [] } }
@@ -166,8 +168,12 @@ describe('actor schedule operations', () => {
       expect(document.getElementById('workflowStudioCanvas').textContent).toContain('Paused');
       expect(document.querySelector('[data-action="toggle-schedule"]').textContent).toBe('Resume');
       expect(global.fetch.mock.calls.filter(([url]) => String(url).startsWith('/api/workflow-studio/workflows/'))).toHaveLength(1);
+      expect(document.querySelector('[data-workflow-id="#V#other_workflow"]').textContent).toContain('Not yet verified');
       document.querySelector('[data-workflow-id="#V#other_workflow"]').click();
       await flush();
+      expect(document.getElementById('workflowStudioTitle').textContent).toBe('#V#other_workflow');
+      expect(document.getElementById('workflowStudioCanvas').textContent).toContain('Loading workflow');
+      expect(document.getElementById('workflowStudioCanvas').getAttribute('aria-busy')).toBe('true');
       expect(document.querySelector('[data-action="create-schedule"]')).toBeNull();
       expect(document.querySelector('[data-action="toggle-schedule"]')).toBeNull();
       document.querySelector('[data-workflow-id="#V#schedule_ui_test"]').click();
@@ -175,6 +181,34 @@ describe('actor schedule operations', () => {
       resolveOther();
       await flush();
       expect(document.querySelector('[data-action="toggle-schedule"]').dataset.scheduleId).toBe('#V#schedule_saved');
+      // A -> B -> A: an earlier A response must not overwrite the newer A.
+      document.querySelector('[data-workflow-id="#V#other_workflow"]').click();
+      await flush();
+      document.querySelector('[data-workflow-id="#V#schedule_ui_test"]').click();
+      await flush();
+      document.querySelector('[data-workflow-id="#V#other_workflow"]').click();
+      await flush();
+      otherRequests[2]();
+      await flush();
+      otherRequests[1]({ description: 'Stale description', is_executable: false });
+      await flush();
+      expect(document.getElementById('workflowStudioSummary').textContent).toBe('Loaded description');
+      const loadedCard = document.querySelector('[data-workflow-id="#V#other_workflow"]');
+      expect(loadedCard.textContent).toContain('Loaded description');
+      expect(loadedCard.textContent).toContain('Executable');
+      expect(loadedCard.getAttribute('aria-pressed')).toBe('true');
+      global.fetch.mockRejectedValueOnce(new Error('Temporary read failure'));
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      loadedCard.click();
+      await flush();
+      expect(document.getElementById('workflowStudioCanvas').getAttribute('aria-busy')).toBe('false');
+      expect(document.getElementById('workflowStudioCanvas').textContent).toContain('Could not load workflow');
+      document.querySelector('[data-action="retry-detail"]').click();
+      await flush();
+      resolveOther();
+      await flush();
+      expect(document.getElementById('workflowStudioSummary').textContent).toBe('Loaded description');
+      consoleError.mockRestore();
     } finally {
       jest.restoreAllMocks();
       delete global.fetch;

--- a/src/frontend/web/von_interface/static/js/workflowStudioPage.js
+++ b/src/frontend/web/von_interface/static/js/workflowStudioPage.js
@@ -237,10 +237,10 @@ export function buildWorkflowLayout(definition) {
       const node = {
         stepId,
         name: cleanText(step.name) || stepId,
-        x: 48 + (depth * 260),
-        y: 56 + (index * 148),
-        width: 208,
-        height: 92,
+        x: 24 + (depth * 292),
+        y: 36 + (index * 156),
+        width: 240,
+        height: 116,
         branch: (outgoingCounts.get(stepId) || 0) > 1 || asArray(step.control_flow?.conditions).length > 0,
         terminal: (outgoingCounts.get(stepId) || 0) === 0,
         actionId: cleanText(step.invokes_action_target || step.invokes_action),
@@ -272,11 +272,15 @@ export function buildWorkflowLayout(definition) {
     .filter(Boolean);
 
   const width = Math.max(720, ...nodes.map((node) => node.x + node.width + 80));
-  const height = Math.max(360, ...nodes.map((node) => node.y + node.height + 60));
+  const height = Math.max(260, ...nodes.map((node) => node.y + node.height + 60));
   return { width, height, nodes, edges: laidOutEdges };
 }
 
 const state = {
+  catalogueStatus: 'loading',
+  detailStatus: 'idle',
+  detailRequest: 0,
+  graphZoom: 1,
   scheduleForm: null,
   scheduleReceipt: null,
   scheduleBusy: false,
@@ -382,7 +386,11 @@ function filterCatalogue() {
 function renderCatalogue() {
   if (!elements.catalogue) return;
   filterCatalogue();
-  if (!state.filteredCatalogue.length) {
+  if (!state.catalogue.length && state.catalogueStatus === 'loading') {
+    elements.catalogue.innerHTML = '<div class="workflow-studio-empty compact" role="status">Loading workflows…</div>';
+  } else if (!state.catalogue.length && state.catalogueStatus === 'error') {
+    elements.catalogue.innerHTML = '<div class="workflow-studio-empty compact">Could not load workflows. Use Refresh to retry.</div>';
+  } else if (!state.filteredCatalogue.length) {
     elements.catalogue.innerHTML = `
       <div class="workflow-studio-empty compact">
         <h3>No workflows match</h3>
@@ -392,17 +400,19 @@ function renderCatalogue() {
   } else {
     elements.catalogue.innerHTML = state.filteredCatalogue.map((item) => {
       const selected = item.workflow_id === state.selectedWorkflowId;
-      const description = cleanText(item.description) || 'No workflow description yet.';
+      const pending = item.executability_reason === 'inspection_summary_pending';
+      const unknown = pending || item.executability_reason === 'classification_error';
+      const description = cleanText(item.description) || (pending ? 'Select to load workflow details.' : 'No workflow description yet.');
       const badges = [
         item.source ? `<span class="workflow-studio-pill">${escapeHtml(item.source)}</span>` : '',
-        item.is_executable
+        unknown ? '<span class="workflow-studio-pill muted">Not yet verified</span>' : item.is_executable
           ? '<span class="workflow-studio-pill success">Executable</span>'
           : '<span class="workflow-studio-pill muted">Design</span>'
       ].join('');
       return `
         <button type="button" class="workflow-studio-catalogue-item${selected ? ' selected' : ''}"
-          data-workflow-id="${escapeHtml(item.workflow_id)}">
-          <div class="workflow-studio-catalogue-title">${escapeHtml(item.workflow_id)}</div>
+          data-workflow-id="${escapeHtml(item.workflow_id)}" aria-pressed="${selected}">
+          <div class="workflow-studio-catalogue-title">${escapeHtml(item.workflow_id).replaceAll('_', '_<wbr>')}</div>
           <div class="workflow-studio-catalogue-description">${escapeHtml(description)}</div>
           <div class="workflow-studio-catalogue-badges">${badges}</div>
         </button>
@@ -411,7 +421,7 @@ function renderCatalogue() {
   }
 
   if (elements.catalogueMeta) {
-    elements.catalogueMeta.textContent = `${state.filteredCatalogue.length} of ${state.catalogue.length} workflows shown`;
+    elements.catalogueMeta.textContent = state.catalogueStatus === 'loading' ? 'Loading catalogue…' : `${state.filteredCatalogue.length} of ${state.catalogue.length} workflows shown`;
   }
 }
 
@@ -442,8 +452,10 @@ function ensureSelectedStep() {
 function renderSummaryHeader() {
   if (!elements.title || !elements.summary || !elements.summaryChips) return;
   if (!state.workflowDetail) {
-    elements.title.textContent = 'Select a workflow';
-    elements.summary.textContent = 'Choose a workflow from the catalogue to inspect topology, decision structure, dataflow, operations, and bounded authoring controls.';
+    elements.title.textContent = state.selectedWorkflowId || 'Select a workflow';
+    elements.summary.textContent = state.detailStatus === 'loading' ? 'Loading workflow details… You can select another workflow while this loads.'
+      : state.detailStatus === 'error' ? 'Workflow details could not be loaded. Retry below or select another workflow.'
+        : 'Choose a workflow from the catalogue to inspect its steps, inputs and operations.';
     elements.summaryChips.innerHTML = '';
     return;
   }
@@ -527,6 +539,13 @@ function renderImprovementGuidanceSection() {
   `;
 }
 
+function graphLabelLines(value, workflowId) {
+  const prefix = `#V#workflow_step_${cleanText(workflowId).replace(/^#V#/, '')}_`;
+  const label = cleanText(value).replace(prefix, '').replace(/^#V#/, '').replaceAll('_', ' ');
+  const lines = label.match(/.{1,27}(?:\s|$)|.{1,27}/g) || ['Unnamed step'];
+  return lines.slice(0, 2).map((line, index) => index === 1 && lines.length > 2 ? `${line.trim().slice(0, 25)}…` : line.trim());
+}
+
 function renderTopologyView() {
   const definition = getDefinition();
   if (!definition) {
@@ -539,7 +558,7 @@ function renderTopologyView() {
   }
   const layout = buildWorkflowLayout(definition);
   const svg = `
-    <svg class="workflow-studio-graph" viewBox="0 0 ${layout.width} ${layout.height}" role="img" aria-label="Workflow topology">
+    <svg class="workflow-studio-graph" style="width:${layout.width * state.graphZoom}px;height:${layout.height * state.graphZoom}px" viewBox="0 0 ${layout.width} ${layout.height}" role="img" aria-label="Workflow topology">
       <defs>
         <marker id="workflowStudioArrow" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto">
           <path d="M0,0 L0,6 L8,3 z" class="workflow-studio-graph-arrow"></path>
@@ -554,10 +573,11 @@ function renderTopologyView() {
       ${layout.nodes.map((node) => `
         <g class="workflow-studio-node ${node.branch ? 'branch' : ''} ${node.terminal ? 'terminal' : ''} ${node.stepId === state.selectedStepId ? 'selected' : ''}"
           data-step-id="${escapeHtml(node.stepId)}" tabindex="0" role="button" aria-label="Select step ${escapeHtml(node.name)}">
+          <title>${escapeHtml(node.name)} — ${escapeHtml(node.actionId || node.subworkflowId || 'No bound action')}</title>
           <rect x="${node.x}" y="${node.y}" rx="18" ry="18" width="${node.width}" height="${node.height}"></rect>
-          <text x="${node.x + 18}" y="${node.y + 28}" class="workflow-studio-node-title">${escapeHtml(node.name)}</text>
-          <text x="${node.x + 18}" y="${node.y + 48}" class="workflow-studio-node-subtitle">${escapeHtml(node.actionId || node.subworkflowId || 'No bound action')}</text>
-          <text x="${node.x + 18}" y="${node.y + 68}" class="workflow-studio-node-meta">${node.branch ? 'Branching' : node.terminal ? 'Terminal' : 'Linear step'}</text>
+          <text class="workflow-studio-node-title">${graphLabelLines(node.name, state.selectedWorkflowId).map((line, i) => `<tspan x="${node.x + 14}" y="${node.y + 26 + i * 18}">${escapeHtml(line)}</tspan>`).join('')}</text>
+          <text x="${node.x + 18}" y="${node.y + 72}" class="workflow-studio-node-subtitle">${escapeHtml((node.actionId || node.subworkflowId || 'No bound action').length > 29 ? (node.actionId || node.subworkflowId).slice(0, 28) + '…' : node.actionId || node.subworkflowId || 'No bound action')}</text>
+          <text x="${node.x + 18}" y="${node.y + 94}" class="workflow-studio-node-meta">${node.branch ? 'Branching' : node.terminal ? 'Terminal' : 'Linear step'}</text>
         </g>
       `).join('')}
     </svg>
@@ -567,7 +587,15 @@ function renderTopologyView() {
       <h3>Topology</h3>
       <p>Derived process graph from authoritative workflow relationships and runtime metadata.</p>
     </div>
-    <div class="workflow-studio-graph-shell">${svg}</div>
+    <div class="workflow-studio-graph-toolbar" role="group" aria-label="Graph zoom">
+      <button type="button" class="btn-mini" data-action="zoom-out" aria-label="Zoom out">−</button>
+      <output aria-live="polite">${Math.round(state.graphZoom * 100)}%</output>
+      <button type="button" class="btn-mini" data-action="zoom-in" aria-label="Zoom in">+</button>
+      <button type="button" class="btn-mini" data-action="zoom-reset">Readable size</button>
+      <button type="button" class="btn-mini" data-action="zoom-fit">Fit graph</button>
+      <span class="workflow-studio-muted">Scroll to explore; select a step for details.</span>
+    </div>
+    <div class="workflow-studio-graph-shell" tabindex="0" role="region" aria-label="Scrollable workflow graph">${svg}</div>
   `;
 }
 
@@ -961,7 +989,14 @@ function renderEditView() {
 function renderCanvas() {
   if (!elements.canvas) return;
   let html;
-  if (!state.workflowDetail) {
+  elements.canvas.setAttribute('aria-busy', String(state.detailStatus === 'loading'));
+  if (state.detailStatus === 'loading' || state.detailStatus === 'error') {
+    html = `<div class="workflow-studio-empty" role="status">
+      <h3>${state.detailStatus === 'loading' ? 'Loading workflow…' : 'Could not load workflow'}</h3>
+      <p>${state.detailStatus === 'loading' ? 'Retrieving the workflow and its operational details. This may take a moment.' : 'Retry the read, or choose another workflow from the catalogue.'}</p>
+      ${state.detailStatus === 'error' ? '<button type="button" data-action="retry-detail">Retry loading</button>' : ''}
+    </div>`;
+  } else if (!state.workflowDetail) {
     html = `
       <div class="workflow-studio-empty">
         <h3>No workflow selected</h3>
@@ -979,7 +1014,11 @@ function renderCanvas() {
   } else {
     html = renderEditView();
   }
+  const previousGraph = elements.canvas.querySelector('.workflow-studio-graph-shell');
+  const scroll = previousGraph ? [previousGraph.scrollLeft, previousGraph.scrollTop] : [0, 0];
   elements.canvas.innerHTML = html;
+  const graph = elements.canvas.querySelector('.workflow-studio-graph-shell');
+  if (graph) [graph.scrollLeft, graph.scrollTop] = scroll;
 }
 
 function renderInspector() {
@@ -1095,16 +1134,21 @@ function renderAll() {
 }
 
 async function loadCatalogue({ selectFirst = false } = {}) {
+  state.catalogueStatus = 'loading';
+  renderCatalogue();
   setConnectionBadge('Loading', 'loading');
   try {
     const data = await fetchJson(`/api/workflow-studio/catalogue?include_designs=${state.showDesigns ? 'true' : 'false'}&limit=300`);
     state.catalogue = asArray(data.items);
+    state.catalogueStatus = 'ready';
     if (!state.selectedWorkflowId && selectFirst && state.catalogue[0]?.workflow_id) {
       state.selectedWorkflowId = state.catalogue[0].workflow_id;
     }
     renderCatalogue();
     setConnectionBadge('Ready', 'ready');
   } catch (error) {
+    state.catalogueStatus = 'error';
+    renderCatalogue();
     console.error('Workflow studio catalogue failed:', error);
     setConnectionBadge('Offline', 'error');
     setStatusBanner(cleanText(error?.payload?.detail) || cleanText(error.message) || 'Could not load workflow catalogue.', 'error');
@@ -1114,8 +1158,12 @@ async function loadCatalogue({ selectFirst = false } = {}) {
 async function loadWorkflowDetail(workflowId) {
   const workflowIdClean = cleanText(workflowId);
   if (!workflowIdClean) return;
+  const request = ++state.detailRequest;
+  state.workflowDetail = null;
+  state.detailStatus = 'loading';
+  state.graphZoom = 1;
+  setStatusBanner('', 'info');
   if (workflowIdClean !== state.selectedWorkflowId || !state.scheduleForm) {
-    state.workflowDetail = null;
     state.scheduleForm = { schedule_type: 'interval', interval_seconds: 3600, inputs: '{}', idempotency_key: crypto.randomUUID() };
     state.scheduleReceipt = null;
   }
@@ -1124,8 +1172,11 @@ async function loadWorkflowDetail(workflowId) {
   renderAll();
   try {
     const data = await fetchJson(`/api/workflow-studio/workflows/${encodeURIComponent(workflowIdClean)}`);
-    if (workflowIdClean !== state.selectedWorkflowId) return;
+    if (request !== state.detailRequest) return;
     state.workflowDetail = data;
+    state.detailStatus = 'ready';
+    state.catalogue = state.catalogue.map(item => item.workflow_id === workflowIdClean
+      ? { ...item, ...data.summary, workflow_id: workflowIdClean } : item);
     const draftSource = buildDraftSource(data);
     state.draftSpec = data.authoring?.available && draftSource.spec
       ? normaliseAuthoringSpecForEditor(draftSource.spec, workflowIdClean)
@@ -1139,7 +1190,9 @@ async function loadWorkflowDetail(workflowId) {
     setStatusBanner('', 'info');
     setConnectionBadge('Ready', 'ready');
   } catch (error) {
-    if (workflowIdClean !== state.selectedWorkflowId) return;
+    if (request !== state.detailRequest) return;
+    state.detailStatus = 'error';
+    renderAll();
     console.error('Workflow studio detail failed:', error);
     setConnectionBadge('Error', 'error');
     setStatusBanner(cleanText(error?.payload?.detail) || cleanText(error.message) || 'Could not load workflow detail.', 'error');
@@ -1493,7 +1546,17 @@ function handleCanvasClick(event) {
   const workflowAction = event.target.closest('[data-action]');
   if (!workflowAction) return;
   const action = cleanText(workflowAction.dataset.action);
-  if (['preview-schedule', 'create-schedule', 'toggle-schedule', 'reload-schedules'].includes(action)) {
+  if (action === 'retry-detail') {
+    void loadWorkflowDetail(state.selectedWorkflowId);
+  } else if (action.startsWith('zoom-')) {
+    const layout = buildWorkflowLayout(getDefinition());
+    const shell = elements.canvas.querySelector('.workflow-studio-graph-shell');
+    if (action === 'zoom-fit') state.graphZoom = Math.min(1, (shell?.clientWidth || 720) / layout.width);
+    else if (action === 'zoom-reset') state.graphZoom = 1;
+    else state.graphZoom = Math.max(0.1, Math.min(2, state.graphZoom + (action === 'zoom-in' ? 0.2 : -0.2)));
+    renderCanvas();
+    elements.canvas.querySelector(`[data-action="${action}"]`)?.focus();
+  } else if (['preview-schedule', 'create-schedule', 'toggle-schedule', 'reload-schedules'].includes(action)) {
     void runScheduleCommand(action, workflowAction);
   } else if (action === 'suggest-description') {
     void requestDescriptionProposal();

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -17362,6 +17362,11 @@ body.settings-body {
 
 /* Workflow Studio */
 
+.workflow-studio-body,
+.workflow-studio-body * {
+    box-sizing: border-box;
+}
+
 .workflow-studio-body {
     min-height: 100vh;
     padding: 0;
@@ -17444,9 +17449,9 @@ body.settings-body {
 
 .workflow-studio-shell {
     display: grid;
-    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-    gap: 24px;
-    padding: 24px 32px 32px;
+    grid-template-columns: minmax(240px, 290px) minmax(0, 1fr);
+    gap: 16px;
+    padding: 20px;
 }
 
 .workflow-studio-sidebar,
@@ -17537,6 +17542,12 @@ body.settings-body {
 }
 
 .workflow-studio-catalogue-item {
+    flex: 0 0 auto;
+    width: 100%;
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    color: #10203a;
     text-align: left;
     border: 1px solid rgba(148, 163, 184, 0.24);
     border-radius: 18px;
@@ -17548,7 +17559,7 @@ body.settings-body {
 
 .workflow-studio-catalogue-item:hover,
 .workflow-studio-catalogue-item.selected {
-    transform: translateY(-1px);
+    background: #e6f5f2;
     border-color: #0f766e;
     box-shadow: 0 14px 30px rgba(15, 118, 110, 0.12);
 }
@@ -17560,6 +17571,10 @@ body.settings-body {
 }
 
 .workflow-studio-catalogue-description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
     margin-top: 6px;
     font-size: 0.9rem;
     color: #475569;
@@ -17591,6 +17606,8 @@ body.settings-body {
 
 .workflow-studio-hero {
     display: flex;
+    flex-wrap: wrap;
+    overflow-wrap: anywhere;
     justify-content: space-between;
     gap: 18px;
     padding: 22px 24px;
@@ -17676,13 +17693,16 @@ body.settings-body {
 
 .workflow-studio-content-grid {
     display: grid;
-    grid-template-columns: minmax(0, 1.5fr) minmax(280px, 360px);
-    gap: 22px;
+    align-items: start;
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+    gap: 16px;
 }
 
 .workflow-studio-canvas-panel,
 .workflow-studio-inspector-panel {
-    padding: 22px;
+    min-width: 0;
+    padding: 18px;
+    overflow-wrap: anywhere;
 }
 
 .workflow-studio-empty {
@@ -17708,11 +17728,11 @@ body.settings-body {
 }
 
 .workflow-studio-card-grid {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
 }
 
 .workflow-studio-editor-grid {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
 }
 
 .workflow-studio-card {
@@ -17784,8 +17804,56 @@ body.settings-body {
 }
 
 .workflow-studio-graph {
-    width: 100%;
-    min-height: 360px;
+    display: block;
+    max-width: none;
+}
+
+.workflow-studio-graph-toolbar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.workflow-studio-graph-shell {
+    max-height: 65vh;
+}
+
+.workflow-studio-body :focus-visible {
+    outline: 3px solid #0f766e;
+    outline-offset: 2px;
+}
+
+.workflow-studio-key-value {
+    display: grid;
+    grid-template-columns: minmax(96px, 0.8fr) minmax(0, 1fr);
+}
+
+.workflow-studio-key-value strong {
+    text-align: right;
+}
+
+.workflow-studio-key-value > *,
+.workflow-studio-hero > *,
+.workflow-studio-list-row > * {
+    min-width: 0;
+}
+
+.workflow-studio-inspector h3 {
+    margin-top: 0;
+}
+
+.workflow-studio-canvas pre,
+.workflow-studio-inspector pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 1440px) {
+    .workflow-studio-content-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
 }
 
 .workflow-studio-edge-path {
@@ -17879,7 +17947,7 @@ body.settings-body {
     font-size: 0.8rem;
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 900px) {
     .workflow-studio-shell,
     .workflow-studio-content-grid {
         grid-template-columns: 1fr;
@@ -17887,7 +17955,7 @@ body.settings-body {
 
     .workflow-studio-sidebar {
         position: static;
-        max-height: none;
+        max-height: 360px;
     }
 }
 


### PR DESCRIPTION
Merge decision: ready — Workflow Studio acknowledges selections immediately and presents readable, contained workflow details once the existing read completes.

## User outcome

Workflow selection previously left a “No workflow selected” placeholder during a slow read. Long identifiers overflowed the catalogue, the inspector could leave the viewport, and the full-width topology scaled long workflows down to illegible text. Loaded executable workflows could retain a “Design” label in the catalogue.

## Material changes

- Explicit loading and recoverable error states, with request sequence checks preventing late A–B–A responses from replacing current details.
- Distinguish uninspected catalogue entries from design artefacts and reconcile the selected card with the returned summary.
- Contain nested panels, wrap identifiers, bound catalogue descriptions and stack panels on smaller screens.
- Open topology at readable size with local scrolling, zoom and fit controls; shorten displayed step labels while retaining exact identities in tooltips and the inspector.

[JVNAUTOSCI-2725](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2725)

## Evidence

- Seven focused Jest tests pass, including expanded real DOM event coverage for loading, retry, request races, metadata reconciliation and existing schedule creation/retry/pause/reload.
- Static frontend lint and diff checks pass.
- Browser acceptance uses candidate assets through a temporary GET-only preview against the live canonical backend. The 14-step arXiv workflow renders readable nodes; fit and reset work; selecting a step updates the inspector. Desktop topology, Operations and Edit have no document overflow. A 390px frame checks the responsive layout.

## Ship boundary

Minimum ship criteria are immediate feedback, honest recovery, current-selection data, consistent known metadata and contained/readable presentation. Wrong-workflow controls, broken existing schedule operations or affected viewport overflow block delivery.

The existing server detail assembly remains slow: two observed reads took 24.24s and 24.93s; the catalogue took 1.53s. This change improves feedback and presentation, and does not claim to reduce backend read latency. Workflow execution, schedule activation, authority changes and a backend redesign are outside scope.


[JVNAUTOSCI-2725]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ