### PR TITLE
Preserve complete federation views at conversation capacity

### DIFF
--- a/src/backend/services/knowledge_federation/continuity.py
+++ b/src/backend/services/knowledge_federation/continuity.py
@@ -221,24 +221,29 @@ def collect_catalogue(db, settings):
             "updated_at": 1,
             "history": {"$slice": [{"$ifNull": ["$history", []]}, -2]},
         }
-        for document in db["chat_history"].aggregate(
-            [
-                {"$match": query},
-                {"$limit": MAX_RECORDS + 1},
-                {"$project": projection},
-                {
-                    "$project": {
-                        "session_id": 1,
-                        "user_id": 1,
-                        "namespace": 1,
-                        "session_name": 1,
-                        "updated_at": 1,
-                        "history.role": 1,
-                        "history.content": 1,
-                    }
-                },
-            ]
+        for scanned, document in enumerate(
+            db["chat_history"].aggregate(
+                [
+                    {"$match": query},
+                    {"$limit": MAX_RECORDS + 1},
+                    {"$project": projection},
+                    {
+                        "$project": {
+                            "session_id": 1,
+                            "user_id": 1,
+                            "namespace": 1,
+                            "session_name": 1,
+                            "updated_at": 1,
+                            "history.role": 1,
+                            "history.content": 1,
+                        }
+                    },
+                ]
+            ),
+            start=1,
         ):
+            if scanned > MAX_RECORDS:
+                raise ValueError("conversation selection capacity exceeded")
             scope = {
                 "user_id": document.get("user_id"),
                 "namespace": document.get("namespace"),

--- a/tests/backend/test_federation_continuity.py
+++ b/tests/backend/test_federation_continuity.py
@@ -347,3 +347,25 @@ def test_compact_refresh_reuses_only_authenticated_unchanged_cache(nodes):
     compact["signature"] = "forged"
     with pytest.raises(PermissionError):
         service.import_snapshot(b, "atlas", compact, db=db)
+
+
+def test_capacity_is_checked_before_filtering_legacy_namespaces(nodes, monkeypatch):
+    a, b, da, db, _ = prepare(nodes)
+    settings = a["exports"]["dgx"]
+    settings.update(
+        conversation_scopes=[], conversation_users=["#V#alice"], file_audiences=[]
+    )
+    da.chat_history.insert_one(
+        {"session_id": "legacy", "user_id": "#V#alice", "history": []}
+    )
+    da.chat_history.insert_one(
+        {
+            "session_id": "later-valid",
+            "user_id": "#V#alice",
+            "namespace": "#V#alice",
+            "history": [],
+        }
+    )
+    monkeypatch.setattr(c, "MAX_RECORDS", 2)
+    with pytest.raises(ValueError, match="capacity exceeded"):
+        c.collect_catalogue(da, settings)


### PR DESCRIPTION
Automatic conversation selection applies its database limit before filtering malformed legacy namespaces. At capacity, that could omit later valid conversations while publishing a partial catalogue.

Count selected source rows before namespace filtering and fail the capture at capacity, preserving the previous complete replica. The deployed catalogues are below the limit; this closes the boundary for continued growth.

Validation: 28 targeted federation tests, including a regression with an invalid legacy row before a later valid row. JVNAUTOSCI-2731; follow-up to #586.
