### PR TITLE
Execute the current responsibility and verify Gmail label changes

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -82,6 +82,11 @@ An already active task coalesces with the existing execution. The workflow
 receipt reports submission or coalescence, with a queue and TaskExecution
 locator. Its successful termination is **not** a domain-completion claim.
 Inspect the linked execution and canonical work product for that outcome.
+The execution prompt identifies the TaskExecution belonging to the current
+turn. Observing that same execution as in progress is not evidence of a
+different worker: the launch has already succeeded and this turn carries the
+domain work. This identity is supplied by the shared queue adapter for both
+Tasks and scheduled launches, without requiring a user to explain the runtime.
 
 ## Requirements that can evolve
 
@@ -118,6 +123,11 @@ Start with the existing task/product and reasonable stated defaults. Split
 guidance into independently governed profiles only when actual consumers or
 revision needs justify it. Keep exact cursor persistence, identity, actor
 authority, queue deduplication and effect read-back in reusable mechanisms.
+Ordinary chat can use the existing `gmail_modify_labels` capability on an
+actor-authorised mailbox, with canonical read-back and lost-response
+reconciliation. It changes only the requested label sets. Completion assessment
+and whether to preserve Inbox remain contextual judgements; a historical
+ingestion workflow's disposition is not compulsory for all paper work.
 
 ## Evidence of low human burden
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -41720,12 +41720,24 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
                 description="Gmail API modify response",
             ),
             category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_fixed_arguments={
+                "allow_mutation": True,
+                "verify_after": True,
+            },
+            ordinary_turn_trusted_argument_choice_bindings={
+                "profile": "gmail_profile",
+            },
             timeout_sec=20.0,
             description=(
-                "Atomically add/remove labels on a Gmail message. Requires "
-                "allow_mutation=true and profile with gmail.modify scope. Use "
-                "verify_after=true for independent canonical state read-back and "
-                "lost-response reconciliation."
+                "Atomically add/remove labels on one authorised Gmail message. "
+                "Resolve mailbox-specific label IDs with gmail_list_labels. "
+                "Only the requested labels change: adding a completion label "
+                "does not implicitly archive or mark the message read. Choose "
+                "disposition from the user's current guidance. Requires a "
+                "profile with gmail.modify scope. Ordinary turns bind "
+                "allow_mutation=true and verify_after=true for independent "
+                "canonical state read-back and lost-response reconciliation."
             ),
         ),
         MethodDefinition(

--- a/src/backend/services/task_execution_submission_service.py
+++ b/src/backend/services/task_execution_submission_service.py
@@ -131,7 +131,9 @@ def _resolve_task_execution_conversation(
     return resolved
 
 
-def _build_task_execution_prompt(task: dict[str, Any]) -> str:
+def _build_task_execution_prompt(
+    task: dict[str, Any], *, task_execution_concept_id: str | None = None
+) -> str:
     """Project the selected task and canonical references, not a shadow product."""
     product = task.get("current_work_product") or {"status": "missing"}
     instruction = task.get("continuation_instruction", "")
@@ -140,6 +142,13 @@ def _build_task_execution_prompt(task: dict[str, Any]) -> str:
         f"Task concept ID: {task.get('task_concept_id', '')}",
         f"Title: {task.get('title') or 'Untitled task'}",
     ]
+    if task_execution_concept_id:
+        parts.append(
+            f"Current execution (this turn): {task_execution_concept_id}. "
+            "Task submission has already succeeded. An in-progress observation "
+            "of this execution refers to your own work in this turn, not another "
+            "worker to wait for."
+        )
     if instruction:
         parts.append(f"New user instruction: {instruction}")
     parts.extend(
@@ -167,7 +176,9 @@ def _enqueue_task_execution(
 
     return chat_prompt_queue_service.create_queue_record(
         scope=scope,
-        prompt_raw=_build_task_execution_prompt(task),
+        prompt_raw=_build_task_execution_prompt(
+            task, task_execution_concept_id=task_execution_concept_id
+        ),
         session_id=task["conversation_session_id"],
         session_name=task.get("conversation_name"),
         status=chat_prompt_queue_service.STATUS_QUEUED,

--- a/tests/backend/test_gmail_label_continuation.py
+++ b/tests/backend/test_gmail_label_continuation.py
@@ -1,0 +1,142 @@
+"""An ordinary task can finish a message without inheriting workflow disposition."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.backend.integrations.google import gmail_service as gmail
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp import catalogue as handlers
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.security.access_control import override_current_actor
+from src.backend.services import mail_profile_resource_vontology_service as profiles
+from src.backend.services.adaptive_turn_service import (
+    _model_visible_input_schema,
+    _trusted_tool_payload,
+    ordinary_turn_capability_delegation,
+)
+
+
+def _gateway():
+    return InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+
+
+def _payload():
+    return _trusted_tool_payload(
+        gateway=_gateway(),
+        tool_name="gmail_modify_labels",
+        model_payload={
+            "profile": "foreign-mail",
+            "message_id": "message-1",
+            "add_labels": ["Label_done"],
+            "remove_labels": [],
+            "allow_mutation": False,
+            "verify_after": False,
+        },
+        trusted_argument_values={"gmail_profile": "#V#gmail_profile_actor"},
+    )
+
+
+def test_ordinary_label_capability_binds_profile_and_verification():
+    gateway = _gateway()
+    assert "gmail_modify_labels" in ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#actor",
+        trusted_argument_values={"gmail_profile": "#V#gmail_profile_actor"},
+    )
+    assert "gmail_modify_labels" not in ordinary_turn_capability_delegation(
+        gateway, user_concept_id="#V#actor"
+    )
+    assert "gmail_modify_labels" not in ordinary_turn_capability_delegation(
+        gateway, user_concept_id=None
+    )
+    schema = _model_visible_input_schema(
+        gateway.get_method_definition("gmail_modify_labels")
+    )
+    assert not {"allow_mutation", "verify_after"}.intersection(schema["properties"])
+    assert _payload() == {
+        "profile": "#V#gmail_profile_actor",
+        "message_id": "message-1",
+        "add_labels": ["Label_done"],
+        "remove_labels": [],
+        "allow_mutation": True,
+        "verify_after": True,
+    }
+
+
+@pytest.mark.parametrize("lost_response", [False, True])
+def test_actor_bound_completion_preserves_inbox_and_reconciles_reply(
+    monkeypatch, lost_response
+):
+    profile = gmail.GmailProfile(
+        profile_id="actor-mail",
+        token_path="/nonexistent/token.json",
+        scopes=[gmail.MUTATION_SCOPE],
+    )
+    monkeypatch.setattr(
+        gmail, "load_profiles_from_env", lambda: {"actor-mail": profile}
+    )
+    monkeypatch.setattr(gmail, "resolve_effective_profile_scopes", lambda p: p.scopes)
+
+    def resolve(**kwargs):
+        assert kwargs == {
+            "user_concept_id": "#V#actor",
+            "requested_profile_id": "#V#gmail_profile_actor",
+        }
+        return {
+            "success": True,
+            "profile_id": "actor-mail",
+            "profile_resource_concept_id": "#V#gmail_profile_actor",
+        }
+
+    monkeypatch.setattr(profiles, "resolve_authorised_gmail_profile_for_user", resolve)
+    api = MagicMock()
+    messages = api.users.return_value.messages.return_value
+    messages.modify.return_value.execute.return_value = {"id": "message-1"}
+    if lost_response:
+        messages.modify.return_value.execute.side_effect = TimeoutError("reply lost")
+    messages.get.return_value.execute.return_value = {
+        "id": "message-1",
+        "labelIds": ["INBOX", "UNREAD", "Label_done"],
+    }
+    monkeypatch.setattr(gmail, "get_service", lambda *_: api)
+    with override_current_actor("#V#actor", "#V#org"):
+        result = handlers._gmail_modify_labels(**_payload())
+    assert result["success"] is True
+    assert result["gmail_label_state_verified"] is True
+    assert result["modify_reconciled_after_error"] is lost_response
+    assert result["readback_label_ids"] == ["INBOX", "UNREAD", "Label_done"]
+    messages.modify.assert_called_once_with(
+        userId="me",
+        id="message-1",
+        body={"addLabelIds": ["Label_done"], "removeLabelIds": []},
+    )
+    messages.get.assert_called_once_with(userId="me", id="message-1", format="minimal")
+
+
+def test_label_handler_rechecks_profile_authority_before_effect(monkeypatch):
+    monkeypatch.setattr(
+        profiles,
+        "resolve_authorised_gmail_profile_for_user",
+        lambda **_: {
+            "success": False,
+            "reason_code": "mail_profile_not_authorised_for_actor",
+        },
+    )
+    monkeypatch.setattr(
+        gmail, "modify_labels", lambda **_: pytest.fail("denied effect")
+    )
+    with override_current_actor("#V#actor", "#V#org"):
+        result = handlers._gmail_modify_labels(
+            profile="foreign-mail",
+            message_id="message-1",
+            allow_mutation=True,
+            add_labels=["Label_done"],
+            verify_after=True,
+        )
+    assert result["error_code"] == "gmail_profile_not_authorised"

--- a/tests/backend/test_task_execute_with_von_routes.py
+++ b/tests/backend/test_task_execute_with_von_routes.py
@@ -133,12 +133,20 @@ def test_execute_with_von_creates_one_linked_server_dispatch(monkeypatch) -> Non
             "launch_request_id": "launch-1",
             "continuation_instruction": "Check the new evidence",
             "current_work_product": {"concept_id": "#V#wrong_brief"},
+            "task_execution_concept_id": "#V#wrong_execution",
         },
     )
 
     assert "Check the new evidence" in queue_call["prompt_raw"]
     assert "#V#brief_selected" in queue_call["prompt_raw"]
     assert "#V#wrong_brief" not in queue_call["prompt_raw"]
+    current_execution = queue_call["task_execution_concept_id"]
+    assert f"Current execution (this turn): {current_execution}" in queue_call["prompt_raw"]
+    assert "#V#wrong_execution" not in queue_call["prompt_raw"]
+    assert (
+        queue_call["execution_envelope"]["workflow_inputs"]["task_execution_concept_id"]
+        == current_execution
+    )
     assert response.status_code == 201
     assert response.get_json()["task_execution"]["queue_id"] == "queue-1"
     assert reconciliation_call["user_concept_id"] == "#V#alice"
@@ -479,6 +487,7 @@ def test_execute_with_von_end_to_end_persists_one_queue_and_execution_attempt(
         # A schedule uses the same atomic active-task key as the UI, even
         # though its short launch workflow has a different instance identity.
         from types import SimpleNamespace
+
         from src.backend.security.access_control import override_current_actor
         from src.backend.workflows.action_registry import (
             WorkflowActionRequest,


### PR DESCRIPTION
Scheduled responsibility turns could mistake their own in-progress TaskExecution for another worker, resubmit the task and stop without doing domain work. The shared Tasks/schedule submission now projects the current execution identity into the turn. Ordinary chat also gains the existing actor-authorised Gmail label editor with mandatory canonical read-back, allowing a completion label while preserving Inbox according to current task guidance.

The change retains queue deduplication, mailbox ownership and OAuth scope checks. Paper adequacy and workflow selection remain revisable task/product guidance; no paper policy is added to Python.

Validation: 68 targeted tests covering Tasks submission and overlap, execution identity propagation, Gmail profile authority, label read-back and lost-response reconciliation. Ruff and diff checks pass. The live pre-change occurrence submitted once and the competing UI launch coalesced correctly, but Luna then attempted self-submission and did no paper repair. Recurrence remains disabled pending a useful live domain encounter on the deployed candidate.

Merge decision: ready for this bounded integration repair; deployment/replay is authorised. Activation is a separate decision requiring paper/mail effect read-back. This does not claim natural first-time setup or historical-mail coverage.

JVNAUTOSCI-2244; related JVNAUTOSCI-2721.
