### PR TITLE
JVNAUTOSCI-2244: Keep maintained briefs editable from ordinary continuation

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -139,6 +139,15 @@ reconciliation. It changes only the requested label sets. Completion assessment
 and whether to preserve Inbox remain contextual judgements; a historical
 ingestion workflow's disposition is not compulsory for all paper work.
 
+For a maintained brief, `upsert_singleton_text_relation` replaces the current
+base body for one predicate and language. Ordinary turns retain replaced text
+values and return their attachment context for recovery; the governed boundary
+checks both the stored content and that the selected group has one relation.
+Read and consolidate useful previous contents before replacing them. The
+additive `upsert_text_relation` remains appropriate for independent notes or
+multiple values. Neither operation changes separately scoped assertions or
+decides which contextual interpretation should prevail.
+
 ## Evidence of low human burden
 
 A detailed diagnostic prompt is useful engineering evidence, but not evidence

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -40488,7 +40488,10 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             ordinary_turn_effect=True,
             ordinary_turn_mutation_subject_argument="concept_id",
             description=(
-                "Add or update a canonical text relation when the actor has mutation "
+                "Attach text, reusing an identical attachment; different text adds "
+                "another row and does not replace previous contents. To maintain "
+                "one current document body, use upsert_singleton_text_relation. "
+                "Requires mutation "
                 "authority over the subject concept. On an actor-bound surface that "
                 "exposes upsert_scoped_assertion, use that capability for knowledge "
                 "about a visible concept the actor does not own. Supports hasContent, "
@@ -40550,7 +40553,24 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
             input_schema=_upsert_singleton_text_relation_input_schema(),
             output_schema=_upsert_singleton_text_relation_output_schema(),
             category="write",
-            description="Upsert a text relation and enforce singleton semantics for (concept, predicate, language) by replacing any other relations in the same group.",
+            ordinary_turn_trusted_argument_bindings={"namespace": "turn_namespace"},
+            ordinary_turn_fixed_arguments={
+                "provenance": None,
+                "garbage_collect": False,
+                "policy": "replace_others",
+            },
+            ordinary_turn_effect=True,
+            ordinary_turn_mutation_subject_argument="concept_id",
+            description=(
+                "Replace the current text of a maintained document or brief, "
+                "leaving one base text relation for the selected concept, predicate "
+                "and language. Read and consolidate useful previous contents first. "
+                "Other languages, predicates and scoped assertions are unaffected. "
+                "Use additive upsert_text_relation for independent notes or "
+                "multiple values. Requires mutation authority over the subject; "
+                "ordinary turns retain replaced text values and return their "
+                "attachment metadata for recovery."
+            ),
         ),
         MethodDefinition(
             name="concept_exists",

--- a/src/backend/services/ontology_mutation_command_service.py
+++ b/src/backend/services/ontology_mutation_command_service.py
@@ -2367,7 +2367,9 @@ def _text_read_back(
     predicate: str | None,
     result: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    relation_id = _clean_text((result or {}).get("relation_id"))
+    relation_id = _clean_text(
+        (result or {}).get("relation_id") or (result or {}).get("kept_relation_id")
+    )
     query: dict[str, Any] = {"subject_concept_id": concept_id}
     if relation_id:
         try:
@@ -2617,7 +2619,7 @@ def canonical_read_back_for_method(
         "add_names_to_concept",
         "delete_text_relation",
     }:
-        return _text_read_back(
+        state = _text_read_back(
             concept_id=_normalise_concept_id(
                 arguments.get("concept_id") or arguments.get("subject_concept_id")
             )
@@ -2625,6 +2627,22 @@ def canonical_read_back_for_method(
             predicate=_normalise_predicate(arguments.get("predicate")),
             result=result,
         )
+        if method == "upsert_singleton_text_relation":
+            from .text_value_service import get_text_relations_summary
+
+            summary = get_text_relations_summary(
+                state["concept_id"],
+                predicates=[_normalise_predicate(arguments.get("predicate")) or ""],
+                languages=[
+                    _clean_text(arguments.get("language") or arguments.get("lang"))
+                    or "en-NZ"
+                ],
+                max_relation_ids_per_group=2,
+            )
+            state["matching_relation_count"] = sum(
+                group["count"] for group in summary["groups"]
+            )
+        return state
     if method == "create_concepts":
         concept_ids = _create_read_back_concept_ids(
             arguments=arguments,
@@ -2824,6 +2842,10 @@ def _verify_method_postcondition(
             exact_relation = exact_relation and (
                 canonical_state.get("context_sha256")
                 == intent.delta.get("context_sha256")
+            )
+        if method == "upsert_singleton_text_relation":
+            exact_relation = exact_relation and (
+                canonical_state.get("matching_relation_count") == 1
             )
         return bool(expected_hash) and exact_relation
     if method == "delete_text_relation":

--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -1517,7 +1517,7 @@ def upsert_singleton_text_relation(
                 "subject_concept_id": subject_concept_id,
                 "predicate": predicate,
             },
-            projection={"_id": 1, "object_text_id": 1},
+            projection={"_id": 1, "object_text_id": 1, "context": 1},
         )
     )
 
@@ -1551,6 +1551,7 @@ def upsert_singleton_text_relation(
             tv_lang_by_id[str(tv.get("_id"))] = str(tv.get("lang") or "")
 
     replaced_relation_ids: List[str] = []
+    replaced_relations: list[dict[str, Any]] = []
     lang_normalised = (lang or "").strip()
     for rel in rels:
         rel_id = str(rel.get("_id"))
@@ -1570,6 +1571,13 @@ def upsert_singleton_text_relation(
             garbage_collect=garbage_collect,
         )
         replaced_relation_ids.append(rel_id)
+        replaced_relations.append(
+            {
+                "relation_id": rel_id,
+                "text_value_id": tv_id_str,
+                "context": rel.get("context") or {},
+            }
+        )
 
     return {
         "success": True,
@@ -1578,6 +1586,8 @@ def upsert_singleton_text_relation(
         "language": lang,
         "kept_relation_id": kept_relation_id,
         "replaced_relation_ids": replaced_relation_ids,
+        "replaced_relations": replaced_relations,
+        "replaced_text_values_retained": not garbage_collect,
         "replaced_count": len(replaced_relation_ids),
         "relation_created": bool(result.get("relation_created")),
         "text_value_id": result.get("text_value_id"),

--- a/tests/backend/test_ordinary_maintained_text_editing.py
+++ b/tests/backend/test_ordinary_maintained_text_editing.py
@@ -1,0 +1,211 @@
+"""Maintained briefs must remain usable after ordinary delegated edits."""
+
+from contextlib import nullcontext
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+from src.backend.db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from src.backend.integrations.internal_mcp import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.services import ontology_mutation_command_service as command
+from src.backend.services import ontology_publication_authority_service as authority
+from src.backend.services import text_value_service as texts
+from src.backend.services.adaptive_turn_service import (
+    _model_visible_input_schema,
+    _trusted_tool_payload,
+    ordinary_turn_capability_delegation,
+)
+
+
+@pytest.fixture
+def editing(monkeypatch):
+    db = mongomock.MongoClient()["maintained_text"]
+    db.relations.create_index(
+        [("subject_concept_id", 1), ("predicate", 1), ("object_text_id", 1)],
+        unique=True,
+    )
+    db.values.create_index([("fingerprint", 1), ("lang", 1)], unique=True)
+    monkeypatch.setattr(TextRelationsRepository, "collection", lambda: db.relations)
+    monkeypatch.setattr(TextValuesRepository, "collection", lambda: db.values)
+    monkeypatch.setattr(texts, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(texts, "_emit_text_relation_mutation_event", lambda **_: None)
+    monkeypatch.setattr(
+        texts,
+        "_invalidate_workflow_routing_projection_for_text_relation_change",
+        lambda **_: None,
+    )
+    monkeypatch.setattr(
+        authority,
+        "get_ontology_authority_delegations_collection",
+        lambda: db.delegations,
+    )
+    monkeypatch.setattr(
+        authority, "get_ontology_mutation_receipts_collection", lambda: db.receipts
+    )
+    monkeypatch.setattr(
+        command, "ontology_mutation_resource_lock", lambda _: nullcontext()
+    )
+    monkeypatch.setattr(command, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(authority, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(
+        command,
+        "concept_publication_context",
+        lambda _: authority.PublicationContext.user("#V#alice"),
+    )
+    gateway = InternalMCPGateway(
+        catalogue=build_default_catalogue(),
+        transport=InternalMCPTransport(),
+        enabled=True,
+    )
+    return db, gateway
+
+
+def test_ordinary_editor_is_discoverable_and_retains_old_text(editing):
+    _, gateway = editing
+    name = "upsert_singleton_text_relation"
+    assert name in ordinary_turn_capability_delegation(
+        gateway,
+        user_concept_id="#V#alice",
+        trusted_argument_values={"turn_namespace": "#V#alice"},
+    )
+    assert name not in ordinary_turn_capability_delegation(
+        gateway, user_concept_id=None
+    )
+    schema = _model_visible_input_schema(gateway.get_method_definition(name))
+    assert {"concept_id", "predicate", "language", "text", "context"} <= set(
+        schema["properties"]
+    )
+    assert not {"namespace", "provenance", "garbage_collect", "policy"} & set(
+        schema["properties"]
+    )
+    payload = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name=name,
+        model_payload={
+            "concept_id": "#V#brief",
+            "predicate": "hasContent",
+            "text": "current",
+            "garbage_collect": True,
+            "provenance": {"actor": "#V#other"},
+        },
+        trusted_argument_values={"turn_namespace": "#V#alice"},
+    )
+    assert payload["garbage_collect"] is False
+    assert payload["provenance"] is None
+    assert payload["namespace"] == "#V#alice"
+
+
+@pytest.mark.parametrize("actor", ["#V#alice", "#V#bob"])
+def test_edit_consolidates_only_authorised_group_with_readback_and_recovery(
+    editing, actor
+):
+    db, gateway = editing
+    originals = []
+    for text, predicate, language in [
+        ("old brief", "hasContent", "en-NZ"),
+        ("competing brief", "hasContent", "en-NZ"),
+        ("French brief", "hasContent", "fr"),
+        ("independent note", "hasNote", "en-NZ"),
+    ]:
+        originals.append(
+            texts.upsert_text_for_concept(
+                subject_concept_id="#V#brief",
+                predicate=predicate,
+                text=text,
+                lang=language,
+                context={"source": text},
+            )
+        )
+    args = _trusted_tool_payload(
+        gateway=gateway,
+        tool_name="upsert_singleton_text_relation",
+        model_payload={
+            "concept_id": "#V#brief",
+            "predicate": "hasContent",
+            "text": "Consolidated current brief",
+        },
+        trusted_argument_values={"turn_namespace": actor},
+    )
+    with authority.override_current_actor(actor, None):
+        grant = command.issue_same_turn_method_delegation(
+            method_name="upsert_singleton_text_relation",
+            arguments=args,
+            actor_concept_id=actor,
+            organisation_concept_id=None,
+            delegate_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            effect_id="edit-brief",
+            turn_id="continuation-turn",
+        )
+        if actor != "#V#alice":
+            assert not grant.get("delegation_id")
+            assert db.relations.count_documents({}) == 4
+            assert db.values.count_documents({}) == 4
+            return
+        assert grant.get("delegation_id"), grant
+        with authority.bind_ontology_invocation(
+            surface="adaptive_turn",
+            executing_agent_concept_id="#V#von_system",
+            audience="adaptive_turn",
+            delegation_id=grant["delegation_id"],
+            effect_id="edit-brief",
+            turn_id="continuation-turn",
+        ):
+            result = gateway.invoke("upsert_singleton_text_relation", args).payload
+            repeated = gateway.invoke("upsert_singleton_text_relation", args).payload
+    assert result["success"] is True, result
+    assert result["authority_receipt"]["status"] == "succeeded"
+    assert result["canonical_read_back"]["matching_relation_count"] == 1
+    assert result["canonical_read_back"]["relation_id"] == result["kept_relation_id"]
+    assert result["replaced_count"] == 2
+    assert result["replaced_text_values_retained"] is True
+    assert repeated["authority_receipt"]["status"] == "succeeded"
+    assert db.relations.count_documents({}) == 3
+    assert db.values.count_documents({}) == 5
+    for original in originals[2:]:
+        assert db.relations.find_one({"_id": ObjectId(original["relation_id"])})
+    # Recovery uses the retained canonical text and recorded attachment context.
+    for old in result["replaced_relations"]:
+        value = db.values.find_one({"_id": ObjectId(old["text_value_id"])})
+        assert value and value["text"] == old["context"]["source"]
+        texts.link_text_to_concept(
+            "#V#brief", "hasContent", old["text_value_id"], old["context"]
+        )
+    assert db.relations.count_documents({}) == 5
+
+
+def test_singleton_postcondition_rejects_a_competing_body(editing):
+    _, _gateway = editing
+    args = {"concept_id": "#V#brief", "predicate": "hasContent", "text": "current"}
+    for text in ["current", "unremoved competing body"]:
+        row = texts.upsert_text_for_concept(
+            subject_concept_id="#V#brief",
+            predicate="hasContent",
+            text=text,
+            lang="en-NZ",
+        )
+        if text == "current":
+            kept_id = row["relation_id"]
+    state = command.canonical_read_back_for_method(
+        method_name="upsert_singleton_text_relation",
+        arguments=args,
+        result={"kept_relation_id": kept_id},
+    )
+    with authority.override_current_actor("#V#alice", None):
+        intent = command.build_ontology_mutation_intent(
+            method_name="upsert_singleton_text_relation",
+            arguments=args,
+        )
+    assert state["matching_relation_count"] == 2
+    assert not command._verify_method_postcondition(
+        method_name="upsert_singleton_text_relation",
+        intent=intent,
+        result={"success": True},
+        canonical_state=state,
+    )


### PR DESCRIPTION
Ordinary task continuation could add text to a brief but could not replace its current body. A live paper-responsibility encounter consequently left competing contents and made the current work product ambiguous.

Expose the existing singleton text editor under subject mutation authority, retain replaced text values and attachment context, and distinguish replacement from additive attachment in tool descriptions. Canonical verification now reads the exact kept relation and requires one body for the selected predicate and language. Other languages, predicates and scoped assertions retain their existing semantics.

Validation: 14 focused tests pass, including normal same-turn authority issuance, another actor's denial, repeat execution, retained neighbouring text, recovery and contradictory read-back. New test lint and diff checks pass; changed source files add no Ruff findings relative to main. Four adjacent provenance tests fail identically on unchanged main and are outside this bounded repair. This PR does not establish a full paper ingestion pass or activate a recurrence.
