### PR TITLE
JVNAUTOSCI-2724 Resume responsibilities from Tasks with current product context

### DIFF
--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -80,6 +80,7 @@ live.
 |---|---|
 | Every task | [`AGENTS.md`](../AGENTS.md) |
 | Substantial, architecture-sensitive, or older-doc-dependent work | This index, then the applicable sections below |
+| Task product selection and continuing a responsibility from Tasks | [Task responsibility continuation](engineering/task_responsibility_continuation.md) |
 | Enduring role competence, organisational continuity, active acquisition, learned reuse or transfer | [Role-learning convergence](engineering/role_learning_convergence.md), with the [staged development rehearsal](engineering/role_convergence_rehearsal.md); live Jira owns delivery status and the next integrating increment |
 | Material security exposure: authentication/authorisation, private or cross-namespace data, secrets, untrusted content with tool authority, effects outside ordinary bounded and recoverable delegation, deployment, or administrator surfaces | [Security considerations](engineering/security_considerations.md) |
 | Substantial agent-behaviour implementation | Relevant sections of the [modern agentic AI primer](engineering/intro_to_modern_agentic_ai_for_coding_agents.md) |

--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -1,0 +1,49 @@
+# Continuing a responsibility from Tasks
+
+- **Kind:** Capability guide
+- **Lifecycle:** Active
+- **Authority:** Describes the Tasks interface and its canonical references;
+  [JVNAUTOSCI-2724](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2724)
+  owns delivery decisions and acceptance evidence.
+- **Review trigger:** Changes to task product selection or execution authority.
+
+A task can explicitly link its current work product using
+`#V#hascurrentworkproduct`. The relation selects a concept identity. Content,
+assertion context and revisions remain on the product; linking it neither copies
+its content nor grants access. Existing tasks remain valid without a product.
+
+Select a task in All Tasks, open its details and save the intended product's
+concept ID. **Open current work product** reads its current actor-effective
+`hasContent` projection. A single non-empty content assertion can be displayed.
+Missing, inaccessible or ambiguous references/content are reported without
+choosing a neighbouring product or guessing a revision from timestamps. The
+concept inspector remains available for accessible products needing revision
+resolution. Product reads do not change task status or start work.
+
+**Discuss** opens the existing task-focused conversation path with the accessible
+product reference alongside the task. This also works for human review tasks;
+it does not transfer their assignment to Von. For an eligible task assigned to
+Von, enter a short new instruction and use **Continue with Von**. The ordinary
+execution route projects the selected task, canonical product reference,
+checkpoint, evidence and instruction into its originating conversation. It
+retains the existing creator, organisation and conversation-owner checks.
+The model can retrieve and revise the product through its ordinary authorised
+tools; the UI does not embed a second product store or prescribe its judgement.
+
+During an active attempt, **Observe Von work** opens the existing conversation.
+The queue and TaskExecution remain authoritative, including across reloads or
+competing clicks; browser state is only an observation and retry aid. A later
+intentional attempt is distinct once the preceding attempt reaches terminal
+state. Queue completion does not imply task completion or a successful revision.
+
+The HTTP task detail response and ordinary `task_get` share the product
+reference projection. `GET /api/tasks/<id>/work-product` additionally returns the
+current body and its SHA-256. `PATCH /api/tasks/<id>` accepts
+`current_work_product_concept_id` (null clears the link). The existing execution
+endpoint accepts an optional `continuation_instruction` of at most 4,000
+characters. Client-supplied product projections do not control the execution
+context.
+
+This is a bounded continuity interface, not evidence of learned role competence.
+Use the [role convergence guide](role_learning_convergence.md) for successive
+encounters, outcomes and remaining human burden.

--- a/src/backend/server/routes/task_routes.py
+++ b/src/backend/server/routes/task_routes.py
@@ -4,6 +4,7 @@ Provides endpoints for creating, reading, updating, and deleting tasks.
 Tasks are stored as Vontology concepts.
 """
 
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -347,18 +348,26 @@ def _resolve_task_execution_conversation(
 
 
 def _build_task_execution_prompt(task: dict[str, Any]) -> str:
-    """Project the represented task intent into the queued conversation turn."""
-
-    task_id = str(task.get("task_concept_id") or "").strip()
-    title = str(task.get("title") or "Untitled task").strip()
-    description = str(task.get("description") or "").strip()
-    prompt = (
-        "Execute the task assigned to Von.\n"
-        f"Task concept ID: {task_id}\n"
-        f"Title: {title}\n"
-        f"Description: {description}"
+    """Project the selected task and canonical references, not a shadow product."""
+    product = task.get("current_work_product") or {"status": "missing"}
+    instruction = task.get("continuation_instruction", "")
+    parts = [
+        "Execute the task assigned to Von.",
+        f"Task concept ID: {task.get('task_concept_id', '')}",
+        f"Title: {task.get('title') or 'Untitled task'}",
+    ]
+    if instruction:
+        parts.append(f"New user instruction: {instruction}")
+    parts.extend(
+        [
+            f"Current work product: {json.dumps(product, ensure_ascii=False)}",
+            f"Next checkpoint / unresolved questions: {task.get('next_checkpoint') or ''}",
+            f"Evidence: {task.get('evidence') or ''}",
+            f"Notes: {task.get('notes') or ''}",
+            f"Description: {task.get('description') or ''}",
+        ]
     )
-    return prompt[: chat_prompt_queue_service.MAX_PROMPT_RAW_CHARS]
+    return "\n".join(parts)[: chat_prompt_queue_service.MAX_PROMPT_RAW_CHARS]
 
 
 def _enqueue_task_execution(
@@ -453,6 +462,12 @@ def execute_task_with_von_route(task_concept_id: str) -> ResponseReturnValue:
         )
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
+        instruction = payload.get("continuation_instruction", "")
+        if not isinstance(instruction, str) or len(instruction) > 4000:
+            raise InvalidTaskExecutionData(
+                "continuation_instruction must be text of at most 4000 characters"
+            )
+        task["continuation_instruction"] = instruction.strip()
         requested_session_id = payload.get("originating_session_id")
         if requested_session_id is not None and requested_session_id != task.get(
             "conversation_session_id"
@@ -686,6 +701,19 @@ def get_task_taxonomy_route() -> ResponseReturnValue:
     except Exception as e:
         logger.error(f"Unexpected error getting task taxonomy: {e}")
         return jsonify({"error": "Internal server error"}), 500
+
+
+@task_bp.route("/<task_concept_id>/work-product", methods=["GET"])
+def get_task_work_product_route(task_concept_id: str) -> ResponseReturnValue:
+    """Read the selected product through the same actor-visible task boundary."""
+    from ...services.task_work_product_service import resolve_task_work_product
+    from ...services.task_management_service import _get_task_doc
+
+    try:
+        _, task_doc = _get_task_doc(task_concept_id)
+        return jsonify(resolve_task_work_product(task_doc, include_content=True)), 200
+    except TaskNotFoundError:
+        return jsonify({"status": "unavailable"}), 404
 
 
 @task_bp.route("/<task_concept_id>", methods=["GET"])

--- a/src/backend/services/task_management_service.py
+++ b/src/backend/services/task_management_service.py
@@ -42,7 +42,9 @@ from .effort_unit_ontology_service import (
     resolve_successor_effort_unit_type_ids,
 )
 from .organisation_membership_service import is_user_member_of_organisation
+from .task_work_product_service import resolve_task_work_product
 from .task_ontology_service import (
+    PREDICATE_HAS_CURRENT_WORK_PRODUCT,
     DEFAULT_TASK_SOURCE_ID,
     EVIDENCE_TEXT_PREDICATES,
     JIRA_IMPORTED_TASK_SOURCE_ID,
@@ -1671,7 +1673,7 @@ def get_task(task_concept_id: str) -> Dict[str, Any]:
         TaskNotFoundError: If task not found
     """
     task_concept_id, doc = _get_task_doc(task_concept_id)
-    return _build_task_response(doc)
+    return {**_build_task_response(doc), "current_work_product": resolve_task_work_product(doc)}
 
 
 def find_task_by_agent_creation_fingerprint(
@@ -4534,6 +4536,21 @@ def update_task_fields(
         raise InvalidTaskDataError("fields must be a non-empty dict")
 
     existing_task = _build_task_response(task_doc)
+    # An explicit reference is validated before any other requested edits.
+    product_field_present = "current_work_product_concept_id" in fields
+    product_id = None
+    if product_field_present:
+        raw_product_id = fields["current_work_product_concept_id"]
+        product_id = _normalise_optional_concept_id(raw_product_id)
+        if raw_product_id not in (None, "") and not product_id:
+            raise InvalidTaskDataError("Invalid current work product reference")
+        if product_id and (
+            not can_access_concept(product_id)
+            or not ConceptsRepository.find_one(
+                {"concept_id": product_id}, projection={"_id": 1}
+            )
+        ):
+            raise InvalidTaskDataError("Current work product is not accessible")
     changed_fields: list[str] = []
     warnings: list[str] = []
     existing_task_type_ids = set(existing_task.get("task_type_ids") or [])
@@ -4610,6 +4627,14 @@ def update_task_fields(
 
     if next_start is not None and next_due is not None and next_start > next_due:
         raise InvalidTaskDataError("start_date must be before or equal to due_date")
+
+    if product_field_present:
+        _replace_single_relationship_target(
+            task_concept_id=task_concept_id,
+            predicate=PREDICATE_HAS_CURRENT_WORK_PRODUCT,
+            new_target_id=product_id,
+        )
+        changed_fields.append("current_work_product_concept_id")
 
     if "status" in fields:
         update_task_status(task_concept_id, str(fields.get("status") or ""))
@@ -5076,6 +5101,7 @@ def update_task_fields(
         if key
         not in {
             "status",
+            "current_work_product_concept_id",
             "assignee_concept_id",
             "assignee_id",
             "created_by_concept_id",

--- a/src/backend/services/task_ontology_service.py
+++ b/src/backend/services/task_ontology_service.py
@@ -21,6 +21,7 @@ TASK_SOURCE_TYPE_ID = "#V#task_source"
 # Keep these predicate IDs in canonical slug form. ``create_concept()`` lowercases
 # concept IDs during canonicalisation, so mixed-case identifiers would bootstrap
 # under a different persisted ID than the one later used for relationship writes.
+PREDICATE_HAS_CURRENT_WORK_PRODUCT = "#V#hascurrentworkproduct"
 PREDICATE_HAS_TASK_SOURCE = "#V#hastasksource"
 PREDICATE_REPORTS_TO = "#V#reportsto"
 PREDICATE_HAS_TASK_ROLE = "#V#hastaskrole"
@@ -167,6 +168,11 @@ _TASK_SOURCE_BY_SLUG.update(
 _PREDICATE_PARENT_CANDIDATES: tuple[str, ...] = ("#V#binary_predicate", "#V#predicate")
 
 _PREDICATE_SPECS: tuple[tuple[str, str, str], ...] = (
+    (
+        PREDICATE_HAS_CURRENT_WORK_PRODUCT,
+        "has current work product",
+        "Links a task to its explicitly selected current work product. The product owns its content and revision; the link grants no access or execution authority.",
+    ),
     (
         PREDICATE_HAS_TASK_SOURCE,
         "has task source",

--- a/src/backend/services/task_work_product_service.py
+++ b/src/backend/services/task_work_product_service.py
@@ -42,7 +42,7 @@ def resolve_task_work_product(
         reference = {"concept_id": product_id}
         rows = get_texts_for_concept(
             product_id,
-            predicate="#V#hasContent",
+            predicate="hasContent",
             limit=2,
             context_view="actor_effective",
         )
@@ -56,7 +56,7 @@ def resolve_task_work_product(
             **reference,
             "status": "ready",
             "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
-            "predicate": "#V#hasContent",
+            "predicate": "hasContent",
             "language": row.get("lang"),
             "context_view": "actor_effective",
             "row_kind": row.get("row_kind", "base_text_relation"),

--- a/src/backend/services/task_work_product_service.py
+++ b/src/backend/services/task_work_product_service.py
@@ -1,0 +1,69 @@
+"""Actor-visible current work products, explicitly linked from canonical tasks.
+
+The relation chooses a product identity, not a revision. A current body is only
+reported when its actor-effective hasContent projection has exactly one row.
+No narrative guesses, newest-row selection, copied product store or authority
+are introduced by this projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from ..db.repositories.concepts_repository import ConceptsRepository
+from ..security.access_control import can_access_concept
+from .text_value_service import get_texts_for_concept
+
+from .task_ontology_service import PREDICATE_HAS_CURRENT_WORK_PRODUCT
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_task_work_product(
+    task_doc: Mapping[str, Any], *, include_content: bool = False
+) -> dict[str, Any]:
+    relationships = task_doc.get("relationships") or {}
+    raw = relationships.get(PREDICATE_HAS_CURRENT_WORK_PRODUCT) or []
+    targets = list(dict.fromkeys([raw] if isinstance(raw, str) else raw))
+    if not targets:
+        return {"status": "missing"}
+    if len(targets) != 1:
+        return {"status": "ambiguous_link"}
+    product_id = targets[0]
+    try:
+        if not can_access_concept(product_id):
+            return {"status": "unavailable"}
+        doc = ConceptsRepository.find_one({"concept_id": product_id})
+        if not doc:
+            return {"status": "unavailable"}
+        reference = {"concept_id": product_id}
+        rows = get_texts_for_concept(
+            product_id,
+            predicate="#V#hasContent",
+            limit=2,
+            context_view="actor_effective",
+        )
+        if len(rows) > 1:
+            return {**reference, "status": "ambiguous_content"}
+        if not rows or not str(rows[0].get("text") or "").strip():
+            return {**reference, "status": "missing_content"}
+        row = rows[0]
+        content = row["text"]
+        result = {
+            **reference,
+            "status": "ready",
+            "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            "predicate": "#V#hasContent",
+            "language": row.get("lang"),
+            "context_view": "actor_effective",
+            "row_kind": row.get("row_kind", "base_text_relation"),
+        }
+        if include_content:
+            result["content"] = content
+        return result
+    except Exception as exc:
+        logger.warning("Task work-product read unavailable: %s", type(exc).__name__)
+        return {"status": "unavailable"}

--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -813,6 +813,9 @@ async function openGlobalTasks() {
     _globalTaskHasMore = false;
     _globalTaskTotal = null;
     _globalTaskLoadGeneration += 1;
+    // The previous generation may still be loading after an auth/scope refresh.
+    // Its response is obsolete; it must not suppress this new workspace load.
+    _isLoading = false;
     _tasks = [];
     _taskDetailState = {};
     _selectedTaskId = '';

--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -8,6 +8,7 @@
 import { deleteJson, getJson, patchJson, postJson, getUserContext } from '../apiService.js';
 import { activateTab } from '../tabNavigation.js';
 import { showToast } from '../utils/toast.js';
+import { renderMarkdownViaServer } from '../markdownUtils.js';
 import { selectBestNameForContext } from '../utils/nameSelection.js';
 
 // Task panel state
@@ -1827,7 +1828,7 @@ function renderTaskExecuteWithVonButton(task, className = '') {
     return `<button type="button" class="task-execute-with-von-btn ${className}"
         data-task-id="${escapeHtml(taskId)}"
         title="${executionActive ? 'Von work is already active' : `Execute with Von in ${escapeHtml(conversationLabel)}`}"
-        ${executionActive ? 'disabled aria-busy="true"' : ''}>${executionActive ? 'Von work active' : 'Execute with Von'}</button>`;
+        ${_taskExecutionLaunchesInFlight.has(taskId) ? 'disabled aria-busy="true"' : ''}>${executionActive ? 'Observe Von work' : 'Execute with Von'}</button>`;
 }
 
 function createTaskLaunchRequestId() {
@@ -2011,8 +2012,8 @@ function refreshTaskExecutionButtonStates() {
     document.querySelectorAll('.task-execute-with-von-btn').forEach((button) => {
         const taskId = String(button.dataset.taskId || '').trim();
         const suppressed = taskId && isTaskExecutionLaunchSuppressed(taskId);
-        button.disabled = Boolean(suppressed);
-        button.textContent = suppressed ? 'Von work active' : 'Execute with Von';
+        button.disabled = _taskExecutionLaunchesInFlight.has(taskId);
+        button.textContent = suppressed ? 'Observe Von work' : (button.dataset.continue === 'true' ? 'Continue with Von' : 'Execute with Von');
         button.setAttribute('aria-busy', suppressed ? 'true' : 'false');
     });
 }
@@ -2021,17 +2022,23 @@ function setTaskExecutionButtonsDisabled(taskId, disabled) {
     document.querySelectorAll('.task-execute-with-von-btn').forEach((button) => {
         if (button.dataset.taskId !== taskId) return;
         const suppressed = disabled || isTaskExecutionLaunchSuppressed(taskId);
-        button.disabled = suppressed;
+        button.disabled = disabled;
         button.textContent = disabled
             ? 'Queuing…'
-            : (suppressed ? 'Von work active' : 'Execute with Von');
+            : (suppressed ? 'Observe Von work' : (button.dataset.continue === 'true' ? 'Continue with Von' : 'Execute with Von'));
         button.setAttribute('aria-busy', suppressed ? 'true' : 'false');
     });
 }
 
-async function executeTaskWithVon(taskId) {
+async function executeTaskWithVon(taskId, { continuation = false } = {}) {
     const cleanedTaskId = String(taskId || '').trim();
     if (!cleanedTaskId || _taskExecutionLaunchesInFlight.has(cleanedTaskId)) return;
+    const active = _taskQueueActivity.find(item => item.task_concept_id === cleanedTaskId
+        && ['queued', 'in_progress'].includes(item.status));
+    if (active?.session_id) {
+        await openTaskConversation(active.session_id);
+        return;
+    }
     _taskExecutionLaunchesInFlight.add(cleanedTaskId);
     setTaskExecutionButtonsDisabled(cleanedTaskId, true);
     const launchRequestId = getOrCreateTaskLaunchRequestId(cleanedTaskId);
@@ -2039,7 +2046,10 @@ async function executeTaskWithVon(taskId) {
     try {
         const response = await postJson(
             `/api/tasks/${encodeURIComponent(cleanedTaskId)}/execute-with-von`,
-            { launch_request_id: launchRequestId },
+            {
+                launch_request_id: launchRequestId,
+                ...(continuation ? { continuation_instruction: getTaskDetailState(cleanedTaskId).continuationInstruction || '' } : {}),
+            },
         );
         if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
         const queueStatus = String(response?.queue_item?.status || '').trim().toLowerCase();
@@ -2074,8 +2084,19 @@ async function executeTaskWithVon(taskId) {
             );
         }
         await loadTaskQueueActivity();
+        if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
+        if (continuation && response?.task?.conversation_session_id) {
+            await openTaskConversation(response.task.conversation_session_id);
+        }
     } catch (err) {
         if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
+        if (err?.payload?.reason_code === 'task_execution_already_active') {
+            await loadTaskQueueActivity();
+            const active = _taskQueueActivity.find(item => item.task_concept_id === cleanedTaskId && ['queued', 'in_progress'].includes(item.status));
+            if (active?.session_id) await openTaskConversation(active.session_id);
+            showToast('Observing the existing Von execution', 'info');
+            return;
+        }
         console.error('[taskPanel] Failed to execute task with Von:', err);
         showToast('Failed to queue Von task execution', 'error');
     } finally {
@@ -2503,6 +2524,62 @@ function renderTaskOrganisationField(task) {
     `;
 }
 
+function renderTaskWorkProduct(task, detailState) {
+    const product = detailState?.product || task.current_work_product;
+    const messages = {
+        missing: 'No current work product linked. Select its concept below.',
+        unavailable: 'The current work product is unavailable in this context. Refresh or select an accessible product.',
+        ambiguous_link: 'More than one product is linked. Select the intended current product below.',
+        ambiguous_content: 'This product has multiple content assertions; none has been selected as current. Resolve the revision on the product before relying on it.',
+        missing_content: 'The linked product has no current content. You can inspect its concept or continue with this limitation.',
+    };
+    const taskId = getTaskId(task);
+    const productId = product?.concept_id || '';
+    const execute = canExecuteTaskWithVon(task);
+    const active = isTaskExecutionLaunchSuppressed(taskId);
+    return `<section class="task-work-product" aria-label="Current work product">
+        <h4>Current work product</h4>
+        <p>${product?.status === 'ready' ? escapeHtml(productId) : escapeHtml(messages[product?.status] || 'Open task details to check its current product.')}</p>
+        ${product?.status === 'ready' ? `<button type="button" class="task-open-product-btn" data-task-id="${escapeHtml(taskId)}" ${detailState.productLoading ? 'disabled' : ''}>${detailState.productLoading ? 'Opening…' : 'Open current work product'}</button>` : ''}
+        ${productId ? `<button type="button" class="task-concept-link" data-concept-id="${escapeHtml(productId)}" data-concept-name="${escapeHtml(productId)}">Inspect product concept</button>` : ''}
+        ${detailState.productError ? `<p role="status">${escapeHtml(detailState.productError)}</p>` : ''}
+        ${detailState.productHtml ? `<div class="task-current-product-content">${detailState.productHtml}</div>` : ''}
+        <label class="task-detail-label">Current work product concept ID
+          <input class="task-detail-input task-current-product-input" value="${escapeHtml(productId)}" placeholder="#V#…" />
+        </label>
+        <button type="button" class="task-save-product-btn" data-task-id="${escapeHtml(taskId)}">Save product link</button>
+        ${execute ? `<label class="task-detail-label">New instruction for Von
+          <textarea class="task-continuation-instruction task-detail-input" data-task-id="${escapeHtml(taskId)}" maxlength="4000" placeholder="What should Von do next?">${escapeHtml(detailState.continuationInstruction || '')}</textarea>
+        </label>
+        <button type="button" class="task-execute-with-von-btn" data-continue="true" data-task-id="${escapeHtml(taskId)}">${active ? 'Observe Von work' : 'Continue with Von'}</button>` : ''}
+    </section>`;
+}
+
+async function openTaskWorkProduct(taskId) {
+    const detailState = getTaskDetailState(taskId);
+    const generation = _taskQueueActivityGeneration;
+    detailState.productLoading = true;
+    detailState.productError = '';
+    detailState.productHtml = '';
+    renderTaskList();
+    try {
+        const product = await getJson(`/api/tasks/${encodeURIComponent(taskId)}/work-product`);
+        if (generation !== _taskQueueActivityGeneration) return;
+        detailState.product = product;
+        if (product.status === 'ready') {
+            const html = await renderMarkdownViaServer(product.content);
+            if (generation !== _taskQueueActivityGeneration) return;
+            detailState.productHtml = html;
+        }
+    } catch (_error) {
+        if (generation !== _taskQueueActivityGeneration) return;
+        detailState.productError = 'Could not open the current product. Try again.';
+    } finally {
+        detailState.productLoading = false;
+        if (generation === _taskQueueActivityGeneration) renderTaskList();
+    }
+}
+
 function renderTaskDetailsPanel(task, detailState) {
     const taskId = getTaskId(task);
     const detailTask = detailState.task || task;
@@ -2536,6 +2613,7 @@ function renderTaskDetailsPanel(task, detailState) {
 
     return `
         <div class="task-detail-panel" data-task-id="${escapeHtml(taskId)}">
+            ${renderTaskWorkProduct(detailTask, detailState)}
             <div class="task-detail-section">
                 <h4>Editable task context</h4>
                 <div class="task-detail-grid">
@@ -2818,6 +2896,7 @@ function renderTaskInspector(task, detailState) {
                 </div>
             </div>
 
+            ${renderTaskWorkProduct(detailTask, detailState)}
             ${renderTaskTimeline(detailState, detailTask)}
 
             <div class="task-inspector-table">
@@ -3211,6 +3290,7 @@ function replaceCachedTask(updatedTask) {
 
 async function loadTaskDetails(taskId, { refreshList = false } = {}) {
     const detailState = getTaskDetailState(taskId);
+    const scopeGenerationAtStart = _taskQueueActivityGeneration;
     detailState.loading = true;
     detailState.error = null;
     renderTaskList();
@@ -3222,6 +3302,7 @@ async function loadTaskDetails(taskId, { refreshList = false } = {}) {
             getJson(`/api/tasks/${encodeURIComponent(taskId)}/attachments?limit=100`),
             getJson(`/api/tasks/${encodeURIComponent(taskId)}/history?limit=200`),
         ]);
+        if (scopeGenerationAtStart !== _taskQueueActivityGeneration) return;
         detailState.task = task;
         detailState.comments = commentsResult.comments || [];
         detailState.attachments = attachmentsResult.attachments || [];
@@ -3400,7 +3481,7 @@ function attachTaskEventListeners() {
             button.addEventListener('click', async (event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                await executeTaskWithVon(event.currentTarget.dataset.taskId);
+                await executeTaskWithVon(event.currentTarget.dataset.taskId, { continuation: event.currentTarget.dataset.continue === 'true' });
             });
         });
 
@@ -3535,6 +3616,36 @@ function attachTaskEventListeners() {
             });
         });
 
+        root.querySelectorAll('.task-continuation-instruction').forEach(input => {
+            input.addEventListener('input', () => {
+                getTaskDetailState(input.dataset.taskId).continuationInstruction = input.value;
+            });
+        });
+        root.querySelectorAll('.task-open-product-btn').forEach(button => {
+            button.addEventListener('click', event => {
+                event.stopPropagation();
+                void openTaskWorkProduct(button.dataset.taskId);
+            });
+        });
+        root.querySelectorAll('.task-save-product-btn').forEach(button => {
+            button.addEventListener('click', async event => {
+                event.stopPropagation();
+                const taskId = button.dataset.taskId;
+                const input = button.closest('.task-work-product').querySelector('.task-current-product-input');
+                button.disabled = true;
+                try {
+                    await patchJson(`/api/tasks/${encodeURIComponent(taskId)}`, { current_work_product_concept_id: input.value.trim() || null });
+                    const detail = getTaskDetailState(taskId);
+                    detail.product = null;
+                    detail.productHtml = '';
+                    await loadTaskDetails(taskId);
+                    showToast('Current product link saved', 'success');
+                } catch (error) {
+                    showToast(error?.message || 'Could not save product link', 'error');
+                    button.disabled = false;
+                }
+            });
+        });
         root.querySelectorAll('.task-discuss-btn').forEach((button) => {
             button.addEventListener('click', (event) => {
                 event.preventDefault();
@@ -3545,6 +3656,7 @@ function attachTaskEventListeners() {
                     detail: {
                         conceptId,
                         conceptName: String(event.currentTarget.dataset.conceptName || '').trim() || conceptId,
+                        focalConceptIds: [conceptId, getTaskDetailState(conceptId)?.task?.current_work_product?.concept_id].filter(Boolean),
                         source: 'task'
                     }
                 }));

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -17975,3 +17975,24 @@ body.settings-body {
         grid-template-columns: 1fr;
     }
 }
+
+/* The product body is a current canonical read, contained within task detail. */
+.task-work-product {
+    padding: 14px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    margin: 12px 0;
+    overflow-wrap: anywhere;
+    min-width: 0;
+}
+.task-work-product > button { margin: 6px 6px 10px 0; }
+.task-work-product .task-detail-label { margin-top: 12px; }
+.task-current-product-content {
+    max-height: 60vh;
+    overflow: auto;
+    background: #f8fafc;
+    padding: 12px;
+    margin: 10px 0;
+}
+.task-current-product-content pre { white-space: pre-wrap; }
+.task-continuation-instruction { min-height: 80px; resize: vertical; }

--- a/tests/backend/test_task_execute_with_von_routes.py
+++ b/tests/backend/test_task_execute_with_von_routes.py
@@ -65,7 +65,7 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
 
     monkeypatch.setattr(
         "src.backend.server.routes.task_routes.get_task",
-        lambda _task_id: _task(),
+        lambda _task_id: {**_task(), "current_work_product": {"status": "ready", "concept_id": "#V#brief_selected"}},
     )
     monkeypatch.setattr(
         "src.backend.server.routes.task_routes.get_conversation_concept",
@@ -123,9 +123,12 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
 
     response = client.post(
         "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
-        json={"launch_request_id": "launch-1"},
+        json={"launch_request_id": "launch-1", "continuation_instruction": "Check the new evidence", "current_work_product": {"concept_id": "#V#wrong_brief"}},
     )
 
+    assert "Check the new evidence" in queue_call["prompt_raw"]
+    assert "#V#brief_selected" in queue_call["prompt_raw"]
+    assert "#V#wrong_brief" not in queue_call["prompt_raw"]
     assert response.status_code == 201
     assert response.get_json()["task_execution"]["queue_id"] == "queue-1"
     assert reconciliation_call["user_concept_id"] == "#V#alice"
@@ -459,9 +462,8 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
         assert duplicate.get_json()["reason_code"] == ("task_execution_already_active")
         first_payload = first.get_json()
         assert first_payload["queue_item"]["dispatch_ready"] is True
-        assert (
-            first_payload["task_execution"]["queue_id"]
-            == (first_payload["queue_item"]["queue_id"])
+        assert first_payload["task_execution"]["queue_id"] == (
+            first_payload["queue_item"]["queue_id"]
         )
 
         queue = mongo_client.get_chat_prompt_queue_collection()
@@ -480,3 +482,21 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
         )
     finally:
         mongo_client.close_connection()
+
+
+def test_continuation_projects_selected_task_product_and_new_instruction():
+    from src.backend.server.routes.task_routes import _build_task_execution_prompt
+
+    selected = _task()
+    selected.update(
+        current_work_product={"status": "ready", "concept_id": "#V#selected_brief"},
+        continuation_instruction="Resolve the remaining discrepancy.",
+        next_checkpoint="Check the missing evidence",
+        evidence="Canonical receipt",
+    )
+    prompt = _build_task_execution_prompt(selected)
+    assert "#V#task_prepare_brief" in prompt
+    assert "#V#selected_brief" in prompt
+    assert "Resolve the remaining discrepancy." in prompt
+    assert "Check the missing evidence" in prompt
+    assert "Canonical receipt" in prompt

--- a/tests/backend/test_task_work_product_service.py
+++ b/tests/backend/test_task_work_product_service.py
@@ -41,7 +41,7 @@ def test_selected_product_is_read_fresh_without_neighbour_substitution(reads):
     assert product["content"] == "Revised A"
     assert product["content_sha256"] == hashlib.sha256(b"Revised A").hexdigest()
     texts.assert_called_with(
-        "#V#brief_a", predicate="#V#hasContent", limit=2, context_view="actor_effective"
+        "#V#brief_a", predicate="hasContent", limit=2, context_view="actor_effective"
     )
 
 

--- a/tests/backend/test_task_work_product_service.py
+++ b/tests/backend/test_task_work_product_service.py
@@ -1,0 +1,133 @@
+"""Current-product selection must remain explicit and actor-visible."""
+
+import hashlib
+from unittest.mock import Mock
+
+import pytest
+
+from src.backend.services import task_work_product_service as service
+from src.backend.services import task_management_service as tasks
+
+
+def task_doc(targets):
+    return {
+        "concept_id": "#V#task_a",
+        "relationships": {
+            service.PREDICATE_HAS_CURRENT_WORK_PRODUCT: targets,
+            "is_an_instance_of": [tasks.TASK_SPECIFICATION_TYPE_ID],
+        },
+    }
+
+
+@pytest.fixture
+def reads(monkeypatch):
+    access = Mock(return_value=True)
+    find = Mock(return_value={"concept_id": "#V#brief_a"})
+    texts = Mock(return_value=[{"text": "Current A", "lang": "en-NZ"}])
+    monkeypatch.setattr(service, "can_access_concept", access)
+    monkeypatch.setattr(service.ConceptsRepository, "find_one", find)
+    monkeypatch.setattr(service, "get_texts_for_concept", texts)
+    return access, find, texts
+
+
+def test_selected_product_is_read_fresh_without_neighbour_substitution(reads):
+    _, _, texts = reads
+    doc = task_doc(["#V#brief_a"])
+    ref = service.resolve_task_work_product(doc)
+    assert ref["concept_id"] == "#V#brief_a"
+    assert "content" not in ref
+    texts.return_value = [{"text": "Revised A", "lang": "en-NZ"}]
+    product = service.resolve_task_work_product(doc, include_content=True)
+    assert product["content"] == "Revised A"
+    assert product["content_sha256"] == hashlib.sha256(b"Revised A").hexdigest()
+    texts.assert_called_with(
+        "#V#brief_a", predicate="#V#hasContent", limit=2, context_view="actor_effective"
+    )
+
+
+@pytest.mark.parametrize(
+    "targets, status",
+    [([], "missing"), (["#V#brief_a", "#V#brief_b"], "ambiguous_link")],
+)
+def test_missing_or_ambiguous_reference_never_guesses(reads, targets, status):
+    access, find, texts = reads
+    assert service.resolve_task_work_product(
+        task_doc(targets), include_content=True
+    ) == {"status": status}
+    access.assert_not_called()
+    find.assert_not_called()
+    texts.assert_not_called()
+
+
+def test_inaccessible_reference_discloses_neither_identity_nor_body(reads):
+    access, find, texts = reads
+    access.return_value = False
+    assert service.resolve_task_work_product(
+        task_doc(["#V#private_b"]), include_content=True
+    ) == {"status": "unavailable"}
+    find.assert_not_called()
+    texts.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "rows, status",
+    [
+        ([], "missing_content"),
+        ([{"text": "Old"}, {"text": "New"}], "ambiguous_content"),
+    ],
+)
+def test_content_ambiguity_does_not_claim_a_current_revision(reads, rows, status):
+    reads[2].return_value = rows
+    product = service.resolve_task_work_product(
+        task_doc(["#V#brief_a"]), include_content=True
+    )
+    assert product == {"concept_id": "#V#brief_a", "status": status}
+
+
+def test_task_get_exposes_canonical_reference_to_existing_consumers(monkeypatch, reads):
+    monkeypatch.setattr(
+        tasks, "_get_task_doc", lambda _: ("#V#task_a", task_doc(["#V#brief_a"]))
+    )
+    monkeypatch.setattr(
+        tasks, "_build_task_response", lambda _: {"task_concept_id": "#V#task_a"}
+    )
+    assert (
+        tasks.get_task("#V#task_a")["current_work_product"]["concept_id"]
+        == "#V#brief_a"
+    )
+
+
+def test_invalid_product_link_cannot_mutate_other_task_fields(monkeypatch):
+    monkeypatch.setattr(tasks, "_get_task_doc", lambda _: ("#V#task_a", task_doc([])))
+    monkeypatch.setattr(tasks, "_build_task_response", lambda _: {})
+    monkeypatch.setattr(tasks, "can_access_concept", lambda _: False)
+    mutation = Mock()
+    monkeypatch.setattr(tasks, "_replace_single_relationship_target", mutation)
+    monkeypatch.setattr(tasks, "update_task_status", mutation)
+    with pytest.raises(tasks.InvalidTaskDataError, match="not accessible"):
+        tasks.update_task_fields(
+            "#V#task_a",
+            fields={
+                "current_work_product_concept_id": "#V#private_b",
+                "status": "completed",
+            },
+        )
+    mutation.assert_not_called()
+
+
+def test_product_route_does_not_read_product_for_unavailable_task(monkeypatch):
+    from flask import Flask
+    from src.backend.server.routes.task_routes import task_bp
+
+    def unavailable(_):
+        raise tasks.TaskNotFoundError("Not accessible")
+
+    monkeypatch.setattr(tasks, "_get_task_doc", unavailable)
+    resolver = Mock()
+    monkeypatch.setattr(service, "resolve_task_work_product", resolver)
+    app = Flask(__name__)
+    app.register_blueprint(task_bp, url_prefix="/api/tasks")
+    response = app.test_client().get("/api/tasks/%23V%23private_task/work-product")
+    assert response.status_code == 404
+    assert response.json == {"status": "unavailable"}
+    resolver.assert_not_called()

--- a/tests/frontend/taskPanelConceptLinks.test.js
+++ b/tests/frontend/taskPanelConceptLinks.test.js
@@ -192,6 +192,7 @@ describe('task panel concept links', () => {
         expect(seen).toEqual([{
             conceptId: '#V#task_2675',
             conceptName: 'Focused discussions',
+            focalConceptIds: ['#V#task_2675'],
             source: 'task',
         }]);
         document.removeEventListener('von:discussConcept', handler);

--- a/tests/frontend/taskPanelExecuteWithVon.test.js
+++ b/tests/frontend/taskPanelExecuteWithVon.test.js
@@ -145,8 +145,11 @@ describe('explicit Execute with Von task control', () => {
         });
         await flushRenderQueue();
 
-        expect(inspectorButton.disabled).toBe(true);
-        expect(inspectorButton.textContent).toBe('Von work active');
+        expect(inspectorButton.disabled).toBe(false);
+        expect(inspectorButton.textContent).toBe('Observe Von work');
+        inspectorButton.click();
+        await flushRenderQueue();
+        expect(postJson).toHaveBeenCalledTimes(1);
         expect(require(toastModulePath).showToast).toHaveBeenCalledWith(
             'Von work queued in Research planning',
             'success',

--- a/tests/frontend/taskPanelExecuteWithVon.test.js
+++ b/tests/frontend/taskPanelExecuteWithVon.test.js
@@ -210,6 +210,10 @@ describe('explicit Execute with Von task control', () => {
                 expectedMessage,
                 expectedToastType,
             );
+            postJson.mockResolvedValueOnce({success: true, task: {conversation_name: 'Research planning'}, queue_item: {status: 'queued'}});
+            document.querySelector('.task-execute-with-von-btn').click();
+            await flushRenderQueue();
+            expect(postJson.mock.calls[2][1].launch_request_id).not.toBe(firstLaunchId);
         },
     );
 

--- a/tests/frontend/taskPanelWorkProduct.test.js
+++ b/tests/frontend/taskPanelWorkProduct.test.js
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+const apiPath = '../../src/frontend/web/von_interface/static/js/apiService.js';
+const panelPath = '../../src/frontend/web/von_interface/static/js/components/taskPanel.js';
+const markdownPath = '../../src/frontend/web/von_interface/static/js/markdownUtils.js';
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
+    getJson: jest.fn(), postJson: jest.fn(), patchJson: jest.fn(), deleteJson: jest.fn(),
+    getUserContext: jest.fn(() => ({user_id: '#V#alice', org_id: '#V#lab'})),
+}));
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({activateTab: jest.fn()}));
+jest.mock('../../src/frontend/web/von_interface/static/js/chatTab.js', () => ({switchToChatSession: jest.fn()}));
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/toast.js', () => ({showToast: jest.fn()}));
+jest.mock('../../src/frontend/web/von_interface/static/js/markdownUtils.js', () => ({
+    renderMarkdownViaServer: jest.fn(async () => '<p>Canonical current brief</p>'),
+}));
+const flush = async () => { await new Promise(resolve => setTimeout(resolve, 0)); await new Promise(resolve => setTimeout(resolve, 0)); };
+const selected = {
+    task_concept_id: '#V#task_a', title: 'Maintain brief A', status: 'pending', priority: 'medium',
+    assignee_concept_id: '#V#von_system', created_by_concept_id: '#V#alice', organisation_concept_id: '#V#lab',
+    originating_conversation_id: '#V#conversation_a', conversation_session_id: 'session-a',
+    task_type_ids: [], current_work_product: {status: 'ready', concept_id: '#V#brief_a'},
+};
+async function setup({product = {status: 'ready', concept_id: '#V#brief_a', content: 'Current A'}, activity = []} = {}) {
+    const api = require(apiPath);
+    api.getJson.mockImplementation(async url => {
+        if (url === '/api/tasks/taxonomy') return {task_types: [], task_sources: [], defaults: {}};
+        if (url === '/von/api/chat_prompt_queue') return {items: activity};
+        if (url.startsWith('/api/tasks/?')) return {tasks: [selected], count: 1};
+        if (url === '/api/tasks/%23V%23task_a') return selected;
+        if (url === '/api/tasks/%23V%23task_a/work-product') return product;
+        return {};
+    });
+    await require(panelPath).showGlobalTasks();
+    await flush();
+    return api;
+}
+beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    document.body.innerHTML = '<div id="globalTasksContainer"></div><span id="taskCountBadge"></span><span id="globalTaskCountBadge"></span>';
+});
+afterEach(() => jest.restoreAllMocks());
+
+test('opens only the selected task canonical product and renders its current body', async () => {
+    const api = await setup();
+    document.querySelector('#globalTaskInspector .task-open-product-btn').click();
+    await flush();
+    expect(api.getJson).toHaveBeenCalledWith('/api/tasks/%23V%23task_a/work-product');
+    expect(require(markdownPath).renderMarkdownViaServer).toHaveBeenCalledWith('Current A');
+    expect(document.querySelector('.task-current-product-content').textContent).toBe('Canonical current brief');
+});
+
+test.each(['ambiguous_content', 'unavailable'])('does not render stale content when a fresh read reports %s', async status => {
+    await setup({product: {status}});
+    document.querySelector('#globalTaskInspector .task-open-product-btn').click();
+    await flush();
+    expect(require(markdownPath).renderMarkdownViaServer).not.toHaveBeenCalled();
+    expect(document.querySelector('.task-current-product-content')).toBeNull();
+    expect(document.querySelector('.task-open-product-btn')).toBeNull();
+});
+
+test('sends a short continuation for the selected task; double click queues once', async () => {
+    const api = await setup();
+    let finish;
+    api.postJson.mockImplementation(() => new Promise(resolve => {finish = resolve;}));
+    const input = document.querySelector('#globalTaskInspector .task-continuation-instruction');
+    input.value = 'Reconcile the missing observation.';
+    input.dispatchEvent(new Event('input'));
+    const button = document.querySelector('#globalTaskInspector [data-continue="true"]');
+    button.click(); button.click();
+    await flush();
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+    expect(api.postJson.mock.calls[0][0]).toBe('/api/tasks/%23V%23task_a/execute-with-von');
+    expect(api.postJson.mock.calls[0][1].continuation_instruction).toBe(input.value);
+    finish({success: true, task: selected, queue_item: {status: 'queued'}, task_execution: {status: 'pending'}});
+    await flush();
+    expect(require('../../src/frontend/web/von_interface/static/js/chatTab.js').switchToChatSession).toHaveBeenCalledWith('session-a');
+});
+
+test('an active task is observed without a second launch after loading Tasks', async () => {
+    const api = await setup({activity: [{task_concept_id: '#V#task_a', session_id: 'session-a', status: 'in_progress', queue_id: 'existing'}]});
+    const button = document.querySelector('#globalTaskInspector [data-continue="true"]');
+    expect(button.textContent).toBe('Observe Von work');
+    button.click(); await flush();
+    expect(api.postJson).not.toHaveBeenCalled();
+    expect(require('../../src/frontend/web/von_interface/static/js/chatTab.js').switchToChatSession).toHaveBeenCalledWith('session-a');
+});

--- a/tests/frontend/taskPanelWorkProduct.test.js
+++ b/tests/frontend/taskPanelWorkProduct.test.js
@@ -85,3 +85,29 @@ test('an active task is observed without a second launch after loading Tasks', a
     expect(api.postJson).not.toHaveBeenCalled();
     expect(require('../../src/frontend/web/von_interface/static/js/chatTab.js').switchToChatSession).toHaveBeenCalledWith('session-a');
 });
+
+
+test('reopening Tasks during an auth/scope reload cannot leave the workspace permanently loading', async () => {
+    const api = require(apiPath);
+    const requests = [];
+    api.getJson.mockImplementation(url => {
+        if (url.startsWith('/api/tasks/?')) return new Promise(resolve => requests.push(resolve));
+        return Promise.resolve({});
+    });
+    const {showGlobalTasks} = require(panelPath);
+    const firstOpen = showGlobalTasks();
+    await flush();
+    document.dispatchEvent(new CustomEvent('orgSwitched', {detail: {organisation_id: '#V#lab'}}));
+    await flush();
+    expect(requests).toHaveLength(2);
+    requests[0]({tasks: [], count: 0});
+    await firstOpen;
+    const reopened = showGlobalTasks();
+    await flush();
+    expect(requests).toHaveLength(3);
+    requests[2]({tasks: [selected], count: 1});
+    await reopened;
+    requests[1]({tasks: [], count: 0});
+    await flush();
+    expect(document.querySelector('#globalTaskInspector').textContent).toContain('Maintain brief A');
+});


### PR DESCRIPTION
Merge decision: ready — the normal Tasks path opens the exact current product and delivers a selected-task continuation through one persisted execution, including browser reload.

## User outcome

A task can open its explicitly linked current work product and continue from a short new instruction. Previously a task-focused discussion preserved the task but had to rediscover the product from narrative records. Active work now offers observation of the existing conversation.

## Material changes

- Add a canonical task-to-current-product relation and actor-effective content projection, shared by task detail and task_get. Missing, inaccessible and ambiguous content remain explicit.
- Add product opening/link controls, product focus for Discuss, and a continuation instruction on the existing actor-bound execution route.
- Reuse queue/TaskExecution identities and observe active work without another launch. Preserve human task assignments and existing execution authority.

[JVNAUTOSCI-2724](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2724) owns the current acceptance decision. The capability guide documents the interface and its limits.

## Evidence

92 targeted backend tests passed; 32 directly affected backend tests passed after the final projection changes. 32 frontend tests passed, including canonical product opening, unavailable/ambiguous content, repeated clicks, active execution observation, later intentional launch identity and overlapping scope/reopen requests. Four targeted queue duplication/concurrency tests also passed. Diff checks passed. Live candidate acceptance passed for product opening and assisted continuation. The exact current body reached the model; one short instruction produced the intended reconciliation in the originating conversation. Canonical read-back confirms one completed execution, pending tasks, unchanged human review and unchanged product content. Browser reload recovered correctly after fixing an overlapping-request loading race.

## Ship boundary

- Minimum: normal authenticated Tasks journey opens the intended current brief, preserves selected-task context through continuation and observes existing work across repeat interaction.
- Stop ship: wrong product/task, false current-content claim, duplicate execution, widened actor visibility or broken existing launch.
- Non-blocking: an unguided Luna answer still misinterpreted a qualification despite receiving the complete correct brief. The assisted continuation corrected that distinction; this does not establish autonomous role competence or an efficiency improvement. That evidence remains under 2721. Tasks list loading still takes tens of seconds against Atlas.
- Non-goals: learned role competence, general scheduling changes, universal conversation context or model routing policy.


[JVNAUTOSCI-2724]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ