### PR TITLE
Recover attachment formats and add source-linked slide evidence

### DIFF
--- a/docs/engineering/otter_archive_and_conversation_images.md
+++ b/docs/engineering/otter_archive_and_conversation_images.md
@@ -73,3 +73,28 @@ actual crop/cache use, latency and any failed attempts. Sparse OCR or model enri
 that a topic is absent. Cached model interpretations can be wrong; scientific claims must remain tied
 to inspectable original evidence. This integration does not reconcile the whole archive, prove
 corpus-wide OCR accuracy, cancel Otter, deploy a network archive service or grant wider access.
+
+## Original presentation decks
+
+`read_presentation_slides` accepts an actor-visible PPTX or PDF file-copy concept
+and returns up to four numbered slide images per call, native text, speaker notes
+(where present), source hashes and a next offset. Images use the existing native
+vision transport and private image viewer; original source bytes remain unchanged.
+The reader recognises Office package structure even when legacy import metadata
+says `.bin`. `read_file_copy` also uses bounded Office extraction for this case,
+with detected type reported separately from stored metadata.
+
+Install LibreOffice (`soffice` on PATH) for PPTX rendering. The converter uses an
+isolated temporary profile and a 90-second process bound. Derived PDFs are cached
+by source hash and renderer version. Optional `include_ocr` caches Tesseract output
+by image hash and engine version. Every call checks source access before reading
+derived caches. The service rejects a PPTX/rendered-PDF slide-count mismatch.
+Renderings can differ from PowerPoint in font/layout details; native text and
+rendered evidence remain separately attributed. Audio, animation and video playback
+are not reconstructed.
+
+Use the returned native images for diagram interpretation, retaining slide numbers,
+source hashes, model and prompt versions with any persisted interpretation. A cached
+render or OCR result is not a verified semantic interpretation. Reuse represented
+workflow authoring for analysis/persistence/recovery rather than treating a successful
+file import, graph creation or schedule as proof of slide understanding.

--- a/src/backend/integrations/google/gmail_service.py
+++ b/src/backend/integrations/google/gmail_service.py
@@ -845,9 +845,7 @@ def list_messages(
         )
         if metadata_error is not None:
             projected_message["metadata_error"] = metadata_error
-            projected_message["metadata_missing_fields"] = list(
-                requested_detail_fields
-            )
+            projected_message["metadata_missing_fields"] = list(requested_detail_fields)
         projected_messages.append(projected_message)
 
     result["messages"] = projected_messages
@@ -1045,18 +1043,18 @@ def decode_attachment_bytes(
     return decoded
 
 
-def find_attachment_part_metadata(
+def list_attachment_part_metadata(
     message: Mapping[str, Any],
     *,
-    attachment_id: str,
     max_parts: int = MAX_GMAIL_ATTACHMENT_MIME_PARTS,
-) -> Dict[str, Any]:
-    """Return trusted MIME metadata for one attachment in a full Gmail message."""
+) -> list[Dict[str, Any]]:
+    """List bounded provider MIME metadata; attachment handles may rotate."""
 
     payload = message.get("payload")
     if not isinstance(payload, Mapping):
-        return {}
+        return []
 
+    results: list[Dict[str, Any]] = []
     effective_max_parts = max(1, int(max_parts))
     pending: list[Mapping[str, Any]] = [payload]
     visited_parts = 0
@@ -1072,10 +1070,12 @@ def find_attachment_part_metadata(
             )
 
         body = part.get("body")
-        if not isinstance(body, Mapping) or body.get("attachmentId") != attachment_id:
+        if not isinstance(body, Mapping) or not body.get("attachmentId"):
             continue
 
-        metadata: Dict[str, Any] = {"attachment_id": attachment_id}
+        metadata: Dict[str, Any] = {"attachment_id": body["attachmentId"]}
+        if isinstance(part.get("partId"), str):
+            metadata["part_id"] = part["partId"]
         filename = part.get("filename")
         if isinstance(filename, str) and filename.strip():
             metadata["filename"] = filename.strip()
@@ -1085,9 +1085,26 @@ def find_attachment_part_metadata(
         size = body.get("size")
         if isinstance(size, int) and size >= 0:
             metadata["reported_size_bytes"] = size
-        return metadata
+        results.append(metadata)
 
-    return {}
+    return results
+
+
+def find_attachment_part_metadata(
+    message: Mapping[str, Any],
+    *,
+    attachment_id: str,
+    max_parts: int = MAX_GMAIL_ATTACHMENT_MIME_PARTS,
+) -> Dict[str, Any]:
+    """Find the MIME part associated with a current provider handle."""
+    return next(
+        (
+            part
+            for part in list_attachment_part_metadata(message, max_parts=max_parts)
+            if part["attachment_id"] == attachment_id
+        ),
+        {},
+    )
 
 
 def list_labels(
@@ -1220,10 +1237,7 @@ def create_label(
 
     service = get_service(profile_id, profiles)
     result = (
-        service.users()
-        .labels()
-        .create(userId=profile.user_id, body=body)
-        .execute()
+        service.users().labels().create(userId=profile.user_id, body=body).execute()
         or {}
     )
     payload = dict(result)
@@ -1745,8 +1759,7 @@ def _outbound_turn_intent_request_id(
             "body_html": body_html,
             "body_language": str(body_language or "").strip().lower() or None,
             "body_authorship": (
-                str(body_authorship or "unspecified").strip().lower()
-                or "unspecified"
+                str(body_authorship or "unspecified").strip().lower() or "unspecified"
             ),
         }
     )

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -7259,6 +7259,30 @@ def _read_file_copy(**kwargs):
             return payload
 
         if as_text:
+            from ...services.file_bytes_text_projection_service import (
+                detect_ooxml_content_type,
+                extract_file_bytes_text_projection,
+            )
+
+            detected_type = detect_ooxml_content_type(bytes(data_bytes))
+            source_type = str(payload.get("content_type") or "").lower()
+            source_name = str(payload.get("original_filename") or "").lower()
+            if (
+                detected_type
+                or source_name.endswith(".pptx")
+                or (source_type in ("", "application/octet-stream"))
+            ):
+                payload.update(
+                    extract_file_bytes_text_projection(
+                        data=bytes(data_bytes),
+                        content_type=detected_type or source_type,
+                        original_filename=source_name,
+                        max_text_chars=250_000,
+                    )
+                )
+                if detected_type:
+                    payload["detected_content_type"] = detected_type
+                return payload
             is_pdf = False
             try:
                 content_type = getattr(info, "content_type", None)
@@ -30284,6 +30308,45 @@ def _gmail_attachment_source_payload(
                 "max_bytes": max_bytes,
             },
         )
+
+    # A full-message read may issue fresh opaque attachment handles. Correlate
+    # only by actual bytes, never filename, size alone or first MIME part.
+    if not part_metadata:
+        candidates = [
+            part
+            for part in gs.list_attachment_part_metadata(message)
+            if part.get("reported_size_bytes") in (None, len(attachment_bytes))
+        ]
+        if len(candidates) > 8:
+            return make_error_response(
+                "gmail_attachment_metadata_unresolved",
+                "Too many MIME candidates; refresh the message and attachment handle.",
+            )
+        matches = []
+        for candidate in candidates:
+            candidate_raw = gs.get_attachment(
+                profile_id=profile,
+                message_id=message_id,
+                attachment_id=candidate["attachment_id"],
+                audit_context={
+                    "namespace": namespace,
+                    "source": audit_source,
+                    "tool": tool_name,
+                    "purpose": "attachment_correlation",
+                },
+            )
+            candidate_bytes = gs.decode_attachment_bytes(
+                candidate_raw, max_bytes=max_bytes
+            )
+            if candidate_bytes == attachment_bytes:
+                matches.append(candidate)
+        if len(matches) != 1:
+            return make_error_response(
+                "gmail_attachment_metadata_unresolved",
+                "Attachment bytes do not identify one MIME part; refresh the message.",
+                details={"matching_parts": len(matches)},
+            )
+        part_metadata = matches[0]
 
     content_sha256 = hashlib.sha256(attachment_bytes).hexdigest()
     content_type = part_metadata.get("content_type")

--- a/src/backend/integrations/internal_mcp/conversation_image_tools.py
+++ b/src/backend/integrations/internal_mcp/conversation_image_tools.py
@@ -20,8 +20,40 @@ def crop_conversation_image(**kwargs):
         return make_error_response("image_detail_unavailable", str(exc))
 
 
+def read_presentation_slides(**kwargs):
+    from ...security.access_control import (
+        get_effective_organisation_concept_id,
+        get_effective_user_concept_id,
+    )
+    from ...services.presentation_evidence_service import (
+        read_presentation_slides as read,
+    )
+    from .catalogue import make_error_response
+
+    try:
+        return read(
+            user_concept_id=get_effective_user_concept_id(),
+            organisation_concept_id=get_effective_organisation_concept_id(),
+            **kwargs,
+        )
+    except (ValueError, PermissionError) as exc:
+        return make_error_response("presentation_evidence_unavailable", str(exc))
+
+
 def definitions():
     return [
+        MethodDefinition(
+            name="read_presentation_slides",
+            handler=read_presentation_slides,
+            input_schema=Schema(
+                required={"file_copy_concept_id": str},
+                optional={"offset": int, "limit": int, "include_ocr": bool},
+                allow_unknown=False,
+            ),
+            output_schema=Schema(required={}, optional={}, allow_unknown=True),
+            category="read",
+            description="Read a private PPTX or PDF file copy as numbered slide images plus native text and speaker notes. Returns actual images to the vision model, source hashes, rendering provenance and pagination (offset default 0, limit 1–4 default 4). Optional include_ocr returns cached OCR tied to image hash and engine version. Detects PPTX bytes even with incorrect .bin metadata. Use for slide diagrams, equations, tables and research presentations; cite slide numbers and image URLs, distinguish visible evidence from inference. Does not send mail or publish source content.",
+        ),
         MethodDefinition(
             name="crop_conversation_image",
             handler=crop_conversation_image,
@@ -39,5 +71,5 @@ def definitions():
             output_schema=Schema(required={}, optional={}, allow_unknown=True),
             category="read",
             description="Inspect a crop of a conversation image, preserving its source and private audience. Supply pixel x/y/width/height and optional integer scale 1–4 (default 2). Use the resulting actual image to recover small text or diagram detail; report what remains unreadable. Original bytes remain unchanged.",
-        )
+        ),
     ]

--- a/src/backend/services/file_bytes_text_projection_service.py
+++ b/src/backend/services/file_bytes_text_projection_service.py
@@ -134,6 +134,43 @@ def _zip_directory_location_before_open(data: bytes) -> tuple[int, int, int]:
     return record
 
 
+def detect_ooxml_content_type(data: bytes) -> str | None:
+    """Recognise an Office package even when imported with generic metadata.
+
+    Bound the central directory before opening it; parsers separately preflight
+    expanded content. This is format evidence, not a metadata mutation.
+    """
+    if not data.startswith(b"PK\x03\x04") or len(data) > MAX_INPUT_BYTES:
+        return None
+    try:
+        _zip_directory_location_before_open(data)
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            names = set(archive.namelist())
+            if "[Content_Types].xml" not in names or "_rels/.rels" not in names:
+                return None
+            kinds = [
+                mime
+                for member, mime in (
+                    (
+                        "ppt/presentation.xml",
+                        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    ),
+                    (
+                        "word/document.xml",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    ),
+                    (
+                        "xl/workbook.xml",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    ),
+                )
+                if member in names
+            ]
+            return kinds[0] if len(kinds) == 1 else None
+    except (zipfile.BadZipFile, _ProjectionResourceLimit, ValueError):
+        return None
+
+
 def _preflight_ooxml_archive(data: bytes, *, document_kind: str) -> None:
     """Reject archive expansion beyond the local OOXML parser envelope."""
 
@@ -802,7 +839,9 @@ def extract_file_bytes_text_projection(
         }
 
     data_bytes = bytes(data)
-    content_type_token = _content_type_token(content_type)
+    content_type_token = detect_ooxml_content_type(data_bytes) or _content_type_token(
+        content_type
+    )
     filename_token = _filename_token(original_filename)
     stop_after_chars = max_text_chars + 1
     resource_truncated = False

--- a/src/backend/services/presentation_evidence_service.py
+++ b/src/backend/services/presentation_evidence_service.py
@@ -1,0 +1,259 @@
+"""Source-preserving slide evidence; interpretation policy belongs to the caller.
+
+Renderings are derived cache entries, keyed by source bytes and renderer version.
+Every request still checks access to the source file before consulting the cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .file_bytes_text_projection_service import (
+    MAX_INPUT_BYTES,
+    _preflight_ooxml_archive,
+    detect_ooxml_content_type,
+)
+
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+EVIDENCE_VERSION = "presentation_evidence.v1"
+
+
+def native_slides(data: bytes) -> list[dict[str, Any]]:
+    from pptx import Presentation
+
+    _preflight_ooxml_archive(data, document_kind="pptx")
+    presentation = Presentation(io.BytesIO(data))
+    slides = []
+
+    def shape_text(shapes):
+        parts = []
+        for shape in shapes:
+            if getattr(shape, "has_text_frame", False):
+                parts.append(shape.text)
+            if getattr(shape, "has_table", False):
+                parts.extend(
+                    "\t".join(cell.text for cell in row.cells)
+                    for row in shape.table.rows
+                )
+            if hasattr(shape, "shapes"):
+                parts.extend(shape_text(shape.shapes))
+        return parts
+
+    for number, slide in enumerate(presentation.slides, 1):
+        notes_frame = (
+            slide.notes_slide.notes_text_frame if slide.has_notes_slide else None
+        )
+        notes = notes_frame.text if notes_frame is not None else ""
+        slides.append(
+            {
+                "slide_number": number,
+                "text": "\n".join(shape_text(slide.shapes)),
+                "notes": notes,
+            }
+        )
+    return slides
+
+
+def render_pdf(data: bytes, *, source_sha256: str) -> tuple[bytes, str, bool]:
+    from .blob_store import get_blob_store_from_env
+
+    executable = shutil.which("soffice")
+    if not executable:
+        raise ValueError(
+            "presentation_renderer_unavailable: install LibreOffice (soffice)"
+        )
+    version = (
+        subprocess.run(
+            [executable, "--version"], capture_output=True, check=True, timeout=15
+        )
+        .stdout.decode()
+        .strip()
+    )
+    renderer = f"libreoffice:{version}:{EVIDENCE_VERSION}"
+    cache_hash = hashlib.sha256(f"{source_sha256}:{renderer}".encode()).hexdigest()
+    key = f"derived/presentations/{cache_hash}.pdf"
+    store = get_blob_store_from_env()
+    try:
+        cached = store.get_bytes(key)
+    except Exception:  # noqa: BLE001 - optional derived cache; render from authorised source
+        cached = None
+    if cached and cached.startswith(b"%PDF-"):
+        return cached, renderer, True
+    _preflight_ooxml_archive(data, document_kind="pptx")
+    with tempfile.TemporaryDirectory(prefix="von-slides-") as root:
+        work = Path(root)
+        (work / "deck.pptx").write_bytes(data)
+        profile = (work / "profile").as_uri()
+        subprocess.run(
+            [
+                executable,
+                f"-env:UserInstallation={profile}",
+                "--headless",
+                "--convert-to",
+                "pdf:impress_pdf_Export",
+                "--outdir",
+                str(work),
+                str(work / "deck.pptx"),
+            ],
+            check=True,
+            capture_output=True,
+            timeout=90,
+        )
+        pdf_path = work / "deck.pdf"
+        if not pdf_path.exists() or pdf_path.stat().st_size > MAX_INPUT_BYTES:
+            raise ValueError("presentation_render_failed_or_too_large")
+        pdf = pdf_path.read_bytes()
+    if not pdf.startswith(b"%PDF-"):
+        raise ValueError("presentation_render_invalid_pdf")
+    store.put_bytes(key, pdf, content_type="application/pdf")
+    return pdf, renderer, False
+
+
+def read_presentation_slides(
+    *,
+    file_copy_concept_id: str,
+    user_concept_id: str,
+    organisation_concept_id: str | None = None,
+    offset: int = 0,
+    limit: int = 4,
+    include_ocr: bool = False,
+) -> dict[str, Any]:
+    import fitz
+
+    from .computer_file_copy_service import fetch_file_copy_bytes
+    from .conversation_image_service import store_image
+
+    if not user_concept_id:
+        raise PermissionError("Authenticated source access is required")
+    if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+        raise ValueError("offset must be a non-negative integer")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 4:
+        raise ValueError("limit must be 1 to 4 slides")
+    source = fetch_file_copy_bytes(
+        file_copy_concept_id=file_copy_concept_id,
+        user_concept_id=user_concept_id,
+        organisation_concept_id=organisation_concept_id,
+        max_bytes=MAX_INPUT_BYTES,
+    )
+    if not source.get("success"):
+        raise PermissionError("Presentation source unavailable to this actor")
+    data = source["data"]
+    source_hash = hashlib.sha256(data).hexdigest()
+    if detect_ooxml_content_type(data) == PPTX_MIME:
+        native = native_slides(data)
+        pdf, renderer, cache_hit = render_pdf(data, source_sha256=source_hash)
+    elif data.startswith(b"%PDF-"):
+        native = None
+        pdf, renderer, cache_hit = data, f"pymupdf:{fitz.VersionBind}", False
+    else:
+        raise ValueError("presentation_format_unsupported: use PPTX or PDF")
+    with fitz.open(stream=pdf, filetype="pdf") as document:
+        count = len(document)
+        if count > 500:
+            raise ValueError("presentation_slide_limit_exceeded")
+        if native is not None and len(native) != count:
+            raise ValueError("presentation_render_slide_count_mismatch")
+        results, attachments = [], []
+        for page_index in range(offset, min(offset + limit, count)):
+            page = document[page_index]
+            scale = min(2, 1800 / max(page.rect.width, page.rect.height))
+            png = page.get_pixmap(
+                matrix=fitz.Matrix(scale, scale), alpha=False
+            ).tobytes("png")
+            provenance = {
+                "kind": "presentation_slide",
+                "source_file_copy_concept_id": file_copy_concept_id,
+                "source_sha256": source_hash,
+                "slide_number": page_index + 1,
+                "renderer": renderer,
+                "rasteriser": f"pymupdf:{fitz.VersionBind}",
+                "evidence_version": EVIDENCE_VERSION,
+            }
+            image = store_image(
+                data=png,
+                filename=f"slide-{page_index + 1}.png",
+                user_concept_id=user_concept_id,
+                provenance=provenance,
+            )
+            slide = (
+                dict(native[page_index])
+                if native
+                else {
+                    "slide_number": page_index + 1,
+                    "text": page.get_text(),
+                    "notes": None,
+                }
+            )
+            slide["text_truncated"] = len(slide["text"]) > 20000
+            slide["notes_truncated"] = len(slide.get("notes") or "") > 20000
+            slide["text"] = slide["text"][:20000]
+            if slide.get("notes"):
+                slide["notes"] = slide["notes"][:20000]
+            if include_ocr:
+                slide["ocr"] = cached_ocr(png)
+            slide["image"] = image
+            results.append(slide)
+            attachments.append(image)
+    return {
+        "success": True,
+        "schema_version": EVIDENCE_VERSION,
+        "source_file_copy_concept_id": file_copy_concept_id,
+        "source_sha256": source_hash,
+        "slide_count": count,
+        "offset": offset,
+        "next_offset": offset + len(results) if offset + len(results) < count else None,
+        "renderer": renderer,
+        "render_cache_hit": cache_hit,
+        "slides": results,
+        "image_attachments": attachments,
+        "note": "Slide images are renderings; native text/notes and visual interpretation are distinct evidence. Cite slide numbers and source image URLs. Presenter is not necessarily paper author.",
+    }
+
+
+def cached_ocr(png: bytes) -> dict[str, Any]:
+    """Cache an extraction independently of later model interpretations."""
+    import pytesseract
+    from PIL import Image
+
+    from .blob_store import get_blob_store_from_env
+
+    engine = (
+        f"tesseract:{pytesseract.get_tesseract_version()}:default:{EVIDENCE_VERSION}"
+    )
+    source_hash = hashlib.sha256(png).hexdigest()
+    cache_hash = hashlib.sha256(f"{source_hash}:{engine}".encode()).hexdigest()
+    store = get_blob_store_from_env()
+    key = f"derived/presentation-ocr/{cache_hash}.json"
+    try:
+        cached = json.loads(store.get_bytes(key))
+        if cached.get("image_sha256") == source_hash and cached.get("engine") == engine:
+            return {**cached, "cache_hit": True}
+    except Exception:  # noqa: BLE001 - optional derived cache
+        cached = None
+    try:
+        with Image.open(io.BytesIO(png)) as image:
+            text = pytesseract.image_to_string(image, timeout=30)
+        result = {
+            "image_sha256": source_hash,
+            "engine": engine,
+            "text": text[:20000],
+            "text_truncated": len(text) > 20000,
+            "cache_hit": False,
+        }
+        store.put_bytes(
+            key, json.dumps(result).encode(), content_type="application/json"
+        )
+        return result
+    except (RuntimeError, OSError) as exc:
+        return {
+            "image_sha256": source_hash,
+            "engine": engine,
+            "error": type(exc).__name__,
+        }

--- a/tests/backend/test_file_bytes_text_projection_service.py
+++ b/tests/backend/test_file_bytes_text_projection_service.py
@@ -294,3 +294,34 @@ def test_images_do_not_implicitly_invoke_unbounded_ocr(monkeypatch):
         "text_truncated": False,
         "text_extraction": "image_text_projection_unsupported",
     }
+
+
+def test_renamed_pptx_uses_package_evidence_not_bin_extension():
+    from pptx import Presentation
+
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[1])
+    slide.shapes.title.text = "Two-layer diffusion"
+    slide.placeholders[1].text = "Scene policy -> image policy"
+    output = io.BytesIO()
+    deck.save(output)
+    result = _project(
+        output.getvalue(),
+        content_type="application/octet-stream",
+        filename="attachment.bin",
+    )
+    assert result["text_extraction"] == "python_pptx"
+    assert "Slide 1" in result["text"]
+    assert "Two-layer diffusion" in result["text"]
+    assert "Scene policy -> image policy" in result["text"]
+    assert len(result["text"]) < 200
+
+
+def test_arbitrary_zip_is_not_decoded_as_text_or_mistaken_for_deck():
+    result = _project(
+        _zip_bytes(("notes.txt", b"hello")),
+        content_type="application/octet-stream",
+        filename="attachment.bin",
+    )
+    assert result["text_extraction"] == "unsupported_binary"
+    assert not result.get("text")

--- a/tests/backend/test_internal_mcp_gmail_attachment_ingestion.py
+++ b/tests/backend/test_internal_mcp_gmail_attachment_ingestion.py
@@ -283,9 +283,7 @@ def test_gmail_attachment_pdf_text_is_extracted_without_import(monkeypatch):
         assert "Flight EZY8159 departs at 12:15" in result["text"]
     else:
         assert result["text_extraction"] == "pdf_text_projection_unsupported"
-        assert result["text_extraction_error"] == (
-            "pdf_parser_isolation_unavailable"
-        )
+        assert result["text_extraction_error"] == ("pdf_parser_isolation_unavailable")
         assert "text" not in result
     assert "computer_file_copy" not in result
 
@@ -849,3 +847,82 @@ def test_stdio_gmail_attachment_surface_returns_same_ephemeral_projection(monkey
     assert "computer_file_copy" not in payload
     assert "data" not in payload
     assert base64.urlsafe_b64encode(source_bytes).decode("ascii") not in repr(payload)
+
+
+def test_rotated_attachment_handle_recovers_metadata_by_bytes(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+
+    _install_actor(monkeypatch)
+    _install_gmail_source(
+        monkeypatch,
+        source_bytes=b"original deck bytes",
+        attachment_id="fresh-handle",
+        filename="deck.pptx",
+        content_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    )
+    result = catalogue._gmail_attachment_source_payload(
+        profile="represented-profile",
+        message_id="message-1",
+        attachment_id="old-handle",
+        namespace="#V#michael_witbrock@sail",
+        tool_name="gmail_import_attachment",
+        max_bytes=1000,
+    )
+    assert result["success"] is True
+    assert result["filename"] == "deck.pptx"
+    assert "presentationml" in result["content_type"]
+    assert result["_bytes"] == b"original deck bytes"
+
+
+def test_rotated_handle_rejects_ambiguous_identical_attachment_parts(monkeypatch):
+    from src.backend.integrations.google import gmail_service
+    from src.backend.integrations.internal_mcp import catalogue
+
+    _install_actor(monkeypatch)
+    _install_gmail_source(monkeypatch, source_bytes=b"same", attachment_id="fresh")
+    message = _gmail_message(attachment_id="fresh", size=4)
+    message["payload"]["parts"].append(
+        {
+            "filename": "other.pptx",
+            "mimeType": "text/plain",
+            "body": {"attachmentId": "another", "size": 4},
+        }
+    )
+    monkeypatch.setattr(gmail_service, "get_message", lambda **kwargs: message)
+    result = catalogue._gmail_attachment_source_payload(
+        profile="represented-profile",
+        message_id="message-1",
+        attachment_id="old",
+        namespace="#V#michael_witbrock@sail",
+        tool_name="gmail_import_attachment",
+        max_bytes=1000,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "gmail_attachment_metadata_unresolved"
+
+
+def test_rotated_handle_does_not_associate_same_size_different_bytes(monkeypatch):
+    from src.backend.integrations.google import gmail_service
+    from src.backend.integrations.internal_mcp import catalogue
+
+    _install_actor(monkeypatch)
+    _install_gmail_source(monkeypatch, source_bytes=b"same", attachment_id="fresh")
+    monkeypatch.setattr(
+        gmail_service,
+        "get_attachment",
+        lambda **kwargs: {
+            "data": base64.urlsafe_b64encode(
+                b"same" if kwargs["attachment_id"] == "old" else b"else"
+            ).decode()
+        },
+    )
+    result = catalogue._gmail_attachment_source_payload(
+        profile="represented-profile",
+        message_id="message-1",
+        attachment_id="old",
+        namespace="#V#michael_witbrock@sail",
+        tool_name="gmail_import_attachment",
+        max_bytes=1000,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "gmail_attachment_metadata_unresolved"

--- a/tests/backend/test_presentation_evidence_service.py
+++ b/tests/backend/test_presentation_evidence_service.py
@@ -1,0 +1,137 @@
+import hashlib
+import io
+
+import fitz
+import pytest
+from pptx import Presentation
+
+from src.backend.services import presentation_evidence_service as service
+
+
+def deck_bytes():
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[1])
+    slide.shapes.title.text = "Test framework"
+    slide.notes_slide.notes_text_frame.text = "Check the arrow direction."
+    slide.shapes.add_table(1, 2, 0, 0, 100000, 100000).table.cell(
+        0, 1
+    ).text = "Result 0.6671"
+    out = io.BytesIO()
+    deck.save(out)
+    return out.getvalue()
+
+
+def pdf_bytes():
+    doc = fitz.open()
+    for n in range(3):
+        page = doc.new_page(width=600, height=400)
+        page.insert_text((40, 40), f"Slide {n + 1}")
+    return doc.tobytes()
+
+
+def test_native_slide_notes_tables_and_order():
+    slides = service.native_slides(deck_bytes())
+    assert len(slides) == 1
+    assert slides[0]["slide_number"] == 1
+    assert "Test framework" in slides[0]["text"]
+    assert "0.6671" in slides[0]["text"]
+    assert slides[0]["notes"] == "Check the arrow direction."
+
+
+def test_source_authority_before_render_or_cache(monkeypatch):
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
+        lambda **kwargs: {"success": False},
+    )
+    monkeypatch.setattr(
+        service, "render_pdf", lambda *args, **kwargs: pytest.fail("must not render")
+    )
+    with pytest.raises(PermissionError):
+        service.read_presentation_slides(
+            file_copy_concept_id="#V#private", user_concept_id="#V#other"
+        )
+
+
+def test_pdf_pagination_preserves_source_and_delivers_native_images(monkeypatch):
+    data = pdf_bytes()
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
+        lambda **kwargs: {"success": True, "data": data},
+    )
+    stored = []
+
+    def store(**kwargs):
+        stored.append(kwargs)
+        return {
+            "concept_id": f"#V#image_{len(stored)}",
+            "provenance": kwargs["provenance"],
+            "url": "/image",
+        }
+
+    monkeypatch.setattr(
+        "src.backend.services.conversation_image_service.store_image", store
+    )
+    result = service.read_presentation_slides(
+        file_copy_concept_id="#V#deck", user_concept_id="#V#owner", offset=1, limit=1
+    )
+    assert result["slide_count"] == 3
+    assert result["next_offset"] == 2
+    assert result["slides"][0]["slide_number"] == 2
+    assert "Slide 2" in result["slides"][0]["text"]
+    assert result["source_sha256"] == hashlib.sha256(data).hexdigest()
+    assert len(result["image_attachments"]) == 1
+    assert stored[0]["data"].startswith(b"\x89PNG")
+    assert stored[0]["user_concept_id"] == "#V#owner"
+    assert stored[0]["provenance"]["source_file_copy_concept_id"] == "#V#deck"
+
+
+def test_ocr_cache_invalidates_on_image_change(monkeypatch):
+    import pytesseract
+    from PIL import Image
+
+    cache, calls = {}, []
+
+    class Store:
+        def get_bytes(self, key):
+            return cache[key]
+
+        def put_bytes(self, key, data, **kwargs):
+            cache[key] = data
+
+    monkeypatch.setattr(
+        "src.backend.services.blob_store.get_blob_store_from_env", lambda: Store()
+    )
+    monkeypatch.setattr(pytesseract, "get_tesseract_version", lambda: "test-1")
+    monkeypatch.setattr(
+        pytesseract,
+        "image_to_string",
+        lambda *args, **kwargs: calls.append(1) or "x -> y",
+    )
+
+    def png(colour):
+        out = io.BytesIO()
+        Image.new("RGB", (10, 10), colour).save(out, "PNG")
+        return out.getvalue()
+
+    first = service.cached_ocr(png("red"))
+    second = service.cached_ocr(png("red"))
+    third = service.cached_ocr(png("blue"))
+    assert not first["cache_hit"] and second["cache_hit"] and not third["cache_hit"]
+    assert len(calls) == 2
+    monkeypatch.setattr(pytesseract, "get_tesseract_version", lambda: "test-2")
+    assert not service.cached_ocr(png("red"))["cache_hit"]
+    assert len(calls) == 3
+
+
+def test_notes_part_without_body_placeholder_is_valid():
+    deck = Presentation()
+    slide = deck.slides.add_slide(deck.slide_layouts[1])
+    notes = slide.notes_slide
+    frame = notes.notes_text_frame
+    body = frame._txBody
+    parent = body.getparent()
+    parent.getparent().remove(parent)
+    assert notes.notes_text_frame is None
+    out = io.BytesIO()
+    deck.save(out)
+    assert service.native_slides(out.getvalue())[0]["notes"] == ""

--- a/tests/backend/test_read_file_copy_tool.py
+++ b/tests/backend/test_read_file_copy_tool.py
@@ -75,8 +75,10 @@ def test_read_file_copy_accepts_matching_authenticated_namespace(monkeypatch):
     )
     monkeypatch.setattr(
         "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
-        lambda **kwargs: captured_kwargs.update(kwargs)
-        or {"success": True, "info": info, "data": b"ok"},
+        lambda **kwargs: (
+            captured_kwargs.update(kwargs)
+            or {"success": True, "info": info, "data": b"ok"}
+        ),
     )
 
     result = catalogue._read_file_copy(
@@ -113,8 +115,10 @@ def test_read_file_copy_returns_text(monkeypatch):
 
     monkeypatch.setattr(
         "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
-        lambda **kwargs: captured_kwargs.update(kwargs)
-        or {"success": True, "info": info, "data": b"hello world"},
+        lambda **kwargs: (
+            captured_kwargs.update(kwargs)
+            or {"success": True, "info": info, "data": b"hello world"}
+        ),
     )
 
     result = catalogue._read_file_copy(concept_id="#V#file_copy_test", max_bytes=20)
@@ -219,3 +223,38 @@ def test_read_file_copy_preserves_typed_spreadsheet_safety_failure(monkeypatch):
     assert result["success"] is False
     assert result["error_code"] == "spreadsheet_archive_uncompressed_too_large"
     assert result["error_details"] == {"member_count": 9}
+
+
+def test_read_file_copy_recovers_renamed_pptx_without_mutating_metadata(monkeypatch):
+    from pptx import Presentation
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.services.computer_file_copy_service import FileCopyBlobInfo
+
+    deck = Presentation()
+    deck.slides.add_slide(deck.slide_layouts[1]).shapes.title.text = "Research result"
+    output = BytesIO()
+    deck.save(output)
+    data = output.getvalue()
+    monkeypatch.setattr(
+        "src.backend.security.access_control.get_effective_user_concept_id",
+        lambda: "#V#owner",
+    )
+    info = FileCopyBlobInfo(
+        concept_id="#V#deck",
+        blob_key="source.bin",
+        blob_backend="local",
+        blob_uri="local://source.bin",
+        content_type="application/octet-stream",
+        original_filename="source.bin",
+        size_bytes=len(data),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.computer_file_copy_service.fetch_file_copy_bytes",
+        lambda **kwargs: {"success": True, "info": info, "data": data},
+    )
+    result = catalogue._read_file_copy(concept_id="#V#deck")
+    assert result["success"] and result["text_extraction"] == "python_pptx"
+    assert "Research result" in result["text"]
+    assert "presentationml" in result["detected_content_type"]
+    assert result["original_filename"] == "source.bin"
+    assert "bytes_base64" not in result


### PR DESCRIPTION
A real emailed PowerPoint was stored as `.bin` after Gmail refreshed its opaque attachment handles. Reading that file decoded package bytes as text, and indexing failed. Imports now recover MIME metadata only through unique byte equality when handles rotate; file reads recognise Office package structure independently of the stored extension and use bounded extraction.

Adds `read_presentation_slides` through the existing private image tool surface. It returns numbered native text/notes and actual slide images to the vision model, with source hashes, renderer provenance, pagination and optional cached OCR. PPTX rendering uses LibreOffice; original bytes remain unchanged. Derived cache reads follow source access checks.

Validation: 88 focused tests passed, 2 skipped; a further notes-without-text-frame regression passed. Real privately held 14-slide deck extracted successfully, rendered to 14 PDF pages, and a diagram image plus OCR was saved through canonical file-copy services. Research content and private receipts are outside Git. Natural-language workflow acceptance follows activation; this PR does not claim automatic reply handling.

An adjacent pre-existing RAG collection test failed because its fixture supplies an untrusted namespace without an actor; it does not exercise the changed extraction path. Tracked under JVNAUTOSCI-2223.
