### PR TITLE
Report verified task edits separately from task completion

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -54,6 +54,11 @@ and product reference. It does not start execution. The bounded ordinary-chat
 projection cannot change the creator or organisation, add an audience, or
 assign work to another person. The general parity editor remains a separate
 explicitly delegated surface.
+The ordinary editor compares the requested fields with its canonical task
+read-back, including the selected product reference. Its receipt verifies the
+edit separately from the task's domain status. A saved checkpoint can be
+verified while the paper work remains pending; contradictory field read-back
+is reported as partial progress with the mismatched fields retained.
 
 ## Recurring encounters
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -36496,6 +36496,44 @@ def _task_import_jira_issues(**kwargs):
     return report
 
 
+def _task_continuation_readback(task_id, fields, task):
+    """Verify the task editor's canonical field values, preserving its response."""
+    from ...services import task_management_service as tasks
+
+    mismatches = []
+    if task.get("task_concept_id") != tasks._normalise_task_concept_id(task_id):
+        mismatches.append("task_concept_id")
+    for key, expected in fields.items():
+        actual = task.get(key)
+        if key == "current_work_product_concept_id":
+            product = task.get("current_work_product") or {}
+            actual = product.get("concept_id")
+            expected = tasks._normalise_optional_concept_id(expected)
+            if product.get("status") in {"unavailable", "ambiguous_link"}:
+                mismatches.append(key)
+                continue
+        elif key in {"start_date", "due_date"}:
+            actual = tasks._parse_datetime(actual)
+            expected = tasks._parse_datetime(expected)
+        elif key == "task_type_ids":
+            actual = set(actual or [])
+            expected = set(tasks.normalise_task_type_ids(expected))
+        elif key in {"assignee_concept_id", "report_to_concept_id"}:
+            expected = tasks._normalise_optional_concept_id(expected)
+        elif key in {"status", "priority"}:
+            expected = str(expected or "").strip().lower()
+        else:
+            expected = tasks._normalise_optional_text(expected, field_name=key)
+        if actual != expected:
+            mismatches.append(key)
+    return {
+        "status": "verified" if not mismatches else "mismatch",
+        "verified": not mismatches,
+        "task": task,
+        "mismatched_fields": mismatches,
+    }
+
+
 def _task_update_fields(**kwargs):
     from ...services.task_management_service import (
         InvalidTaskDataError,
@@ -36600,7 +36638,9 @@ def _task_update_fields(**kwargs):
                 "effect_status": "succeeded",
                 "changed": False,
                 "idempotent_replay": True,
-                "canonical_read_back": current_task,
+                "canonical_read_back": _task_continuation_readback(
+                    task_id, kwargs["fields"], current_task
+                ),
             }
 
     try:
@@ -36611,12 +36651,18 @@ def _task_update_fields(**kwargs):
         )
         result["success"] = True
         if kwargs.get("actor_bound_continuation") is True:
+            readback = _task_continuation_readback(
+                task_id, kwargs["fields"], result["task"]
+            )
             result.update(
-                effect_status="succeeded",
+                success=readback["verified"],
+                effect_status="succeeded" if readback["verified"] else "partial",
                 changed=bool(result.get("changed_fields")),
                 idempotent_replay=not bool(result.get("changed_fields")),
-                canonical_read_back=result["task"],
+                canonical_read_back=readback,
             )
+            if not readback["verified"]:
+                result["error_code"] = "task_update_readback_mismatch"
         return result
     except TaskNotFoundError as exc:
         return make_error_response("NOT_FOUND", str(exc))

--- a/tests/backend/test_task_continuation_mcp.py
+++ b/tests/backend/test_task_continuation_mcp.py
@@ -11,6 +11,8 @@ from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
 from src.backend.security.access_control import override_current_actor
 from src.backend.services import task_management_service
 from src.backend.services.adaptive_turn_service import (
+    _canonical_effect_readback_receipt,
+    _canonically_verified_material_effect_ids,
     _model_visible_input_schema,
     _trusted_tool_payload,
 )
@@ -82,12 +84,88 @@ def test_ordinary_continuation_links_product_and_delegates_without_duplicate_wri
         first = handlers._task_update_fields(**payload)
         repeat = handlers._task_update_fields(**payload)
     assert first["effect_status"] == "succeeded"
-    assert first["canonical_read_back"]["current_work_product"]["status"] == "ready"
-    assert first["canonical_read_back"]["assignee_concept_id"] == "#V#von_system"
+    assert first["canonical_read_back"]["task"]["current_work_product"]["status"] == "ready"
+    assert first["canonical_read_back"]["task"]["assignee_concept_id"] == "#V#von_system"
+    receipt = _canonical_effect_readback_receipt(first)
+    assert receipt["verified"] is True
+    material, verified = _canonically_verified_material_effect_ids(
+        [
+            {
+                "effect_id": "task-edit",
+                "status": "ok",
+                "execution_method": "task_update_fields",
+            }
+        ],
+        {
+            "task-edit": {
+                "effect_status": first["effect_status"],
+                "changed": first["changed"],
+                "turn_finality_required": True,
+                "canonical_readback": receipt,
+            }
+        },
+    )
+    assert material == verified == {"task-edit"}
     assert repeat["changed"] is False
     assert repeat["idempotent_replay"] is True
     assert len(writes) == 1
     assert task["created_by_concept_id"] == "#V#alice"
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        {"task_concept_id": "#V#wrong_task"},
+        {"next_checkpoint": "Old checkpoint"},
+        {"current_work_product": {"concept_id": "#V#wrong_brief", "status": "ready"}},
+    ],
+)
+def test_task_update_does_not_verify_a_contradictory_canonical_readback(
+    monkeypatch, task_state, corrupt
+):
+    original_update = task_management_service.update_task_fields
+
+    def contradictory_update(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        result["task"].update(corrupt)
+        return result
+
+    monkeypatch.setattr(
+        task_management_service, "update_task_fields", contradictory_update
+    )
+    with override_current_actor("#V#alice", "#V#lab"):
+        result = handlers._task_update_fields(
+            **_payload(
+                current_work_product_concept_id="#V#selected_brief",
+                next_checkpoint="Inspect the newly represented paper",
+            )
+        )
+    assert result["success"] is False
+    assert result["error_code"] == "task_update_readback_mismatch"
+    assert result["effect_status"] == "partial"
+    assert _canonical_effect_readback_receipt(result)["verified"] is False
+
+
+def test_task_receipt_compares_editor_normalisation_without_copying_its_policy():
+    receipt = handlers._task_continuation_readback(
+        "#V#task_test",
+        {
+            "notes": "  Keep the experiment limitations visible.  ",
+            "priority": "HIGH",
+            "due_date": "2026-09-09T12:00:00+12:00",
+            "report_to_concept_id": "",
+            "current_work_product_concept_id": None,
+        },
+        {
+            "task_concept_id": "#V#task_test",
+            "notes": "Keep the experiment limitations visible.",
+            "priority": "high",
+            "due_date": "2026-09-09T00:00:00Z",
+            "report_to_concept_id": None,
+            "current_work_product": {"status": "missing"},
+        },
+    )
+    assert receipt["verified"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ordinary task updates saved their checkpoint correctly but returned a raw task record as the effect receipt. Its domain status (for example pending) was mistaken for an unverified edit, producing a noisy partial-effect report and relegating useful progress to a non-authoritative draft.

Compare the requested fields with the canonical task read-back using the existing editor's normalisers. Return an explicit verification receipt containing the unchanged task record; retain the existing top-level task response. A contradictory identity, checkpoint or selected product is reported as partial with mismatched fields. Verification of an edit is independent of completion of the underlying responsibility.

Validation: 29 targeted task/launch/action tests pass, including the actual adaptive effect-receipt consumer, contradictory read-back controls, normalised dates/text and idempotent continuation. Ruff and diff checks pass. The observed live false-negative report is from Luna request c6953a43-a488-4ae2-b20b-cef2f4a6d382; its paper child later failed independently, so that domain failure is not reclassified by this repair.

Merge decision: ready for the bounded reporting repair. Recurrence remains disabled until a useful paper/mail outcome is verified. JVNAUTOSCI-2244; related JVNAUTOSCI-2721.
