### PR TITLE
JVNAUTOSCI-2244 Allow reversible relationship corrections in ordinary chat

### DIFF
--- a/docs/engineering/role_convergence_test_programme.md
+++ b/docs/engineering/role_convergence_test_programme.md
@@ -200,6 +200,43 @@ people, evidence format and relevant constraints, not merely the nouns. An
 explicitly settled, unchanged responsibility is the non-applicability control:
 Von should avoid unnecessary searches, questions and work-product churn.
 
+### Paper-email responsibility encounters
+
+The email-paper encounter under [2244](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2244)
+tests a second real responsibility alongside the readiness brief. Michael has
+authorised periodic processing, historical coverage, representation improvement
+and completion labels. This is a separate effect scope from the brief-only
+cycle above. Preserve private email provenance and the current Inbox-disposition
+preference. Current activation decisions and actual run evidence belong in Jira;
+these encounters are a reusable evaluation design, not another delivery ledger.
+The [task continuity guide](task_responsibility_continuation.md) owns the
+mechanism and contextual-completeness guidance.
+
+| Encounter | Ordinary instruction or situation | Evidence to inspect |
+| --- | --- | --- |
+| Assume the job | “Keep up with papers people email to Von, including the older ones, and mark each email done when its papers are represented.” | Resolve the connected mailbox and existing work; save one responsibility, useful current guidance and progress. Count questions, setup choices and any operator-supplied component identities. |
+| Continue after interruption | “Please finish the paper trial we were working on.” | Recover the same task, source and partial artefacts; inspect actual prior outcomes; repair the outstanding gap without another task or overlapping launch. A same-conversation success does not establish fresh-context recovery. |
+| Revise the expectation | A real new use is introduced, for example “I want to compare this paper's evaluation with our planned experiment.” | Identify what that use requires, inspect the existing representation and source, and enrich the relevant missing evidence. Preserve the earlier assessment with its expectation and revision; an old completion label alone cannot pass. Do not supply the desired assessment or extraction plan. |
+| Work through history | An intended paper email is outside Inbox or predates recent processing. | Reach it through bounded whole-mailbox traversal and retained progress. A successful newest-Inbox query cannot establish historical coverage. |
+| Revisit completion | Previously completed mail is encountered under a changed expectation, or its linked paper has a demonstrated missing part. | Reassess current evidence, preserve useful work and repair the gap. Distinguish assessment currency from email labels and from a workflow merely terminating. |
+| Repeat or overlap | Resume through Tasks while a scheduled execution of that task is active; later resume after it terminates. | Active work coalesces with its existing queue/execution. A later encounter remains possible and reconciles prior effects. Unchanged adequate work should not cause duplicate artefacts or repeated acquisition. |
+
+Use one real paper and an appropriate neighbouring case to support a bounded
+delivery claim; do not make every encounter a release gate by default. Record
+the minimum evidence for the current claim before running it. All-history
+coverage is a continuing outcome requiring a traversal/completion account,
+not a conclusion from a single successful paper. Report partial work honestly
+and keep incomplete mail eligible for recovery.
+
+Separate engineering-assisted runs from ordinary-language runs. Record supplied
+workflow/tool identifiers, exact repair instructions, manual state corrections,
+repeated briefing, latency and model cost. A short prompt that depends on an
+earlier technical briefing proves continuation from that briefing, not natural
+setup from scratch. When an ordinary run fails, first distinguish missing
+capability, inaccessible context, transport and authority from model judgement.
+Use a bounded matched Luna/Terra comparison only when model adequacy remains a
+decision-relevant explanation; a stronger model cannot supply a missing tool.
+
 ## 5. What counts as evidence
 
 Freeze the outcome expectation and available source snapshot before each new

--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -59,10 +59,19 @@ explicitly delegated surface.
 
 `#V#task_continuation_workflow` submits the same task operation as **Continue
 with Von**, through `task_execution_submission_service`. Its release input is
-`src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json`;
-publish it with the existing `bootstrap_repo_seed_workflow_bundle` operator
-service and read back the live definition. Repository presence alone is not
-activation. An actor-owned schedule supplies the task and an explicit enabled
+`src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json`.
+For a new workflow identity, first use the existing
+`bootstrap_workflow_concept_identities` release service with a registry containing
+only that release's workflow. Then publish its graph with
+`bootstrap_repo_seed_workflow_bundle` and read back the live definition. The
+identity must exist before the graph publisher attaches its migration receipt.
+The bundle records the exact reviewed unversioned identity surface produced by
+that bootstrap; an unrelated or changed live surface still requires an explicit
+migration decision.
+Use the authorised release context and preserve its visibility; an operational
+credential does not confer global semantic publication authority.
+Repository presence alone is not activation. An actor-owned schedule supplies
+the task and an explicit enabled
 model/provider; it does not copy the task's domain programme into code.
 
 Each occurrence reads the current task, product reference and checkpoint.
@@ -122,6 +131,8 @@ responsibility. Inspect whether Von reuses earlier components, requirements
 and evidence, rather than requiring the human to reconstruct their interfaces.
 One focussed question may be useful when a material fact is unavailable;
 making the user write an execution specification is not the target experience.
+The [role test programme](role_convergence_test_programme.md#paper-email-responsibility-encounters)
+defines the corresponding continuation and changing-expectation encounters.
 
 This is a bounded continuity interface, not evidence of learned role competence.
 Use the [role convergence guide](role_learning_convergence.md) for successive

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -40614,7 +40614,23 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_remove_relationship_input_schema(),
             output_schema=_remove_relationship_output_schema(),
             category="write",
-            description="Remove a relationship between two concepts (concept-to-concept only). Use to clean incorrect type/instance links or other structural predicates. Text relation removal is not supported in this tool.",
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="source_id",
+            ordinary_turn_fixed_arguments={
+                "mode": "soft_delete",
+                "cascade": "warn",
+                "confirmed": False,
+                "operator_override": False,
+            },
+            description=(
+                "Correct one unsupported or duplicate concept-to-concept "
+                "relationship using its exact source, predicate and target, or "
+                "its relation identity. This removes the relationship, not the "
+                "concepts. Ordinary chat uses audited soft deletion with an "
+                "undo token; canonical source and inverse-target authority "
+                "checks still apply. Inspect source evidence and the resulting "
+                "relationships. Text relation removal is not supported."
+            ),
         ),
         MethodDefinition(
             name="preview_remove_relationship",

--- a/src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/task_continuation_workflow_seed_bundle.json
@@ -4,6 +4,11 @@
   "schema_version": "repo_seed_workflow_bundle.v1",
   "seed_version": "1",
   "source_tag": "JVNAUTOSCI-2244",
+  "known_legacy_authority_payload_sha256_by_seed_version": {
+    "#V#task_continuation_workflow": {
+      "unversioned": ["595b29efc45198f316b0e64b1fee3a5fb017929ce6690f2972b228a1eb4805f2"]
+    }
+  },
   "supported_action_ids": ["task.submit_execution"],
   "workflows": [{
     "workflow_id": "#V#task_continuation_workflow",

--- a/tests/backend/test_internal_mcp_relationship_removal_tools.py
+++ b/tests/backend/test_internal_mcp_relationship_removal_tools.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import Any
+
+import mongomock
+import pytest
 
 from src.backend.integrations.internal_mcp import build_default_catalogue
 from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
@@ -98,7 +103,7 @@ def _install_relationship_state(monkeypatch):
         if not projection:
             return {"concept_id": concept_id, "relationships": dict(relationships)}
         projected_rels: dict[str, Any] = {}
-        for key in projection.keys():
+        for key in projection:
             if not isinstance(key, str):
                 continue
             if key == "concept_id":
@@ -134,7 +139,7 @@ def _install_relationship_state(monkeypatch):
                 inv_values = target.setdefault(inv_kind, [])
                 if source_id in inv_values:
                     inv_values.remove(source_id)
-                    changed = True or changed
+                    changed = True
         elif action == "add":
             if target_id not in source_values:
                 source_values.append(target_id)
@@ -145,7 +150,7 @@ def _install_relationship_state(monkeypatch):
                 inv_values = target.setdefault(inv_kind, [])
                 if source_id not in inv_values:
                     inv_values.append(source_id)
-                    changed = True or changed
+                    changed = True
         return changed
 
     monkeypatch.setattr(
@@ -178,6 +183,146 @@ def test_relationship_removal_methods_registered() -> None:
     assert "preview_remove_relationship" in methods
     assert "remove_relationships_bulk" in methods
     assert "undo_relationship_removal" in methods
+
+
+def test_ordinary_turn_can_discover_a_reversible_relationship_correction():
+    from src.backend.services.adaptive_turn_service import (
+        _model_visible_input_schema,
+        _trusted_tool_payload,
+        ordinary_turn_capability_delegation,
+    )
+
+    gateway = _build_gateway()
+    delegated = ordinary_turn_capability_delegation(gateway, user_concept_id="#V#alice")
+    assert "remove_relationship" in delegated
+    assert "remove_relationships_bulk" not in delegated
+    assert "remove_relationship" not in ordinary_turn_capability_delegation(
+        gateway, user_concept_id=None
+    )
+    definition = gateway.get_method_definition("remove_relationship")
+    schema = _model_visible_input_schema(definition)
+    assert {"source_id", "predicate", "target", "reason"} <= set(schema["properties"])
+    assert not {"mode", "cascade", "confirmed", "operator_override"}.intersection(
+        schema["properties"]
+    )
+
+    # A caller cannot turn this ordinary correction into permanent removal or
+    # cascade deletion. The general explicitly delegated editor is unchanged.
+    payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="remove_relationship",
+        model_payload={
+            "source_id": "#V#source",
+            "predicate": "#V#authored_by",
+            "target": "#V#duplicate_occurrence",
+            "reason": "Source author list and occurrence provenance reconciled",
+            "mode": "hard_delete",
+            "cascade": "delete_dependent",
+            "confirmed": True,
+            "operator_override": True,
+        },
+        trusted_argument_values={},
+    )
+    assert payload["mode"] == "soft_delete"
+    assert payload["cascade"] == "warn"
+    assert payload["confirmed"] is False
+    assert payload["operator_override"] is False
+    assert payload["source_id"] == "#V#source"
+    assert payload["target"] == "#V#duplicate_occurrence"
+
+
+@pytest.mark.parametrize("has_semantic_role", [True, False])
+def test_same_turn_correction_issues_authority_and_reads_back_exact_effect(
+    monkeypatch, has_semantic_role
+):
+    from src.backend.services import ontology_mutation_command_service as command
+    from src.backend.services import ontology_publication_authority_service as authority
+    from src.backend.services.adaptive_turn_service import _trusted_tool_payload
+
+    gateway = _build_gateway()
+    audit_db = _install_fake_db(monkeypatch)
+    state, mutations = _install_relationship_state(monkeypatch)
+    database = mongomock.MongoClient()["ordinary_correction"]
+    monkeypatch.setattr(
+        authority,
+        "get_ontology_authority_delegations_collection",
+        lambda: database["delegations"],
+    )
+    monkeypatch.setattr(
+        authority,
+        "get_ontology_mutation_receipts_collection",
+        lambda: database["receipts"],
+    )
+    monkeypatch.setattr(
+        command, "ontology_mutation_resource_lock", lambda _: nullcontext()
+    )
+    monkeypatch.setattr(command, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(authority, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(
+        command,
+        "concept_publication_context",
+        lambda _: authority.PublicationContext.global_context(),
+    )
+    role = authority.AuthorityRoleEvidence(
+        role=authority.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE,
+        actor_concept_id="#V#alice",
+        organisation_concept_id=None,
+        relation_id="role-alice-global",
+        revision="test-revision",
+    )
+    monkeypatch.setattr(
+        authority,
+        "resolve_live_semantic_roles",
+        lambda _: (role,) if has_semantic_role else (),
+    )
+    arguments = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="remove_relationship",
+        model_payload={
+            "source_id": "#V#source",
+            "predicate": "is_a_type_of",
+            "target": "#V#target",
+            "reason": "Correct the source-supported relationship",
+        },
+        trusted_argument_values={},
+    )
+    with authority.override_current_actor("#V#alice", None):
+        # Exercise production same-turn issuance, not a manually injected grant.
+        grant = command.issue_same_turn_method_delegation(
+            method_name="remove_relationship",
+            arguments=arguments,
+            actor_concept_id="#V#alice",
+            organisation_concept_id=None,
+            delegate_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            effect_id="correction-effect",
+            turn_id="correction-turn",
+        )
+        if not has_semantic_role:
+            assert not grant.get("delegation_id")
+            assert grant["effect_status"] == "not_started"
+            assert mutations == [] and audit_db.audit.rows == []
+            return
+        assert grant.get("delegation_id"), json.dumps(grant)
+        with authority.bind_ontology_invocation(
+            surface="adaptive_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="correction-effect",
+            turn_id="correction-turn",
+        ):
+            first = gateway.invoke("remove_relationship", arguments).payload
+            repeated = gateway.invoke("remove_relationship", arguments).payload
+    assert first["authority_receipt"]["status"] == "succeeded", first
+    assert first["canonical_read_back"]["relationship_present"] is False
+    assert first["canonical_read_back"]["inverse_relationship_present"] is False
+    assert first["undo_token"]
+    assert state["#V#source"]["is_a_type_of"] == []
+    assert state["#V#target"]["has_subtype"] == []
+    assert repeated["authority_receipt"]["status"] == "succeeded"
+    assert len(mutations) == 1
+    assert len(audit_db.tombstone.rows) == 1
 
 
 def test_sessionless_remove_relationship_gateway_fails_before_audit(monkeypatch):


### PR DESCRIPTION
Ordinary chat could add represented relationships and preview their removal, but could not correct an incorrect link. In the continuing paper-email trial Luna found nine author links for six source authors, searched for removal, and returned to ingestion without resolving the duplicates. Expose the existing single-relationship removal service with fixed audited soft deletion and no destructive cascade. Existing exact semantic-authority checks and same-turn delegation still govern the effect.

Complete the task-continuation release input with the exact reviewed source digest for its newly bootstrapped identity. Document that publication sequence and add reusable ordinary-language, continuation, changed-expectation, historical-mail and overlap encounters to the existing role test programme. Detailed repair prompts count as operator assistance.

Validation: 60 targeted tests passed, including production same-turn delegation issuance with canonical effect read-back, no duplicate mutation on retry, denial without the required semantic role, protected ordinary arguments and workflow contract validation. Ruff on the changed test file and diff checks passed. Three broader route/seed assertions also fail against the unchanged origin/main catalogue (same failures); they concern pre-existing error ordering, Gmail description wording and an old environment-variable assertion.

This delivers the bounded correction capability. Recurring mailbox activation remains pending live paper completion and scheduled continuation evidence; it does not claim full historical coverage or learned role competence.
