### PR TITLE
Preserve verified ontology read-back in finality receipts

### DIFF
--- a/src/backend/services/ontology_publication_authority_service.py
+++ b/src/backend/services/ontology_publication_authority_service.py
@@ -2316,6 +2316,14 @@ def execute_authorised_ontology_mutation(
             postcondition_verified = bool(verify_read_back(result, canonical_state))
         except Exception:  # noqa: BLE001 - a verifier failure cannot imply success
             postcondition_verified = False
+        if isinstance(canonical_state, Mapping):
+            # Preserve the exact verifier's result through evidence projection
+            # and finality reporting; handler success alone is not this proof.
+            canonical_state = {
+                **canonical_state,
+                "verified": postcondition_verified,
+                "status": "verified" if postcondition_verified else "unverified",
+            }
         if not postcondition_verified:
             result = {
                 **result,

--- a/tests/backend/test_ontology_authority_tier3_regressions.py
+++ b/tests/backend/test_ontology_authority_tier3_regressions.py
@@ -475,7 +475,11 @@ def test_global_admin_can_adopt_historical_scope_with_canonical_read_back(
 
     assert result["success"] is True
     assert result["authority_decision"]["allowed"] is True
-    assert result["canonical_read_back"] == after
+    assert result["canonical_read_back"] == {
+        **after,
+        "verified": True,
+        "status": "verified",
+    }
     assert removed == [
         {
             "source_id": "#V#legacy_concept",

--- a/tests/backend/test_ontology_publication_authority_service.py
+++ b/tests/backend/test_ontology_publication_authority_service.py
@@ -632,6 +632,52 @@ def test_mutation_receipt_reconciles_and_replays_idempotently(
     assert receipts.count_documents({}) == 1
 
 
+@pytest.mark.parametrize(
+    "case", ["verified", "contradictory", "raises", "no_verifier", "preview"]
+)
+def test_receipt_exposes_only_actual_postcondition_verification(
+    authority_stores, monkeypatch, case
+):
+    service, _delegations, receipts = authority_stores
+    role = _evidence(service, role=service.GLOBAL_ONTOLOGY_ADMINISTRATOR_ROLE)
+    monkeypatch.setattr(service, "resolve_live_semantic_roles", lambda _actor: (role,))
+    canonical = {"relationship_present": case != "contradictory"}
+    calls = []
+
+    def verify(result, state):
+        calls.append(state)
+        if case == "raises":
+            raise RuntimeError("read-back proof unavailable")
+        return state["relationship_present"] is True
+
+    with service.override_current_actor("#V#admin", None):
+        result = service.execute_authorised_ontology_mutation(
+            intent=_intent(service, idempotency_key="receipt-proof-" + case),
+            mutate=lambda: {"success": True, "changed": True},
+            read_back=lambda: dict(canonical),
+            verify_read_back=None if case == "no_verifier" else verify,
+            preview=case == "preview",
+        )
+    expected = None if case in {"no_verifier", "preview"} else case == "verified"
+    assert result["canonical_read_back"].get("verified") is expected
+    assert (
+        result["authority_receipt"]["canonical_read_back"].get("verified") is expected
+    )
+    assert result["canonical_read_back"].get("status") == (
+        None if expected is None else "verified" if expected else "unverified"
+    )
+    assert len(calls) == (0 if expected is None else 1)
+    if expected is False:
+        assert result["success"] is False
+        assert result["authority_receipt"]["status"] == "indeterminate"
+        assert result["error_code"] == "ontology_mutation_postcondition_failed"
+    elif case == "preview":
+        assert result["authority_receipt"]["status"] == "previewed"
+    else:
+        assert result["authority_receipt"]["status"] == "succeeded"
+    assert receipts.count_documents({}) == 1
+
+
 def test_indeterminate_receipt_can_be_finalised_by_exact_later_reconciliation(
     authority_stores,
 ) -> None:

--- a/tests/backend/test_ordinary_maintained_text_editing.py
+++ b/tests/backend/test_ordinary_maintained_text_editing.py
@@ -17,10 +17,14 @@ from src.backend.services import ontology_mutation_command_service as command
 from src.backend.services import ontology_publication_authority_service as authority
 from src.backend.services import text_value_service as texts
 from src.backend.services.adaptive_turn_service import (
+    _build_effect_outcome_report,
+    _canonical_effect_readback_receipt,
+    _canonically_verified_material_effect_ids,
     _model_visible_input_schema,
     _trusted_tool_payload,
     ordinary_turn_capability_delegation,
 )
+from src.backend.services.turn_evidence_store import TrustedTurnScope
 
 
 @pytest.fixture
@@ -161,11 +165,51 @@ def test_edit_consolidates_only_authorised_group_with_readback_and_recovery(
             repeated = gateway.invoke("upsert_singleton_text_relation", args).payload
     assert result["success"] is True, result
     assert result["authority_receipt"]["status"] == "succeeded"
+    assert result["authority_receipt"]["canonical_read_back"]["verified"] is True
+    receipt = _canonical_effect_readback_receipt(result)
+    material, verified = _canonically_verified_material_effect_ids(
+        [
+            {
+                "effect_id": "edit-brief",
+                "status": "ok",
+                "execution_method": "upsert_singleton_text_relation",
+            }
+        ],
+        {
+            "edit-brief": {
+                "effect_status": "succeeded",
+                "changed": True,
+                "turn_finality_required": True,
+                "canonical_readback": receipt,
+            }
+        },
+    )
+    assert material == verified == {"edit-brief"}
+    screen, report = _build_effect_outcome_report(
+        terminal_status="effect_partially_completed",
+        effect_snapshot={
+            "edit-brief": {
+                "effect_status": "succeeded",
+                "changed": True,
+                "canonical_readback": receipt,
+            }
+        },
+        tool_invocations=[
+            {"effect_id": "edit-brief", "tool": "upsert_singleton_text_relation"}
+        ],
+        trusted_scope=TrustedTurnScope(
+            user_concept_id=actor, organisation_concept_id=None, namespace=actor
+        ),
+    )
+    assert report["facts"][0]["canonical_readback_verified"] is True
+    assert "succeeded with canonical read-back" in screen
+    assert "did not verify" not in screen
     assert result["canonical_read_back"]["matching_relation_count"] == 1
     assert result["canonical_read_back"]["relation_id"] == result["kept_relation_id"]
     assert result["replaced_count"] == 2
     assert result["replaced_text_values_retained"] is True
     assert repeated["authority_receipt"]["status"] == "succeeded"
+    assert repeated["canonical_read_back"]["verified"] is True
     assert db.relations.count_documents({}) == 3
     assert db.values.count_documents({}) == 5
     for original in originals[2:]:


### PR DESCRIPTION
A maintained-brief edit could pass the governed content and singleton checks, persist a succeeded receipt, and still be described by the final response as unverified. Preserve the exact verifier's result as the existing `verified`/`status` read-back contract so evidence projection and finality report the saved edit correctly.

The flag is emitted only when the postcondition verifier runs. Contradictions and verifier exceptions remain unverified; previews and calls without a verifier gain no proof. No authority decision or domain-completion criterion changes.

Validation: 93 targeted authority, role and maintained-text tests pass; the ordinary editor test exercises the actual evidence projection and finality report, including idempotent replay. Ruff and diff checks pass. The observed EnvHarness encounter still has a pending domain workflow; fixing the brief receipt does not certify that paper or activate a schedule.

Tracks JVNAUTOSCI-2244 and the continuing-responsibility encounter under JVNAUTOSCI-2721.
