### PR TITLE
JVNAUTOSCI-2244 Recover from brief ontology mutation contention

### DIFF
--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Callable, Mapping, Sequence
-from contextlib import ExitStack
+import time
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -68,6 +69,56 @@ from .text_relation_read_policy import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Acquisition only: do not occupy a request worker indefinitely behind a busy
+# lease. Recent successful relationship handlers took about 42 seconds; allow
+# twice that duration with headroom. This does not time out an executing effect.
+_MUTATION_CONTENTION_WAIT_SECONDS = 90.0
+
+
+@contextmanager
+def _acquire_mutation_resource_locks(resource_keys: Sequence[str]) -> Iterator[None]:
+    """Wait for the existing lock set without retrying any mutation body.
+
+    Release partial acquisitions before waiting, so contenders never retain one
+    resource while waiting for another. The caller must recheck live scope and
+    authority after acquisition, as it does for an uncontended command.
+    """
+    started = time.monotonic()
+    deadline = started + _MUTATION_CONTENTION_WAIT_SECONDS
+    delay = 0.25
+    attempts = 0
+    while True:
+        locks = ExitStack()
+        attempts += 1
+        try:
+            for resource_key in sorted(set(resource_keys)):
+                locks.enter_context(ontology_mutation_resource_lock(resource_key))
+        except OntologyMutationResourceBusy:
+            locks.close()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning("Ontology mutation lock contention wait exhausted")
+                raise
+            if attempts == 1:
+                logger.info("Waiting for contended ontology mutation resources")
+            time.sleep(min(delay, remaining))
+            delay = min(delay * 2, 1.0)
+        except BaseException:
+            locks.close()
+            raise
+        else:
+            break
+    with locks:
+        if attempts > 1:
+            logger.info(
+                "Ontology mutation locks acquired after contention: attempts=%s wait_ms=%.0f",
+                attempts,
+                (time.monotonic() - started) * 1000,
+            )
+        # Deliberately outside the acquisition retry handler. Once the effect
+        # begins, even a retryable exception must follow receipt reconciliation.
+        yield
 
 
 @dataclass
@@ -3565,8 +3616,9 @@ def execute_governed_ontology_method(
                         resource_keys.add(
                             f"ontology-publication-scope:{expected_concept_id}"
                         )
-                for resource_key in sorted(resource_keys):
-                    locks.enter_context(ontology_mutation_resource_lock(resource_key))
+                locks.enter_context(
+                    _acquire_mutation_resource_locks(tuple(resource_keys))
+                )
                 for concept_id, expected_fingerprint in expected.items():
                     try:
                         current = scope_read_back(concept_id)

--- a/tests/backend/test_ontology_mutation_contention.py
+++ b/tests/backend/test_ontology_mutation_contention.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from contextlib import ExitStack, contextmanager
+from threading import Event, Thread, Timer
+from types import SimpleNamespace
+
+import mongomock
+import pytest
+
+
+@pytest.fixture
+def governed_command(monkeypatch):
+    """Real command, authority, lease and receipt path; isolated domain storage."""
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+
+    database = mongomock.MongoClient()["test_contention"]
+    receipts = database["receipts"]
+    receipts.create_index("receipt_id", unique=True)
+    monkeypatch.setattr(
+        authority, "get_ontology_mutation_receipts_collection", lambda: receipts
+    )
+    monkeypatch.setattr(authority, "_gateway_actor_trust_source", lambda: None)
+    role = authority.AuthorityRoleEvidence(
+        role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#admin",
+        organisation_concept_id=None,
+        relation_id="role:admin",
+        revision="1",
+    )
+    state = {"relationship_present": False, "scope_fingerprint": "original"}
+    roles = [role]
+    monkeypatch.setattr(
+        authority, "resolve_live_semantic_roles", lambda _: tuple(roles)
+    )
+    intent = authority.OntologyMutationIntent(
+        operation="relationship.add",
+        publication_context=authority.PublicationContext.global_context(),
+        target_concept_ids=("#V#paper", "#V#author"),
+        tool_name="add_relationship",
+        predicate="#V#has_author",
+        delta={
+            "target": "#V#author",
+            "affected_scope_fingerprints": {"#V#paper": "original"},
+        },
+        idempotency_key="contention-effect",
+    )
+    monkeypatch.setattr(command, "build_ontology_mutation_intent", lambda **_: intent)
+    monkeypatch.setattr(command, "scope_read_back", lambda _: dict(state))
+    monkeypatch.setattr(
+        command, "canonical_read_back_for_method", lambda **_: dict(state)
+    )
+    # Recovery suggestion discovery is a separate domain read, not this test's
+    # authority or lease boundary.
+    monkeypatch.setattr(
+        command, "_scoped_assertion_recovery_is_executable", lambda **_: False
+    )
+    writes = []
+
+    def mutate():
+        writes.append("effect")
+        state["relationship_present"] = True
+        return {"success": True, "changed": True, "added": True}
+
+    def run(effect=mutate):
+        with authority.override_current_actor("#V#admin", None):
+            return command.execute_governed_ontology_method(
+                method_name="add_relationship",
+                arguments={
+                    "source_id": "#V#paper",
+                    "predicate": "#V#has_author",
+                    "target": "#V#author",
+                },
+                mutate=effect,
+            )
+
+    with authority.override_current_actor("#V#admin", None):
+        resource_key = authority.ontology_authority_resource_keys(intent)[0]
+    return command, authority, receipts, state, roles, writes, run, resource_key
+
+
+def test_short_contention_completes_once_and_replays_same_receipt(governed_command):
+    _, authority, receipts, _, _, writes, run, key = governed_command
+    held = ExitStack()
+    held.enter_context(authority.ontology_mutation_resource_lock(key))
+    release = Timer(0.1, held.close)
+    release.start()
+    try:
+        first = run()
+    finally:
+        release.join(timeout=2)
+        held.close()
+    assert first["success"] is True, first
+    assert first["canonical_read_back"]["relationship_present"] is True
+    replay = run()
+    assert replay["idempotent_replay"] is True
+    assert writes == ["effect"]
+    assert receipts.count_documents({}) == 1
+
+
+@pytest.fixture
+def clock(monkeypatch, governed_command):
+    command = governed_command[0]
+    now = [0.0]
+    sleeps = []
+
+    def sleep(seconds):
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    fake = SimpleNamespace(monotonic=lambda: now[0], sleep=sleep)
+    monkeypatch.setattr(command, "time", fake)
+    return fake, sleeps
+
+
+@pytest.mark.parametrize("change", ["scope", "authority"])
+def test_scope_and_authority_are_rechecked_after_waiting(
+    governed_command, clock, change
+):
+    _, authority, _, state, roles, writes, run, key = governed_command
+    fake, _ = clock
+    with ExitStack() as held:
+        held.enter_context(authority.ontology_mutation_resource_lock(key))
+
+        def release_and_change(_seconds):
+            if change == "scope":
+                state["scope_fingerprint"] = "changed"
+            else:
+                roles.clear()
+            held.close()
+
+        fake.sleep = release_and_change
+        result = run()
+    assert result["success"] is False
+    assert result["changed"] is False
+    assert result["effect_status"] == "not_started"
+    if change == "scope":
+        assert result["error_code"] == "ontology_mutation_scope_precondition_failed"
+    else:
+        assert "authority" in result["error_code"]
+    assert writes == []
+
+
+def test_partial_lock_set_is_released_before_waiting(governed_command, clock):
+    command, authority = governed_command[:2]
+    fake, _ = clock
+    with ExitStack() as held:
+        held.enter_context(authority.ontology_mutation_resource_lock("z"))
+
+        def release(_seconds):
+            # Another operation can acquire the earlier key during the wait.
+            with authority.ontology_mutation_resource_lock("a"):
+                pass
+            held.close()
+
+        fake.sleep = release
+        with (
+            command._acquire_mutation_resource_locks(("z", "a")),
+            pytest.raises(authority.OntologyMutationResourceBusy),
+            authority.ontology_mutation_resource_lock("a"),
+        ):
+            pass
+    with authority.ontology_mutation_resource_lock("a"):
+        pass
+
+
+def test_persistent_contention_stops_before_effect(
+    governed_command, clock, monkeypatch
+):
+    command, authority, _, _, _, writes, run, key = governed_command
+    fake, sleeps = clock
+    monkeypatch.setattr(command, "_MUTATION_CONTENTION_WAIT_SECONDS", 2.0)
+    with authority.ontology_mutation_resource_lock(key):
+        result = run()
+    assert fake.monotonic() == 2.0
+    assert sleeps == [0.25, 0.5, 1.0, 0.25]
+    assert result["error_code"] == "ontology_mutation_resource_busy"
+    assert result["effect_status"] == "not_started"
+    assert result["changed"] is False
+    assert writes == []
+
+
+def test_unrelated_acquisition_error_is_not_retried(
+    governed_command, clock, monkeypatch
+):
+    command, authority = governed_command[:2]
+    _, sleeps = clock
+    real_lock = authority.ontology_mutation_resource_lock
+
+    @contextmanager
+    def lock(key):
+        if key == "z":
+            raise ConnectionError("store unavailable")
+        with real_lock(key):
+            yield
+
+    monkeypatch.setattr(command, "ontology_mutation_resource_lock", lock)
+    with (
+        pytest.raises(ConnectionError),
+        command._acquire_mutation_resource_locks(("a", "z")),
+    ):
+        pytest.fail("must not enter mutation body")
+    with real_lock("a"):
+        pass
+    assert sleeps == []
+
+
+def test_body_busy_exception_is_not_retried(governed_command, clock):
+    command, authority = governed_command[:2]
+    _, sleeps = clock
+    calls = []
+    with (
+        pytest.raises(authority.OntologyMutationResourceBusy),
+        command._acquire_mutation_resource_locks(("a",)),
+    ):
+        calls.append("effect may have started")
+        raise authority.OntologyMutationResourceBusy("body failure")
+    assert len(calls) == 1
+    assert sleeps == []
+    with authority.ontology_mutation_resource_lock("a"):
+        pass
+
+
+def test_same_effect_during_wait_does_not_launch_another_mutation(
+    governed_command, monkeypatch
+):
+    command, authority, receipts, _, _, writes, run, key = governed_command
+    waiting = Event()
+    resume = Event()
+    results = []
+
+    def sleep(_seconds):
+        waiting.set()
+        assert resume.wait(timeout=3)
+
+    monkeypatch.setattr(
+        command, "time", SimpleNamespace(monotonic=command.time.monotonic, sleep=sleep)
+    )
+    worker = Thread(target=lambda: results.append(run()))
+    with ExitStack() as held:
+        held.enter_context(authority.ontology_mutation_resource_lock(key))
+        worker.start()
+        try:
+            assert waiting.wait(timeout=3)
+            second = run()
+            assert second["effect_status"] == "in_progress"
+            assert writes == []
+        finally:
+            held.close()
+            resume.set()
+            worker.join(timeout=3)
+    assert not worker.is_alive()
+    assert results[0]["success"] is True
+    assert writes == ["effect"]
+    assert receipts.count_documents({}) == 1


### PR DESCRIPTION
Merge decision: ready — ordinary governed ontology commands can survive short-lived contention for their existing locks, with authority and scope rechecked before the effect.

## User outcome

A parallel paper metadata write can currently fail immediately with `ontology_mutation_resource_busy`, even when the competing operation is about to release its lock. This can terminalise otherwise recoverable workflows. [JVNAUTOSCI-2244](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2244), within the 2721 reliability programme.

## Material changes

Wait up to 90 seconds to acquire the existing command lock set, releasing partial acquisitions between attempts and backing off from 250 ms to 1 second. The acquisition window is based on observed successful relationship handlers around 42 seconds, with twice that duration plus headroom; it bounds occupied request workers without interrupting an executing mutation. Scope fingerprints and live authority are still checked under the acquired locks. Mutation bodies, unknown failures and previously finalised receipts are never retried by this helper.

## Evidence

- Baseline regression failed when a real lease was released 100 ms later; candidate succeeds once and replays the receipt.
- 84 targeted tests pass: new contention cases plus publication authority, recovery/reuse, create containment, identity consolidation and membership scope coordination.
- Tests cover partial-lock release, bounded exhaustion, unrelated storage failures, no body retry, scope change, authority revocation and a concurrent request with the same effect identity.
- Live internal-MCP check used normal server-issued exact delegation and actual Atlas leases/receipts. The existing paper-title upsert recovered after two acquisition attempts (3.76 s acquisition, 14.08 s whole command). Canonical read-back and repeated effect confirmed the same title relation, successful receipt and no duplicate. This was a controlled no-op upsert, not a new full-paper replay or a browser test.
- Changed tests pass Ruff; command lint has only its existing unrelated FURB188 finding. Diff whitespace check passes.

## Ship boundary

- Minimum ship criteria met: transient contention recovers, one effect remains one effect, live scope/authority changes still prevent execution, and canonical read-back agrees.
- Stop-ship: repeated effects, retained partial locks during waits, bypassed authority/scope checks, or retrying an unknown executed effect.
- Non-blocking: prolonged contention can still exhaust the acquisition window; already finalised failed receipts retain their existing replay semantics. The earlier paper run's duplicate-author and broader workflow recovery issues remain unresolved.
- Non-goals: reader/writer lock redesign, model or prompt changes, full paper-workflow certification, and automatic retry of prior failed receipts.


[JVNAUTOSCI-2244]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ