### PR TITLE
Distinguish unchecked source currency from a changed source

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -118,6 +118,11 @@ alone cannot establish currency under a revised expectation. Preserve earlier
 evidence and receipts; reassess and fill the demonstrated gap instead of
 discarding the representation or downloading everything again. Different uses
 may have different adequate representations of the same canonical paper.
+Marker reads distinguish `source_fingerprint_comparison=not_requested` from
+`mismatched`. The former means no expected source fingerprint was supplied;
+its legacy false matches/current flags do not establish a changed source.
+Supply current source evidence for that comparison, independently of whether
+the earlier representation meets the current user expectation.
 Privacy scope remains distinct from semantic applicability; see
 [contextual knowledge evolution](contextual_knowledge_evolution.md).
 

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -11522,7 +11522,10 @@ def _source_processing_marker_input_schema(*, read_only: bool = False) -> Schema
                 "source processing marker lookup: source_system and source_item_id "
                 "identify the source item. Supply the exact stable source_profile for "
                 "profile-scoped markers; omit it only to read an historical "
-                "profileless marker."
+                "profileless marker. Supply source_fingerprint from the current "
+                "source evidence to compare currency. Without it, comparison is "
+                "not_requested; the legacy false matches/current flags do not "
+                "establish that the source changed."
             )
             if read_only
             else (
@@ -11575,6 +11578,7 @@ def _source_processing_marker_output_schema() -> Schema:
             "stored_source_fingerprint": (str, type(None)),
             "expected_source_fingerprint": (str, type(None)),
             "source_fingerprint_matches": (bool, type(None)),
+            "source_fingerprint_comparison": str,
             "source_processing_current": (bool, type(None)),
             "stored_processing_authority_fingerprint": (str, type(None)),
             "expected_processing_authority_fingerprint": (str, type(None)),
@@ -40161,7 +40165,12 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             description=(
                 "Read the durable Vontology marker for a source item, if one "
                 "exists. Use before repeating source-processing work so a workflow "
-                "can reuse represented evidence instead of mutating the source system."
+                "can reuse represented evidence instead of mutating the source system. "
+                "To assess currency, supply source_fingerprint from current source "
+                "evidence and, where relevant, processing_authority_fingerprint. "
+                "Omitting the expected source fingerprint returns comparison="
+                "not_requested, not evidence of a changed source. Marker existence "
+                "does not prove adequacy under a revised user expectation."
             ),
         ),
         MethodDefinition(

--- a/src/backend/services/source_processing_marker_service.py
+++ b/src/backend/services/source_processing_marker_service.py
@@ -341,6 +341,18 @@ def _marker_response_from_payload(
         and expected_fingerprint
         and stored_source_fingerprint == expected_fingerprint
     )
+    # Keep the legacy boolean for workflow consumers, but do not present an
+    # omitted comparison as evidence that the source changed.
+    if not expected_fingerprint:
+        source_fingerprint_comparison = "not_requested"
+    elif not marker_exists:
+        source_fingerprint_comparison = "marker_missing"
+    elif not stored_source_fingerprint:
+        source_fingerprint_comparison = "stored_fingerprint_missing"
+    else:
+        source_fingerprint_comparison = (
+            "matched" if source_fingerprint_matches else "mismatched"
+        )
     source_system = _clean_text(payload.get("source_system")).lower()
     represented_outputs_required = bool(require_represented_artifacts) or (
         source_system
@@ -391,6 +403,7 @@ def _marker_response_from_payload(
         "stored_source_fingerprint": stored_source_fingerprint or None,
         "expected_source_fingerprint": expected_fingerprint or None,
         "source_fingerprint_matches": source_fingerprint_matches,
+        "source_fingerprint_comparison": source_fingerprint_comparison,
         "processing_status": stored_processing_status or None,
         "stored_processing_authority_fingerprint": (
             stored_authority_fingerprint or None

--- a/tests/backend/test_source_processing_marker_service.py
+++ b/tests/backend/test_source_processing_marker_service.py
@@ -6,6 +6,36 @@ from typing import Any
 import pytest
 
 
+@pytest.mark.parametrize(
+    "exists,stored,expected,comparison,current",
+    [
+        (True, "source-1", None, "not_requested", False),
+        (True, "source-1", "source-1", "matched", True),
+        (True, "source-1", "source-2", "mismatched", False),
+        (False, None, "source-1", "marker_missing", False),
+        (True, None, "source-1", "stored_fingerprint_missing", False),
+    ],
+)
+def test_marker_distinguishes_unrequested_comparison_from_changed_source(
+    exists, stored, expected, comparison, current
+):
+    from src.backend.services import source_processing_marker_service as service
+
+    result = service._marker_response_from_payload(
+        marker_concept_id="#V#marker",
+        source_item_id="source-item",
+        marker_exists=exists,
+        evidence_payload={
+            "processing_status": "completed",
+            "source_fingerprint": stored,
+        },
+        expected_source_fingerprint=expected,
+    )
+    assert result["source_fingerprint_comparison"] == comparison
+    assert result["source_fingerprint_matches"] is current
+    assert result["source_processing_current"] is current
+
+
 def test_find_existing_concept_ids_matches_canonicalised_ids(monkeypatch) -> None:
     from src.backend.db.repositories.concepts_repository import ConceptsRepository
     from src.backend.services import source_processing_marker_service as service


### PR DESCRIPTION
Luna and Terra repeatedly treated source_fingerprint_matches=false as evidence that a paper email was stale, although their marker lookup supplied no expected fingerprint. That conflated an unrequested comparison with a mismatch and sent continuation back into unnecessary recovery.

Expose source_fingerprint_comparison with distinct not_requested, marker_missing, stored_fingerprint_missing, matched and mismatched states. Keep existing matches/current booleans and processing requirements unchanged for workflow consumers. Clarify the lookup's interface and the distinction between source currency and adequacy under revised user expectations.

Validation: 31 targeted marker/task tests pass, including missing, matching and changed source identities and existing authority-fingerprint/artefact checks. Diff checks pass. Ruff reports only two unchanged legacy findings in the service; the changed test is clean. This is an additive diagnostic correction, not automatic certification of represented papers.

Merge decision: ready for this bounded clarification. The public-paper/colleague-use refinement remains the next live acceptance encounter; all paper schedules are still disabled. JVNAUTOSCI-2244.
