### PR TITLE
JVNAUTOSCI-2244 Resume continuing tasks from chat and schedules

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -2,10 +2,13 @@
 
 - **Kind:** Capability guide
 - **Lifecycle:** Active
-- **Authority:** Describes the Tasks interface and its canonical references;
+- **Authority:** Describes task continuity and its canonical references;
   [JVNAUTOSCI-2724](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2724)
-  owns delivery decisions and acceptance evidence.
-- **Review trigger:** Changes to task product selection or execution authority.
+  owns the original interface delivery; the continuing paper-email encounter
+  is tracked in [JVNAUTOSCI-2244](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2244)
+  and [JVNAUTOSCI-2721](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2721).
+- **Review trigger:** Changes to task product selection, recurring execution,
+  contextual requirements or execution authority.
 
 A task can explicitly link its current work product using
 `#V#hascurrentworkproduct`. The relation selects a concept identity. Content,
@@ -43,6 +46,82 @@ current body and its SHA-256. `PATCH /api/tasks/<id>` accepts
 endpoint accepts an optional `continuation_instruction` of at most 4,000
 characters. Client-supplied product projections do not control the execution
 context.
+
+Ordinary chat can use `task_update_fields` to attach the current product, revise
+the checkpoint and evidence, and assign an actor-created task to `#V#von_system`
+with the actor as its report recipient. This reuses the existing task editor
+and product reference. It does not start execution. The bounded ordinary-chat
+projection cannot change the creator or organisation, add an audience, or
+assign work to another person. The general parity editor remains a separate
+explicitly delegated surface.
+
+## Recurring encounters
+
+`#V#task_continuation_workflow` submits the same task operation as **Continue
+with Von**, through `task_execution_submission_service`. Its release input is
+`src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json`;
+publish it with the existing `bootstrap_repo_seed_workflow_bundle` operator
+service and read back the live definition. Repository presence alone is not
+activation. An actor-owned schedule supplies the task and an explicit enabled
+model/provider; it does not copy the task's domain programme into code.
+
+Each occurrence reads the current task, product reference and checkpoint.
+The originating conversation carries its shared situation and prior work.
+The workflow's durable instance gives an idempotent launch identity; the queue's
+atomic active-task key prevents overlap with both scheduled and UI launches.
+An already active task coalesces with the existing execution. The workflow
+receipt reports submission or coalescence, with a queue and TaskExecution
+locator. Its successful termination is **not** a domain-completion claim.
+Inspect the linked execution and canonical work product for that outcome.
+
+## Requirements that can evolve
+
+For a paper responsibility, “fully represented” is relative to the applicable
+user, paper class, purpose and current expectation. It is not an immutable
+property of the paper, a universal list of predicates, or proof that a named
+workflow ran. Bibliographic acquisition, document retrieval, scientific
+interpretation, identity reconciliation and source disposition remain
+separable capabilities. Choose and improve them against the current job.
+
+Keep the initial expectation as inspectable, revisable text in the working
+account. When acquisition, assessment and later audit need a shared independent
+reference, give that expectation a represented profile identity and read its
+current actor-effective body. Existing representation-contract profiles are
+worth inspecting, but their historical tool-requirement contracts do not by
+themselves express contextual adequacy. Do not silently reinterpret one as the
+new completeness policy or replace its public semantics with one user's needs.
+
+An assessment should preserve which expectation and revision it applied,
+the use context, evidence actually inspected, and remaining gaps. The existing
+source-processing marker's authority fingerprint can bind the effective
+expectation when the marker is used for resumption. A label or an old marker
+alone cannot establish currency under a revised expectation. Preserve earlier
+evidence and receipts; reassess and fill the demonstrated gap instead of
+discarding the representation or downloading everything again. Different uses
+may have different adequate representations of the same canonical paper.
+Privacy scope remains distinct from semantic applicability; see
+[contextual knowledge evolution](contextual_knowledge_evolution.md).
+
+Other guidance that may need revision includes mailbox selection and intent,
+coverage and backlog priority, effort per encounter, retry/audit cadence,
+model and prompt choice, Inbox disposition and notification preferences.
+Start with the existing task/product and reasonable stated defaults. Split
+guidance into independently governed profiles only when actual consumers or
+revision needs justify it. Keep exact cursor persistence, identity, actor
+authority, queue deduplication and effect read-back in reusable mechanisms.
+
+## Evidence of low human burden
+
+A detailed diagnostic prompt is useful engineering evidence, but not evidence
+of a natural user experience. Record supplied workflow IDs, repair plans,
+manual state fixes and repeated briefing as operator assistance. After repair,
+exercise an ordinary request such as “Keep up with papers people email to Von,
+including the older ones, and mark each email done when its papers are
+represented.” A later short instruction should recover and revise the same
+responsibility. Inspect whether Von reuses earlier components, requirements
+and evidence, rather than requiring the human to reconstruct their interfaces.
+One focussed question may be useful when a material fact is unavailable;
+making the user write an execution specification is not the target experience.
 
 This is a bounded continuity interface, not evidence of learned role competence.
 Use the [role convergence guide](role_learning_convergence.md) for successive

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -36519,13 +36519,104 @@ def _task_update_fields(**kwargs):
             suggestions=["Provide fields to update, e.g. {'status': 'in_progress'}"],
         )
 
+    actor_id = kwargs.get("actor_concept_id") or kwargs.get("namespace")
+    if kwargs.get("actor_bound_continuation") is True:
+        actor_scope, current_task, authority_error = _authorise_task_actor_mutation(
+            kwargs, surface="task_update_fields"
+        )
+        if authority_error is not None:
+            return authority_error
+        assert actor_scope is not None and current_task is not None
+        actor_id = actor_scope.user_concept_id
+        # Ordinary continuation may revise the work, but cannot transfer its
+        # ownership or widen its audience through the general parity editor.
+        continuation_fields = {
+            "status",
+            "title",
+            "description",
+            "priority",
+            "task_type_ids",
+            "task_role",
+            "next_checkpoint",
+            "progress_signal",
+            "evidence",
+            "notes",
+            "start_date",
+            "due_date",
+            "current_work_product_concept_id",
+            "assignee_concept_id",
+            "report_to_concept_id",
+        }
+        unsupported = sorted(set(fields) - continuation_fields)
+        if unsupported:
+            return make_error_response(
+                "task_continuation_fields_denied",
+                f"Fields outside ordinary task continuation: {unsupported}",
+            )
+        from ...services.task_execution_service import VON_SYSTEM_CONCEPT_ID
+
+        if "assignee_concept_id" in fields:
+            if (
+                fields["assignee_concept_id"] not in (actor_id, VON_SYSTEM_CONCEPT_ID)
+                or current_task.get("created_by_concept_id") != actor_id
+            ):
+                return make_error_response(
+                    "task_assignment_scope_denied",
+                    "The task creator may assign continuing work to themselves or Von.",
+                )
+        if "report_to_concept_id" in fields and fields["report_to_concept_id"] not in (
+            None,
+            "",
+            actor_id,
+        ):
+            return make_error_response(
+                "task_report_scope_denied",
+                "Ordinary task continuation may report to the authenticated actor.",
+            )
+        # Do not append another history event or replace an unchanged relation
+        # when a model retries an already successful continuation update.
+        product = current_task.get("current_work_product") or {}
+        current_product_id = (
+            object()
+            if product.get("status") in {"unavailable", "ambiguous_link"}
+            else product.get("concept_id")
+        )
+        fields = {
+            key: value
+            for key, value in fields.items()
+            if value
+            != (
+                current_product_id
+                if key == "current_work_product_concept_id"
+                else current_task.get(key)
+            )
+        }
+        if not fields:
+            return {
+                "success": True,
+                "task": current_task,
+                "changed_fields": [],
+                "warnings": [],
+                "effect_status": "succeeded",
+                "changed": False,
+                "idempotent_replay": True,
+                "canonical_read_back": current_task,
+            }
+
     try:
         result = update_task_fields(
             task_id,
             fields=fields,
-            actor_concept_id=kwargs.get("actor_concept_id") or kwargs.get("namespace"),
+            actor_concept_id=actor_id,
         )
         result["success"] = True
+        if kwargs.get("actor_bound_continuation") is True:
+            result.update(
+                effect_status="succeeded",
+                changed=bool(result.get("changed_fields")),
+                idempotent_replay=not bool(result.get("changed_fields")),
+                canonical_read_back=result["task"],
+            )
         return result
     except TaskNotFoundError as exc:
         return make_error_response("NOT_FOUND", str(exc))
@@ -44392,6 +44483,9 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                     "fields": (dict,),
                     "actor_concept_id": (str, type(None)),
                     "namespace": (str, type(None)),
+                    "acting_user_concept_id": (str, type(None)),
+                    "organisation_concept_id": (str, type(None)),
+                    "actor_bound_continuation": (bool,),
                 },
                 allow_unknown=True,
                 scalar_source_fields={
@@ -44406,14 +44500,35 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                     "evidence, notes, reference_code, start_date, due_date, labels, "
                     "components, fix_versions, sprint_values, backlog_rank, "
                     "reporter_concept_id, watcher_concept_ids, parent_task_concept_id, "
-                    "epic_task_concept_id."
+                    "epic_task_concept_id, current_work_product_concept_id. "
+                    "For ordinary continuation use title, description, status, priority, "
+                    "task_type_ids, task_role, next_checkpoint, progress_signal, evidence, "
+                    "notes, start_date, due_date, current_work_product_concept_id, "
+                    "assignee_concept_id (self or #V#von_system, creator only), and "
+                    "report_to_concept_id (self)."
                 ),
             ),
             output_schema=task_update_fields_output_schema,
             category="write",
+            ordinary_turn_trusted_argument_bindings={
+                "actor_concept_id": "actor_user_concept_id",
+                "acting_user_concept_id": "actor_user_concept_id",
+                "organisation_concept_id": "actor_organisation_concept_id",
+                "namespace": "turn_namespace",
+            },
+            ordinary_turn_fixed_arguments={"actor_bound_continuation": True},
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="task_concept_id",
             description=(
-                "Update multiple task fields atomically from an MCP perspective. "
-                "Useful for Jira-style edit operations."
+                "Revise an existing task and its next checkpoint, evidence, or notes. "
+                "Attach the canonical current work product with "
+                "current_work_product_concept_id so it opens from Tasks; its readable "
+                "body belongs in the product's actor-effective hasContent. For a "
+                "continuing responsibility delegated to Von, the creator can assign "
+                "it to #V#von_system and set report_to_concept_id to themselves. "
+                "This preserves the task and does not launch execution or a schedule. "
+                "Ordinary chat edits only tasks created by or assigned to the "
+                "authenticated actor in the same organisation."
             ),
         ),
         MethodDefinition(

--- a/src/backend/server/routes/task_routes.py
+++ b/src/backend/server/routes/task_routes.py
@@ -4,7 +4,6 @@ Provides endpoints for creating, reading, updating, and deleting tasks.
 Tasks are stored as Vontology concepts.
 """
 
-import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -13,22 +12,14 @@ from typing import Any
 from flask import Blueprint, jsonify, redirect, request, session, url_for
 from flask.typing import ResponseReturnValue
 
-from ...services import chat_history_service, chat_prompt_queue_service
-from ...services.chat_prompt_queue_dispatch_service import (
-    wake_chat_prompt_queue_dispatcher,
-)
-from ...services.conversation_concept_service import get_conversation_concept
-from ...services.conversation_turn_admission_service import build_conversation_key
+from ...services import chat_prompt_queue_service
 from ...services.namespace_service import resolve_canonical_namespace
+from ...services.task_execution_submission_service import submit_task_execution
 from ...services.task_execution_service import (
-    VON_SYSTEM_CONCEPT_ID,
     InvalidTaskExecutionData,
     TaskExecutionAccessError,
     TaskExecutionNotFoundError,
     TaskExecutionTransitionError,
-    reconcile_task_execution_queue_record,
-    task_execution_concept_id_for_launch,
-    task_execution_enqueue_submission_id_for_launch,
 )
 from ...services.task_external_resource_action_service import (
     TaskExternalResourceActionAccessError,
@@ -244,161 +235,6 @@ def _get_task_execution_actor_context() -> dict[str, str]:
     }
 
 
-def _resolve_task_execution_conversation(
-    *,
-    task: dict[str, Any],
-    actor_context: dict[str, str],
-) -> dict[str, Any]:
-    """Read back the task's actor-owned originating conversation."""
-
-    task_org_id = task.get("organisation_concept_id")
-    if task_org_id != actor_context["organisation_concept_id"]:
-        raise TaskExecutionAccessError(
-            "task_organisation_mismatch",
-            "The task does not belong to the active organisation",
-        )
-    if task.get("assignee_concept_id") != VON_SYSTEM_CONCEPT_ID:
-        raise TaskExecutionAccessError(
-            "task_not_assigned_to_von",
-            "The task must be assigned to Von before it can be executed",
-        )
-    if task.get("created_by_concept_id") != actor_context["actor_concept_id"]:
-        raise TaskExecutionAccessError(
-            "task_creator_mismatch",
-            "Only the task creator can authorise Von to execute this task",
-        )
-    if str(task.get("status") or "").strip().lower() not in {
-        "pending",
-        "in_progress",
-    }:
-        raise TaskExecutionAccessError(
-            "task_not_executable",
-            "Only a pending or in-progress task can be executed",
-        )
-    conversation_id = task.get("originating_conversation_id")
-    if not isinstance(conversation_id, str) or not conversation_id.strip():
-        raise TaskExecutionAccessError(
-            "originating_conversation_required",
-            "The task must be associated with an originating conversation",
-        )
-    conversation = get_conversation_concept(conversation_id.strip())
-    if not isinstance(conversation, dict):
-        raise TaskExecutionAccessError(
-            "originating_conversation_unavailable",
-            "The originating conversation is not accessible",
-        )
-    actor_id = actor_context["actor_concept_id"]
-    org_id = actor_context["organisation_concept_id"]
-    namespace = actor_context["namespace"]
-    if conversation.get("owner_concept_id") != actor_id:
-        raise TaskExecutionAccessError(
-            "originating_conversation_owner_mismatch",
-            "The originating conversation belongs to a different actor",
-        )
-    conversation_org_id = conversation.get("organisation_concept_id")
-    if conversation_org_id != org_id:
-        raise TaskExecutionAccessError(
-            "originating_conversation_organisation_mismatch",
-            "The originating conversation belongs to a different organisation",
-        )
-    conversation_namespace = conversation.get("namespace")
-    if conversation_namespace:
-        canonical_conversation_namespace = resolve_canonical_namespace(
-            conversation_namespace,
-            actor_id,
-            org_id,
-        )
-        if canonical_conversation_namespace != namespace:
-            raise TaskExecutionAccessError(
-                "originating_conversation_namespace_mismatch",
-                "The originating conversation belongs to a different namespace",
-            )
-    session_id = conversation.get("session_id")
-    if not isinstance(session_id, str) or not session_id.strip():
-        raise TaskExecutionAccessError(
-            "originating_conversation_session_required",
-            "The originating conversation has no session identifier",
-        )
-    session_id = session_id.strip()
-    task_session_id = task.get("conversation_session_id")
-    if task_session_id and task_session_id != session_id:
-        raise TaskExecutionAccessError(
-            "originating_conversation_session_mismatch",
-            "The task and originating conversation session identifiers differ",
-        )
-    if not chat_history_service.has_chat_history_session(
-        actor_id,
-        session_id,
-        namespace=namespace,
-        include_legacy=False,
-    ):
-        raise TaskExecutionAccessError(
-            "originating_conversation_history_unavailable",
-            "The originating conversation history is not available in this scope",
-        )
-    resolved = dict(task)
-    resolved["originating_conversation_id"] = conversation_id.strip()
-    resolved["conversation_session_id"] = session_id
-    resolved["conversation_name"] = (
-        conversation.get("name")
-        or conversation.get("topic")
-        or task.get("conversation_name")
-    )
-    return resolved
-
-
-def _build_task_execution_prompt(task: dict[str, Any]) -> str:
-    """Project the selected task and canonical references, not a shadow product."""
-    product = task.get("current_work_product") or {"status": "missing"}
-    instruction = task.get("continuation_instruction", "")
-    parts = [
-        "Execute the task assigned to Von.",
-        f"Task concept ID: {task.get('task_concept_id', '')}",
-        f"Title: {task.get('title') or 'Untitled task'}",
-    ]
-    if instruction:
-        parts.append(f"New user instruction: {instruction}")
-    parts.extend(
-        [
-            f"Current work product: {json.dumps(product, ensure_ascii=False)}",
-            f"Next checkpoint / unresolved questions: {task.get('next_checkpoint') or ''}",
-            f"Evidence: {task.get('evidence') or ''}",
-            f"Notes: {task.get('notes') or ''}",
-            f"Description: {task.get('description') or ''}",
-        ]
-    )
-    return "\n".join(parts)[: chat_prompt_queue_service.MAX_PROMPT_RAW_CHARS]
-
-
-def _enqueue_task_execution(
-    *,
-    scope: dict[str, str],
-    task: dict[str, Any],
-    task_execution_concept_id: str,
-    enqueue_submission_id: str,
-    execution_envelope: dict[str, Any],
-    conversation_key: str,
-) -> dict[str, Any]:
-    """Narrow adapter around the durable server-dispatch queue contract."""
-
-    return chat_prompt_queue_service.create_queue_record(
-        scope=scope,
-        prompt_raw=_build_task_execution_prompt(task),
-        session_id=task["conversation_session_id"],
-        session_name=task.get("conversation_name"),
-        status=chat_prompt_queue_service.STATUS_QUEUED,
-        source="von_task",
-        conversation_key=conversation_key,
-        enqueue_submission_id=enqueue_submission_id,
-        dispatch_mode=chat_prompt_queue_service.DISPATCH_MODE_SERVER,
-        execution_envelope_version=1,
-        execution_envelope=execution_envelope,
-        task_concept_id=task["task_concept_id"],
-        task_execution_concept_id=task_execution_concept_id,
-        server_dispatch_ready=False,
-    )
-
-
 def _task_execution_error_response(exc: Exception) -> ResponseReturnValue:
     if isinstance(exc, TaskExecutionAccessError):
         status = 401 if exc.reason_code == "not_authenticated" else 403
@@ -445,173 +281,17 @@ def _task_execution_error_response(exc: Exception) -> ResponseReturnValue:
 
 @task_bp.route("/<task_concept_id>/execute-with-von", methods=["POST"])
 def execute_task_with_von_route(task_concept_id: str) -> ResponseReturnValue:
-    """Explicitly launch one actor-bound Von execution for a task."""
-
-    task_execution: dict[str, Any] | None = None
-    queue_record: dict[str, Any] | None = None
-    actor_context: dict[str, str] | None = None
-    task: dict[str, Any] | None = None
+    """Launch the same actor-bound task operation used by scheduled work."""
     try:
-        actor_context = _get_task_execution_actor_context()
-        # A task point read is not sufficient authority by itself. Bind it to
-        # the trusted creator, active organisation, and actor-owned originating
-        # conversation instead of accepting any request payload scope.
-        task = _resolve_task_execution_conversation(
-            task=dict(get_task(task_concept_id)),
-            actor_context=actor_context,
+        result, status = submit_task_execution(
+            task_concept_id,
+            actor_context=_get_task_execution_actor_context(),
+            payload=request.get_json(silent=True) or {},
         )
-        payload = request.get_json(silent=True)
-        payload = payload if isinstance(payload, dict) else {}
-        instruction = payload.get("continuation_instruction", "")
-        if not isinstance(instruction, str) or len(instruction) > 4000:
-            raise InvalidTaskExecutionData(
-                "continuation_instruction must be text of at most 4000 characters"
-            )
-        task["continuation_instruction"] = instruction.strip()
-        requested_session_id = payload.get("originating_session_id")
-        if requested_session_id is not None and requested_session_id != task.get(
-            "conversation_session_id"
-        ):
-            raise TaskExecutionAccessError(
-                "originating_conversation_session_mismatch",
-                "The requested conversation does not match the task",
-            )
-        launch_request_id = payload.get("launch_request_id")
-        if launch_request_id is None:
-            raise InvalidTaskExecutionData("launch_request_id is required")
-        if not isinstance(launch_request_id, str) or not launch_request_id.strip():
-            raise InvalidTaskExecutionData("launch_request_id must be a string")
-        launch_request_id = launch_request_id.strip()
-        if len(launch_request_id) > 200:
-            raise InvalidTaskExecutionData("launch_request_id is too long")
-
-        execution_concept_id = task_execution_concept_id_for_launch(
-            task_concept_id=task["task_concept_id"],
-            creator_concept_id=actor_context["actor_concept_id"],
-            organisation_concept_id=actor_context["organisation_concept_id"],
-            launch_request_id=launch_request_id,
-        )
-        enqueue_submission_id = task_execution_enqueue_submission_id_for_launch(
-            task_concept_id=task["task_concept_id"],
-            creator_concept_id=actor_context["actor_concept_id"],
-            organisation_concept_id=actor_context["organisation_concept_id"],
-            launch_request_id=launch_request_id,
-        )
-        execution_envelope = {
-            "initiation_id": launch_request_id,
-            "turn_kind": "user_message",
-            "workflow_inputs": {
-                "task_concept_id": task["task_concept_id"],
-                "task_execution_concept_id": execution_concept_id,
-                "originating_conversation_concept_id": task[
-                    "originating_conversation_id"
-                ],
-                "conversation_session_id": task["conversation_session_id"],
-                "authority_actor_concept_id": actor_context["actor_concept_id"],
-                "authority_organisation_concept_id": actor_context[
-                    "organisation_concept_id"
-                ],
-                "authority_namespace": actor_context["namespace"],
-                "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
-            },
-        }
-        scope = {
-            "user_concept_id": actor_context["actor_concept_id"],
-            "organisation_concept_id": actor_context["organisation_concept_id"],
-            "namespace": actor_context["namespace"],
-        }
-        conversation_key = build_conversation_key(
-            owner_user_id=actor_context["actor_concept_id"],
-            history_namespace=actor_context["namespace"],
-            conversation_session_id=task["conversation_session_id"],
-        )
-        queue_record = _enqueue_task_execution(
-            scope=scope,
-            task=task,
-            task_execution_concept_id=execution_concept_id,
-            enqueue_submission_id=enqueue_submission_id,
-            execution_envelope=execution_envelope,
-            conversation_key=conversation_key,
-        )
-        queue_replayed = bool(queue_record.get("idempotent_replay"))
-        task_execution = reconcile_task_execution_queue_record(
-            {
-                **queue_record,
-                **scope,
-                "execution_envelope": execution_envelope,
-            }
-        )
-        if (
-            queue_record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
-            and not queue_record.get("dispatch_ready")
-        ):
-            queue_record = chat_prompt_queue_service.activate_server_dispatch_record(
-                scope=scope,
-                queue_id=str(queue_record["queue_id"]),
-                enqueue_submission_id=enqueue_submission_id,
-                task_execution_concept_id=execution_concept_id,
-            )
-            queue_record["idempotent_replay"] = queue_replayed
-        wake_chat_prompt_queue_dispatcher()
-        return jsonify(
-            {
-                "success": True,
-                "task": {
-                    "task_concept_id": task["task_concept_id"],
-                    "title": task.get("title"),
-                    "originating_conversation_id": task[
-                        "originating_conversation_id"
-                    ],
-                    "conversation_session_id": task["conversation_session_id"],
-                    "conversation_name": task.get("conversation_name"),
-                },
-                "task_execution": task_execution,
-                "queue_item": queue_record,
-                "idempotent_replay": queue_replayed,
-            }
-        ), (200 if queue_replayed else 201)
+        return jsonify(result), status
     except TaskNotFoundError as exc:
         return jsonify({"success": False, "error": str(exc)}), 404
-    except Exception as exc:  # noqa: BLE001 - preserve route error boundary
-        # Once the unready queue outbox exists, do not delete it on an unknown
-        # projection acknowledgement. The server dispatcher owns durable
-        # reconciliation and the exact client launch ID makes retries safe.
-        if (
-            queue_record
-            and actor_context
-            and task
-            and queue_record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
-            and not queue_record.get("dispatch_ready")
-        ):
-            logger.warning(
-                "Task launch accepted for durable reconciliation queue_id=%s: %s",
-                queue_record.get("queue_id"),
-                exc,
-            )
-            wake_chat_prompt_queue_dispatcher()
-            return jsonify(
-                {
-                    "success": True,
-                    "reconciliation_pending": True,
-                    "warning": "Task execution projection is being reconciled",
-                    "task": {
-                        "task_concept_id": task["task_concept_id"],
-                        "title": task.get("title"),
-                        "originating_conversation_id": task[
-                            "originating_conversation_id"
-                        ],
-                        "conversation_session_id": task[
-                            "conversation_session_id"
-                        ],
-                        "conversation_name": task.get("conversation_name"),
-                    },
-                    "task_execution": None,
-                    "queue_item": queue_record,
-                    "idempotent_replay": bool(
-                        queue_record.get("idempotent_replay")
-                    ),
-                }
-            ), 202
+    except Exception as exc:
         return _task_execution_error_response(exc)
 
 

--- a/src/backend/services/task_execution_submission_service.py
+++ b/src/backend/services/task_execution_submission_service.py
@@ -1,0 +1,370 @@
+"""Canonical task launch shared by Tasks and durable schedule occurrences.
+
+Callers supply an already authenticated actor context. Task/conversation
+ownership, active-execution deduplication and the queue outbox are checked here;
+task descriptions and changing work products remain canonical task references.
+An accepted launch is not a claim that the task's work has succeeded.
+"""
+
+import json
+import logging
+from typing import Any
+
+from . import chat_history_service, chat_prompt_queue_service
+from .chat_prompt_queue_dispatch_service import wake_chat_prompt_queue_dispatcher
+from .conversation_concept_service import get_conversation_concept
+from .conversation_turn_admission_service import build_conversation_key
+from .namespace_service import resolve_canonical_namespace
+from .task_execution_service import (
+    VON_SYSTEM_CONCEPT_ID,
+    InvalidTaskExecutionData,
+    TaskExecutionAccessError,
+    reconcile_task_execution_queue_record,
+    task_execution_concept_id_for_launch,
+    task_execution_enqueue_submission_id_for_launch,
+)
+from .task_management_service import get_task
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_task_execution_conversation(
+    *,
+    task: dict[str, Any],
+    actor_context: dict[str, str],
+) -> dict[str, Any]:
+    """Read back the task's actor-owned originating conversation."""
+
+    task_org_id = task.get("organisation_concept_id")
+    if task_org_id != actor_context["organisation_concept_id"]:
+        raise TaskExecutionAccessError(
+            "task_organisation_mismatch",
+            "The task does not belong to the active organisation",
+        )
+    if task.get("assignee_concept_id") != VON_SYSTEM_CONCEPT_ID:
+        raise TaskExecutionAccessError(
+            "task_not_assigned_to_von",
+            "The task must be assigned to Von before it can be executed",
+        )
+    if task.get("created_by_concept_id") != actor_context["actor_concept_id"]:
+        raise TaskExecutionAccessError(
+            "task_creator_mismatch",
+            "Only the task creator can authorise Von to execute this task",
+        )
+    if str(task.get("status") or "").strip().lower() not in {
+        "pending",
+        "in_progress",
+    }:
+        raise TaskExecutionAccessError(
+            "task_not_executable",
+            "Only a pending or in-progress task can be executed",
+        )
+    conversation_id = task.get("originating_conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id.strip():
+        raise TaskExecutionAccessError(
+            "originating_conversation_required",
+            "The task must be associated with an originating conversation",
+        )
+    conversation = get_conversation_concept(conversation_id.strip())
+    if not isinstance(conversation, dict):
+        raise TaskExecutionAccessError(
+            "originating_conversation_unavailable",
+            "The originating conversation is not accessible",
+        )
+    actor_id = actor_context["actor_concept_id"]
+    org_id = actor_context["organisation_concept_id"]
+    namespace = actor_context["namespace"]
+    if conversation.get("owner_concept_id") != actor_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_owner_mismatch",
+            "The originating conversation belongs to a different actor",
+        )
+    conversation_org_id = conversation.get("organisation_concept_id")
+    if conversation_org_id != org_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_organisation_mismatch",
+            "The originating conversation belongs to a different organisation",
+        )
+    conversation_namespace = conversation.get("namespace")
+    if conversation_namespace:
+        canonical_conversation_namespace = resolve_canonical_namespace(
+            conversation_namespace,
+            actor_id,
+            org_id,
+        )
+        if canonical_conversation_namespace != namespace:
+            raise TaskExecutionAccessError(
+                "originating_conversation_namespace_mismatch",
+                "The originating conversation belongs to a different namespace",
+            )
+    session_id = conversation.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise TaskExecutionAccessError(
+            "originating_conversation_session_required",
+            "The originating conversation has no session identifier",
+        )
+    session_id = session_id.strip()
+    task_session_id = task.get("conversation_session_id")
+    if task_session_id and task_session_id != session_id:
+        raise TaskExecutionAccessError(
+            "originating_conversation_session_mismatch",
+            "The task and originating conversation session identifiers differ",
+        )
+    if not chat_history_service.has_chat_history_session(
+        actor_id,
+        session_id,
+        namespace=namespace,
+        include_legacy=False,
+    ):
+        raise TaskExecutionAccessError(
+            "originating_conversation_history_unavailable",
+            "The originating conversation history is not available in this scope",
+        )
+    resolved = dict(task)
+    resolved["originating_conversation_id"] = conversation_id.strip()
+    resolved["conversation_session_id"] = session_id
+    resolved["conversation_name"] = (
+        conversation.get("name")
+        or conversation.get("topic")
+        or task.get("conversation_name")
+    )
+    return resolved
+
+
+def _build_task_execution_prompt(task: dict[str, Any]) -> str:
+    """Project the selected task and canonical references, not a shadow product."""
+    product = task.get("current_work_product") or {"status": "missing"}
+    instruction = task.get("continuation_instruction", "")
+    parts = [
+        "Execute the task assigned to Von.",
+        f"Task concept ID: {task.get('task_concept_id', '')}",
+        f"Title: {task.get('title') or 'Untitled task'}",
+    ]
+    if instruction:
+        parts.append(f"New user instruction: {instruction}")
+    parts.extend(
+        [
+            f"Current work product: {json.dumps(product, ensure_ascii=False)}",
+            f"Next checkpoint / unresolved questions: {task.get('next_checkpoint') or ''}",
+            f"Evidence: {task.get('evidence') or ''}",
+            f"Notes: {task.get('notes') or ''}",
+            f"Description: {task.get('description') or ''}",
+        ]
+    )
+    return "\n".join(parts)[: chat_prompt_queue_service.MAX_PROMPT_RAW_CHARS]
+
+
+def _enqueue_task_execution(
+    *,
+    scope: dict[str, str],
+    task: dict[str, Any],
+    task_execution_concept_id: str,
+    enqueue_submission_id: str,
+    execution_envelope: dict[str, Any],
+    conversation_key: str,
+) -> dict[str, Any]:
+    """Narrow adapter around the durable server-dispatch queue contract."""
+
+    return chat_prompt_queue_service.create_queue_record(
+        scope=scope,
+        prompt_raw=_build_task_execution_prompt(task),
+        session_id=task["conversation_session_id"],
+        session_name=task.get("conversation_name"),
+        status=chat_prompt_queue_service.STATUS_QUEUED,
+        source="von_task",
+        conversation_key=conversation_key,
+        enqueue_submission_id=enqueue_submission_id,
+        dispatch_mode=chat_prompt_queue_service.DISPATCH_MODE_SERVER,
+        execution_envelope_version=1,
+        execution_envelope=execution_envelope,
+        task_concept_id=task["task_concept_id"],
+        task_execution_concept_id=task_execution_concept_id,
+        server_dispatch_ready=False,
+    )
+
+
+def submit_task_execution(
+    task_concept_id: str,
+    *,
+    actor_context: dict[str, str],
+    payload: dict[str, Any],
+    model: str | None = None,
+    model_provider: str | None = None,
+    model_parameters: dict[str, Any] | None = None,
+    source_workflow_instance_id: str | None = None,
+) -> tuple[dict[str, Any], int]:
+    """Submit/reconcile one launch; keep its outbox on an uncertain receipt."""
+
+    task_execution: dict[str, Any] | None = None
+    queue_record: dict[str, Any] | None = None
+    task: dict[str, Any] | None = None
+    try:
+        # A task point read is not sufficient authority by itself. Bind it to
+        # the trusted creator, active organisation, and actor-owned originating
+        # conversation instead of accepting any request payload scope.
+        task = _resolve_task_execution_conversation(
+            task=dict(get_task(task_concept_id)),
+            actor_context=actor_context,
+        )
+        payload = payload if isinstance(payload, dict) else {}
+        instruction = payload.get("continuation_instruction", "")
+        if not isinstance(instruction, str) or len(instruction) > 4000:
+            raise InvalidTaskExecutionData(
+                "continuation_instruction must be text of at most 4000 characters"
+            )
+        task["continuation_instruction"] = instruction.strip()
+        requested_session_id = payload.get("originating_session_id")
+        if requested_session_id is not None and requested_session_id != task.get(
+            "conversation_session_id"
+        ):
+            raise TaskExecutionAccessError(
+                "originating_conversation_session_mismatch",
+                "The requested conversation does not match the task",
+            )
+        launch_request_id = payload.get("launch_request_id")
+        if launch_request_id is None:
+            raise InvalidTaskExecutionData("launch_request_id is required")
+        if not isinstance(launch_request_id, str) or not launch_request_id.strip():
+            raise InvalidTaskExecutionData("launch_request_id must be a string")
+        launch_request_id = launch_request_id.strip()
+        if len(launch_request_id) > 200:
+            raise InvalidTaskExecutionData("launch_request_id is too long")
+
+        execution_concept_id = task_execution_concept_id_for_launch(
+            task_concept_id=task["task_concept_id"],
+            creator_concept_id=actor_context["actor_concept_id"],
+            organisation_concept_id=actor_context["organisation_concept_id"],
+            launch_request_id=launch_request_id,
+        )
+        enqueue_submission_id = task_execution_enqueue_submission_id_for_launch(
+            task_concept_id=task["task_concept_id"],
+            creator_concept_id=actor_context["actor_concept_id"],
+            organisation_concept_id=actor_context["organisation_concept_id"],
+            launch_request_id=launch_request_id,
+        )
+        execution_envelope = {
+            "initiation_id": launch_request_id,
+            "turn_kind": "user_message",
+            "workflow_inputs": {
+                "task_concept_id": task["task_concept_id"],
+                "task_execution_concept_id": execution_concept_id,
+                "originating_conversation_concept_id": task[
+                    "originating_conversation_id"
+                ],
+                "conversation_session_id": task["conversation_session_id"],
+                "authority_actor_concept_id": actor_context["actor_concept_id"],
+                "authority_organisation_concept_id": actor_context[
+                    "organisation_concept_id"
+                ],
+                "authority_namespace": actor_context["namespace"],
+                "executor_concept_id": VON_SYSTEM_CONCEPT_ID,
+            },
+        }
+        if model:
+            from ..languagemodels.llm_interface import assert_model_execution_allowed
+
+            assert_model_execution_allowed(
+                provider=model_provider,
+                model=model,
+                user_concept_id=actor_context["actor_concept_id"],
+                org_concept_id=actor_context["organisation_concept_id"],
+            )
+            execution_envelope["model"] = model
+            execution_envelope["model_provider"] = model_provider
+        if model_parameters:
+            execution_envelope["model_parameters"] = dict(model_parameters)
+        if source_workflow_instance_id:
+            execution_envelope["workflow_inputs"][
+                "source_workflow_instance_id"
+            ] = source_workflow_instance_id
+        scope = {
+            "user_concept_id": actor_context["actor_concept_id"],
+            "organisation_concept_id": actor_context["organisation_concept_id"],
+            "namespace": actor_context["namespace"],
+        }
+        conversation_key = build_conversation_key(
+            owner_user_id=actor_context["actor_concept_id"],
+            history_namespace=actor_context["namespace"],
+            conversation_session_id=task["conversation_session_id"],
+        )
+        queue_record = _enqueue_task_execution(
+            scope=scope,
+            task=task,
+            task_execution_concept_id=execution_concept_id,
+            enqueue_submission_id=enqueue_submission_id,
+            execution_envelope=execution_envelope,
+            conversation_key=conversation_key,
+        )
+        queue_replayed = bool(queue_record.get("idempotent_replay"))
+        task_execution = reconcile_task_execution_queue_record(
+            {
+                **queue_record,
+                **scope,
+                "execution_envelope": execution_envelope,
+            }
+        )
+        if queue_record.get(
+            "status"
+        ) == chat_prompt_queue_service.STATUS_QUEUED and not queue_record.get(
+            "dispatch_ready"
+        ):
+            queue_record = chat_prompt_queue_service.activate_server_dispatch_record(
+                scope=scope,
+                queue_id=str(queue_record["queue_id"]),
+                enqueue_submission_id=enqueue_submission_id,
+                task_execution_concept_id=execution_concept_id,
+            )
+            queue_record["idempotent_replay"] = queue_replayed
+        wake_chat_prompt_queue_dispatcher()
+        return (
+            {
+                "success": True,
+                "task": {
+                    "task_concept_id": task["task_concept_id"],
+                    "title": task.get("title"),
+                    "originating_conversation_id": task["originating_conversation_id"],
+                    "conversation_session_id": task["conversation_session_id"],
+                    "conversation_name": task.get("conversation_name"),
+                },
+                "task_execution": task_execution,
+                "queue_item": queue_record,
+                "idempotent_replay": queue_replayed,
+            }
+        ), (200 if queue_replayed else 201)
+    except Exception as exc:
+        # Once the unready queue outbox exists, do not delete it on an unknown
+        # projection acknowledgement. The server dispatcher owns durable
+        # reconciliation and the exact client launch ID makes retries safe.
+        if (
+            queue_record
+            and actor_context
+            and task
+            and queue_record.get("status") == chat_prompt_queue_service.STATUS_QUEUED
+            and not queue_record.get("dispatch_ready")
+        ):
+            logger.warning(
+                "Task launch accepted for durable reconciliation queue_id=%s: %s",
+                queue_record.get("queue_id"),
+                exc,
+            )
+            wake_chat_prompt_queue_dispatcher()
+            return (
+                {
+                    "success": True,
+                    "reconciliation_pending": True,
+                    "warning": "Task execution projection is being reconciled",
+                    "task": {
+                        "task_concept_id": task["task_concept_id"],
+                        "title": task.get("title"),
+                        "originating_conversation_id": task[
+                            "originating_conversation_id"
+                        ],
+                        "conversation_session_id": task["conversation_session_id"],
+                        "conversation_name": task.get("conversation_name"),
+                    },
+                    "task_execution": None,
+                    "queue_item": queue_record,
+                    "idempotent_replay": bool(queue_record.get("idempotent_replay")),
+                }
+            ), 202
+        raise

--- a/src/backend/workflows/durable/registry_factory.py
+++ b/src/backend/workflows/durable/registry_factory.py
@@ -2075,6 +2075,7 @@ def _register_durable_action_modules(registry: ActionRegistry) -> None:
     from .testing_workflow_actions import register_testing_workflow_actions
     from .tool_result_hint_actions import register_tool_result_hint_actions
     from .turn_execution_actions import register_turn_execution_actions
+    from .task_execution_actions import register_task_execution_actions
     from .workflow_creation_workflow import register_workflow_creation_actions
     from .workflow_introspection_maintenance_workflow import (
         register_workflow_introspection_maintenance_actions,
@@ -2121,6 +2122,7 @@ def _register_durable_action_modules(registry: ActionRegistry) -> None:
     register_tool_result_hint_actions(registry)
     register_workflow_mcp_tool_actions(registry)
     register_turn_execution_actions(registry)
+    register_task_execution_actions(registry)
 
 
 def build_durable_action_registry() -> ActionRegistry:

--- a/src/backend/workflows/durable/task_execution_actions.py
+++ b/src/backend/workflows/durable/task_execution_actions.py
@@ -1,0 +1,106 @@
+"""Resume a canonical task through the same queue used by the Tasks UI.
+
+This action submits work. Its receipt says nothing about domain completion;
+the linked TaskExecution and conversation retain progress and outcome evidence.
+"""
+
+from ...services.chat_prompt_queue_service import ChatPromptQueueTaskAlreadyActive
+from ...services.task_execution_submission_service import submit_task_execution
+from ...services.workflow_actor_scope_service import (
+    resolve_authoritative_workflow_actor_scope,
+)
+from ..action_registry import (
+    ActionRegistry,
+    ActionSpec,
+    WorkflowActionRequest,
+    WorkflowActionResult,
+)
+
+TASK_SUBMIT_EXECUTION_ACTION_ID = "task.submit_execution"
+
+
+def submit_task_execution_action(
+    request: WorkflowActionRequest,
+) -> WorkflowActionResult:
+    try:
+        # The durable worker installs the actor persisted on the instance.
+        # Workflow inputs cannot replace that actor or choose another owner.
+        scope = resolve_authoritative_workflow_actor_scope(allow_unscoped_claims=False)
+        if not scope.user_concept_id or not scope.organisation_concept_id:
+            raise ValueError("task_execution_actor_and_organisation_required")
+        instance_id = getattr(request.trace, "instance_id", None)
+        if not isinstance(instance_id, str) or not instance_id:
+            raise ValueError("task_execution_durable_instance_required")
+        task_id = request.inputs.get("task_concept_id")
+        if not isinstance(task_id, str) or not task_id.strip():
+            raise ValueError("task_concept_id_required")
+        model = request.inputs.get("model")
+        provider = request.inputs.get("model_provider")
+        if (
+            not isinstance(model, str)
+            or not model.strip()
+            or not isinstance(provider, str)
+            or not provider.strip()
+        ):
+            raise ValueError("task_execution_explicit_model_and_provider_required")
+        parameters = request.inputs.get("model_parameters")
+        if parameters is not None and not isinstance(parameters, dict):
+            raise ValueError("task_execution_model_parameters_invalid")
+        result, status = submit_task_execution(
+            task_id.strip(),
+            actor_context={
+                "actor_concept_id": scope.user_concept_id,
+                "organisation_concept_id": scope.organisation_concept_id,
+                "namespace": scope.namespace,
+            },
+            payload={
+                "launch_request_id": f"workflow-task:{instance_id}",
+                "continuation_instruction": request.inputs.get(
+                    "continuation_instruction"
+                )
+                or "",
+            },
+            model=model.strip(),
+            model_provider=provider.strip(),
+            model_parameters=parameters,
+            source_workflow_instance_id=instance_id,
+        )
+        queue = result["queue_item"]
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "task_launch_status": "accepted",
+                "task_concept_id": task_id.strip(),
+                "queue_id": queue["queue_id"],
+                "task_execution_concept_id": queue.get("task_execution_concept_id"),
+                "conversation_session_id": queue.get("session_id"),
+                "queue_status": queue.get("status"),
+                "idempotent_replay": bool(result.get("idempotent_replay")),
+                "reconciliation_pending": status == 202,
+                "domain_completion_claim": False,
+            },
+        )
+    except ChatPromptQueueTaskAlreadyActive as exc:
+        # UI and schedule launches meet at the queue's atomic task key. A
+        # later occurrence coalesces here even after this launch workflow ends.
+        return WorkflowActionResult(
+            status="success",
+            outputs={
+                "task_launch_status": "already_active",
+                "queue_id": exc.queue_id,
+                "task_execution_concept_id": exc.task_execution_concept_id,
+                "domain_completion_claim": False,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve the durable action failure receipt
+        return WorkflowActionResult(status="failed", error=str(exc))
+
+
+def register_task_execution_actions(registry: ActionRegistry) -> None:
+    registry.register_if_absent(
+        ActionSpec(
+            action_id=TASK_SUBMIT_EXECUTION_ACTION_ID,
+            handler=submit_task_execution_action,
+            description="Submit one actor-owned task continuation through the canonical Tasks queue; coalesce an already active execution.",
+        )
+    )

--- a/src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json
@@ -1,0 +1,55 @@
+{
+  "family_id": "task_continuation_workflow_seed_bundle",
+  "managed_by": "workflow_repo_seed_bootstrap",
+  "schema_version": "repo_seed_workflow_bundle.v1",
+  "seed_version": "1",
+  "source_tag": "JVNAUTOSCI-2244",
+  "supported_action_ids": ["task.submit_execution"],
+  "workflows": [{
+    "workflow_id": "#V#task_continuation_workflow",
+    "display_name": "Continue a Task with Von",
+    "description": "Resume an existing task assigned to Von through its canonical conversation and Tasks execution queue. Suitable for a recurring responsibility whose current work product, guidance and checkpoints evolve between encounters. Accepting a launch does not establish completion of the task's work.",
+    "content": "Read the current actor-owned task and its current work-product reference, validate its originating conversation, and submit one continuation through the same deduplicated queue as Continue with Von in Tasks. Repeated attempts of one durable instance reuse its launch; a later occurrence coalesces with any active execution of this task, including a launch from Tasks. The task, work product and conversation carry domain requirements, chosen components, preferences, unfinished work and outcome evidence. This workflow adds no domain policy or copied work-product store. Inspect the returned queue and TaskExecution for the actual work outcome.",
+    "type_ids": ["#V#ai_workflow", "#V#durable_workflow"],
+    "launch_input_contract": {
+      "schema_version": "workflow_launch_input_contract.v1",
+      "required_inputs": ["task_concept_id", "model", "model_provider"],
+      "input_mappings": [
+        {"target_context_key": "task_concept_id", "source_expression": "inputs.task_concept_id", "extractor": "identity", "required": true},
+        {"target_context_key": "model", "source_expression": "inputs.model", "extractor": "identity", "required": true},
+        {"target_context_key": "model_provider", "source_expression": "inputs.model_provider", "extractor": "identity", "required": true},
+        {"target_context_key": "model_parameters", "source_expression": "inputs.model_parameters", "extractor": "identity", "required": false},
+        {"target_context_key": "continuation_instruction", "source_expression": "inputs.continuation_instruction", "extractor": "identity", "required": false}
+      ]
+    },
+    "text_relations": [{
+      "predicate": "#V#hasWorkflowDiscoveryExemplarsJson",
+      "lang": "en-NZ",
+      "text": "{\"schema_version\":\"workflow_discovery_exemplars.v1\",\"keywords\":[\"continue a task\",\"recurring responsibility\",\"resume saved work\",\"schedule task continuation\"],\"examples\":[\"Keep this responsibility up to date every few hours.\",\"Continue the work from this task and its current brief.\",\"Schedule Von to resume an existing task regularly.\"],\"routing_notes\":[\"Reuse an existing task assigned to Von; its creator must be the authenticated actor.\",\"Keep changing domain requirements and progress in the task and its current work product.\",\"This workflow submits or coalesces a task execution; follow the returned queue and TaskExecution to inspect the work.\"]}"
+    }],
+    "publication_spec": {
+      "initial_state": "submit_task",
+      "steps": [{
+        "state_id": "submit_task",
+        "action_id": "task.submit_execution",
+        "execution_mode": "deterministic",
+        "context_input_mapping_specs": [
+          {"concept_id": "#V#workflow_mapping_task_continuation_task_id", "context_key": "task_concept_id", "tool_param": "task_concept_id", "required": true},
+          {"concept_id": "#V#workflow_mapping_task_continuation_model", "context_key": "model", "tool_param": "model", "required": true},
+          {"concept_id": "#V#workflow_mapping_task_continuation_provider", "context_key": "model_provider", "tool_param": "model_provider", "required": true},
+          {"concept_id": "#V#workflow_mapping_task_continuation_parameters", "context_key": "model_parameters", "tool_param": "model_parameters", "required": false},
+          {"concept_id": "#V#workflow_mapping_task_continuation_instruction", "context_key": "continuation_instruction", "tool_param": "continuation_instruction", "required": false}
+        ],
+        "tool_output_mapping_specs": [
+          {"concept_id": "#V#workflow_mapping_task_continuation_queue", "context_key": "queue_id", "tool_output_field": "queue_id"},
+          {"concept_id": "#V#workflow_mapping_task_continuation_execution", "context_key": "task_execution_concept_id", "tool_output_field": "task_execution_concept_id"},
+          {"concept_id": "#V#workflow_mapping_task_continuation_launch_status", "context_key": "task_launch_status", "tool_output_field": "task_launch_status"},
+          {"concept_id": "#V#workflow_mapping_task_continuation_domain_claim", "context_key": "domain_completion_claim", "tool_output_field": "domain_completion_claim"}
+        ],
+        "writes_context_keys": ["queue_id", "task_execution_concept_id", "task_launch_status", "domain_completion_claim"],
+        "next_state": "done",
+        "on_failure_state": "failed"
+      }, {"state_id": "done"}, {"state_id": "failed"}]
+    }
+  }]
+}

--- a/tests/backend/test_task_continuation_mcp.py
+++ b/tests/backend/test_task_continuation_mcp.py
@@ -1,0 +1,137 @@
+"""Ordinary chat can maintain a task without transferring its authority."""
+
+from copy import deepcopy
+
+import pytest
+
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp import catalogue as handlers
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.security.access_control import override_current_actor
+from src.backend.services import task_management_service
+from src.backend.services.adaptive_turn_service import (
+    _model_visible_input_schema,
+    _trusted_tool_payload,
+)
+
+
+@pytest.fixture
+def task_state(monkeypatch):
+    task = {
+        "task_concept_id": "#V#task_test",
+        "created_by_concept_id": "#V#alice",
+        "assignee_concept_id": "#V#alice",
+        "organisation_concept_id": "#V#lab",
+        "current_work_product": {"status": "missing"},
+    }
+    writes = []
+    monkeypatch.setattr(task_management_service, "get_task", lambda _: deepcopy(task))
+
+    def update(task_id, *, fields, actor_concept_id):
+        assert task_id == task["task_concept_id"]
+        assert actor_concept_id == "#V#alice"
+        writes.append(deepcopy(fields))
+        for key, value in fields.items():
+            if key == "current_work_product_concept_id":
+                task["current_work_product"] = {"concept_id": value, "status": "ready"}
+            else:
+                task[key] = value
+        return {"task": deepcopy(task), "changed_fields": list(fields), "warnings": []}
+
+    monkeypatch.setattr(task_management_service, "update_task_fields", update)
+    return task, writes
+
+
+def _payload(**fields):
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    return _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="task_update_fields",
+        model_payload={
+            "task_concept_id": "#V#task_test",
+            "fields": fields,
+            "actor_bound_continuation": False,
+            "actor_concept_id": "#V#spoofed",
+        },
+        trusted_argument_values={
+            "actor_user_concept_id": "#V#alice",
+            "actor_organisation_concept_id": "#V#lab",
+            "turn_namespace": "#V#alice@lab",
+        },
+    )
+
+
+def test_ordinary_continuation_links_product_and_delegates_without_duplicate_write(
+    task_state,
+):
+    task, writes = task_state
+    payload = _payload(
+        current_work_product_concept_id="#V#paper_responsibility_brief",
+        assignee_concept_id="#V#von_system",
+        report_to_concept_id="#V#alice",
+        next_checkpoint="Continue from the saved backlog checkpoint",
+    )
+    assert payload["actor_bound_continuation"] is True
+    assert payload["actor_concept_id"] == "#V#alice"
+    with override_current_actor("#V#alice", "#V#lab"):
+        first = handlers._task_update_fields(**payload)
+        repeat = handlers._task_update_fields(**payload)
+    assert first["effect_status"] == "succeeded"
+    assert first["canonical_read_back"]["current_work_product"]["status"] == "ready"
+    assert first["canonical_read_back"]["assignee_concept_id"] == "#V#von_system"
+    assert repeat["changed"] is False
+    assert repeat["idempotent_replay"] is True
+    assert len(writes) == 1
+    assert task["created_by_concept_id"] == "#V#alice"
+
+
+@pytest.mark.parametrize(
+    "field,value,code",
+    [
+        ("organisation_concept_id", "#V#other_org", "task_continuation_fields_denied"),
+        ("created_by_concept_id", "#V#bob", "task_continuation_fields_denied"),
+        ("watcher_concept_ids", ["#V#bob"], "task_continuation_fields_denied"),
+        ("assignee_concept_id", "#V#bob", "task_assignment_scope_denied"),
+        ("report_to_concept_id", "#V#bob", "task_report_scope_denied"),
+    ],
+)
+def test_continuation_rejects_scope_changes_before_any_edit(
+    task_state, field, value, code
+):
+    _, writes = task_state
+    with override_current_actor("#V#alice", "#V#lab"):
+        result = handlers._task_update_fields(
+            **_payload(notes="Should not persist", **{field: value})
+        )
+    assert result["error_code"] == code
+    assert writes == []
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"organisation_concept_id": "#V#other_org"},
+        {"created_by_concept_id": "#V#bob", "assignee_concept_id": "#V#bob"},
+    ],
+)
+def test_continuation_requires_control_of_same_org_task(task_state, changes):
+    task, writes = task_state
+    task.update(changes)
+    with override_current_actor("#V#alice", "#V#lab"):
+        result = handlers._task_update_fields(**_payload(notes="Should not persist"))
+    assert result["error_code"] == "task_actor_scope_denied"
+    assert writes == []
+
+
+def test_continuation_schema_exposes_product_and_hides_authority_switch():
+    definition = build_default_catalogue().get("task_update_fields")
+    assert definition.ordinary_turn_effect is True
+    schema = _model_visible_input_schema(definition)
+    assert "actor_bound_continuation" not in schema["properties"]
+    assert "actor_concept_id" not in schema["properties"]
+    assert "current_work_product_concept_id" in definition.description

--- a/tests/backend/test_task_execute_with_von_routes.py
+++ b/tests/backend/test_task_execute_with_von_routes.py
@@ -64,15 +64,21 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
     reconciliation_call: dict = {}
 
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
-        lambda _task_id: {**_task(), "current_work_product": {"status": "ready", "concept_id": "#V#brief_selected"}},
+        "src.backend.services.task_execution_submission_service.get_task",
+        lambda _task_id: {
+            **_task(),
+            "current_work_product": {
+                "status": "ready",
+                "concept_id": "#V#brief_selected",
+            },
+        },
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_conversation_concept",
+        "src.backend.services.task_execution_submission_service.get_conversation_concept",
         lambda _conversation_id: _conversation(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        "src.backend.services.task_execution_submission_service.chat_history_service.has_chat_history_session",
         lambda *_args, **_kwargs: True,
     )
 
@@ -101,15 +107,15 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
         }
 
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.create_queue_record",
         _create_queue_record,
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        "src.backend.services.task_execution_submission_service.reconcile_task_execution_queue_record",
         _reconcile_execution,
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.activate_server_dispatch_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.activate_server_dispatch_record",
         lambda **_kwargs: {
             **_create_queue_record(**queue_call),
             "dispatch_ready": True,
@@ -117,13 +123,17 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
     )
     wake_dispatcher = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        "src.backend.services.task_execution_submission_service.wake_chat_prompt_queue_dispatcher",
         wake_dispatcher,
     )
 
     response = client.post(
         "/api/tasks/%23V%23task_prepare_brief/execute-with-von",
-        json={"launch_request_id": "launch-1", "continuation_instruction": "Check the new evidence", "current_work_product": {"concept_id": "#V#wrong_brief"}},
+        json={
+            "launch_request_id": "launch-1",
+            "continuation_instruction": "Check the new evidence",
+            "current_work_product": {"concept_id": "#V#wrong_brief"},
+        },
     )
 
     assert "Check the new evidence" in queue_call["prompt_raw"]
@@ -153,20 +163,20 @@ def test_execute_with_von_replays_an_already_linked_launch_without_rebinding(
     client = _build_client()
     _set_actor(client)
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: _task(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_conversation_concept",
+        "src.backend.services.task_execution_submission_service.get_conversation_concept",
         lambda _conversation_id: _conversation(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        "src.backend.services.task_execution_submission_service.chat_history_service.has_chat_history_session",
         lambda *_args, **_kwargs: True,
     )
     execution_id = "#V#task_execution_replayed"
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.create_queue_record",
         lambda **kwargs: {
             "queue_id": "queue-original",
             "status": "in_progress",
@@ -188,15 +198,15 @@ def test_execute_with_von_replays_an_already_linked_launch_without_rebinding(
     )
     activate = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        "src.backend.services.task_execution_submission_service.reconcile_task_execution_queue_record",
         reconcile,
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.activate_server_dispatch_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.activate_server_dispatch_record",
         activate,
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        "src.backend.services.task_execution_submission_service.wake_chat_prompt_queue_dispatcher",
         MagicMock(),
     )
 
@@ -215,7 +225,7 @@ def test_execute_with_von_requires_authenticated_actor(monkeypatch) -> None:
     client = _build_client()
     get_task = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         get_task,
     )
 
@@ -237,7 +247,7 @@ def test_execute_with_von_rejects_legacy_identity_header_actor(monkeypatch) -> N
         lambda: ("#V#alice", "legacy_identity_header"),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         get_task,
     )
 
@@ -257,7 +267,7 @@ def test_execute_with_von_deliberately_requires_active_org_scope(monkeypatch) ->
     _set_actor(client, include_org=False)
     get_task = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         get_task,
     )
 
@@ -278,11 +288,11 @@ def test_execute_with_von_rejects_non_creator_even_when_task_is_visible(
     _set_actor(client)
     create_queue = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: _task(creator="#V#bob"),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.create_queue_record",
         create_queue,
     )
 
@@ -301,11 +311,11 @@ def test_execute_with_von_rejects_terminal_task(monkeypatch) -> None:
     _set_actor(client)
     create_queue = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: _task(status="completed"),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.create_queue_record",
         create_queue,
     )
 
@@ -323,15 +333,15 @@ def test_execute_with_von_requires_client_launch_identity(monkeypatch) -> None:
     client = _build_client()
     _set_actor(client)
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: _task(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_conversation_concept",
+        "src.backend.services.task_execution_submission_service.get_conversation_concept",
         lambda _conversation_id: _conversation(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        "src.backend.services.task_execution_submission_service.chat_history_service.has_chat_history_session",
         lambda *_args, **_kwargs: True,
     )
 
@@ -362,20 +372,20 @@ def test_durable_queue_is_not_relabelled_failed_when_execution_binding_needs_rec
     client = _build_client()
     _set_actor(client)
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: _task(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_conversation_concept",
+        "src.backend.services.task_execution_submission_service.get_conversation_concept",
         lambda _conversation_id: _conversation(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        "src.backend.services.task_execution_submission_service.chat_history_service.has_chat_history_session",
         lambda *_args, **_kwargs: True,
     )
 
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_prompt_queue_service.create_queue_record",
+        "src.backend.services.task_execution_submission_service.chat_prompt_queue_service.create_queue_record",
         lambda **kwargs: {
             "queue_id": "queue-durable",
             "status": "queued",
@@ -386,12 +396,12 @@ def test_durable_queue_is_not_relabelled_failed_when_execution_binding_needs_rec
         },
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.reconcile_task_execution_queue_record",
+        "src.backend.services.task_execution_submission_service.reconcile_task_execution_queue_record",
         MagicMock(side_effect=RuntimeError("execution binding must be reconciled")),
     )
     wake = MagicMock()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        "src.backend.services.task_execution_submission_service.wake_chat_prompt_queue_dispatcher",
         wake,
     )
 
@@ -416,7 +426,7 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
     _set_actor(client)
     task = _task()
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_task",
+        "src.backend.services.task_execution_submission_service.get_task",
         lambda _task_id: dict(task),
     )
     monkeypatch.setattr(
@@ -424,11 +434,11 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
         lambda _task_id: dict(task),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.get_conversation_concept",
+        "src.backend.services.task_execution_submission_service.get_conversation_concept",
         lambda _conversation_id: _conversation(),
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.chat_history_service.has_chat_history_session",
+        "src.backend.services.task_execution_submission_service.chat_history_service.has_chat_history_session",
         lambda *_args, **_kwargs: True,
     )
     monkeypatch.setattr(
@@ -437,7 +447,7 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
         lambda **_kwargs: None,
     )
     monkeypatch.setattr(
-        "src.backend.server.routes.task_routes.wake_chat_prompt_queue_dispatcher",
+        "src.backend.services.task_execution_submission_service.wake_chat_prompt_queue_dispatcher",
         lambda: None,
     )
 
@@ -466,6 +476,41 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
             first_payload["queue_item"]["queue_id"]
         )
 
+        # A schedule uses the same atomic active-task key as the UI, even
+        # though its short launch workflow has a different instance identity.
+        from types import SimpleNamespace
+        from src.backend.security.access_control import override_current_actor
+        from src.backend.workflows.action_registry import (
+            WorkflowActionRequest,
+            WorkflowEnvironment,
+        )
+        from src.backend.workflows.durable.task_execution_actions import (
+            submit_task_execution_action,
+        )
+
+        monkeypatch.setattr(
+            "src.backend.languagemodels.llm_interface.assert_model_execution_allowed",
+            lambda **_kwargs: {"allowed": True},
+        )
+        with override_current_actor("#V#alice", "#V#research_lab"):
+            scheduled = submit_task_execution_action(
+                WorkflowActionRequest(
+                    action_id="task.submit_execution",
+                    inputs={
+                        "task_concept_id": task["task_concept_id"],
+                        "model": "gpt-5.6-luna",
+                        "model_provider": "openai",
+                    },
+                    data={},
+                    environment=WorkflowEnvironment(llm_client=None),
+                    trace=SimpleNamespace(instance_id="scheduled-encounter-1"),
+                )
+            )
+        assert scheduled.status == "success"
+        assert scheduled.outputs["task_launch_status"] == "already_active"
+        assert scheduled.outputs["queue_id"] == first_payload["queue_item"]["queue_id"]
+        assert scheduled.outputs["domain_completion_claim"] is False
+
         queue = mongo_client.get_chat_prompt_queue_collection()
         assert queue is not None
         assert queue.count_documents({"task_concept_id": task["task_concept_id"]}) == 1
@@ -485,7 +530,9 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
 
 
 def test_continuation_projects_selected_task_product_and_new_instruction():
-    from src.backend.server.routes.task_routes import _build_task_execution_prompt
+    from src.backend.services.task_execution_submission_service import (
+        _build_task_execution_prompt,
+    )
 
     selected = _task()
     selected.update(

--- a/tests/backend/test_task_execution_actions.py
+++ b/tests/backend/test_task_execution_actions.py
@@ -1,0 +1,115 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.backend.security.access_control import override_current_actor
+from src.backend.workflows.action_registry import (
+    WorkflowActionRequest,
+    WorkflowEnvironment,
+)
+from src.backend.workflows.durable import task_execution_actions as actions
+
+
+def _request(**inputs):
+    return WorkflowActionRequest(
+        action_id="task.submit_execution",
+        inputs={
+            "task_concept_id": "#V#responsibility",
+            "model": "gpt-5.6-luna",
+            "model_provider": "openai",
+            **inputs,
+        },
+        data={"user_concept_id": "#V#untrusted", "namespace": "#V#untrusted@other"},
+        environment=WorkflowEnvironment(llm_client=None),
+        trace=SimpleNamespace(instance_id="durable-occurrence-1"),
+    )
+
+
+def test_scheduled_task_uses_trusted_actor_stable_instance_and_selected_model(
+    monkeypatch,
+):
+    calls = []
+
+    def submit(task_id, **kwargs):
+        calls.append((task_id, kwargs))
+        return {
+            "queue_item": {
+                "queue_id": "queue-1",
+                "session_id": "chat-1",
+                "task_execution_concept_id": "#V#execution_1",
+                "status": "queued",
+            }
+        }, 201
+
+    monkeypatch.setattr(actions, "submit_task_execution", submit)
+    with override_current_actor("#V#alice", "#V#lab"):
+        first = actions.submit_task_execution_action(_request())
+        actions.submit_task_execution_action(_request())
+    assert first.status == "success"
+    assert first.outputs["domain_completion_claim"] is False
+    assert calls[0] == calls[1]
+    task_id, kwargs = calls[0]
+    assert task_id == "#V#responsibility"
+    assert kwargs["actor_context"] == {
+        "actor_concept_id": "#V#alice",
+        "organisation_concept_id": "#V#lab",
+        "namespace": "#V#alice@lab",
+    }
+    assert (
+        kwargs["payload"]["launch_request_id"] == "workflow-task:durable-occurrence-1"
+    )
+    assert kwargs["model"] == "gpt-5.6-luna"
+    assert kwargs["model_provider"] == "openai"
+
+
+def test_scheduled_task_rejects_actor_claims_without_ambient_authority(monkeypatch):
+    monkeypatch.setattr(
+        actions,
+        "submit_task_execution",
+        lambda *_a, **_k: pytest.fail("must not submit"),
+    )
+    with override_current_actor(None, None):
+        result = actions.submit_task_execution_action(
+            _request(user_concept_id="#V#alice", org_concept_id="#V#lab")
+        )
+    assert result.status == "failed"
+
+
+def test_scheduled_task_requires_explicit_model_before_submission(monkeypatch):
+    monkeypatch.setattr(
+        actions,
+        "submit_task_execution",
+        lambda *_a, **_k: pytest.fail("must not submit"),
+    )
+    with override_current_actor("#V#alice", "#V#lab"):
+        result = actions.submit_task_execution_action(_request(model=None))
+    assert result.error == "task_execution_explicit_model_and_provider_required"
+
+
+def test_release_bundle_uses_registered_task_submission_action():
+    from src.backend.workflows.durable.registry_factory import (
+        build_durable_action_registry,
+    )
+    from src.backend.workflows.workflow_concept_authority_service import (
+        build_repo_seed_workflow_definitions,
+    )
+
+    definition = build_repo_seed_workflow_definitions(
+        target_workflow_ids=["#V#task_continuation_workflow"]
+    )["#V#task_continuation_workflow"]
+    action_ids = [
+        a.action_id for state in definition.states.values() for a in state.actions
+    ]
+    assert action_ids == ["task.submit_execution"]
+    registry = build_durable_action_registry()
+    assert registry.get("task.submit_execution") is not None
+    from src.backend.workflows.workflow_definition_identity_service import (
+        validate_workflow_definition_contract,
+    )
+
+    report = validate_workflow_definition_contract(
+        definition=definition,
+        supported_action_ids=action_ids,
+        enforce_supported_actions=True,
+    )
+    assert report["valid"], report["errors"]


### PR DESCRIPTION
Continuing work could be saved by chat as disconnected notes and a human-assigned task, while the Tasks UI and scheduler had no shared way to resume that responsibility. Ordinary chat can now revise the existing task, attach its canonical current work product and assign execution to Von. A small represented task-continuation workflow submits through the same task/conversation/queue transaction as the UI, so scheduled and manual launches share active-task deduplication.

The launch transaction is moved intact out of the HTTP route. The new action requires the persisted actor context and explicit enabled model/provider, uses the durable instance for retry identity, and reports accepted/coalesced launch receipts rather than domain completion. Chat's bounded projection cannot transfer task ownership or widen its audience. Domain requirements and checkpoints stay on the task and current work product; the guide describes contextual, revisable representation expectations and separates diagnostic prompts from natural-use acceptance.

Validation: 89 targeted backend tests passed across task editing, product selection, task execution, routes and MCP compatibility. The new tests cover ordinary trusted argument binding, canonical product/assignment read-back, duplicate updates, scope denial, workflow contract validity and a scheduled attempt coalescing with an active UI task. New modules pass Ruff; `git diff --check` is clean. Existing unrelated lint debt is unchanged.

This delivers the integration mechanism. It does not claim that the recurring paper responsibility has passed live acceptance, that a schedule is active, or that historical mailbox coverage is complete. Those deployment and outcome checks remain tracked under JVNAUTOSCI-2244 and JVNAUTOSCI-2721.
