### PR TITLE
Deliver native image evidence in workflow tool continuations

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -7462,6 +7462,7 @@ class InternalMCPChatOrchestrator:
         tool_categories = data.get("tool_categories", {})
         invocations = data.setdefault("invocations", [])
         tool_messages = data.setdefault("tool_messages", [])
+        batch_image_messages: list[dict[str, Any]] = []
         iteration_count = data.get("iteration_count", 0)
         allowed_write_tools: set = data.get("allowed_write_tools", set())
         recent_user_prompts = data.get("recent_user_prompts", [])
@@ -8167,6 +8168,16 @@ class InternalMCPChatOrchestrator:
                     continue
 
                 result = self._gateway.invoke(tool_name, payload)
+                if (
+                    isinstance(result.payload, Mapping)
+                    and result.payload.get("success") is not False
+                    and result.payload.get("image_attachments")
+                ):
+                    batch_image_messages.append({
+                        "role": "user",
+                        "content": "Retrieved source image evidence from " + tool_name,
+                        "image_attachments": result.payload["image_attachments"],
+                    })
                 if tool_name_key == "workflow_execute" and isinstance(
                     aux_llm_calls, list
                 ):
@@ -8464,6 +8475,13 @@ class InternalMCPChatOrchestrator:
                 if isinstance(tool_request, Mapping):
                     _append_tool_limit_result(tool_request)
             remaining_tool_calls = []
+
+        # Keep provider tool-call responses intact; images are separate source
+        # messages after the batch, hydrated and re-authorised at the provider.
+        # The adaptive chat path already does this; durable llm.action uses this
+        # execution path and otherwise receives only image descriptor JSON.
+        augmented_context.extend(batch_image_messages)
+        tool_messages.extend(batch_image_messages)
 
         # Store remaining overflow tool calls for the backfill handler.
         data["allowed_write_tools"] = allowed_write_tools

--- a/tests/backend/test_orchestrator_tool_call_validation.py
+++ b/tests/backend/test_orchestrator_tool_call_validation.py
@@ -171,3 +171,31 @@ def test_tool_calling_loop_records_terminal_timeout_not_late_success(
         )
         is False
     )
+
+
+def test_workflow_tool_images_follow_correlated_tool_batch(monkeypatch):
+    """Durable LLM steps need native image evidence, not only descriptor JSON."""
+    monkeypatch.setattr(orchestrator_mod, 'validate_tool_target_contract',
+                        lambda **kwargs: SimpleNamespace(ok=True,resolution_evidence=()))
+    descriptor = {'concept_id':'#V#slide_image','sha256':'synthetic'}
+    catalogue = MethodCatalogue()
+    catalogue.register(MethodDefinition(name='synthetic_slide_read',
+        handler=lambda **kwargs: {'success':True,'image_attachments':[descriptor]},
+        input_schema=Schema(required={}, optional={}, allow_unknown=False),
+        category='read'))
+    gateway = InternalMCPGateway(catalogue=catalogue,transport=InternalMCPTransport(),enabled=True)
+    orchestrator = InternalMCPChatOrchestrator(gateway=gateway,max_tool_invocations=2)
+    request = WorkflowActionRequest(action_id='tool_calling.execute',inputs={},
+        environment=WorkflowEnvironment(llm_client=None,gateway=gateway,user_namespace='#V#user',max_tool_invocations=2),
+        data={'prompt':'Read the slide images','response':'','augmented_context':[],
+              'tool_calls':[{'action':'call_tool','tool':'synthetic_slide_read','payload':{},'_call_id':f'call-{i}'} for i in range(2)],
+              'method_catalogue':gateway.describe_methods(), 'tool_categories':{'synthetic_slide_read':'read'},
+              'iteration_count':0,'aux_llm_calls':[],'llm_calls':[]})
+    orchestrator._action_tool_calling_execute(request)
+    messages = request.data['tool_messages']
+    assert [m['role'] for m in messages] == ['tool','tool','user','user']
+    assert [m['tool_call_id'] for m in messages[:2]] == ['call-0','call-1']
+    assert messages[2]['image_attachments'] == [descriptor]
+    assert 'tool_call_id' not in messages[2]
+    assert request.data['augmented_context'][-2:] == messages[-2:]
+    assert 'base64' not in str(messages)


### PR DESCRIPTION
Durable `llm.action` steps received image descriptors as tool-result JSON, while ordinary adaptive chat also supplied native image messages. A slideshow workflow could therefore run without seeing its diagrams. Preserve successful tool-returned image descriptors in separate source messages after the correlated tool-response batch; existing provider hydration still rechecks source access and keeps bytes out of retained telemetry.

Validation: the new two-tool regression verifies correlated response ordering, separate image messages and retained descriptors. The LLM-step suite plus this test passed 65 tests. One adjacent timeout fixture expects an elapsed-time hard boundary although its tool enables only an advisory timeout; its failure does not involve images. Actual slideshow workflow acceptance follows activation. JVNAUTOSCI-2223.
