### PR TITLE
JVNAUTOSCI-2721 Make replay outcome claims evidence-based

### DIFF
--- a/docs/engineering/authenticated_browser_workflow_replay_harness.md
+++ b/docs/engineering/authenticated_browser_workflow_replay_harness.md
@@ -126,3 +126,46 @@ projection facts from `JVNAUTOSCI-2421`. A local run may still be acceptable
 evidence for `JVNAUTOSCI-2422` when it emits a precise Gmail profile/OAuth
 blocker, because the harness itself has then proven the authenticated replay
 path and identified the missing external precondition.
+
+## Multi-turn outcome rebaselines
+
+The companion `run_live_multi_turn_followup_replay.py` and its JSON bank retain
+useful task families independently of older routing and telemetry designs.
+The bank's `assessment_scope: outcome` keeps expected workflow identity and
+observed action failures in `integration_checks`, separate from outcome checks.
+A competent alternative route or successful recovery does not by itself fail
+the user job. Callers explicitly testing workflow integration can retain the
+legacy default `workflow_integration` scope. Completion-gate rejection still
+fails the outcome checks.
+
+The shipped bank requires a separate source-grounded review. Its automated
+verdict is therefore `inconclusive` when its checks pass but that review is
+outstanding, and `fail` when a checked requirement fails. Preserve both the
+machine result and the review disposition; do not rewrite inconclusive machine
+results as automated passes. Keyword or distinct-ID coverage alone cannot prove
+that the intended targets were accurately described or that effects persisted.
+For the dynamic two-issue Jira case, two distinct issue keys are necessary;
+review must additionally confirm the requested issue and its immediate
+predecessor against Jira, and assess each summary.
+
+Legacy obligation-suppression probes remain available for historical integration
+replays. An absent ledger or decision is unavailable evidence, not a successful
+negative check. The current outcome bank no longer requires the retired ledger
+shape. Retire obsolete implementation expectations rather than useful jobs;
+retain failed current jobs in the results.
+
+`visible_answer` is retained as a compatibility field. Its source is a server
+turn record or task result; it does **not** prove browser delivery. Reports name
+that surface and report `browser_delivery: not_observed`. A completed transport
+without an answer fails, and saved prose cannot establish that the UI displayed
+it. Browser acceptance needs a separate actual browser observation. Likewise,
+browser-test fixture authentication does not establish normal owner authority
+for integrations such as Jira.
+
+For a bounded rebaseline, freeze a small selection of existing jobs, the model,
+entry surface, effect scope and review criteria before submission. Use fresh
+sessions for independent families, preserve context within each family, and
+reconcile pending requests before any retry. Verify source facts and canonical
+read-back for effects, record model identity and release, and report pass,
+failure, blocked or unassessed outcomes separately. A single representative
+sample is not a reliability rate, a model ranking or broad certification.

--- a/scripts/live_multi_turn_followup_prompt_bank.json
+++ b/scripts/live_multi_turn_followup_prompt_bank.json
@@ -9,15 +9,18 @@
     "multi_target": "A question about the current target AND earlier ones together. The answer must address each target distinctly and must not collapse to a single concept (JVNAUTOSCI-2564 anti-over-constraint guardrail)."
   },
   "expectation_keys": {
-    "expected_workflow_id": "Optional workflow concept ID expected to be selected for this turn.",
-    "require_completed": "Background task must reach terminal status completed.",
+    "assessment_scope": "outcome separates route/action diagnostics from outcome checks; workflow_integration (legacy default) includes them in the verdict.",
+    "requires_manual_review": "Reason canonical outcome review is needed. The runner reports inconclusive until reviewed separately; never infer correctness from keyword checks.",
+    "response_distinct_match": "Regex pattern and minimum number of distinct full matches. Textual coverage only; does not prove identity or correctness.",
+    "expected_workflow_id": "Optional workflow concept ID expected in execution evidence; diagnostic only for outcome cases.",
+    "require_completed": "Background task must reach terminal status completed and a non-empty answer must be available; browser delivery remains unobserved.",
     "forbid_decisions": "Turn execution record decision must not be one of these (e.g. escalation_required on a bare follow-up).",
-    "require_prior_obligation_suppression": "The turn record must show prior-contract conditional obligations suppressed (execution.summary.expected_outcome_obligation_carry_forward.suppressed_prior_obligations non-empty) OR carry no unsatisfied obligation sourced from the prior turn's contract.",
+    "require_prior_obligation_suppression": "Legacy integration probe only. Requires explicit suppression or an observed obligation ledger, and no inherited unsatisfied obligations. Missing telemetry is inconclusive.",
     "forbid_unsatisfied_obligation_sources": "No UNSATISFIED required-tool obligation may cite one of these sources (default probe: turn_expected_outcome_conditional_required_tools).",
     "allow_obligation_carry_forward": "Explicit continuation: obligation inheritance is legitimate; no suppression requirement.",
     "response_must_mention_any": "Visible answer must contain at least one of these strings (target grounding).",
     "response_must_not_mention": "Visible answer must contain none of these strings (stale-referent grounding guard).",
-    "response_must_mention_all_groups": "For multi-target turns: for EACH group (list of alternative strings), the answer must mention at least one entry; proves per-target coverage without forcing a single binding.",
+    "response_must_mention_all_groups": "For multi-target turns: for EACH group (list of alternative strings), the answer must mention at least one entry; checks textual coverage only; source-grounded review is still required.",
     "notes": "Free-text reviewer guidance; not machine-checked."
   },
   "cases": [
@@ -30,6 +33,8 @@
           "role": "task",
           "prompt": "Please ingest https://arxiv.org/abs/2406.15341 into Von, including the normal download/file-copy path if available, then read back the represented paper concept so I can see what was stored.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "expected_workflow_id": "#V#arxiv_paper_representation_workflow",
             "require_completed": true,
             "response_must_mention_any": ["2406.15341", "GenoTEX", "genotex"],
@@ -40,10 +45,10 @@
           "role": "bare_followup",
           "prompt": "Do you have a concept for https://arxiv.org/abs/2406.15341",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "forbid_decisions": ["escalation_required"],
-            "require_prior_obligation_suppression": true,
-            "forbid_unsatisfied_obligation_sources": ["turn_expected_outcome_conditional_required_tools"],
             "response_must_mention_any": ["2406.15341", "GenoTEX", "genotex"],
             "notes": "Exact JVNAUTOSCI-2563 motivating shape. Prior paper/file-copy referents may be reused for a direct existence answer; the prior ingestion/read-back tool family must not become this turn's obligations."
           }
@@ -52,6 +57,8 @@
           "role": "different_target_followup",
           "prompt": "Is this paper represented? https://arxiv.org/pdf/2603.22519v2",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "response_must_mention_any": ["2603.22519", "LLMon", "llmon"],
             "response_must_not_mention": ["genotex_an_llm_agent_benchmark", "arxiv_pdf_file_46934c89"],
@@ -62,8 +69,9 @@
           "role": "explicit_continuation",
           "prompt": "Please verify the representation of the paper you ingested at the start of this conversation and confirm its stored concept is still retrievable.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "response_must_mention_any": ["2406.15341", "GenoTEX", "genotex"],
             "notes": "Legitimate continuation: verification obligations for the earlier operation may carry; the answer must address the T1 paper, resolved through prior referents."
           }
@@ -72,6 +80,8 @@
           "role": "multi_target",
           "prompt": "Is 2603.22519 represented, and what about the paper we ingested earlier? Answer for each separately.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "response_must_mention_all_groups": [
               ["2603.22519", "LLMon", "llmon"],
@@ -91,6 +101,8 @@
           "role": "task",
           "prompt": "List my three most recent Gmail messages with sender, subject, and received time. Read-only: do not modify, label, or send anything.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "notes": "Establishes mailbox referents (message IDs/subjects) with a read-only contract shape."
           }
@@ -99,10 +111,10 @@
           "role": "bare_followup",
           "prompt": "Which Gmail profile did you just use for that listing?",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "forbid_decisions": ["escalation_required"],
-            "require_prior_obligation_suppression": true,
-            "forbid_unsatisfied_obligation_sources": ["turn_expected_outcome_conditional_required_tools"],
             "notes": "A narrow status question sharing the mail topic. It must not inherit the prior turn's mail retrieval/detail tool family as fresh obligations; the profile referent from T1 may be reused directly."
           }
         },
@@ -110,8 +122,9 @@
           "role": "explicit_continuation",
           "prompt": "Show me the full details of the most recent message from that list, including its body.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "notes": "Legitimate continuation: reuses the message referent from T1 and may carry per-message detail obligations (gmail_get_message grounded in a listed message ID)."
           }
         }
@@ -126,6 +139,8 @@
           "role": "task",
           "prompt": "What is the most recently created Task in the JVNAUTOSCI Jira project? Give me its key, summary, and status.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "response_must_mention_any": ["JVNAUTOSCI-"],
             "notes": "Establishes a concrete Jira issue-key referent via read-only jira_search."
@@ -135,10 +150,10 @@
           "role": "bare_followup",
           "prompt": "Do you have a represented Vontology concept for that Jira issue?",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "forbid_decisions": ["escalation_required"],
-            "require_prior_obligation_suppression": true,
-            "forbid_unsatisfied_obligation_sources": ["turn_expected_outcome_conditional_required_tools"],
             "notes": "Narrow concept-existence question. The issue-key referent from T1 must be reusable; the prior Jira search/read tool family must not be inherited as obligations, and no Jira import/reconciliation path may activate."
           }
         },
@@ -146,8 +161,9 @@
           "role": "explicit_continuation",
           "prompt": "Fetch the full details of that issue directly from Jira, including description and assignee.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "response_must_mention_any": ["JVNAUTOSCI-"],
             "notes": "Legitimate continuation: jira_get_issue on the carried issue-key referent."
           }
@@ -156,11 +172,11 @@
           "role": "multi_target",
           "prompt": "Summarise both that issue and the one created immediately before it, separately.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "response_must_mention_all_groups": [
-              ["JVNAUTOSCI-"]
-            ],
-            "notes": "Two-target coverage; the runner cannot know the keys in advance so machine checks are weak here — the reviewer must confirm two distinct issue keys appear and are summarised separately."
+            "response_distinct_match": {"pattern": "\\bJVNAUTOSCI-[0-9]+\\b", "minimum": 2},
+            "notes": "Two distinct issue keys are necessary. Review canonical Jira sources to confirm these are the intended issue and its immediate predecessor, each summarised accurately."
           }
         }
       ]
@@ -174,6 +190,8 @@
           "role": "task",
           "prompt": "On Jira issue JVNAUTOSCI-2591, add the label uc05-live-validated if it is absent, without changing any other field. Then fetch that exact issue directly from Jira and report its key, status, and complete label list so the change is verified by read-back.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "response_must_mention_all_groups": [
               ["JVNAUTOSCI-2591"],
@@ -186,8 +204,9 @@
           "role": "explicit_continuation",
           "prompt": "Repeat that exact operation for JVNAUTOSCI-2591. Do not create a duplicate label or change another field. Fetch the issue again and report the complete label list from Jira.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "response_must_mention_all_groups": [
               ["JVNAUTOSCI-2591"],
               ["uc05-live-validated"]
@@ -206,6 +225,8 @@
           "role": "task",
           "prompt": "Create a represented note concept containing exactly this text: 'Multi-turn replay checkpoint for the follow-up family.' Then read it back so I can see the stored concept.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "response_must_mention_any": ["Multi-turn replay checkpoint"],
             "notes": "Establishes a freshly created concept referent through the generic representation path (create + text relation + read-back)."
@@ -215,10 +236,10 @@
           "role": "bare_followup",
           "prompt": "Do you have a concept for that note?",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
             "forbid_decisions": ["escalation_required"],
-            "require_prior_obligation_suppression": true,
-            "forbid_unsatisfied_obligation_sources": ["turn_expected_outcome_conditional_required_tools"],
             "response_must_mention_any": ["Multi-turn replay checkpoint", "note"],
             "notes": "Deictic narrow lookup: the note referent must resolve from prior context; the prior mutation/read-back tool family must not be inherited as fresh obligations."
           }
@@ -227,8 +248,9 @@
           "role": "explicit_continuation",
           "prompt": "Verify the note concept you created is still retrievable and show me its stored content.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "response_must_mention_any": ["Multi-turn replay checkpoint"],
             "notes": "Legitimate verification continuation: read-back obligations for the earlier mutation may carry."
           }
@@ -244,6 +266,8 @@
           "role": "task",
           "prompt": "Create today's operational-reliability programme status digest from current JVNAUTOSCI Jira evidence, current repository evidence, and the prior represented digest. Persist it as the canonical digest work product. Include verified changes, milestones, blockers, unresolved or stale obligations, decisions needed, deadlines, and evidence gaps. Keep Jira Done, workflow completed, and capability passed distinct. Read-only outside the digest work product: do not transition, comment on, close, assign, or otherwise change Jira, GitHub, mail, or workflow instances.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "expected_workflow_id": "#V#lab_project_status_digest_workflow",
             "require_completed": true,
             "response_must_mention_all_groups": [
@@ -259,9 +283,10 @@
           "role": "explicit_continuation",
           "prompt": "Run that digest again against current evidence. Reuse the same represented digest work product and preserve each outstanding commitment's canonical source/task identity when its owner or due date changes. Absence from a search window does not resolve it. Tell me what changed since the prior digest and what evidence is unavailable. Keep every external system read-only.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "expected_workflow_id": "#V#lab_project_status_digest_workflow",
             "require_completed": true,
-            "allow_obligation_carry_forward": true,
             "response_must_mention_all_groups": [
               ["#V#operational_reliability_status_digest"],
               ["evidence gap", "unavailable"],
@@ -281,6 +306,8 @@
           "role": "task",
           "prompt": "Please ingest https://arxiv.org/abs/2408.12065 into Von. Include the PDF download/file-copy path if it works, but if the PDF cannot be fetched, still represent the paper from its metadata and tell me explicitly what was skipped.",
           "expectations": {
+            "assessment_scope": "outcome",
+            "requires_manual_review": "Verify the requested outcome against canonical sources and effects; keyword checks alone do not establish correctness.",
             "expected_workflow_id": "#V#arxiv_paper_representation_workflow",
             "require_completed": true,
             "response_must_mention_any": ["2408.12065"],

--- a/scripts/run_live_multi_turn_followup_replay.py
+++ b/scripts/run_live_multi_turn_followup_replay.py
@@ -27,11 +27,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import time
 import uuid
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -39,6 +41,9 @@ import requests
 
 from scripts.run_authenticated_browser_workflow_replay import (
     ReplayCase,
+    _as_mapping,
+    _request_json,
+    _safe_text,
     apply_target_session_context,
     build_workflow_capability_preflight,
     collect_run_environment,
@@ -50,9 +55,6 @@ from scripts.run_authenticated_browser_workflow_replay import (
     poll_replay_task,
     require_agent_test_server,
     submit_background_generate,
-    _as_mapping,
-    _request_json,
-    _safe_text,
 )
 
 BANK_PATH = Path(__file__).with_name("live_multi_turn_followup_prompt_bank.json")
@@ -78,6 +80,9 @@ KNOWN_EXPECTATION_KEYS = frozenset(
         "response_must_not_mention",
         "response_must_mention_all_groups",
         "notes",
+        "assessment_scope",
+        "response_distinct_match",
+        "requires_manual_review",
     }
 )
 DEFAULT_FORBIDDEN_OBLIGATION_SOURCES = (
@@ -113,10 +118,32 @@ def validate_bank(payload: Mapping[str, Any]) -> None:
         for index, turn in enumerate(turns):
             role = _safe_text(turn.get("role"))
             if role not in KNOWN_TURN_ROLES:
-                raise ValueError(f"Case {case_id} turn {index} has unknown role {role!r}.")
+                raise ValueError(
+                    f"Case {case_id} turn {index} has unknown role {role!r}."
+                )
             if not _safe_text(turn.get("prompt")):
                 raise ValueError(f"Case {case_id} turn {index} has an empty prompt.")
             expectations = turn.get("expectations") or {}
+            if expectations.get("assessment_scope", "workflow_integration") not in {
+                "outcome",
+                "workflow_integration",
+            }:
+                raise ValueError(
+                    f"Case {case_id} turn {index}: invalid assessment_scope"
+                )
+            distinct_match = expectations.get("response_distinct_match")
+            if distinct_match is not None:
+                if (
+                    not isinstance(distinct_match, Mapping)
+                    or not isinstance(distinct_match.get("pattern"), str)
+                    or not distinct_match["pattern"]
+                    or type(distinct_match.get("minimum")) is not int
+                    or distinct_match["minimum"] < 1
+                ):
+                    raise ValueError(
+                        f"Case {case_id} turn {index}: invalid response_distinct_match"
+                    )
+                re.compile(distinct_match["pattern"])
             unknown = set(expectations) - KNOWN_EXPECTATION_KEYS
             if unknown:
                 raise ValueError(
@@ -403,6 +430,16 @@ def _carry_forward_projection(turn_record: Mapping[str, Any]) -> dict[str, Any]:
     return _as_mapping(summary.get("expected_outcome_obligation_carry_forward"))
 
 
+def _has_obligation_ledger(turn_record: Mapping[str, Any]) -> bool:
+    """An absent retired ledger is not evidence of an empty obligation set."""
+    return any(
+        isinstance(effect, Mapping)
+        and isinstance(effect.get("required_tool_obligations"), Mapping)
+        and isinstance(effect["required_tool_obligations"].get("obligations"), list)
+        for effect in turn_record.get("required_effects") or []
+    )
+
+
 def _selected_workflow_execution_summary(
     turn_record: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -426,9 +463,9 @@ def evaluate_turn_expectations(
 ) -> dict[str, Any]:
     """Evaluate one turn's evidence against its bank expectations.
 
-    Returns {verdict: pass|fail|inconclusive, checks: [...]} where every check
-    records what was expected, what was observed, and whether it held. Checks
-    that need evidence the run could not capture are inconclusive, not silent.
+    Returns verdict, checks and separate integration_checks. Every check records
+    what was expected, observed and whether it held. Unavailable evidence and
+    outstanding source-grounded review are inconclusive, not silent passes.
     """
 
     checks: list[dict[str, Any]] = []
@@ -457,9 +494,10 @@ def evaluate_turn_expectations(
             except ValueError:
                 parsed_answer = None
             looks_like_raw_payload = isinstance(parsed_answer, (dict, list)) or (
-                raw_answer_text[:80].replace(" ", "").replace("\n", "").startswith(
-                    ('{"', "[{", "['", '["')
-                )
+                raw_answer_text[:80]
+                .replace(" ", "")
+                .replace("\n", "")
+                .startswith(('{"', "[{", "['", '["'))
             )
         if looks_like_raw_payload:
             add(
@@ -472,6 +510,7 @@ def evaluate_turn_expectations(
     if expectations.get("require_completed"):
         status = (_safe_text(terminal_status) or "").lower()
         add("require_completed", status == "completed", status, "completed")
+        add("answer_available", bool(raw_answer_text), bool(raw_answer_text), True)
 
     # A background task can reach its transport-level ``completed`` state after
     # Von has safely returned a grounded non-success.  That is not capability
@@ -480,9 +519,7 @@ def evaluate_turn_expectations(
     # failure cannot be reported green merely because polling terminated.
     completion_gate = _as_mapping(turn_record.get("completion_gate"))
     if completion_gate:
-        safe_to_claim_completion = completion_gate.get(
-            "safe_to_claim_completion"
-        )
+        safe_to_claim_completion = completion_gate.get("safe_to_claim_completion")
         add(
             "completion_gate_safe_to_claim_completion",
             safe_to_claim_completion is True,
@@ -498,11 +535,9 @@ def evaluate_turn_expectations(
             "persisted completion gate safe_to_claim_completion=true",
         )
 
-    # A recovery stage must not turn a failed selected workflow into a green
-    # capability result merely by producing plausible prose.  When the
-    # persisted selected-workflow execution summary is available, require all
-    # of its observed actions to have succeeded.  This is deliberately generic:
-    # it applies to every workflow and does not encode domain-specific policy.
+    # Preserve the stricter historical workflow-integration observation. Outcome
+    # cases separate this diagnostic below: a recovered action failure is not
+    # itself evidence that the requested end state failed.
     selected_execution_summary = _selected_workflow_execution_summary(turn_record)
     if selected_execution_summary:
         failed_action_ids = [
@@ -551,8 +586,8 @@ def evaluate_turn_expectations(
     ]
     if forbid_decisions:
         decision = (_safe_text(turn_record.get("decision")) or "").lower()
-        if not turn_record:
-            add("forbid_decisions", None, "turn record unavailable", forbid_decisions)
+        if not decision:
+            add("forbid_decisions", None, "decision unavailable", forbid_decisions)
         else:
             add(
                 "forbid_decisions",
@@ -574,11 +609,11 @@ def evaluate_turn_expectations(
         if _safe_text(item)
     )
     if forbidden_sources:
-        if not turn_record:
+        if not _has_obligation_ledger(turn_record):
             add(
                 "forbid_unsatisfied_obligation_sources",
                 None,
-                "turn record unavailable",
+                "obligation ledger unavailable",
                 list(forbidden_sources),
             )
         else:
@@ -601,11 +636,13 @@ def evaluate_turn_expectations(
             )
 
     if expectations.get("require_prior_obligation_suppression"):
-        if not turn_record:
+        if not _has_obligation_ledger(turn_record) and not _carry_forward_projection(
+            turn_record
+        ).get("suppressed_prior_obligations"):
             add(
                 "require_prior_obligation_suppression",
                 None,
-                "turn record unavailable",
+                "suppression and obligation ledger unavailable",
                 "suppression recorded or no inherited unsatisfied obligations",
             )
         else:
@@ -621,7 +658,7 @@ def evaluate_turn_expectations(
             ]
             add(
                 "require_prior_obligation_suppression",
-                bool(suppressed) or not inherited_unsatisfied,
+                not inherited_unsatisfied,
                 {
                     "suppressed_prior_obligations": suppressed,
                     "inherited_unsatisfied_count": len(inherited_unsatisfied),
@@ -659,13 +696,56 @@ def evaluate_turn_expectations(
                 all_ok = False
         add("response_must_mention_all_groups", all_ok, group_results, groups)
 
+    distinct_match = expectations.get("response_distinct_match")
+    if distinct_match:
+        matches = sorted(
+            {
+                match.group(0).casefold()
+                for match in re.finditer(
+                    distinct_match["pattern"], raw_answer_text, re.IGNORECASE
+                )
+            }
+        )
+        add(
+            "response_distinct_match",
+            len(matches) >= distinct_match["minimum"],
+            matches,
+            distinct_match,
+        )
+
+    if expectations.get("requires_manual_review"):
+        add(
+            "manual_outcome_review",
+            None,
+            "not assessed by this runner",
+            expectations["requires_manual_review"],
+        )
+
+    # An outcome case may succeed using another route or recover after a failed
+    # action. Preserve those integration observations without making them the
+    # outcome oracle. Existing integration callers retain their old contract.
+    integration_checks = []
+    if expectations.get("assessment_scope") == "outcome":
+        integration_names = {
+            "expected_workflow_id",
+            "selected_workflow_has_no_failed_actions",
+        }
+        integration_checks = [
+            check for check in checks if check["check"] in integration_names
+        ]
+        checks = [check for check in checks if check["check"] not in integration_names]
+
     outcomes = {check["outcome"] for check in checks}
     verdict = (
         "fail"
         if "fail" in outcomes
         else ("inconclusive" if "inconclusive" in outcomes else "pass")
     )
-    return {"verdict": verdict, "checks": checks}
+    return {
+        "verdict": verdict,
+        "checks": checks,
+        "integration_checks": integration_checks,
+    }
 
 
 # --------------------------------------------------------------------------
@@ -811,12 +891,12 @@ def run_case(
                 "client_request_id": client_request_id,
                 "task_id": task_id,
                 "observation_pending": observation_pending,
-                "reconciliation": dict(
-                    _as_mapping(evidence.get("reconciliation"))
-                ),
+                "reconciliation": dict(_as_mapping(evidence.get("reconciliation"))),
                 "terminal_status": terminal_status,
                 "visible_answer": visible_answer,
                 "visible_answer_source": visible_answer_source,
+                "answer_evidence_surface": "server_record_or_task_result",
+                "browser_delivery": "not_observed",
                 "selected_workflow_ids": selected_workflow_ids,
                 "observed_workflow_ids": observed_workflow_ids,
                 "workflow_evidence_ids": workflow_evidence_ids,
@@ -862,6 +942,7 @@ def run_case(
         "turn_count": len(turn_reports),
         "turns": turn_reports,
         "overall_verdict": overall,
+        "claim_scope": "bank expectations over server evidence; not browser delivery or reliability certification",
     }
 
 
@@ -1008,9 +1089,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     return (
         0
-        if all(
-            r["overall_verdict"] in {"pass", "inconclusive"} for r in reports
-        )
+        if all(r["overall_verdict"] in {"pass", "inconclusive"} for r in reports)
         else 1
     )
 

--- a/tests/test_run_live_multi_turn_followup_replay.py
+++ b/tests/test_run_live_multi_turn_followup_replay.py
@@ -131,9 +131,7 @@ def test_bare_followup_fails_when_prior_contract_obligation_unsatisfied() -> Non
     )
     assert _verdict(result) == "fail"
     assert _check(result, "forbid_decisions")["outcome"] == "fail"
-    assert (
-        _check(result, "forbid_unsatisfied_obligation_sources")["outcome"] == "fail"
-    )
+    assert _check(result, "forbid_unsatisfied_obligation_sources")["outcome"] == "fail"
 
 
 def test_missing_turn_record_is_inconclusive_not_silent_pass() -> None:
@@ -159,9 +157,7 @@ def test_different_target_grounding_fails_on_stale_concept_leak() -> None:
             "response_must_mention_any": ["target_b_token"],
             "response_must_not_mention": ["stale_concept_from_target_a"],
         },
-        visible_answer=(
-            "Verified: stale_concept_from_target_a is represented."
-        ),
+        visible_answer=("Verified: stale_concept_from_target_a is represented."),
         terminal_status="completed",
         selected_workflow_ids=[],
         turn_record={"decision": "completed"},
@@ -255,8 +251,7 @@ def test_visible_answer_prose_does_not_trigger_raw_payload_check() -> None:
     )
     assert _verdict(result) == "pass"
     assert all(
-        check["check"] != "visible_answer_not_raw_payload"
-        for check in result["checks"]
+        check["check"] != "visible_answer_not_raw_payload" for check in result["checks"]
     )
 
 
@@ -280,8 +275,7 @@ def test_completed_transport_task_fails_when_completion_gate_rejects_success() -
     assert _verdict(result) == "fail"
     assert _check(result, "require_completed")["outcome"] == "pass"
     assert (
-        _check(result, "completion_gate_safe_to_claim_completion")["outcome"]
-        == "fail"
+        _check(result, "completion_gate_safe_to_claim_completion")["outcome"] == "fail"
     )
 
 
@@ -316,8 +310,7 @@ def test_recovery_answer_cannot_hide_selected_workflow_action_failure() -> None:
 
     assert _verdict(result) == "fail"
     assert (
-        _check(result, "selected_workflow_has_no_failed_actions")["outcome"]
-        == "fail"
+        _check(result, "selected_workflow_has_no_failed_actions")["outcome"] == "fail"
     )
 
 
@@ -365,9 +358,7 @@ def test_nested_workflow_evidence_can_satisfy_expected_workflow_check() -> None:
     )
 
     result = runner.evaluate_turn_expectations(
-        expectations={
-            "expected_workflow_id": "#V#arxiv_paper_representation_workflow"
-        },
+        expectations={"expected_workflow_id": "#V#arxiv_paper_representation_workflow"},
         visible_answer="Paper representation completed and read back.",
         terminal_status="completed",
         selected_workflow_ids=workflow_evidence_ids,
@@ -482,3 +473,93 @@ def test_extract_visible_answer_prefers_turn_record_checked_final_response() -> 
 
     assert answer == "Current target could not be verified yet."
     assert source == "requested_evidence_lineage.final_response.text_checked_preview"
+
+
+def test_absent_legacy_fields_do_not_prove_suppression_or_decision():
+    result = runner.evaluate_turn_expectations(
+        expectations={
+            "require_prior_obligation_suppression": True,
+            "forbid_decisions": ["escalation_required"],
+        },
+        visible_answer="Yes.",
+        terminal_status="completed",
+        selected_workflow_ids=[],
+        turn_record={"execution": {"summary": {}}},
+    )
+    assert result["verdict"] == "inconclusive"
+    assert all(c["outcome"] == "inconclusive" for c in result["checks"])
+
+
+def test_recorded_suppression_cannot_hide_an_unsatisfied_inherited_obligation():
+    result = runner.evaluate_turn_expectations(
+        expectations={"require_prior_obligation_suppression": True},
+        visible_answer="Done.",
+        terminal_status="completed",
+        selected_workflow_ids=[],
+        turn_record=_record_with_obligation(
+            sources=["turn_expected_outcome_conditional_required_tools"],
+            satisfied=False,
+            suppressed=["another obligation"],
+        ),
+    )
+    assert _check(result, "require_prior_obligation_suppression")["outcome"] == "fail"
+
+
+def test_two_target_bank_case_rejects_repeated_single_key_and_requires_review():
+    case = next(
+        c
+        for c in runner.load_bank()["cases"]
+        if c["case_id"] == "jira_lookup_followup_family"
+    )
+    expectations = case["turns"][-1]["expectations"]
+
+    def evaluate(answer):
+        return runner.evaluate_turn_expectations(
+            expectations=expectations,
+            visible_answer=answer,
+            terminal_status="completed",
+            selected_workflow_ids=[],
+            turn_record={"decision": "completed"},
+        )
+
+    assert evaluate("JVNAUTOSCI-12 and JVNAUTOSCI-12")["verdict"] == "fail"
+    both = evaluate("JVNAUTOSCI-12 and JVNAUTOSCI-13")
+    assert _check(both, "response_distinct_match")["outcome"] == "pass"
+    assert both["verdict"] == "inconclusive"  # Two invented keys are not success.
+
+
+def test_completed_transport_without_answer_is_not_a_pass():
+    result = runner.evaluate_turn_expectations(
+        expectations={"require_completed": True},
+        visible_answer=None,
+        terminal_status="completed",
+        selected_workflow_ids=[],
+        turn_record={},
+    )
+    assert result["verdict"] == "fail"
+
+
+def test_outcome_scope_preserves_route_mismatch_as_separate_diagnostic():
+    result = runner.evaluate_turn_expectations(
+        expectations={
+            "assessment_scope": "outcome",
+            "expected_workflow_id": "expected",
+            "requires_manual_review": "Canonical read-back",
+        },
+        visible_answer="Completed using a direct tool and read-back.",
+        terminal_status="completed",
+        selected_workflow_ids=["direct"],
+        turn_record={},
+    )
+    assert result["verdict"] == "inconclusive"
+    assert result["integration_checks"][0]["outcome"] == "fail"
+
+
+def test_bank_retires_obligation_telemetry_from_outcome_cases():
+    for case in runner.load_bank()["cases"]:
+        for turn in case["turns"]:
+            ex = turn["expectations"]
+            assert ex["assessment_scope"] == "outcome"
+            assert ex["requires_manual_review"]
+            assert "require_prior_obligation_suppression" not in ex
+            assert "forbid_unsatisfied_obligation_sources" not in ex


### PR DESCRIPTION
Multi-turn replays could pass when obsolete obligation telemetry was missing, and the dynamic two-issue Jira check accepted a single issue-key prefix. They also mixed workflow routing expectations with user-outcome evidence and described persisted answers without making the browser-delivery limitation explicit.

Make missing ledger/decision evidence inconclusive, reject completed transport without an answer, require two distinct Jira keys, and require separate source-grounded review for the shipped outcome bank. Preserve routing and action-failure observations as separate integration diagnostics for outcome cases; existing integration callers retain their contract. Reports explicitly identify server answer evidence and unobserved browser delivery. The harness guide documents these limits and bounded rebaseline practice.

Validation: 37 targeted replay/oracle and suite-report tests passed; negative controls cover missing telemetry, contradictory suppression, duplicate keys, absent answers and route/outcome separation. Applied the evaluator to a current deployed-server turn and verified the pending-review classification. No new lint findings (eight pre-existing exception-handling findings remain). No runtime, model, prompt or authority configuration change. A small Luna live rebaseline is recorded separately under JVNAUTOSCI-2721; this PR makes no general reliability or browser acceptance claim.
