### PR TITLE
Keep authored workflow tools available across task and mail steps

### DIFF
--- a/src/backend/integrations/internal_mcp/orchestrator.py
+++ b/src/backend/integrations/internal_mcp/orchestrator.py
@@ -6056,6 +6056,11 @@ class InternalMCPChatOrchestrator:
                     ),
                     required_prompt_tools=required_prompt_tools,
                     context_telemetry=tool_plan_context_telemetry,
+                    authored_tool_names=(
+                        tuple(sorted(allowed_tool_names))
+                        if request.action_id == "llm.action"
+                        else ()
+                    ),
                     prefer_default_model=bool(data.get("prefer_default_model")),
                     timeout_override_sec=timeout_override_sec,
                     workflow_stage_id="tool_plan",
@@ -9266,6 +9271,11 @@ class InternalMCPChatOrchestrator:
                     prompt=follow_up_prompt,
                     context=follow_up_context,
                     tool_definitions=continuation_tool_definitions,
+                    authored_tool_names=(
+                        tuple(sorted(allowed_tool_names))
+                        if request.action_id == "llm.action"
+                        else ()
+                    ),
                     default_client=llm_client,
                     default_model=structured_continuation.model,
                     policy_state=policy_state,
@@ -10848,6 +10858,7 @@ class InternalMCPChatOrchestrator:
         tool_definitions: Sequence[ToolDefinition],
         method_catalogue: Mapping[str, Any] | None,
         required_prompt_tools: Sequence[str],
+        authored_tool_names: Sequence[str] = (),
     ) -> _StructuredToolCandidateResolution:
         """Resolve deterministic tool candidates with provider-aware capping."""
 
@@ -10922,6 +10933,15 @@ class InternalMCPChatOrchestrator:
             seen_required.add(key)
             required_tools.append(candidate)
         required_lookup = {tool_name.lower() for tool_name in required_tools}
+        # An authored LLM step has already selected its bounded tool vocabulary.
+        # Follow-up family hints must not erase cross-domain tools from that set.
+        # Availability/authority filtering happens before this resolver; these
+        # names cannot add a definition that the caller did not supply.
+        authored_lookup = {
+            name.strip().lower()
+            for name in authored_tool_names
+            if isinstance(name, str) and name.strip().lower() in definitions_by_name
+        }
 
         baseline_tools: list[str] = []
         seen_baseline: set[str] = set()
@@ -10972,6 +10992,7 @@ class InternalMCPChatOrchestrator:
                 profile == "planner"
                 and _is_relation_bearing_tool(tool_name)
                 and key not in required_lookup
+                and key not in authored_lookup
                 and not relation_grounding_requested
             ):
                 _mark_excluded(tool_name, "relation_evidence_not_required")
@@ -10979,6 +11000,7 @@ class InternalMCPChatOrchestrator:
             if (
                 relation_grounding_requested
                 and key not in required_lookup
+                and key not in authored_lookup
                 and _is_inventory_only_tool(tool_name)
             ):
                 _mark_excluded(tool_name, "inventory_only_relation_grounding")
@@ -11037,6 +11059,9 @@ class InternalMCPChatOrchestrator:
         warnings: list[str] = []
 
         _append_bucket(required_tools)
+        _append_bucket(
+            [name for name in ordered_tool_names if name.lower() in authored_lookup]
+        )
         _append_bucket(baseline_tools)
         _append_bucket(family_matched_tools)
         if profile == "planner":
@@ -11069,7 +11094,7 @@ class InternalMCPChatOrchestrator:
             _append_bucket(read_tools)
             _append_bucket(write_tool_names)
 
-        if profile == "planner" and not required_tools:
+        if profile == "planner" and not required_tools and not authored_lookup:
             planner_cap = max(
                 1,
                 min(
@@ -17072,6 +17097,7 @@ class InternalMCPChatOrchestrator:
         workflow_action_id: str | None = None,
         method_catalogue: Mapping[str, Any] | None = None,
         required_prompt_tools: Sequence[str] = (),
+        authored_tool_names: Sequence[str] = (),
         context_telemetry: Mapping[str, Any] | None = None,
         prefer_default_model: bool = False,
         timeout_override_sec: float | None = None,
@@ -17408,6 +17434,7 @@ class InternalMCPChatOrchestrator:
                 tool_definitions=tool_definitions,
                 method_catalogue=method_catalogue,
                 required_prompt_tools=required_prompt_tools,
+                authored_tool_names=authored_tool_names,
             )
             available_tool_definitions = list(tool_candidates.tool_definitions)
             available_tool_name_lookup = {

--- a/tests/backend/test_authored_workflow_tool_continuity.py
+++ b/tests/backend/test_authored_workflow_tool_continuity.py
@@ -1,0 +1,61 @@
+"""An explicit workflow's tool vocabulary survives changing family hints."""
+
+from unittest.mock import MagicMock
+
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.orchestrator import (
+    InternalMCPChatOrchestrator,
+)
+
+
+def test_authored_mail_tools_survive_task_followup_without_becoming_required(
+    monkeypatch,
+):
+    gateway = MagicMock(spec=InternalMCPGateway)
+    gateway.enabled = True
+    catalogue = {
+        name: {
+            "description": name,
+            "category": "read",
+            "input_schema": {"required": {}, "optional": {}},
+        }
+        for name in (
+            "task_get",
+            "gmail_get_message",
+            "gmail_list_messages",
+            "fetch_concept",
+        )
+    }
+    gateway.describe_methods.return_value = catalogue
+    orch = InternalMCPChatOrchestrator(gateway=gateway)
+    monkeypatch.setattr(
+        orch, "_collect_structured_tool_family_hints", lambda **k: ("vontology",)
+    )
+    definitions = orch._convert_mcp_tools_to_structured_definitions(
+        method_catalogue=catalogue
+    )
+    arguments = dict(
+        prompt="Continue after reading the task",
+        context=[],
+        stage="tool_follow_up",
+        workflow_action_id="llm.action",
+        provider="openai",
+        tool_definitions=definitions,
+        method_catalogue=catalogue,
+        required_prompt_tools=[],
+    )
+    baseline = orch._resolve_structured_tool_candidates(**arguments)
+    assert "gmail_get_message" not in baseline.candidate_tool_names
+    authored = orch._resolve_structured_tool_candidates(
+        **arguments, authored_tool_names=[*catalogue, "unavailable_tool"]
+    )
+    assert set(authored.candidate_tool_names) == set(catalogue)
+    assert authored.required_tools == ()
+    assert "unavailable_tool" not in authored.candidate_tool_names
+
+    orch._structured_tool_candidate_cap_override = 2
+    capped = orch._resolve_structured_tool_candidates(
+        **arguments, authored_tool_names=list(catalogue)
+    )
+    assert len(capped.candidate_tool_names) == 2
+    assert capped.truncation_applied

--- a/tests/backend/test_orchestrator_model_fallback_execution.py
+++ b/tests/backend/test_orchestrator_model_fallback_execution.py
@@ -4704,6 +4704,7 @@ def test_tool_calling_backfill_finalises_when_required_tool_is_missing_at_cap(
             "aux_llm_calls": [],
             "llm_calls": [],
             "iteration_count": 1,
+            "llm_allowed_tools": ["fetch_concept", "gmail_get_message"],
             "remaining_tool_calls": [],
             "invocations": [{"tool": "fetch_concept", "status": "ok"}],
             "method_catalogue": {
@@ -4767,6 +4768,7 @@ def test_tool_calling_backfill_finalises_when_required_tool_is_missing_at_cap(
         "Tool-use limit reached: this turn reached "
         "`internal_mcp_max_tool_invocations=1` after 1 tool call(s)."
     )
+    assert "gmail_get_message" in continuation_calls[0]["authored_tool_names"]
     assert len(continuation_calls) == 1
     assert continuation_calls[0]["tool_choice_override"] == "none"
     assert [result.call_id for result in continuation_calls[0]["tool_results"]] == [


### PR DESCRIPTION
An authored workflow spanning task records and Gmail lost its mail tools after reading the task: each structured follow-up rebuilt a family shortlist from recent context. A real deck-reply preflight consequently stopped early or substituted stale file metadata for a mail read.

Preserve the authored LLM step's bounded tool vocabulary in initial planning and structured continuations. Only definitions already supplied by the availability/authority filter can be retained. Provider caps, invocation limits and ordinary adaptive-chat shortlisting remain unchanged; retaining a tool does not make calling it mandatory.

Validation: task-to-mail shortlist regression covers changing family hints, unavailable tools and provider caps. Continuation regression checks vocabulary propagation while retaining the exhausted-call-budget stop. 83 tests passed; three timeout-specific tests were excluded from this tool-selection change.

JVNAUTOSCI-2223. Real mail/deck workflow verification remains an activation acceptance check, not a claim made by this merge.
