### PR TITLE
Fix Atlas scans in text identity and cancellation recovery (JVNAUTOSCI-2727)

### DIFF
--- a/src/backend/db/mongo_client.py
+++ b/src/backend/db/mongo_client.py
@@ -2451,6 +2451,18 @@ def _ensure_relationship_extent_index_indexes(coll: Collection) -> None:
 
 def _ensure_chat_prompt_queue_indexes(coll: Collection) -> None:
     existing_indexes = {idx["name"] for idx in coll.list_indexes()}
+    if "status_cancellation_requested_id" not in existing_indexes:
+        # Recovery polls even when no cancellation is pending. Keep that empty
+        # lookup off the full queue while preserving oldest-request ordering.
+        coll.create_index(
+            [
+                ("status", ASCENDING),
+                ("cancellation_requested_at", ASCENDING),
+                ("_id", ASCENDING),
+            ],
+            name="status_cancellation_requested_id",
+            partialFilterExpression={"cancellation_requested_at": {"$type": "date"}},
+        )
     if "queue_id_1_unique" not in existing_indexes:
         coll.create_index(
             [("queue_id", ASCENDING)], name="queue_id_1_unique", unique=True

--- a/src/backend/db/repositories/text_value_repository.py
+++ b/src/backend/db/repositories/text_value_repository.py
@@ -64,6 +64,18 @@ class TextValuesRepository:
         return None
 
     @staticmethod
+    def find_one_by_fingerprint(
+        fingerprint: str, lang: str
+    ) -> Optional[Dict[str, Any]]:
+        """Use the partial fingerprint index without changing text identity."""
+
+        # Equality alone can choose lang_1 and scan every value in a language.
+        # Explicitly imply fingerprint_lang_unique's string partial predicate.
+        return TextValuesRepository.find_one(
+            {"fingerprint": {"$eq": fingerprint, "$type": "string"}, "lang": lang}
+        )
+
+    @staticmethod
     def find(
         filter: Dict[str, Any],
         projection: Optional[Dict[str, Any]] = None,

--- a/src/backend/services/text_value_service.py
+++ b/src/backend/services/text_value_service.py
@@ -296,7 +296,7 @@ def create_text_value(
     tv = TextValueModel(text=stored_text, lang=lang, provenance=provenance)
 
     # Try to find by fingerprint+lang
-    existing = TextValuesRepository.find_one({"fingerprint": fp, "lang": tv.lang})
+    existing = TextValuesRepository.find_one_by_fingerprint(fp, tv.lang)
     if existing and existing.get("_id"):
         if identity_mode == "exact" and existing.get("text") != tv.text:
             raise ValueError("Exact TextValue fingerprint resolved to different bytes")
@@ -317,7 +317,7 @@ def create_text_value(
         # fingerprint/lang index remains authoritative, so reconcile to that
         # exact canonical row rather than failing an otherwise idempotent
         # upsert.
-        existing = TextValuesRepository.find_one({"fingerprint": fp, "lang": tv.lang})
+        existing = TextValuesRepository.find_one_by_fingerprint(fp, tv.lang)
         if existing and existing.get("_id"):
             if identity_mode == "exact" and existing.get("text") != tv.text:
                 raise ValueError(
@@ -1132,9 +1132,7 @@ def delete_text_relation_by_predicate_and_text(
             normalized_context["name_type"] = name_type.strip().upper()
             context = normalized_context
 
-    text_value = TextValuesRepository.find_one(
-        {"fingerprint": fingerprint, "lang": lang}
-    )
+    text_value = TextValuesRepository.find_one_by_fingerprint(fingerprint, lang)
     if not text_value:
         # Legacy fallback: direct text/lang lookup
         text_value = TextValuesRepository.find_one({"text": raw_text, "lang": lang})

--- a/tests/backend/test_mongo_collection_index_guards.py
+++ b/tests/backend/test_mongo_collection_index_guards.py
@@ -525,6 +525,16 @@ def test_chat_prompt_queue_indexes_support_idempotent_dispatch_and_retention() -
     mc._ensure_chat_prompt_queue_indexes(coll)
 
     indexes = {index["name"]: index for index in coll.list_indexes()}
+    cancellation = indexes["status_cancellation_requested_id"]
+    assert list(cancellation["key"].items()) == [
+        ("status", mc.ASCENDING),
+        ("cancellation_requested_at", mc.ASCENDING),
+        ("_id", mc.ASCENDING),
+    ]
+    assert cancellation["partialFilterExpression"] == {
+        "cancellation_requested_at": {"$type": "date"}
+    }
+    assert not cancellation.get("unique", False)
     submission = indexes["scope_enqueue_submission_id_unique"]
     assert list(submission["key"].items()) == [
         ("user_concept_id", mc.ASCENDING),

--- a/tests/backend/test_text_value_fingerprint_preserves_newlines.py
+++ b/tests/backend/test_text_value_fingerprint_preserves_newlines.py
@@ -10,6 +10,7 @@ from src.backend.db.repositories.text_value_repository import (
 from src.backend.security.access_control import bypass_access_control
 from src.backend.services.text_value_service import (
     create_text_value,
+    delete_text_relation_by_predicate_and_text,
     upsert_text_for_concept,
 )
 
@@ -122,7 +123,7 @@ def test_create_text_value_reconciles_duplicate_key_race(monkeypatch):
     """A concurrent insert winner is returned by its canonical fingerprint row."""
 
     existing_id = ObjectId()
-    lookups: list[dict[str, str]] = []
+    lookups: list[dict[str, object]] = []
 
     def find_one(query):
         lookups.append(query)
@@ -139,6 +140,45 @@ def test_create_text_value_reconciles_duplicate_key_race(monkeypatch):
 
     text_value_id = create_text_value("Same title", lang="en-NZ")
 
-    expected = {"fingerprint": "same title||en-nz", "lang": "en-NZ"}
+    expected = {
+        "fingerprint": {"$eq": "same title||en-nz", "$type": "string"},
+        "lang": "en-NZ",
+    }
     assert text_value_id == str(existing_id)
     assert lookups == [expected, expected]
+
+
+def test_fingerprint_lookup_preserves_language_identity_and_relation_removal():
+    """Indexed lookup keeps deduplication and language-specific deletion exact."""
+
+    concepts = ConceptsRepository.collection()
+    if concepts is None:
+        pytest.skip("MongoDB not configured for this test run")
+    concept_id = "#V#fingerprint_language_test"
+    concepts.insert_one({"concept_id": concept_id, "relationships": {}})
+
+    with bypass_access_control():
+        english = upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="Shared text",
+            lang="en",
+        )
+        french = upsert_text_for_concept(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="Shared text",
+            lang="fr",
+        )
+        assert create_text_value("SHARED text", lang="en") == english["text_value_id"]
+        assert english["text_value_id"] != french["text_value_id"]
+        delete_text_relation_by_predicate_and_text(
+            subject_concept_id=concept_id,
+            predicate="hasDescription",
+            text="Shared text",
+            lang="en",
+        )
+
+    remaining = list(TextRelationsRepository.find({"subject_concept_id": concept_id}))
+    assert len(remaining) == 1
+    assert str(remaining[0]["object_text_id"]) == french["text_value_id"]


### PR DESCRIPTION
Merge decision: ready — bounded live execution plans eliminate full-language text identity scans and empty cancellation-queue collection scans, with existing behaviour preserved by 106 targeted tests.

## User outcome

Reduce recurring Atlas database work in text creation/reuse and interrupted-cancellation recovery. An English-NZ fingerprint miss previously examined 183,644 documents; an empty cancellation recovery poll examined all 1,074 queue documents.

## Material changes

- Route fingerprint lookups, duplicate-insert reconciliation and text-relation removal through a repository lookup that explicitly implies the existing partial compound index's string predicate.
- Add a non-unique partial index on status, cancellation request time and ID, retaining the existing recovery filter and ordering.
- Preserve normalised/exact text identity, language matching and all cancellation decisions.

[JVNAUTOSCI-2727](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2727) owns delivery status, including the separately attributed obsolete Windows embedding client. The corrected materialised embedding queue query already exists on main.

## Evidence

- 106 targeted tests passed across text fingerprint identity, newline preservation, language-specific relation removal, duplicate recovery, queue behaviour, collection index setup and existing embedding queue semantics.
- Live read-only `executionStats`: English-NZ fingerprint miss 183,644 documents / 342 ms → zero documents / 0 ms; English miss 2,251 → zero; both select `fingerprint_lang_unique`.
- Canonical additive index setup materialised only `status_cancellation_requested_id`, preserving every existing index. The unchanged recovery query moved from `COLLSCAN` plus `SORT`, 1,074 examined documents, to the new index with zero examined documents and no blocking sort.
- Current embedding query uses `embedding_status_updated_at_desc`, examining one key/document for one result.
- Python 3.11 grammar check (1,440 files), PDM lock check and diff whitespace check passed. Black reports pre-existing formatting outside the changed lines in three files; no unrelated reformatting included.

## Ship boundary

- Minimum ship criteria: preserve text identity and cancellation semantics while proving index-backed execution for the two changed paths; required CI passes.
- Stop-ship conditions: changed language/identity results, incorrect cancellation, destructive index replacement or no demonstrated scan reduction.
- Non-blocking observations: historical Atlas Query Shape Insights returns 403, so these cumulative counters do not establish the exact alert's cause. The old embedding query is from Windows and requires that client's update/restart; it is tracked in Jira and is not claimed fixed by this PR.
- Non-goals: alert suppression, query framework changes, semantic policy changes, unrelated search optimisation or broad remote deployment.


[JVNAUTOSCI-2727]: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ