### PR TITLE
Keep continuing task checkpoints current across revisions

### DIFF
--- a/src/backend/services/task_management_service.py
+++ b/src/backend/services/task_management_service.py
@@ -30,6 +30,7 @@ from ..security.visibility_predicates import (
 from ..services.text_value_service import (
     get_texts_for_concept,
     get_texts_for_concepts,
+    upsert_singleton_text_relation,
     upsert_text_for_concept,
 )
 from ..utils.concept_id_utils import (
@@ -461,11 +462,15 @@ def _upsert_optional_task_text(
             log_field_name=predicate,
         )
 
-    upsert_text_for_concept(
+    # These are current task fields, not an additive collection of notes.
+    # Otherwise repeated revisions eventually push the current checkpoint
+    # beyond the bounded task reader. Keep replaced values recoverable.
+    upsert_singleton_text_relation(
         subject_concept_id=task_concept_id,
         predicate=predicate,
         text=value,
         lang=lang,
+        garbage_collect=False,
     )
 
 

--- a/tests/backend/test_task_current_text_persistence.py
+++ b/tests/backend/test_task_current_text_persistence.py
@@ -1,0 +1,115 @@
+"""Continuing tasks retain their current fields after many ordinary edits."""
+
+from unittest.mock import Mock
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+from src.backend.db.repositories.concepts_repository import ConceptsRepository
+from src.backend.db.repositories.text_value_repository import (
+    TextRelationsRepository,
+    TextValuesRepository,
+)
+from src.backend.integrations.internal_mcp import catalogue
+from src.backend.services import task_management_service as tasks
+from src.backend.services import text_value_service as texts
+
+
+@pytest.fixture
+def task_store(monkeypatch):
+    db = mongomock.MongoClient()["task_current_text"]
+    monkeypatch.setattr(ConceptsRepository, "collection", lambda: db.concepts)
+    monkeypatch.setattr(TextRelationsRepository, "collection", lambda: db.relations)
+    monkeypatch.setattr(TextValuesRepository, "collection", lambda: db.values)
+    monkeypatch.setattr(texts, "can_access_concept", lambda _: True)
+    monkeypatch.setattr(texts, "filter_accessible_concept_ids", lambda ids: set(ids))
+    monkeypatch.setattr(texts, "_emit_text_relation_mutation_event", lambda **_: None)
+    monkeypatch.setattr(texts, "_invalidate_stats_for_predicate_change", lambda _: None)
+    monkeypatch.setattr(
+        texts,
+        "_invalidate_workflow_routing_projection_for_text_relation_change",
+        lambda **_: None,
+    )
+    doc = {"concept_id": "#V#continuing_task", "relationships": {}, "metadata": {}}
+    db.concepts.insert_one(doc)
+    monkeypatch.setattr(tasks, "_get_task_doc", lambda cid: (cid, doc))
+    monkeypatch.setattr(
+        tasks, "resolve_task_work_product", lambda _: {"status": "missing"}
+    )
+    monkeypatch.setattr(tasks, "_append_task_history_event", Mock())
+    return db
+
+
+def seed(text, *, predicate="hasNote", lang="en-NZ", task="#V#continuing_task"):
+    return texts.upsert_text_for_concept(
+        subject_concept_id=task,
+        predicate=predicate,
+        text=text,
+        lang=lang,
+    )
+
+
+def test_current_fields_survive_legacy_overflow_and_repeated_revisions(task_store):
+    # Reproduce the old additive store exceeding the task reader's 50 rows.
+    old_values = [seed(f"Old observation {i}")["text_value_id"] for i in range(60)]
+    seed("Standing research requirements", predicate="hasDescription")
+    seed("Conserver cette traduction", lang="fr")
+    seed("An independent annotation", predicate="hasContent")
+    seed("Another task's note", task="#V#another_task")
+
+    for revision in range(55):
+        fields = {
+            "notes": f"Observation {revision}",
+            "next_checkpoint": f"Inspect source {revision}",
+            "progress_signal": f"Progress {revision}",
+            "evidence": f"Evidence {revision}",
+        }
+        result = tasks.update_task_fields("#V#continuing_task", fields=fields)
+        receipt = catalogue._task_continuation_readback(
+            "#V#continuing_task",
+            fields,
+            result["task"],
+        )
+        assert receipt["verified"] is True
+        assert all(result["task"][key] == value for key, value in fields.items())
+        assert result["task"]["description"] == "Standing research requirements"
+
+    # List and point reads agree; the storage test uses the real text readers.
+    listed = tasks._build_task_responses([tasks._get_task_doc("#V#continuing_task")[1]])
+    assert listed[0]["notes"] == "Observation 54"
+    assert listed[0]["next_checkpoint"] == "Inspect source 54"
+    assert (
+        task_store.relations.count_documents(
+            {"subject_concept_id": "#V#continuing_task"}
+        )
+        == 7
+    )
+    assert len(texts.get_texts_for_concept("#V#continuing_task", lang="fr")) == 1
+    assert (
+        texts.get_texts_for_concept("#V#another_task")[0]["text"]
+        == "Another task's note"
+    )
+    assert (
+        task_store.values.count_documents(
+            {"_id": {"$in": [ObjectId(value) for value in old_values]}}
+        )
+        == 60
+    )
+
+
+@pytest.mark.parametrize("field", ["notes", "next_checkpoint", "evidence"])
+def test_repeated_value_and_clear_keep_other_fields(task_store, field):
+    seed("Independent note", predicate="hasContent")
+    for _ in range(2):
+        result = tasks.update_task_fields(
+            "#V#continuing_task", fields={field: "Current"}
+        )
+        assert result["task"][field] == "Current"
+    assert task_store.relations.count_documents({}) == 2
+    cleared = tasks.update_task_fields("#V#continuing_task", fields={field: None})
+    assert cleared["task"][field] is None
+    assert (
+        texts.get_texts_for_concept("#V#continuing_task")[0]["text"]
+        == "Independent note"
+    )

--- a/tests/backend/test_task_management_service.py
+++ b/tests/backend/test_task_management_service.py
@@ -1615,7 +1615,7 @@ class TestTaskParityDatesAndEpic:
     @patch("src.backend.services.task_management_service.get_task")
     @patch("src.backend.services.task_management_service.ConceptsRepository")
     @patch("src.backend.services.task_management_service.get_texts_for_concept")
-    @patch("src.backend.services.task_management_service.upsert_text_for_concept")
+    @patch("src.backend.services.task_management_service.upsert_singleton_text_relation")
     def test_update_task_fields_supports_task_taxonomy_context(
         self,
         mock_upsert: MagicMock,


### PR DESCRIPTION
A continuing task could lose its latest checkpoint or notes after repeated edits: task_update_fields appended old and new values until the bounded reader excluded the newly written state. The paper-email responsibility demonstrated this as a task_update_readback_mismatch.

Use the existing singleton editor for current optional task fields, retaining replaced TextValues for recovery. This keeps checkpoint, evidence, progress, notes and role fields current without changing authority or adding a history store.

Validation: 85 targeted task, continuation and storage tests pass. The new storage test reproduces legacy overflow, then verifies 55 revisions through actual text persistence, task point/list reads and the canonical effect receipt; unrelated content, another task and translations survive. The previous additive behaviour fails this same test. Clear and repeated-value cases pass. No new Ruff findings; the two existing files retain their prior lint baseline.

Jira: JVNAUTOSCI-2244. This supports the continuing-responsibility programme under JVNAUTOSCI-2721; it does not establish paper adequacy or activate recurrence.
