### PR TITLE
Fix exclusive durable task ownership and stale-worker dispatch

### DIFF
--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -125,6 +125,7 @@ from `AGENTS.md`.
 | [Frontend browser validation](engineering/frontend_browser_user_view_validation.md) | Active practical guide | Risk-tiered reference; browser evidence needs a dated locator when used |
 | [Real-path replay and telemetry loop](engineering/real_path_server_replay_and_telemetry_loop.md) | Active practical guide | Risk-tiered protocol; exact-path evidence outranks prose, but full protocol is not universal |
 | [Operational engineering guide](engineering/operational_engineering_guide.md) | Active companion runbook | Consult by operational need and revalidate host/tool-specific details |
+| [Durable task ownership](engineering/durable_task_ownership.md) | Active implementation and rollout contract | Task exclusivity, lease fencing, uncertain-effect recovery and legacy-worker database admission; verify runtime activation separately from merge |
 | [Atlas egress reconciler](engineering/atlas_egress_reconciler_runbook.md) | Active bounded operational runbook | Use for the standalone mobile-client/DGX database access-list reconciler; revalidate Atlas API policy and credentials live |
 | [Authority-alignment scan](engineering/maintaining_global_design_constraints_and_authority_alignment_with_coding_agents.md) | Active companion guide | Advisory structural review procedure under `AGENTS.md` |
 

--- a/docs/engineering/durable_task_ownership.md
+++ b/docs/engineering/durable_task_ownership.md
@@ -1,0 +1,93 @@
+# Durable task ownership
+
+Tracking: JVNAUTOSCI-2729; federation lifecycle planning: JVNAUTOSCI-2593.
+
+## Contract
+
+Background durable workers share the existing workflow-instance lease and
+`claim_token`. The partial unique index `active_task_owner_unique` allows one
+active owner for each `task_ownership_key`. Acquiring the lease and ownership
+uses the same atomic document update. An expired lease is reclaimed on that
+instance, retaining its checkpoint. A duplicate instance cannot bypass it.
+An ordinary pause retains ownership. Successful completion releases ownership;
+failed/cancelled owners without uncheckpointed effects can be released by the
+next claimant with a conditional update. Conflicting candidates back off while
+polling continues to unrelated work.
+
+Keys include persisted user, organisation, and namespace. Identity preference
+is input `task_concept_id`/`task_id`, then schedule ID, event idempotency key,
+then instance ID. The key is persisted before input compaction. Producers must
+use the same canonical task ID to coordinate different launches. Related work
+without a shared identity is not automatically inferred to be the same task.
+Child tasks that need independent background execution need distinct task IDs.
+
+This serialises work. The existing event idempotency key still deduplicates a
+logical occurrence at submission; sequential launches without such an identity
+are not magically exactly-once. Supervised conversation mirror instances and
+the separate chat prompt queue retain their existing coordination mechanisms.
+
+## Actions and uncertain effects
+
+The worker binds a trusted claim context alongside its authenticated actor.
+ActionRegistry checks it before explicit/fallback actions. The MCP gateway
+checks again inside the actual transport handler thread, after queueing. Tool
+payloads cannot supply or override the claim. Ownership does not grant actor
+authority.
+
+Covered MCP mutations reserve an `uncheckpointed_effects` entry atomically
+against the current, unexpired claim before invoking the handler. Entries carry
+an effect ID, method, payload digest, time and bounded outcome metadata, not
+email bodies or credentials. A returned result is observed; checkpointing
+acknowledges observed effects atomically with workflow state. A handler that
+raises, remains in flight after a timeout, or loses its process leaves an
+uncertain entry. Recovery cannot silently replay that instance or release its
+task to a duplicate. Reads do not create effect entries.
+
+No lease can retract an external request already sent. Existing provider
+idempotency and delivery receipts remain authoritative. A direct custom action
+that bypasses MCP gets the entry ownership check but must retain its own
+effect/idempotency contract; this change does not assert that arbitrary Python
+side effects are transactionally fenced.
+
+For uncertain effects, first drain the old execution (lease expiry alone does
+not prove its handler stopped), inspect provider/canonical receipts, and decide
+the correct continuation checkpoint. A trusted operator can call
+`WorkflowInstanceManager.reconcile_claim_effects` with the exact old token,
+effect IDs, evidence and verified checkpoint. It rejects an active lease and
+changed effect inventory, records a reconciliation receipt and leaves the
+instance manually paused for the existing authority-aware resume preflight.
+Do not clear the marker merely to make a retry run. Ownership/effect metadata
+is exposed with instance diagnostics.
+
+## Legacy workers and activation
+
+SC448086's observed July build replaces `claimed_by_build` on every claim and
+does not advertise `durable_task_ownership_v1`. Database document validation
+can reject those writes even though that code ignores new application checks.
+Use `claim_admission_validator` with strict/error validation. The operator
+script `scripts/durable_claim_admission.py` previews by default, preserves
+existing validation rules, and records prior options for rollback. `--apply`
+requires a database principal with `collMod`; Atlas Data Explorer's Validation
+tab is also an administrator activation surface.
+
+For a staged rollout, `--worker-pattern '^worker_SC448086_'` constrains only
+that legacy host. Deploy capable workers before expanding to `^worker_`.
+Verify the exact existing validator, then test a synthetic legacy
+`findOneAndUpdate` and a compatible claimant. A database rejection (code 121),
+not a heartbeat disappearing, is the acceptance evidence. The old process may
+remain alive and continue heartbeat/scheduler writes. Check for already-running
+claims separately; this rule cannot retract an action already started.
+
+This is compatibility enforcement against the inspected implementation, not an
+authentication boundary against a malicious database writer that forges build
+metadata or has bypassDocumentValidation privilege. Broader admission-service,
+per-node credentials and fleet upgrades remain separate federation work.
+Keep completed one-off schedules disabled; do not send real email as a canary.
+
+## Validation
+
+`tests/backend/test_durable_task_ownership.py` exercises competing claims,
+duplicate-instance fairness, scope separation, checkpoint takeover, stale
+dispatch, uncertain effects and legacy-validator semantics. Use a real MongoDB
+canary as well: mongomock does not implement server document validation.
+Run affected durable-worker/executor and MCP gateway/transport regressions.

--- a/scripts/durable_claim_admission.py
+++ b/scripts/durable_claim_admission.py
@@ -1,0 +1,64 @@
+"""Inspect/install the durable-worker database admission fence.
+
+Use --worker-pattern for a bounded legacy-host rollout. Existing validators
+are preserved. Activation is explicit and prints a rollback receipt.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.backend.db.mongo_client import get_db
+from src.backend.workflows.durable.task_ownership import claim_admission_validator
+
+
+def install_admission(
+    db, *, collection="workflow_instances", worker_pattern="^worker_", apply=False
+):
+    options = db[collection].options()
+    rule = claim_admission_validator(worker_pattern)
+    existing = options.get("validator", {})
+    validator = (
+        existing
+        if existing == rule
+        else {"$and": [existing, rule]} if existing else rule
+    )
+    receipt = {
+        "collection": collection,
+        "previous": {
+            "validator": existing,
+            "validationLevel": options.get("validationLevel", "strict"),
+            "validationAction": options.get("validationAction", "error"),
+        },
+        "proposed": {
+            "validator": validator,
+            "validationLevel": "strict",
+            "validationAction": "error",
+        },
+        "applied": False,
+    }
+    if apply:
+        db.command({"collMod": collection, **receipt["proposed"]})
+        actual = db[collection].options()
+        receipt["applied"] = all(
+            actual.get(k) == v for k, v in receipt["proposed"].items()
+        )
+        if not receipt["applied"]:
+            raise RuntimeError("claim_admission_readback_mismatch")
+    return receipt
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--worker-pattern", default="^worker_")
+    parser.add_argument("--receipt", type=Path, required=True)
+    args = parser.parse_args()
+    result = install_admission(
+        get_db(), worker_pattern=args.worker_pattern, apply=args.apply
+    )
+    args.receipt.write_text(json.dumps(result, indent=2, default=str))
+    print(json.dumps(result, default=str))

--- a/src/backend/integrations/internal_mcp/gateway.py
+++ b/src/backend/integrations/internal_mcp/gateway.py
@@ -882,9 +882,17 @@ class InternalMCPGateway:
                                 payload=dict(injected_fault.payload),
                                 duration_ms=0.0,
                             )
+                        from ...workflows.durable.task_ownership import (
+                            ownership_checked_handler,
+                        )
+
                         transport_result = self._transport.execute(
                             method_name=definition.name,
-                            handler=definition.handler,
+                            handler=ownership_checked_handler(
+                                definition.handler,
+                                method_name=definition.name,
+                                category=definition.category,
+                            ),
                             payload=dict(payload_dict),
                             timeout_sec=timeout,
                             category=definition.category,

--- a/src/backend/workflows/action_registry.py
+++ b/src/backend/workflows/action_registry.py
@@ -427,6 +427,9 @@ class ActionRegistry:
             str(spec.concept_id or "").strip() if spec is not None else None
         ) or None
         try:
+            from .durable.task_ownership import assert_current_task_claim
+
+            assert_current_task_claim()
             request = WorkflowActionRequest(
                 action_id=resolved_action_id or action_target_id,
                 inputs=inputs,

--- a/src/backend/workflows/durable/instance_manager.py
+++ b/src/backend/workflows/durable/instance_manager.py
@@ -46,6 +46,7 @@ from .models import (
     WorkflowSchedule,
 )
 from .vontology_schedule_repository import VontologyScheduleRepository
+from .task_ownership import task_key, ensure_task_ownership_index
 from .worker_identity import (
     build_claim_provenance,
     get_configured_min_worker_build,
@@ -92,6 +93,8 @@ _WORKFLOW_INSTANCE_STATUS_SUMMARY_PROJECTION: dict[str, Any] = {
     "lock_expires_at": 1,
     "claimed_at": 1,
     "claimed_by_build": 1,
+    "task_ownership_key": 1,
+    "uncheckpointed_effects": 1,
     "min_worker_build": 1,
     "claim_ineligible_reason": 1,
     "claim_ineligible_detected_at": 1,
@@ -164,6 +167,7 @@ def _ensure_indexes() -> None:
             )
 
         # Worker polling: find claimable instances
+        ensure_task_ownership_index(instances_coll)
         if "status_lock_expires" not in existing:
             instances_coll.create_index(
                 [("status", ASCENDING), ("lock_expires_at", ASCENDING)],
@@ -396,11 +400,133 @@ class WorkflowInstanceManager:
         self._lock_ttl = lock_ttl_seconds
         self._schedule_repo = VontologyScheduleRepository()
         _ensure_indexes()
+        self._task_ownership_index_ready = False
 
     def _get_instances_collection(self) -> Collection | None:
         """Get the workflow_instances collection."""
         db = get_db()
         return db[WORKFLOW_INSTANCES_COLLECTION] if db is not None else None
+
+    def is_current_claim(self, instance_id: str, worker_id: str, token: str) -> bool:
+        coll = self._get_instances_collection()
+        if coll is None:
+            return False
+        doc = coll.find_one(
+            self._claim_fence_query(
+                instance_id=instance_id,
+                worker_id=worker_id,
+                claim_token=token,
+                require_unexpired=True,
+            )
+        )
+        return bool(doc and doc.get("task_ownership_active"))
+
+    def begin_claim_effect(self, instance_id, worker_id, token, method_name, payload):
+        coll = self._get_instances_collection()
+        if coll is None or not self.is_current_claim(instance_id, worker_id, token):
+            raise RuntimeError("durable_task_claim_lost")
+        effect_id = str(uuid.uuid4())
+        payload_hash = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        effect = {
+            "effect_id": effect_id,
+            "method": method_name,
+            "payload_sha256": payload_hash,
+            "state": "started",
+            "started_at": datetime.now(timezone.utc),
+        }
+        result = coll.update_one(
+            self._claim_fence_query(
+                instance_id=instance_id,
+                worker_id=worker_id,
+                claim_token=token,
+                require_unexpired=True,
+            ),
+            {"$push": {"uncheckpointed_effects": effect}},
+        )
+        if not result.modified_count:
+            raise RuntimeError("durable_task_claim_lost")
+        return effect_id
+
+    def observe_claim_effect(self, instance_id, effect_id, result):
+        # Observations may arrive after lease expiry. They grant no execution
+        # rights and cannot rewrite checkpoints or clear reconciliation holds.
+        coll = self._get_instances_collection()
+        if coll is None:
+            raise RuntimeError("durable_effect_observation_store_unavailable")
+        receipt = {
+            key: result[key]
+            for key in ("success", "status", "error_code")
+            if isinstance(result, Mapping) and key in result
+        }
+        coll.update_one(
+            {"instance_id": instance_id, "uncheckpointed_effects.effect_id": effect_id},
+            {
+                "$set": {
+                    "uncheckpointed_effects.$.state": "returned",
+                    "uncheckpointed_effects.$.receipt": receipt,
+                }
+            },
+        )
+
+    def reconcile_claim_effects(
+        self,
+        instance_id: str,
+        *,
+        expected_effect_ids: list[str],
+        evidence: str,
+        expected_claim_token: str,
+        current_state: str,
+        workflow_data: dict[str, Any],
+        step_index: int,
+    ) -> bool:
+        """Trusted operator recovery after external read-back and worker drain.
+
+        The caller supplies the verified continuation checkpoint. This is not
+        exposed as a model-controlled bypass or inferred from a tool timeout.
+        Keep paused for ordinary authority-aware resume_instance preflight.
+        """
+        if not evidence.strip() or not current_state or not expected_effect_ids:
+            raise ValueError("effect_reconciliation_requires_evidence_and_checkpoint")
+        coll = self._get_instances_collection()
+        if coll is None:
+            return False
+        now = datetime.now(timezone.utc)
+        query = {
+            "instance_id": instance_id,
+            "claim_token": expected_claim_token,
+            "uncheckpointed_effects.effect_id": {"$all": expected_effect_ids},
+            "uncheckpointed_effects": {"$size": len(expected_effect_ids)},
+            "$or": [{"lock_expires_at": None}, {"lock_expires_at": {"$lte": now}}],
+        }
+        compacted = self._compact_instance_payload_field(
+            workflow_data, field="workflow_data", instance_id=instance_id
+        )
+        return bool(
+            coll.update_one(
+                query,
+                {
+                    "$set": {
+                        "status": "paused",
+                        "manual_resume_required": True,
+                        "locked_by": None,
+                        "lock_expires_at": None,
+                        "completed_at": None,
+                        "current_state": current_state,
+                        "workflow_data": compacted,
+                        "step_index": step_index,
+                        "uncheckpointed_effects": [],
+                        "effect_reconciliation_receipt": {
+                            "effect_ids": expected_effect_ids,
+                            "evidence": evidence,
+                            "reconciled_at": now,
+                        },
+                        "progress_message": "effects reconciled; awaiting checkpoint resume",
+                    }
+                },
+            ).modified_count
+        )
 
     @staticmethod
     def _normalise_status_filter(
@@ -850,6 +976,7 @@ class WorkflowInstanceManager:
             event_idempotency_key=event_idempotency_key,
         )
 
+        ownership_key = task_key(instance.to_doc())
         compacted_inputs = self._compact_instance_payload_field(
             instance.inputs,
             field="inputs",
@@ -882,6 +1009,7 @@ class WorkflowInstanceManager:
             )
 
         instance_doc = instance.to_doc()
+        instance_doc["task_ownership_key"] = ownership_key
         instance_doc["auto_claim_enabled"] = bool(auto_claim_enabled)
         if not auto_claim_enabled:
             # Legacy-claim shield (JVNAUTOSCI-2503): workers running builds
@@ -1604,6 +1732,11 @@ class WorkflowInstanceManager:
         worker_id_clean = str(worker_id or "").strip()
         if not worker_id_clean:
             return None
+        # Index creation is mandatory for claimants, but read-only instance
+        # diagnostics must not require schema-administration privileges.
+        if not self._task_ownership_index_ready:
+            ensure_task_ownership_index(coll)
+            self._task_ownership_index_ready = True
         normalised_build_identity = normalise_worker_build_identity(
             worker_build_identity,
             worker_id=worker_id_clean,
@@ -1639,6 +1772,15 @@ class WorkflowInstanceManager:
         # re-execute the same turn (JVNAUTOSCI-2503).
         query: dict[str, Any] = {
             "auto_claim_enabled": {"$ne": False},
+            "uncheckpointed_effects.0": {"$exists": False},
+            "$and": [
+                {
+                    "$or": [
+                        {"task_claim_retry_at": {"$exists": False}},
+                        {"task_claim_retry_at": {"$lte": now}},
+                    ]
+                }
+            ],
             "workflow_id": {"$nin": sorted(_RETIRED_AUTO_CLAIM_WORKFLOW_IDS)},
             "$or": [
                 {"status": WorkflowInstanceStatus.PENDING.value},
@@ -1699,50 +1841,76 @@ class WorkflowInstanceManager:
             *,
             claim_sort: list[tuple[str, int]],
         ) -> dict[str, Any] | None:
-            # Use $setOnInsert for started_at only if not already set
-            claimed_doc = coll.find_one_and_update(
-                {**claim_query, "started_at": None},
-                {
-                    "$set": {
-                        "status": WorkflowInstanceStatus.RUNNING.value,
-                        "locked_by": worker_id_clean,
-                        "lock_expires_at": lock_expires,
-                        "started_at": now,
-                        "claimed_at": now,
-                        "claimed_by_build": claim_provenance,
-                        "claim_token": claim_token,
-                        "claim_ineligible_reason": None,
-                        "claim_ineligible_detected_at": None,
-                        "progress_message": "running",
-                        "progress_updated_at": now,
-                    }
-                },
-                sort=claim_sort,
-                return_document=True,
-            )
-
-            # If no doc found with started_at=None, try without that constraint
-            if claimed_doc is None:
-                claimed_doc = coll.find_one_and_update(
-                    claim_query,
-                    {
-                        "$set": {
-                            "status": WorkflowInstanceStatus.RUNNING.value,
-                            "locked_by": worker_id_clean,
-                            "lock_expires_at": lock_expires,
-                            "claimed_at": now,
-                            "claimed_by_build": claim_provenance,
-                            "claim_token": claim_token,
-                            "claim_ineligible_reason": None,
-                            "claim_ineligible_detected_at": None,
-                            "progress_message": "running",
-                            "progress_updated_at": now,
-                        }
-                    },
+            excluded: list[str] = []
+            busy_keys: list[str] = []
+            for _ in range(20):
+                candidate_query = {
+                    "$and": [
+                        claim_query,
+                        {"instance_id": {"$nin": excluded}},
+                        {"task_ownership_key": {"$nin": busy_keys}},
+                    ]
+                }
+                candidate = coll.find_one(
+                    {"$and": [candidate_query, {"task_ownership_active": True}]},
                     sort=claim_sort,
-                    return_document=True,
-                )
-            return claimed_doc
+                ) or coll.find_one(candidate_query, sort=claim_sort)
+                if candidate is None:
+                    return None
+                identifier = candidate["instance_id"]
+                key = task_key(candidate)
+                try:
+                    claimed = coll.find_one_and_update(
+                        {"$and": [claim_query, {"instance_id": identifier}]},
+                        {
+                            "$set": {
+                                "status": WorkflowInstanceStatus.RUNNING.value,
+                                "locked_by": worker_id_clean,
+                                "lock_expires_at": lock_expires,
+                                "started_at": candidate.get("started_at") or now,
+                                "claimed_at": now,
+                                "claimed_by_build": claim_provenance,
+                                "claim_token": claim_token,
+                                "task_ownership_key": key,
+                                "task_ownership_active": True,
+                                "claim_ineligible_reason": None,
+                                "claim_ineligible_detected_at": None,
+                                "progress_message": "running",
+                                "progress_updated_at": now,
+                            }
+                        },
+                        return_document=True,
+                    )
+                    if claimed is not None:
+                        return claimed
+                except DuplicateKeyError:
+                    # Terminal owners can be released with a single conditional
+                    # write. A concurrent resume changes status and defeats this
+                    # release, or competes under the same unique index.
+                    released = coll.update_one(
+                        {
+                            "task_ownership_key": key,
+                            "task_ownership_active": True,
+                            "status": {"$in": ["completed", "failed", "cancelled"]},
+                            "uncheckpointed_effects.0": {"$exists": False},
+                        },
+                        {"$set": {"task_ownership_active": False}},
+                    )
+                    if released.modified_count:
+                        continue
+                    coll.update_one(
+                        {"$and": [claim_query, {"instance_id": identifier}]},
+                        {
+                            "$set": {
+                                "task_claim_retry_at": now + timedelta(seconds=5),
+                                "task_ownership_key": key,
+                                "progress_message": "waiting for task owner",
+                            }
+                        },
+                    )
+                    busy_keys.append(key)
+                excluded.append(identifier)
+            return None
 
         doc: dict[str, Any] | None = None
         if not workflow_ids:
@@ -2000,6 +2168,12 @@ class WorkflowInstanceManager:
             claim_token=claim_token,
             require_unexpired=(worker_id is not None or claim_token is not None),
         )
+        # Never persist a resumable checkpoint over a still-running or uncertain
+        # mutation. Successful checkpointing acknowledges observed effects.
+        checkpoint_query["uncheckpointed_effects"] = {
+            "$not": {"$elemMatch": {"state": "started"}}
+        }
+        update["$set"]["uncheckpointed_effects"] = []
         if projected_attestation is not None:
             checkpoint_query.update(
                 {
@@ -2180,6 +2354,11 @@ class WorkflowInstanceManager:
             claim_token=claim_token,
             require_unexpired=(worker_id is not None or claim_token is not None),
         )
+        completion_query["uncheckpointed_effects"] = {
+            "$not": {"$elemMatch": {"state": "started"}}
+        }
+        update["$set"]["task_ownership_active"] = False
+        update["$set"]["uncheckpointed_effects"] = []
         instance_before = self._find_one_and_update_instance(
             completion_query,
             update,

--- a/src/backend/workflows/durable/models.py
+++ b/src/backend/workflows/durable/models.py
@@ -221,6 +221,9 @@ class WorkflowInstance:
     claimed_at: datetime | None = None
     claimed_by_build: dict[str, Any] | None = None
     claim_token: str | None = None
+    task_ownership_key: str | None = None
+    task_ownership_active: bool = False
+    uncheckpointed_effects: list[dict[str, Any]] = field(default_factory=list)
     authority_checkpoint_attestation: dict[str, Any] | None = None
     min_worker_build: str | None = None
     claim_ineligible_reason: str | None = None
@@ -314,6 +317,9 @@ class WorkflowInstance:
             "claimed_at": self.claimed_at,
             "claimed_by_build": self.claimed_by_build,
             "claim_token": self.claim_token,
+            "task_ownership_key": self.task_ownership_key,
+            "task_ownership_active": self.task_ownership_active,
+            "uncheckpointed_effects": self.uncheckpointed_effects,
             "authority_checkpoint_attestation": (self.authority_checkpoint_attestation),
             "min_worker_build": self.min_worker_build,
             "claim_ineligible_reason": self.claim_ineligible_reason,
@@ -381,6 +387,9 @@ class WorkflowInstance:
                 if isinstance(doc.get("authority_checkpoint_attestation"), dict)
                 else None
             ),
+            task_ownership_key=doc.get("task_ownership_key"),
+            task_ownership_active=bool(doc.get("task_ownership_active")),
+            uncheckpointed_effects=list(doc.get("uncheckpointed_effects") or []),
             min_worker_build=doc.get("min_worker_build"),
             claim_ineligible_reason=doc.get("claim_ineligible_reason"),
             claim_ineligible_detected_at=doc.get("claim_ineligible_detected_at"),

--- a/src/backend/workflows/durable/task_ownership.py
+++ b/src/backend/workflows/durable/task_ownership.py
@@ -1,0 +1,134 @@
+"""Scope-bound durable task identity and trusted action-dispatch fencing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+TASK_OWNERSHIP_CAPABILITY = "durable_task_ownership_v1"
+TASK_OWNERSHIP_INDEX = "active_task_owner_unique"
+
+
+def task_key(document: Mapping[str, Any]) -> str:
+    if document.get("task_ownership_key"):
+        return document["task_ownership_key"]
+    inputs = document.get("inputs") or {}
+    task = inputs.get("task_concept_id") or inputs.get("task_id")
+    identity = (
+        ["task", task]
+        if isinstance(task, str) and task.strip()
+        else (
+            ["schedule", document["schedule_id"]]
+            if document.get("schedule_id")
+            else (
+                ["event", document["event_idempotency_key"]]
+                if document.get("event_idempotency_key")
+                else ["instance", document["instance_id"]]
+            )
+        )
+    )
+    scope = [document.get("user_id"), document.get("org_id"), document.get("namespace")]
+    return hashlib.sha256(
+        json.dumps([scope, identity], sort_keys=True).encode()
+    ).hexdigest()
+
+
+def ensure_task_ownership_index(instances: Any) -> None:
+    partial_filter = {
+        "task_ownership_active": True,
+        "task_ownership_key": {"$type": "string"},
+    }
+    existing = instances.index_information().get(TASK_OWNERSHIP_INDEX)
+    if existing is not None:
+        if (existing.get("unique") is not True
+            or existing.get("key") != [("task_ownership_key", 1)]
+            or existing.get("partialFilterExpression") != partial_filter):
+            raise RuntimeError("durable_task_ownership_index_mismatch")
+        return
+    instances.create_index(
+        [("task_ownership_key", 1)],
+        name=TASK_OWNERSHIP_INDEX,
+        unique=True,
+        partialFilterExpression=partial_filter,
+    )
+
+
+@dataclass(frozen=True)
+class TaskClaim:
+    manager: Any
+    instance_id: str
+    worker_id: str
+    token: str
+
+    def assert_current(self) -> None:
+        if not self.manager.is_current_claim(
+            self.instance_id, self.worker_id, self.token
+        ):
+            raise RuntimeError("durable_task_claim_lost")
+
+
+_CLAIM: ContextVar[TaskClaim | None] = ContextVar("durable_task_claim", default=None)
+
+
+@contextmanager
+def bind_task_claim(manager: Any, instance_id: str, worker_id: str, token: str | None):
+    # Supervised execution has its own authority path and no background lease.
+    binding = _CLAIM.set(
+        TaskClaim(manager, instance_id, worker_id, token) if token else None
+    )
+    try:
+        yield
+    finally:
+        _CLAIM.reset(binding)
+
+
+def assert_current_task_claim() -> None:
+    claim = _CLAIM.get()
+    if claim is not None:
+        claim.assert_current()
+
+
+def ownership_checked_handler(
+    handler: Callable[..., Any], *, method_name: str, category: str
+):
+    """Check inside the transport thread, after queueing and before invocation."""
+
+    def invoke(**payload: Any):
+        claim = _CLAIM.get()
+        if claim is None:
+            return handler(**payload)
+        claim.assert_current()
+        effect_id = None
+        if category != "read":
+            effect_id = claim.manager.begin_claim_effect(
+                claim.instance_id, claim.worker_id, claim.token, method_name, payload
+            )
+        result = handler(**payload)
+        if effect_id is not None:
+            claim.manager.observe_claim_effect(claim.instance_id, effect_id, result)
+        return result
+
+    return invoke
+
+
+def claim_admission_validator(worker_pattern: str = "^worker_") -> dict[str, Any]:
+    """Database-enforced compatibility fence for legacy claim implementations.
+
+    This rejects the observed old code which replaces claimed_by_build on each
+    claim. It is compatibility enforcement, not protection against a malicious
+    database writer spoofing capabilities or bypassing document validation.
+    """
+    return {
+        "$nor": [
+            {
+                "status": "running",
+                "locked_by": {"$regex": worker_pattern},
+                "claimed_by_build.capabilities": {"$ne": TASK_OWNERSHIP_CAPABILITY},
+            }
+        ]
+    }

--- a/src/backend/workflows/durable/worker.py
+++ b/src/backend/workflows/durable/worker.py
@@ -591,7 +591,15 @@ class DurableWorkflowWorker:
             # actor bound across definition loading *and the complete workflow
             # run* so LLM prompt resolution, nested workflow loading, explicit
             # actions, and fallback tools all enforce the same authority.
-            with override_current_actor(instance.user_id, instance.org_id):
+            from .task_ownership import bind_task_claim
+
+            with (
+                override_current_actor(instance.user_id, instance.org_id),
+                bind_task_claim(
+                    self._instance_manager, instance_id, self._worker_id, claim_token
+                ),
+            ):
+
                 def _load_definition_with_authority() -> tuple[
                     Any,
                     dict[str, Any] | None,

--- a/src/backend/workflows/durable/worker_identity.py
+++ b/src/backend/workflows/durable/worker_identity.py
@@ -163,6 +163,7 @@ def build_worker_build_identity(worker_id: str) -> dict[str, Any]:
     version_info["pid"] = os.getpid()
     version_info["capabilities"] = [
         EXACT_AUTHORITY_SNAPSHOT_WORKER_CAPABILITY,
+        "durable_task_ownership_v1",
     ]
     return normalise_worker_build_identity(version_info, worker_id=worker_id)
 

--- a/tests/backend/test_durable_task_ownership.py
+++ b/tests/backend/test_durable_task_ownership.py
@@ -1,0 +1,268 @@
+"""Competing-instance and stale-dispatch regressions, without external effects."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from threading import Barrier
+
+import mongomock
+import pytest
+
+from src.backend.workflows.durable import instance_manager as im
+from src.backend.workflows.durable.task_ownership import (
+    bind_task_claim,
+    claim_admission_validator,
+    ensure_task_ownership_index,
+    ownership_checked_handler,
+    task_key,
+)
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    db = mongomock.MongoClient(tz_aware=True).db
+    monkeypatch.setattr(im, "get_db", lambda: db)
+    monkeypatch.setattr(im, "_ensure_indexes", lambda: None)
+    monkeypatch.setattr(im, "get_configured_min_worker_build", lambda: None)
+    manager = im.WorkflowInstanceManager()
+    # Model a provisioned collection; mongomock's create_index does not apply
+    # partial-filter expressions when scanning pre-existing rows.
+    ensure_task_ownership_index(db.workflow_instances)
+    monkeypatch.setattr(manager, "_record_durable_episode_start", lambda **kw: None)
+    monkeypatch.setattr(manager, "_broadcast_instance", lambda *a, **kw: None)
+    return manager
+
+
+def make_instance(manager, identifier, *, task="task-one", user="user-one"):
+    doc = {
+        "instance_id": identifier,
+        "workflow_id": "test-workflow",
+        "user_id": user,
+        "org_id": "org",
+        "namespace": user + "/org",
+        "status": "pending",
+        "created_at": datetime.now(UTC),
+        "inputs": {"task_concept_id": task},
+    }
+    manager._get_instances_collection().insert_one(doc)
+    return doc
+
+
+def expire(manager, instance):
+    manager._get_instances_collection().update_one(
+        {"instance_id": instance.instance_id},
+        {
+            "$set": {
+                "lock_expires_at": datetime.now(UTC) - timedelta(seconds=1)
+            }
+        },
+    )
+
+
+def test_atomic_task_claim_race(manager):
+    docs = [make_instance(manager, str(i)) for i in range(8)]
+    barrier = Barrier(8)
+
+    def contend(doc):
+        barrier.wait()
+        return (
+            manager.find_and_claim_instance("worker-" + doc["instance_id"]) is not None
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        assert sum(pool.map(contend, docs)) == 1
+
+
+def test_duplicate_waits_takeover_keeps_checkpoint_and_unrelated_work_progresses(
+    manager,
+):
+    make_instance(manager, "original")
+    first = manager.find_and_claim_instance("worker-a")
+    assert first
+    coll = manager._get_instances_collection()
+    coll.update_one(
+        {"instance_id": "original"},
+        {"$set": {"current_state": "saved", "step_index": 4}},
+    )
+    make_instance(manager, "duplicate")
+    make_instance(manager, "independent", task="another-task")
+    independent = manager.find_and_claim_instance("worker-b")
+    assert independent.instance_id == "independent"
+    expire(manager, first)
+    successor = manager.find_and_claim_instance("worker-c")
+    assert successor.instance_id == "original"
+    assert successor.current_state == "saved" and successor.step_index == 4
+    assert successor.claim_token != first.claim_token
+    assert not manager.is_current_claim("original", "worker-a", first.claim_token)
+    assert not manager.extend_lock(
+        "original", "worker-a", claim_token=first.claim_token
+    )
+    assert manager.is_current_claim("original", "worker-c", successor.claim_token)
+
+
+def test_scope_isolation_and_persisted_identity():
+    doc = {
+        "instance_id": "one",
+        "user_id": "a",
+        "org_id": "org",
+        "namespace": "a/org",
+        "inputs": {"task_concept_id": "task"},
+    }
+    assert task_key(doc) != task_key({**doc, "user_id": "b"})
+    assert task_key(doc) != task_key({**doc, "org_id": "other"})
+    assert task_key(doc) == task_key(
+        {"task_ownership_key": task_key(doc), "inputs": {"blob": "ref"}}
+    )
+
+
+def test_handler_checks_after_transport_queue_and_never_calls_stale_owner(manager):
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+    calls = []
+    wrapped = ownership_checked_handler(
+        lambda **p: calls.append(p), method_name="send", category="write"
+    )
+    with bind_task_claim(manager, "one", "worker-a", first.claim_token):
+        expire(manager, first)  # Time spent queued in the transport.
+        with pytest.raises(RuntimeError, match="durable_task_claim_lost"):
+            wrapped(to="fixture")
+    assert calls == []
+
+
+def test_unknown_effect_prevents_takeover_and_duplicate_execution(manager):
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+
+    def unknown(**payload):
+        raise TimeoutError("unknown remote outcome")
+
+    wrapped = ownership_checked_handler(unknown, method_name="send", category="write")
+    with bind_task_claim(manager, "one", "worker-a", first.claim_token), pytest.raises(TimeoutError):
+        wrapped(to="fixture")
+    expire(manager, first)
+    make_instance(manager, "duplicate")
+    assert manager.find_and_claim_instance("worker-b") is None
+    assert manager.find_and_claim_instance("worker-c") is None
+    effect = manager._get_instances_collection().find_one({"instance_id": "one"})[
+        "uncheckpointed_effects"
+    ][0]
+    assert effect["state"] == "started" and "to" not in effect
+
+
+def test_observed_effect_is_acknowledged_only_by_checkpoint(manager):
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+    wrapped = ownership_checked_handler(
+        lambda **p: {"success": True}, method_name="write", category="write"
+    )
+    with bind_task_claim(manager, "one", "worker-a", first.claim_token):
+        assert wrapped(value=1) == {"success": True}
+    coll = manager._get_instances_collection()
+    assert (
+        coll.find_one({"instance_id": "one"})["uncheckpointed_effects"][0]["state"]
+        == "returned"
+    )
+    assert manager.checkpoint(
+        "one",
+        current_state="next",
+        workflow_data={},
+        step_index=1,
+        worker_id="worker-a",
+        claim_token=first.claim_token,
+    )
+    assert coll.find_one({"instance_id": "one"})["uncheckpointed_effects"] == []
+    expire(manager, first)
+    assert manager.find_and_claim_instance("worker-b").instance_id == "one"
+
+
+def test_legacy_claim_validator_rejects_observed_sc_build():
+    # Query semantics test. Real Mongo validation and legacy findAndModify are
+    # also exercised in the operator activation canary; mongomock has no validators.
+    coll = mongomock.MongoClient().db.rows
+    coll.insert_many(
+        [
+            {
+                "_id": "old",
+                "status": "running",
+                "locked_by": "worker_SC448086_568144",
+                "claimed_by_build": {"git_commit": "d5ce3b6"},
+            },
+            {
+                "_id": "new",
+                "status": "running",
+                "locked_by": "worker_SC448086_new",
+                "claimed_by_build": {"capabilities": ["durable_task_ownership_v1"]},
+            },
+            {"_id": "dgx", "status": "running", "locked_by": "worker_DGX_1"},
+            {"_id": "queued", "status": "pending"},
+        ]
+    )
+    assert {
+        d["_id"] for d in coll.find(claim_admission_validator("^worker_SC448086_"))
+    } == {"new", "dgx", "queued"}
+
+
+def test_pause_retains_owner_and_terminal_release_allows_next_occurrence(manager):
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+    make_instance(manager, "two")
+    assert manager.release_lock("one", "worker-a", claim_token=first.claim_token)
+    resumed = manager.find_and_claim_instance("worker-b")
+    assert resumed.instance_id == "one"
+    coll = manager._get_instances_collection()
+    coll.update_one({"instance_id": "one"}, {"$set": {"status": "failed"}})
+    assert manager.find_and_claim_instance("worker-c").instance_id == "two"
+
+
+def test_reconciliation_requires_drain_exact_inventory_and_evidence(manager):
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+    effect = manager.begin_claim_effect(
+        "one", "worker-a", first.claim_token, "send", {}
+    )
+    kwargs = {
+        "expected_effect_ids": [effect],
+        "evidence": "provider receipt verified; old process stopped",
+        "expected_claim_token": first.claim_token,
+        "current_state": "next",
+        "workflow_data": {},
+        "step_index": 1,
+    }
+    assert not manager.reconcile_claim_effects("one", **kwargs)  # Active lease.
+    expire(manager, first)
+    assert not manager.reconcile_claim_effects(
+        "one", **{**kwargs, "expected_effect_ids": ["wrong"]}
+    )
+    assert manager.reconcile_claim_effects("one", **kwargs)
+    doc = manager._get_instances_collection().find_one({"instance_id": "one"})
+    assert doc["manual_resume_required"] and doc["current_state"] == "next"
+    assert not doc["uncheckpointed_effects"]
+    assert manager.find_and_claim_instance("worker-b") is None
+
+
+def test_actual_gateway_transport_preserves_claim_and_records_effect(manager):
+    from src.backend.integrations.internal_mcp.gateway import (
+        InternalMCPGateway,
+        MethodCatalogue,
+        MethodDefinition,
+    )
+    from src.backend.integrations.internal_mcp.schemas import Schema
+    from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+
+    make_instance(manager, "one")
+    first = manager.find_and_claim_instance("worker-a")
+    catalogue = MethodCatalogue()
+    catalogue.register(
+        MethodDefinition(
+            name="fixture_write",
+            handler=lambda: {"success": True},
+            input_schema=Schema(required={}, optional={}, allow_unknown=False),
+            category="write",
+        )
+    )
+    gateway = InternalMCPGateway(
+        catalogue=catalogue, transport=InternalMCPTransport(), enabled=True
+    )
+    with bind_task_claim(manager, "one", "worker-a", first.claim_token):
+        assert gateway.invoke("fixture_write", {}).payload["success"]
+    doc = manager._get_instances_collection().find_one({"instance_id": "one"})
+    assert doc["uncheckpointed_effects"][0]["state"] == "returned"

--- a/tests/backend/test_durable_workflow_worker.py
+++ b/tests/backend/test_durable_workflow_worker.py
@@ -114,6 +114,10 @@ class _PollManagerStub:
 
 
 class _SuccessfulWorkerManagerStub(_WorkerManagerStub):
+    def is_current_claim(self, instance_id: str, worker_id: str, token: str) -> bool:
+        instance = self.instances[instance_id]
+        return instance.locked_by == worker_id and instance.claim_token == token
+
     def __init__(self, instances: list[WorkflowInstance]) -> None:
         super().__init__()
         self.instances = {instance.instance_id: instance for instance in instances}


### PR DESCRIPTION
Different workflow instances for the same task could run on different Von workers despite correct per-instance locking. Durable claims now atomically acquire a scope-bound task key under a partial unique index. Pauses retain ownership, expiry resumes the owning instance and its checkpoint, and competing instances yield to unrelated work.

Trusted claim context is checked at action entry and again inside MCP transport handlers. Mutations record uncheckpointed effect reservations; uncertain outcomes block automatic takeover until receipt-based reconciliation. This does not promise exactly-once external sends or transactional fencing of arbitrary custom Python actions.

Adds a database admission validator and rollout tool for legacy workers. The observed SC448086 July claim implementation was rejected with error 121 against the actual Atlas workflow collection after a narrowly scoped strict/error validator was activated; no active SC448086 claims remained. Other workers are unaffected by that staged rule. Remote process shutdown/upgrade is not claimed.

Validation: 198 targeted durable, worker, executor, gateway and transport tests passed; Python 3.11 syntax validation passed; new-file Ruff checks passed. A real Atlas canary with four concurrent claimants produced one owner, preserved the checkpoint on takeover and rejected the stale owner. Two file-copy ingestion tests fail identically on unchanged main and are outside this change.

Jira: JVNAUTOSCI-2729. Wider fleet governance remains in JVNAUTOSCI-2593. Deployment of the merged version to the Mac and DGX follows merge.
