### PR TITLE
JVNAUTOSCI-2244: Resolve Gmail processing markers across profile names

### DIFF
--- a/docs/engineering/task_responsibility_continuation.md
+++ b/docs/engineering/task_responsibility_continuation.md
@@ -102,8 +102,13 @@ workflow ran. Bibliographic acquisition, document retrieval, scientific
 interpretation, identity reconciliation and source disposition remain
 separable capabilities. Choose and improve them against the current job.
 
-Keep the initial expectation as inspectable, revisable text in the working
-account. When acquisition, assessment and later audit need a shared independent
+Keep current requirements and the adequacy expectation as inspectable, revisable
+task guidance (the task description is the existing smallest adequate surface).
+Keep changing progress and encounter evidence in the working account and
+checkpoint. Replacing a progress brief must not erase the current requirements.
+An assessment can quote the expectation it applied, with its revision or source,
+without becoming a second authority for it. When acquisition, assessment and
+later audit need a shared independent
 reference, give that expectation a represented profile identity and read its
 current actor-effective body. Existing representation-contract profiles are
 worth inspecting, but their historical tool-requirement contracts do not by
@@ -125,6 +130,14 @@ Supply current source evidence for that comparison, independently of whether
 the earlier representation meets the current user expectation.
 Privacy scope remains distinct from semantic applicability; see
 [contextual knowledge evolution](contextual_knowledge_evolution.md).
+
+For an authorised Gmail profile, marker reads and writes resolve its represented
+resource ID and runtime alias to the same existing marker. A sole legacy marker
+is reused; new markers use the represented resource identity. If both spellings
+already have records, the resource-keyed record is selected and alternate IDs
+are exposed for inspection without deleting or merging their evidence. Opaque
+source fingerprints are still compared exactly. None of this identity handling
+establishes adequacy under the current task guidance.
 
 Other guidance that may need revision includes mailbox selection and intent,
 coverage and backlog priority, effort per encounter, retry/audit cadence,

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -40170,7 +40170,10 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "evidence and, where relevant, processing_authority_fingerprint. "
                 "Omitting the expected source fingerprint returns comparison="
                 "not_requested, not evidence of a changed source. Marker existence "
-                "does not prove adequacy under a revised user expectation."
+                "does not prove adequacy under a revised user expectation. "
+                "An authorised Gmail profile's resource ID and runtime alias "
+                "resolve to the same existing marker; alternate historical marker "
+                "IDs are exposed for inspection."
             ),
         ),
         MethodDefinition(
@@ -40190,7 +40193,8 @@ def _build_default_catalogue_core_definitions() -> List[MethodDefinition]:
                 "item as processed into represented artefacts. This is additive "
                 "Vontology state and should be called only after durable "
                 "representation and read-back have verified processing success. It "
-                "does not mutate the source system."
+                "does not mutate the source system. Authorised Gmail profile IDs "
+                "and runtime aliases reuse the same marker identity."
             ),
         ),
         *build_spreadsheet_record_tool_definitions(),

--- a/src/backend/services/source_processing_marker_service.py
+++ b/src/backend/services/source_processing_marker_service.py
@@ -267,6 +267,52 @@ def source_processing_marker_concept_id(
     return f"#V#source_processing_marker_{slug}_{digest}"
 
 
+def _source_profile_identities(
+    source_system: str, source_profile: str | None
+) -> tuple[list[str], dict[str, Any]]:
+    """Resolve authorised mailbox aliases without changing opaque source keys."""
+    profile = _clean_text(source_profile)
+    if source_system.lower() != "gmail" or not profile:
+        return [profile], {}
+
+    from ..security.access_control import get_effective_user_concept_id
+    from .mail_profile_resource_vontology_service import (
+        resolve_authorised_gmail_profile_for_user,
+    )
+
+    actor = get_effective_user_concept_id()
+    if not actor:
+        return [profile], {}
+    resolved = resolve_authorised_gmail_profile_for_user(
+        user_concept_id=actor, requested_profile_id=profile
+    )
+    if not resolved.get("success"):
+        # Reading an accessible historical marker does not itself require
+        # access to the mailbox. Do not infer aliases outside actor authority.
+        return [profile], {}
+    identities = _ordered_unique(
+        [resolved.get("profile_resource_concept_id"), resolved.get("profile_id")]
+    )
+    return identities, {
+        "requested_profile": profile,
+        "profile_resource_concept_id": resolved.get("profile_resource_concept_id"),
+        "runtime_profile_alias": resolved.get("profile_id"),
+    }
+
+
+def _profile_marker_candidates(
+    source_system: str, source_profile: str | None, source_item_id: str
+) -> tuple[dict[str, str], dict[str, Any]]:
+    profiles, resolution = _source_profile_identities(source_system, source_profile)
+    return {
+        source_processing_marker_concept_id(
+            source_system=source_system, source_profile=profile,
+            source_item_id=source_item_id,
+        ): profile
+        for profile in profiles
+    }, resolution
+
+
 def _extract_concept_ids_from_outputs(value: Any) -> tuple[list[str], list[str]]:
     represented_ids: list[str] = []
     file_copy_ids: list[str] = []
@@ -467,14 +513,19 @@ def get_source_processing_marker(
             "error_code": "missing_source_processing_marker_key",
             "error": "source_system and source_item_id are required.",
         }
-    marker_concept_id = source_processing_marker_concept_id(
-        source_system=source_system_clean,
-        source_profile=source_profile,
-        source_item_id=source_item_clean,
+    candidates, profile_resolution = _profile_marker_candidates(
+        source_system_clean, source_profile, source_item_clean
     )
-    marker_exists = _concept_exists(marker_concept_id)
+    if len(candidates) == 1:
+        existing_ids = {cid for cid in candidates if _concept_exists(cid)}
+    else:
+        existing_ids = _find_existing_concept_ids(list(candidates))
+    marker_concept_id = next(
+        (cid for cid in candidates if cid in existing_ids), next(iter(candidates))
+    )
+    marker_exists = marker_concept_id in existing_ids
     payload = _load_marker_payload(marker_concept_id) if marker_exists else None
-    return _marker_response_from_payload(
+    result = _marker_response_from_payload(
         marker_concept_id=marker_concept_id,
         source_item_id=source_item_clean,
         marker_exists=marker_exists,
@@ -485,6 +536,11 @@ def get_source_processing_marker(
         ),
         require_represented_artifacts=require_represented_artifacts,
     )
+    result["source_profile_resolution"] = profile_resolution
+    result["alternate_marker_concept_ids"] = [
+        cid for cid in candidates if cid in existing_ids and cid != marker_concept_id
+    ]
+    return result
 
 
 def record_source_processing_marker(
@@ -581,13 +637,15 @@ def record_source_processing_marker(
                 ),
             }
 
-    marker_concept_id = source_processing_marker_concept_id(
-        source_system=source_system_clean,
-        source_profile=source_profile_clean,
-        source_item_id=source_item_clean,
+    candidates, profile_resolution = _profile_marker_candidates(
+        source_system_clean, source_profile_clean, source_item_clean
     )
     support_ids = [str(spec["concept_id"]) for spec in _SUPPORT_TYPE_SPECS]
-    existing_ids = _find_existing_concept_ids([*support_ids, marker_concept_id])
+    existing_ids = _find_existing_concept_ids([*support_ids, *candidates])
+    marker_concept_id = next(
+        (cid for cid in candidates if cid in existing_ids), next(iter(candidates))
+    )
+    source_profile_clean = candidates[marker_concept_id]
     support_created = _ensure_support_concepts(existing_ids=existing_ids)
     marker_exists = marker_concept_id in existing_ids
     previous_payload = _load_marker_payload(marker_concept_id) if marker_exists else None
@@ -674,7 +732,7 @@ def record_source_processing_marker(
         context={"source": "source_processing_marker_service"},
         garbage_collect=True,
     )
-    return _marker_response_from_payload(
+    result = _marker_response_from_payload(
         marker_concept_id=marker_concept_id,
         source_item_id=source_item_clean,
         marker_exists=True,
@@ -688,6 +746,11 @@ def record_source_processing_marker(
         ),
         require_represented_artifacts=require_represented_artifacts,
     )
+    result["source_profile_resolution"] = profile_resolution
+    result["alternate_marker_concept_ids"] = [
+        cid for cid in candidates if cid in existing_ids and cid != marker_concept_id
+    ]
+    return result
 
 
 __all__ = [

--- a/tests/backend/test_source_processing_marker_service.py
+++ b/tests/backend/test_source_processing_marker_service.py
@@ -6,6 +6,132 @@ from typing import Any
 import pytest
 
 
+@pytest.fixture
+def authorised_mail_marker_store(monkeypatch):
+    from src.backend.security import access_control
+    from src.backend.services import mail_profile_resource_vontology_service as profiles
+    from src.backend.services import source_processing_marker_service as service
+
+    resource, alias = "#V#gmail_profile_lab", "lab-mail"
+    payloads = {}
+    existing = {str(spec["concept_id"]) for spec in service._SUPPORT_TYPE_SPECS}
+    monkeypatch.setattr(
+        access_control, "get_effective_user_concept_id", lambda: "#V#alice"
+    )
+
+    def resolve(*, user_concept_id, requested_profile_id):
+        assert user_concept_id == "#V#alice"
+        return {
+            "success": requested_profile_id in {resource, alias},
+            "profile_resource_concept_id": resource,
+            "profile_id": alias,
+        }
+
+    monkeypatch.setattr(profiles, "resolve_authorised_gmail_profile_for_user", resolve)
+    monkeypatch.setattr(
+        service, "_find_existing_concept_ids", lambda ids: set(ids) & existing
+    )
+    monkeypatch.setattr(service, "_concept_exists", lambda cid: cid in existing)
+    monkeypatch.setattr(service, "_load_marker_payload", lambda cid: payloads.get(cid))
+    monkeypatch.setattr(
+        service.concept_service,
+        "create_concept",
+        lambda **kw: existing.add(kw["concept_id"]),
+    )
+
+    def write(**kwargs):
+        payloads[kwargs["subject_concept_id"]] = json.loads(kwargs["text"])
+        return {"success": True}
+
+    monkeypatch.setattr(service, "upsert_singleton_text_relation", write)
+    return service, resource, alias, existing, payloads
+
+
+@pytest.mark.parametrize("existing_spelling", [None, "alias", "resource"])
+def test_mail_profile_spellings_reuse_one_marker_on_read_and_write(
+    authorised_mail_marker_store, existing_spelling
+):
+    service, resource, alias, existing, payloads = authorised_mail_marker_store
+    profile = alias if existing_spelling == "alias" else resource
+    expected_id = service.source_processing_marker_concept_id(
+        source_system="gmail", source_profile=profile, source_item_id="message-1"
+    )
+    if existing_spelling:
+        existing.add(expected_id)
+        payloads[expected_id] = {
+            "processing_status": "completed",
+            "source_fingerprint": "source-1",
+        }
+        for spelling in (resource, alias):
+            read = service.get_source_processing_marker(
+                source_system="gmail",
+                source_profile=spelling,
+                source_item_id="message-1",
+                source_fingerprint="source-1",
+            )
+            assert read["source_processing_marker"] == expected_id
+            assert read["source_processing_current"] is True
+    for spelling in (resource, alias):
+        written = service.record_source_processing_marker(
+            source_system="gmail",
+            source_profile=spelling,
+            source_item_id="message-1",
+            processing_status="completed",
+            source_fingerprint="source-1",
+        )
+        assert written["source_processing_marker"] == expected_id
+        assert written["source_processing_current"] is True
+    assert set(payloads) == {expected_id}
+    assert payloads[expected_id]["source_profile"] == profile
+
+
+def test_existing_duplicate_marker_evidence_is_exposed_without_merging(
+    authorised_mail_marker_store,
+):
+    service, resource, alias, existing, payloads = authorised_mail_marker_store
+    ids = [
+        service.source_processing_marker_concept_id(
+            source_system="gmail", source_profile=spelling, source_item_id="message-1"
+        )
+        for spelling in (resource, alias)
+    ]
+    existing.update(ids)
+    payloads.update(
+        {
+            cid: {"processing_status": "completed", "source_fingerprint": str(i)}
+            for i, cid in enumerate(ids)
+        }
+    )
+    for spelling in (resource, alias):
+        result = service.get_source_processing_marker(
+            source_system="gmail",
+            source_profile=spelling,
+            source_item_id="message-1",
+            source_fingerprint="0",
+        )
+        assert result["source_processing_marker"] == ids[0]
+        assert result["alternate_marker_concept_ids"] == [ids[1]]
+        assert result["source_profile_resolution"]["runtime_profile_alias"] == alias
+    assert payloads[ids[1]]["source_fingerprint"] == "1"
+
+
+def test_marker_alias_resolution_does_not_infer_other_mailbox_authority(
+    authorised_mail_marker_store,
+):
+    service, resource, alias, existing, payloads = authorised_mail_marker_store
+    marker_id = service.source_processing_marker_concept_id(
+        source_system="gmail", source_profile=alias, source_item_id="message-1"
+    )
+    existing.add(marker_id)
+    payloads[marker_id] = {"processing_status": "completed"}
+    for system, profile in [("gmail", "someone-elses-mail"), ("dataset", resource)]:
+        read = service.get_source_processing_marker(
+            source_system=system, source_profile=profile, source_item_id="message-1"
+        )
+        assert read["source_processing_marker_exists"] is False
+        assert read["source_profile_resolution"] == {}
+
+
 @pytest.mark.parametrize(
     "exists,stored,expected,comparison,current",
     [


### PR DESCRIPTION
The same Gmail mailbox can be supplied as a represented profile ID or its runtime alias. Source-marker lookup treated them as different keys: a live historical-paper encounter saw no marker through one name, then reused an already-completed marker through the other and incorrectly claimed new progress.

Resolve those names through the existing actor-authorised mail-profile resolver. Reads and writes reuse a sole existing legacy marker; new records use the represented resource identity. Existing alternate records are exposed without deleting or merging their evidence. Opaque fingerprints, other source systems and unrecognised profile keys retain their semantics. Clarify that standing task guidance survives separately from progress-only brief updates.

Validation: 37 marker, mail-profile and authority tests pass. Candidate code canonically reads the same marker and artefacts through both mailbox names for two live messages, one with an alias-keyed marker and one with a resource-keyed marker. Diff checks pass; the two service Ruff findings are unchanged from main. This proves identity reconciliation, not semantic adequacy of the old paper or unattended backlog coverage. Paper schedules remain paused pending that separate acceptance work.
