### PR TITLE
Preserve workflow context for admitted LLM tool writes

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -12,6 +12,7 @@ import threading
 import time
 import requests
 from contextvars import copy_context
+from contextlib import nullcontext
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from typing import (
@@ -8167,7 +8168,22 @@ class InternalMCPChatOrchestrator:
                     )
                     continue
 
-                result = self._gateway.invoke(tool_name, payload)
+                invocation_context = nullcontext()
+                if request.workflow_id and request.workflow_state_id:
+                    from ...workflows.workflow_mcp_tool_actions import (
+                        _ontology_invocation_context,
+                    )
+
+                    # Carry the same admitted, actor-bound effect provenance as
+                    # deterministic workflow tool steps. The canonical authority
+                    # resolver still checks live target/scope permissions.
+                    invocation_context = _ontology_invocation_context(
+                        request=request,
+                        resolved_tool_name=tool_name,
+                        invocation_id=call_id or str(iteration_count),
+                    )
+                with invocation_context:
+                    result = self._gateway.invoke(tool_name, payload)
                 if (
                     isinstance(result.payload, Mapping)
                     and result.payload.get("success") is not False

--- a/src/backend/workflows/llm_step_executor.py
+++ b/src/backend/workflows/llm_step_executor.py
@@ -3674,6 +3674,10 @@ def _execute_llm_step_inner(request: WorkflowActionRequest) -> WorkflowActionRes
         trace=request.trace,
         action_target_id=request.action_target_id,
         contract_concept_id=request.contract_concept_id,
+        workflow_id=request.workflow_id,
+        workflow_state_id=request.workflow_state_id,
+        workflow_state_metadata=request.workflow_state_metadata,
+        execution_scope=request.execution_scope,
     )
     try:
         plan_result = _run_llm_call_with_timeout(

--- a/src/backend/workflows/workflow_mcp_tool_actions.py
+++ b/src/backend/workflows/workflow_mcp_tool_actions.py
@@ -368,6 +368,7 @@ def _ontology_invocation_context(
     *,
     request: WorkflowActionRequest,
     resolved_tool_name: str,
+    invocation_id: str | None = None,
 ):
     """Bind provenance for a workflow write admitted by its mutation ceiling."""
 
@@ -414,6 +415,8 @@ def _ontology_invocation_context(
         f"workflow:{workflow_id or 'unbound_workflow'}:{effect_scope}:"
         f"{state_id}:{resolved_tool_name}"
     )
+    if invocation_id:
+        effect_id = f"{effect_id}:{invocation_id}"
     return bind_ontology_invocation(
         surface="workflow",
         executing_agent_concept_id="#V#von_system",

--- a/tests/backend/test_llm_step_executor.py
+++ b/tests/backend/test_llm_step_executor.py
@@ -1732,6 +1732,7 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
             return "selected-model"
 
         def _action_tool_calling_plan(self, request):
+            captured["workflow_context"] = (request.workflow_id, request.workflow_state_id, request.workflow_state_metadata)
             captured["shared_prefer_default_model"] = request.data.get(
                 "prefer_default_model"
             )
@@ -1771,6 +1772,8 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
 
     request = WorkflowActionRequest(
         action_id="llm.action",
+        workflow_id="#V#slides", workflow_state_id="interpret",
+        workflow_state_metadata={"mutation_authority": "low"},
         inputs={},
         environment=WorkflowEnvironment(
             llm_client=MagicMock(),
@@ -1789,6 +1792,7 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
     result = execute_llm_step(request)
 
     assert result.status == "success"
+    assert captured["workflow_context"] == ("#V#slides", "interpret", {"mutation_authority": "low"})
     assert captured["shared_prefer_default_model"] is True
     assert captured["prefer_default_model"] is True
     llm_call = result.outputs["llm_calls"][0]
@@ -1803,8 +1807,8 @@ def test_execute_llm_step_tool_mode_marks_user_model_preference(
         "schema_version": "workflow_step_output_contract.v1",
         "output_format": "json_value",
         "prompt_concept_id": None,
-        "workflow_id": None,
-        "workflow_state_id": None,
+        "workflow_id": "#V#slides",
+        "workflow_state_id": "interpret",
         "response_contract_text": None,
         "required_json_fields": [],
         "json_field_defaults": {},

--- a/tests/backend/test_orchestrator_tool_call_validation.py
+++ b/tests/backend/test_orchestrator_tool_call_validation.py
@@ -199,3 +199,47 @@ def test_workflow_tool_images_follow_correlated_tool_batch(monkeypatch):
     assert 'tool_call_id' not in messages[2]
     assert request.data['augmented_context'][-2:] == messages[-2:]
     assert 'base64' not in str(messages)
+
+
+def test_workflow_llm_write_binds_distinct_effects_only_after_admission(monkeypatch):
+    from dataclasses import fields
+    from src.backend.services.ontology_publication_authority_service import current_ontology_invocation
+    from src.backend.workflows.trace_model import WorkflowExecutionTrace
+
+    monkeypatch.setattr(orchestrator_mod, "validate_tool_target_contract",
+                        lambda **kwargs: SimpleNamespace(ok=True, resolution_evidence=()))
+    seen = []
+    catalogue = MethodCatalogue()
+    def record(**kwargs):
+        seen.append(current_ontology_invocation())
+        return {"success": True}
+    catalogue.register(MethodDefinition(name="upsert_text_relation", handler=record,
+        input_schema=Schema(required={}, optional={}, allow_unknown=True), category="write"))
+    gateway = InternalMCPGateway(catalogue=catalogue, transport=InternalMCPTransport(), enabled=True)
+    orchestrator = InternalMCPChatOrchestrator(gateway=gateway, max_tool_invocations=2)
+    policy_values = {f.name: {} for f in fields(orchestrator_mod._ResolvedWritePolicyDecision)}
+    policy_values.update(allowed_tools=frozenset({"upsert_text_relation"}), reason="admitted",
+        decision_basis="workflow", outcome="allowed", user_denial_detected=False,
+        confirmation_required_tools=frozenset(), effective_mutation_authority="unrestricted",
+        guardrail_events=(), profile_concept_id=None)
+    monkeypatch.setattr(orchestrator, "_resolve_allowed_write_tools",
+                        lambda **kwargs: orchestrator_mod._ResolvedWritePolicyDecision(**policy_values))
+    request = WorkflowActionRequest(action_id="llm.action", inputs={},
+        environment=WorkflowEnvironment(llm_client=None, gateway=gateway, max_tool_invocations=2),
+        workflow_id="#V#slides", workflow_state_id="interpret",
+        trace=WorkflowExecutionTrace(workflow_id="#V#slides", execution_id="run", instance_id="durable"),
+        data={"prompt":"Save slide evidence", "response":"", "augmented_context":[],
+              "tool_calls":[{"action":"call_tool", "tool":"upsert_text_relation", "payload":{}, "_call_id":f"call-{i}"} for i in range(2)],
+              "method_catalogue":gateway.describe_methods(), "tool_categories":{"upsert_text_relation":"write"},
+              "iteration_count":0, "aux_llm_calls":[], "llm_calls":[]})
+    orchestrator._action_tool_calling_execute(request)
+    assert len(seen) == 2
+    assert all(context.actor_bound_workflow_effect for context in seen)
+    assert [context.effect_id for context in seen] == [
+        f"workflow:#V#slides:durable:interpret:upsert_text_relation:call-{i}" for i in range(2)]
+    assert current_ontology_invocation() is None
+    seen.clear()
+    policy_values.update(allowed_tools=frozenset(), outcome="denied")
+    request.data.update(iteration_count=0, tool_calls=[{"action":"call_tool", "tool":"upsert_text_relation", "payload":{}, "_call_id":"blocked"}])
+    orchestrator._action_tool_calling_execute(request)
+    assert not seen


### PR DESCRIPTION
Durable LLM steps lost their workflow and state metadata when constructing the internal tool loop. Ontology writes consequently arrived as unlabelled agent effects and failed with `ontology_agent_delegation_required`, despite being admitted by the workflow mutation ceiling.

Preserve the trusted workflow context and use the existing workflow ontology invocation binder after tool admission. Each LLM tool call gets a distinct effect identifier. Canonical live actor/target/scope checks and denied-write gates remain in force.

Validation: 164 targeted workflow and ontology-authority tests passed, including metadata propagation, distinct effect IDs, denied-call non-execution, cross-context authority checks and reserved-governance checks. One unrelated pre-existing advisory-versus-hard-timeout fixture was deselected. Real slideshow workflow replay follows activation.
