### PR TITLE
Collect new Otter meetings on demand and daily (JVNAUTOSCI-314)

### DIFF
--- a/docs/engineering/otter_archive_and_conversation_images.md
+++ b/docs/engineering/otter_archive_and_conversation_images.md
@@ -98,3 +98,72 @@ source hashes, model and prompt versions with any persisted interpretation. A ca
 render or OCR result is not a verified semantic interpretation. Reuse represented
 workflow authoring for analysis/persistence/recovery rather than treating a successful
 file import, graph creation or schedule as proof of slide understanding.
+
+## New meeting collection
+
+[JVNAUTOSCI-314](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-314) adds a
+collector using Otter's [official hosted MCP](https://help.otter.ai/hc/en-us/articles/35287607569687-Otter-MCP-Server).
+Von authenticates its own read-only OAuth client. A connector available inside
+ChatGPT/Codex is not a credential or execution service available to the Von server.
+No model call is needed for discovery, copying, deduplication or scheduling.
+
+The existing private archive remains the source store. Its operator-only
+`import-live` CLI saves immutable source JSON and content-hashed revisions without
+modifying the original backup. Query MCP access remains read-only. The collector
+stores operational jobs, retry IDs and receipts beside the archive in
+`collection/state.sqlite3`; canonical concept and scoped-assertion services own
+meeting representation and participant links. Source text cannot trigger tools.
+
+Configure `collection/settings.json` beside the archive database with `enabled`,
+`owner_user_concept_id` matching the deployment binding, and the authorised Otter
+`account_email`. Keep this file and the sibling `credentials` directory private
+and outside Git. Run `pdm run python scripts/collect_otter.py authorise`, open the
+URL in `credentials/authorisation-request.json`, and authorise Otter access. The
+loopback callback verifies OAuth state; saved token expiry survives restarts and
+refresh tokens support unattended renewal. Revoked consent requires operator
+reauthorisation and appears as a failed run, never a successful empty import.
+
+The owning Von actor can use `otter_collect_now` for date-window discovery or
+exact meeting IDs/URLs, and `otter_collection_status` to inspect durable receipts.
+The ordinary-turn resource selector comes from trusted server context. The local
+Von stdio MCP also exposes these tools under its explicit operator provenance.
+Dates are `YYYY-MM-DD`. Optional `participant_bindings` maps a requested meeting
+ID to exact transcript speaker labels and reviewed existing person concept IDs.
+Existing reviewed bindings survive scheduled refreshes; a corrected binding
+retracts the prior collector-authored link. Unreconciled named speakers receive
+private meeting-local person concepts; unknown speaker labels remain unresolved.
+Calendar invitees are preserved as source metadata, not asserted to have attended.
+
+An operator can run `collect`, `daily`, `work` or `status` with the same script.
+`collect --meeting ID` forces a fresh source fetch even for a preserved meeting.
+`--after` and `--before` select a discovery window; `--bindings-file` supplies
+reviewed participant bindings. Requests persist before worker launch, workers
+serialise through a host lock, and interrupted jobs and failed items can resume.
+Source and assertion writes are idempotent; receipts distinguish new, revised,
+unchanged, unavailable and failed content. No-transcript notices preserve metadata
+and remain pending for retry.
+
+On macOS, run `install-schedule` **from the deployed runtime checkout**, using its
+Python environment. It installs `org.von.otter-collection` as a per-user launchd
+job at 06:00 in the host's local timezone. The user must remain logged in; launchd
+handles a calendar job missed during sleep when the host wakes. Inspect with
+`launchctl print gui/$(id -u)/org.von.otter-collection`; `launchctl kickstart` on
+that service exercises the installed job. Job logs and receipts remain private.
+On Linux, an equivalent owner crontab can invoke the deployed script's `daily`
+action. Daily requests deduplicate by UTC date; explicit `collect` remains
+available to retry or refresh immediately.
+
+Discovery defaults to the past seven days and retries retained failures. Otter's
+current responses may omit both a cursor and an explicit completion reason.
+Such runs report `discovery_complete=false` and never advance the completeness
+watermark; `completed_with_coverage_limit` means all **returned** meetings were
+preserved, not that the source was exhaustively enumerated. Older newly shared
+meetings or old transcript edits may require an explicit date window or ID.
+Audio and new screenshots are not supplied by these hosted MCP tools. Existing
+archive images remain available through the archive image routes.
+
+The later workflow to request slides from presenters, connect decks and fully
+represent mentioned papers is tracked in
+[JVNAUTOSCI-2732](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2732).
+It must be authored and exercised through the Von UI; collection does not send
+presenter requests or assert paper interpretations.

--- a/scripts/collect_otter.py
+++ b/scripts/collect_otter.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Explicit local operator entry point; no credentials are accepted as arguments."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def main():
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "action",
+        choices=["authorise", "collect", "daily", "work", "status", "install-schedule"],
+    )
+    parser.add_argument("--resource-id", default="personal_otter_archive")
+    parser.add_argument("--meeting", action="append", default=[])
+    parser.add_argument("--after")
+    parser.add_argument("--before")
+    parser.add_argument("--bindings-file", type=Path)
+    parser.add_argument("--run-id")
+    args = parser.parse_args()
+    from src.backend.integrations.internal_mcp.otter_archive_proxy_mcp import (
+        _build_otter_archive_config,
+    )
+    from src.backend.services import otter_collection_service as service
+
+    if args.action == "authorise":
+        from src.backend.integrations.otter_live_client import authorise
+
+        archive = _build_otter_archive_config(resource_id=args.resource_id)
+        result = asyncio.run(authorise(archive.database.parent / "credentials"))
+    elif args.action in {"collect", "daily"}:
+        result = service.enqueue(
+            args.resource_id,
+            meeting_ids=args.meeting,
+            created_after=args.after,
+            created_before=args.before,
+            participant_bindings=json.loads(args.bindings_file.read_text())
+            if args.bindings_file
+            else None,
+            daily=args.action == "daily",
+            spawn=False,
+        )
+        print(json.dumps(result), flush=True)
+        service.work(args.resource_id)
+        result = service.status(args.resource_id, result["run_id"])
+    elif args.action == "install-schedule":
+        result = install_schedule(args.resource_id)
+    elif args.action == "work":
+        result = service.work(args.resource_id)
+    else:
+        result = service.status(args.resource_id, args.run_id)
+    print(json.dumps(result), flush=True)
+    if args.action in {"collect", "daily"} and any(
+        r["status"] in {"failed", "partial"} for r in result.get("runs", [])
+    ):
+        return 1
+    return 0
+
+
+def install_schedule(resource_id):
+    """Install an operator-requested per-user macOS job against this checkout."""
+    import os
+    import plistlib
+    import subprocess
+
+    from src.backend.integrations.otter_live_client import private_json
+    from src.backend.services.otter_collection_service import config
+
+    if sys.platform != "darwin":
+        raise RuntimeError("Use the documented cron entry on non-macOS hosts")
+    _, root, settings = config(resource_id)
+    label = "org.von.otter-collection"
+    plist_path = Path.home() / "Library" / "LaunchAgents" / (label + ".plist")
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path = root / "schedule.log"
+    log_path.touch(mode=0o600, exist_ok=True)
+    payload = {
+        "Label": label,
+        "ProgramArguments": [
+            sys.executable,
+            str(ROOT / "scripts/collect_otter.py"),
+            "daily",
+            "--resource-id",
+            resource_id,
+        ],
+        "WorkingDirectory": str(ROOT),
+        "StartCalendarInterval": {"Hour": 6, "Minute": 0},
+        "StandardOutPath": str(log_path),
+        "StandardErrorPath": str(log_path),
+        "EnvironmentVariables": {"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+    }
+    domain = "gui/" + str(os.getuid())
+    present = subprocess.run(
+        ["launchctl", "print", domain + "/" + label], capture_output=True, check=False
+    )
+    if present.returncode == 0:
+        subprocess.run(
+            ["launchctl", "bootout", domain + "/" + label],
+            check=True,
+            capture_output=True,
+        )
+    plist_path.write_bytes(plistlib.dumps(payload))
+    plist_path.chmod(0o600)
+    subprocess.run(
+        ["launchctl", "bootstrap", domain, str(plist_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["launchctl", "print", domain + "/" + label], check=True, capture_output=True
+    )
+    settings["schedule"] = {
+        "enabled": True,
+        "scheduler": "launchd",
+        "label": label,
+        "time": "06:00",
+        "timezone": "host local timezone",
+        "checkout": str(ROOT),
+        "requires": "logged-in macOS host; execution resumes after sleep",
+    }
+    private_json(root / "settings.json", settings)
+    return {"success": True, "schedule": settings["schedule"]}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -41507,6 +41507,7 @@ def _build_default_catalogue_knowledge_io_definitions() -> List[MethodDefinition
             ),
         ),
         *otter_archive_definitions(),
+        *otter_collection_definitions(),
         *knowkat_definitions(),
         *conversation_image_definitions(),
         # Owner-scoped LinkedIn export search via a local external MCP server.
@@ -46301,6 +46302,7 @@ def _register_dynamic_catalogue_methods(
 
 from .conversation_image_tools import definitions as conversation_image_definitions
 from .otter_archive_tools import definitions as otter_archive_definitions
+from .otter_collection_tools import definitions as otter_collection_definitions
 
 
 def build_default_catalogue() -> MethodCatalogue:

--- a/src/backend/integrations/internal_mcp/otter_collection_tools.py
+++ b/src/backend/integrations/internal_mcp/otter_collection_tools.py
@@ -1,0 +1,79 @@
+"""Explicit collect-now and receipt tools sharing the existing archive owner binding."""
+
+from .gateway import MethodDefinition
+from .schemas import Schema
+
+
+def call_collection(action, **arguments):
+    from ...services import otter_collection_service
+    from .otter_archive_proxy_mcp import resolve_otter_archive_invocation_authority
+
+    try:
+        resource_id = arguments.pop("resource_id")
+        allowed = (
+            {"meeting_ids", "created_after", "created_before", "participant_bindings"}
+            if action == "enqueue"
+            else {"run_id"}
+        )
+        if set(arguments) - allowed:
+            raise ValueError("unexpected_collection_arguments")
+        authority = resolve_otter_archive_invocation_authority(resource_id=resource_id)
+        result = getattr(otter_collection_service, action)(resource_id, **arguments)
+        return {
+            **result,
+            "authority": {
+                **authority.receipt(),
+                "access": "collect_private_source"
+                if action == "enqueue"
+                else "read_only",
+            },
+        }
+    except Exception as exc:  # noqa: BLE001 - redact transport and credential errors
+        return {
+            "success": False,
+            "error_code": getattr(exc, "reason_code", "otter_collection_unavailable"),
+            "error_type": type(exc).__name__,
+        }
+
+
+def definitions():
+    from functools import partial
+
+    return [
+        MethodDefinition(
+            name="otter_collect_now",
+            handler=partial(call_collection, "enqueue"),
+            input_schema=Schema(
+                required={"resource_id": str},
+                optional={
+                    "meeting_ids": list,
+                    "created_after": str,
+                    "created_before": str,
+                    "participant_bindings": dict,
+                },
+                allow_unknown=False,
+            ),
+            output_schema=Schema(required={}, optional={}, allow_unknown=True),
+            category="write",
+            ordinary_turn_effect=True,
+            ordinary_turn_trusted_argument_bindings={
+                "resource_id": "otter_archive_resource_id"
+            },
+            description="Collect new Otter meetings now or refresh exact IDs/URLs into the private archive and link participants. Dates use YYYY-MM-DD. Optional participant_bindings maps requested meeting ID to exact source speaker label to reviewed existing person concept ID. Returns a queued run ID; inspect otter_collection_status before claiming collection complete.",
+        ),
+        MethodDefinition(
+            name="otter_collection_status",
+            handler=partial(call_collection, "status"),
+            input_schema=Schema(
+                required={"resource_id": str},
+                optional={"run_id": str},
+                allow_unknown=False,
+            ),
+            output_schema=Schema(required={}, optional={}, allow_unknown=True),
+            category="read",
+            ordinary_turn_trusted_argument_bindings={
+                "resource_id": "otter_archive_resource_id"
+            },
+            description="Inspect Otter collection runs, failures, participant concept links and scheduled collection configuration. Queued or running is not imported.",
+        ),
+    ]

--- a/src/backend/integrations/otter_live_client.py
+++ b/src/backend/integrations/otter_live_client.py
@@ -1,0 +1,201 @@
+"""OAuth-authenticated read client for Otter's official hosted MCP service.
+
+Credentials belong to the collector, never to the archive query subprocess.
+No interactive login is attempted by an unattended collection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+from mcp import ClientSession
+from mcp.client.auth import OAuthClientProvider
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    OAuthToken,
+)
+
+OTTER_MCP_URL = "https://mcp.otter.ai/mcp"
+
+
+def private_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, filename = tempfile.mkstemp(dir=path.parent, prefix=".private-")
+    temporary = Path(filename)
+    with os.fdopen(fd, "w") as stream:
+        json.dump(value, stream, ensure_ascii=False)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    path.chmod(0o600)
+
+
+class CredentialStore:
+    def __init__(self, root: Path):
+        self.root = root
+
+    def read(self, name, model):
+        path = self.root / (name + ".json")
+        return model.model_validate_json(path.read_text()) if path.exists() else None
+
+    async def get_tokens(self):
+        token = self.read("tokens", OAuthToken)
+        if token and token.expires_in is not None:
+            # Legacy files use their write time; a restart must not renew a token.
+            path = self.root / "tokens.json"
+            saved = json.loads(path.read_text())
+            expiry = saved.get("expires_at", path.stat().st_mtime + token.expires_in)
+            token.expires_in = max(0, int(expiry - time.time()))
+        return token
+
+    async def set_tokens(self, tokens):
+        data = tokens.model_dump(mode="json")
+        if tokens.expires_in is not None:
+            data["expires_at"] = time.time() + tokens.expires_in
+        private_json(self.root / "tokens.json", data)
+
+    async def get_client_info(self):
+        return self.read("client", OAuthClientInformationFull)
+
+    async def set_client_info(self, client_info):
+        private_json(self.root / "client.json", client_info.model_dump(mode="json"))
+
+
+def unwrap(value):
+    """Decode nested MCP text envelopes without altering source text."""
+    for _ in range(8):
+        if hasattr(value, "model_dump"):
+            value = value.model_dump(mode="json")
+        if isinstance(value, dict) and value.get("isError"):
+            raise RuntimeError("otter_tool_failed")
+        if isinstance(value, dict) and value.get("structuredContent") is not None:
+            value = value["structuredContent"]
+        elif isinstance(value, dict) and isinstance(value.get("content"), list):
+            texts = [x["text"] for x in value["content"] if x.get("type") == "text"]
+            if len(texts) != 1:
+                raise ValueError("otter_response_shape_unsupported")
+            value = texts[0]
+        elif isinstance(value, dict) and set(value) == {"result"}:
+            value = value["result"]
+        elif isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError:
+                return value
+        else:
+            return value
+    raise ValueError("otter_response_nesting_exceeded")
+
+
+class PersistentOAuthProvider(OAuthClientProvider):
+    async def _initialize(self):
+        await super()._initialize()
+        token = self.context.current_tokens
+        if token and token.expires_in is not None:
+            self.context.token_expiry_time = time.time() + token.expires_in - 30
+        # SDK 1.x does not persist discovery or initialise expiry from stored tokens.
+        # Rediscover from Otter's fixed official issuer before unattended refresh.
+        if token and token.refresh_token:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(
+                    "https://otter.ai/.well-known/oauth-authorization-server"
+                )
+                response.raise_for_status()
+                self.context.oauth_metadata = OAuthMetadata.model_validate(
+                    response.json()
+                )
+                self.context.auth_server_url = "https://otter.ai/"
+
+
+@asynccontextmanager
+async def otter_session(
+    credential_root: Path, *, redirect_handler=None, callback_handler=None
+):
+    async def no_login(_url):
+        raise RuntimeError("otter_reauthorisation_required")
+
+    provider = PersistentOAuthProvider(
+        server_url=OTTER_MCP_URL,
+        client_metadata=OAuthClientMetadata(
+            client_name="Von private Otter collector",
+            redirect_uris=["http://127.0.0.1:18764/callback"],
+            token_endpoint_auth_method="none",
+        ),
+        storage=CredentialStore(credential_root),
+        redirect_handler=redirect_handler or no_login,
+        callback_handler=callback_handler,
+    )
+    async with (
+        streamablehttp_client(OTTER_MCP_URL, auth=provider) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        yield session
+
+
+async def authorise(credential_root: Path):
+    """Local operator login with a loopback-only OAuth callback; SDK checks state."""
+    from urllib.parse import parse_qs, urlparse
+
+    future = asyncio.get_running_loop().create_future()
+
+    async def receive(reader, writer):
+        try:
+            header = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), 10)
+            target = header.split(b" ", 2)[1].decode("ascii")
+            parsed = urlparse(target)
+            query = parse_qs(parsed.query)
+            if parsed.path != "/callback" or "code" not in query:
+                writer.write(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+            else:
+                body = b"Otter authorisation received. You may close this tab."
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: "
+                    + str(len(body)).encode()
+                    + b"\r\n\r\n"
+                    + body
+                )
+            await writer.drain()
+            if parsed.path == "/callback" and "code" in query and not future.done():
+                future.set_result((query["code"][0], query.get("state", [None])[0]))
+        except (TimeoutError, asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+
+    async def redirect(url):
+        private_json(credential_root / "authorisation-request.json", {"url": url})
+        print(
+            "Otter authorisation ready in private authorisation-request.json",
+            flush=True,
+        )
+
+    async def callback():
+        return await future
+
+    server = await asyncio.start_server(receive, "127.0.0.1", 18764)
+    try:
+        async with (
+            server,
+            otter_session(
+                credential_root, redirect_handler=redirect, callback_handler=callback
+            ) as session,
+        ):
+            listing = await session.list_tools()
+            private_json(
+                credential_root / "tool-schemas.json",
+                [t.model_dump(mode="json") for t in listing.tools],
+            )
+            return {"authenticated": True, "tools": [t.name for t in listing.tools]}
+    finally:
+        (credential_root / "authorisation-request.json").unlink(missing_ok=True)

--- a/src/backend/mcp_server/mcp_stdio_server.py
+++ b/src/backend/mcp_server/mcp_stdio_server.py
@@ -1263,6 +1263,7 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent]:  # type: ig
         if name in (
             _TRUSTED_LOCAL_OPERATOR_GMAIL_TOOLS
             | _TRUSTED_LOCAL_OPERATOR_CONVERSATION_TOOLS
+            | {"otter_collect_now", "otter_collection_status"}
         ):
             # This stdio server is the deliberately local coding/operator
             # surface. Bind that provenance only around explicitly listed
@@ -4712,7 +4713,19 @@ async def _handle_assign_task(arguments: dict[str, Any]) -> list[TextContent]:
         return [_json_text({"error": str(exc), "success": False})]
 
 
+async def _handle_otter_collect_now(arguments: dict[str, Any]) -> list[TextContent]:
+    from src.backend.integrations.internal_mcp.otter_collection_tools import call_collection
+    return [_json_text(call_collection("enqueue", **arguments))]
+
+
+async def _handle_otter_collection_status(arguments: dict[str, Any]) -> list[TextContent]:
+    from src.backend.integrations.internal_mcp.otter_collection_tools import call_collection
+    return [_json_text(call_collection("status", **arguments))]
+
+
 _TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[TextContent]]]] = {
+    "otter_collect_now": _handle_otter_collect_now,
+    "otter_collection_status": _handle_otter_collection_status,
     "get_context": _handle_get_context,
     "create_concepts": _handle_create_concepts,
     "find_subconcepts": _handle_find_subconcepts,

--- a/src/backend/mcp_server/vontology_mcp.json
+++ b/src/backend/mcp_server/vontology_mcp.json
@@ -2678,7 +2678,7 @@
         },
         {
             "name": "fetch_concept_content",
-            "description": "Fetch rendered markdown content for a concept (content_html + md_content + raw_doc). Use reconstruct_md=false to avoid masking missing md_content.",
+            "description": "Fetch concept content (content_html + md_content + raw_doc). The default reconstruct_md=true includes stored text relations when no legacy markdown exists. reconstruct_md=false inspects legacy markdown/metadata only; empty md_content in that mode does not mean the concept has no stored text. Use get_text_relations for direct labelled text rows.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3134,7 +3134,7 @@
         },
         {
             "name": "get_source_processing_marker",
-            "description": "Read the durable Vontology marker for a source item, if one exists. Use before repeating source-processing work so a workflow can reuse represented evidence instead of mutating the source system.",
+            "description": "Read the durable Vontology marker for a source item, if one exists. Use before repeating source-processing work so a workflow can reuse represented evidence instead of mutating the source system. To assess currency, supply source_fingerprint from current source evidence and, where relevant, processing_authority_fingerprint. Omitting the expected source fingerprint returns comparison=not_requested, not evidence of a changed source. Marker existence does not prove adequacy under a revised user expectation. An authorised Gmail profile's resource ID and runtime alias resolve to the same existing marker; alternate historical marker IDs are exposed for inspection.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3195,7 +3195,7 @@
                     "source_item_id"
                 ],
                 "additionalProperties": true,
-                "description": "source processing marker lookup: source_system and source_item_id identify the source item. Supply the exact stable source_profile for profile-scoped markers; omit it only to read an historical profileless marker.",
+                "description": "source processing marker lookup: source_system and source_item_id identify the source item. Supply the exact stable source_profile for profile-scoped markers; omit it only to read an historical profileless marker. Supply source_fingerprint from the current source evidence to compare currency. Without it, comparison is not_requested; the legacy false matches/current flags do not establish that the source changed.",
                 "x-von-argument-aliases": {
                     "profile": "source_profile",
                     "profile_id": "source_profile"
@@ -3549,7 +3549,7 @@
         },
         {
             "name": "gmail_modify_labels",
-            "description": "Atomically add/remove labels on a Gmail message. Requires allow_mutation=true and profile with gmail.modify scope. Use verify_after=true for independent canonical state read-back and lost-response reconciliation.",
+            "description": "Atomically add/remove labels on one authorised Gmail message. Resolve mailbox-specific label IDs with gmail_list_labels. Only the requested labels change: adding a completion label does not implicitly archive or mark the message read. Choose disposition from the user's current guidance. Requires a profile with gmail.modify scope. Ordinary turns bind allow_mutation=true and verify_after=true for independent canonical state read-back and lost-response reconciliation.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -3912,6 +3912,9 @@
                     "issue_key": {
                         "type": "string"
                     },
+                    "resource_id": {
+                        "type": "string"
+                    },
                     "start_at": {
                         "type": "integer"
                     },
@@ -3948,6 +3951,9 @@
                     "expand": {
                         "type": "array",
                         "items": {}
+                    },
+                    "resource_id": {
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -4196,6 +4202,9 @@
                 "type": "object",
                 "properties": {
                     "jql": {
+                        "type": "string"
+                    },
+                    "resource_id": {
                         "type": "string"
                     },
                     "max_results": {
@@ -4802,6 +4811,55 @@
             }
         },
         {
+            "name": "otter_collect_now",
+            "description": "Collect new Otter meetings now or refresh exact IDs/URLs into the private archive and link participants. Dates use YYYY-MM-DD. Optional participant_bindings maps requested meeting ID to exact source speaker label to reviewed existing person concept ID. Returns a queued run ID; inspect otter_collection_status before claiming collection complete.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "meeting_ids": {
+                        "type": "array",
+                        "items": {}
+                    },
+                    "created_after": {
+                        "type": "string"
+                    },
+                    "created_before": {
+                        "type": "string"
+                    },
+                    "participant_bindings": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                "required": [
+                    "resource_id"
+                ],
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "otter_collection_status",
+            "description": "Inspect Otter collection runs, failures, participant concept links and scheduled collection configuration. Queued or running is not imported.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "run_id": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "resource_id"
+                ],
+                "additionalProperties": false
+            }
+        },
+        {
             "name": "preview_remove_relationship",
             "description": "Preview relationship removal effects without mutating data. Supports relation_id or triple selectors and returns impact/warning diagnostics.",
             "inputSchema": {
@@ -4964,7 +5022,7 @@
         },
         {
             "name": "record_source_processing_marker",
-            "description": "Create or update a durable Vontology marker that records a source item as processed into represented artefacts. This is additive Vontology state and should be called only after durable representation and read-back have verified processing success. It does not mutate the source system.",
+            "description": "Create or update a durable Vontology marker that records a source item as processed into represented artefacts. This is additive Vontology state and should be called only after durable representation and read-back have verified processing success. It does not mutate the source system. Authorised Gmail profile IDs and runtime aliases reuse the same marker identity.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -5090,7 +5148,7 @@
         },
         {
             "name": "remove_relationship",
-            "description": "Remove a relationship between two concepts (concept-to-concept only). Use to clean incorrect type/instance links or other structural predicates. Text relation removal is not supported in this tool.",
+            "description": "Correct one unsupported or duplicate concept-to-concept relationship using its exact source, predicate and target, or its relation identity. This removes the relationship, not the concepts. Ordinary chat uses audited soft deletion with an undo token; canonical source and inverse-target authority checks still apply. Inspect source evidence and the resulting relationships. Text relation removal is not supported.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -7230,7 +7288,7 @@
         },
         {
             "name": "upsert_singleton_text_relation",
-            "description": "Upsert a text relation and enforce singleton semantics for (concept, predicate, language) by replacing any other relations in the same group.",
+            "description": "Replace the current text of a maintained document or brief, leaving one base text relation for the selected concept, predicate and language. Read and consolidate useful previous contents first. Other languages, predicates and scoped assertions are unaffected. Use additive upsert_text_relation for independent notes or multiple values. Requires mutation authority over the subject; ordinary turns retain replaced text values and return their attachment metadata for recovery.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -7289,7 +7347,7 @@
         },
         {
             "name": "upsert_text_relation",
-            "description": "Add or update a canonical text relation when the actor has mutation authority over the subject concept. On an actor-bound surface that exposes upsert_scoped_assertion, use that capability for knowledge about a visible concept the actor does not own. Supports hasContent, hasDescription, hasNote, hasName, and existing custom predicate concepts.",
+            "description": "Attach text, reusing an identical attachment; different text adds another row and does not replace previous contents. To maintain one current document body, use upsert_singleton_text_relation. Requires mutation authority over the subject concept. On an actor-bound surface that exposes upsert_scoped_assertion, use that capability for knowledge about a visible concept the actor does not own. Supports hasContent, hasDescription, hasNote, hasName, and existing custom predicate concepts.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -7691,7 +7749,7 @@
         },
         {
             "name": "workflow_create_schedule",
-            "description": "Create a scheduled trigger for a workflow. Supports three types: 'interval' (run every N seconds), 'cron' (5-field cron expression), 'once' (run at a specific time). The scheduler will automatically create workflow instances when schedules are due.",
+            "description": "Create a scheduled trigger for a workflow. Supports three types: 'interval' (run every N seconds), 'cron' (5-field cron expression), 'once' (run at a specific time). Cron uses UTC and weekday 0=Monday. Intervals first run after one interval. The scheduler will automatically create workflow instances when schedules are due.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -7730,6 +7788,12 @@
                         "additionalProperties": true
                     },
                     "description": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "idempotency_key": {
                         "type": [
                             "string",
                             "null"

--- a/src/backend/services/otter_collection_service.py
+++ b/src/backend/services/otter_collection_service.py
@@ -1,0 +1,435 @@
+"""Owner-bound live collection, with a private durable queue and resumable receipts.
+
+The host scheduler and Von tools run the same worker. SQLite here is operational
+state only; all represented concepts/assertions use canonical Von services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import uuid
+from contextlib import contextmanager
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+from ..integrations.internal_mcp.otter_archive_proxy_mcp import (
+    _build_otter_archive_config,
+)
+from ..integrations.otter_live_client import otter_session, unwrap
+
+
+def now():
+    return datetime.now(UTC).isoformat()
+
+
+def config(resource_id):
+    archive = _build_otter_archive_config(resource_id=resource_id)
+    root = archive.database.parent / "collection"
+    settings_path = root / "settings.json"
+    if not settings_path.exists():
+        raise RuntimeError("otter_collection_not_configured")
+    settings = json.loads(settings_path.read_text())
+    if settings.get("owner_user_concept_id") != archive.owner_user_concept_id:
+        raise PermissionError("otter_collection_owner_mismatch")
+    if not settings.get("enabled"):
+        raise RuntimeError("otter_collection_disabled")
+    return archive, root, settings
+
+
+@contextmanager
+def state_db(root):
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = root / "state.sqlite3"
+    db = sqlite3.connect(path, timeout=30)
+    path.chmod(0o600)
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE IF NOT EXISTS jobs(id TEXT PRIMARY KEY, created TEXT, status TEXT,
+          request TEXT, receipt TEXT, daily_key TEXT UNIQUE);
+        CREATE TABLE IF NOT EXISTS pending(id TEXT PRIMARY KEY);
+        CREATE TABLE IF NOT EXISTS state(key TEXT PRIMARY KEY,value TEXT);
+    """)
+    try:
+        yield db
+        db.commit()
+    finally:
+        db.close()
+
+
+def meeting_id(value):
+    if not isinstance(value, str):
+        raise TypeError("meeting_id_must_be_string")
+    if value.startswith("https://otter.ai/u/"):
+        value = value.removeprefix("https://otter.ai/u/").split("?")[0]
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", value):
+        raise ValueError("invalid_otter_meeting_id")
+    return value
+
+
+def enqueue(
+    resource_id,
+    *,
+    meeting_ids=None,
+    created_after=None,
+    created_before=None,
+    participant_bindings=None,
+    daily=False,
+    spawn=True,
+):
+    _, root, _ = config(resource_id)
+    ids = list(dict.fromkeys(meeting_id(x) for x in (meeting_ids or [])))
+    if len(ids) > 25:
+        raise ValueError("at_most_25_exact_meetings_per_request")
+    for value in (created_after, created_before):
+        if value:
+            date.fromisoformat(value)
+    if created_after and created_before and created_after > created_before:
+        raise ValueError("invalid_date_range")
+    bindings = participant_bindings or {}
+    if not isinstance(bindings, dict) or len(bindings) > 80:
+        raise ValueError("invalid_participant_bindings")
+    # Bindings are case-sensitive meeting-local speaker labels -> reviewed person IDs.
+    # A payload cannot select an account, executable, archive or acting user.
+    for cid, labels in bindings.items():
+        if cid not in ids or not isinstance(labels, dict):
+            raise ValueError("bindings_require_an_exact_requested_meeting")
+        for label, target in labels.items():
+            if (
+                not isinstance(label, str)
+                or not label
+                or len(label) > 200
+                or not isinstance(target, str)
+                or not target.startswith("#V#")
+            ):
+                raise ValueError("invalid_participant_binding")
+    request = {
+        "meeting_ids": ids,
+        "created_after": created_after,
+        "created_before": created_before,
+        "participant_bindings": bindings,
+    }
+    run_id = uuid.uuid4().hex
+    daily_key = datetime.now(UTC).date().isoformat() if daily else None
+    with state_db(root) as db:
+        db.executemany(
+            "INSERT OR IGNORE INTO pending VALUES(?)", [(cid,) for cid in ids]
+        )
+        for cid, labels in bindings.items():
+            db.execute(
+                "INSERT OR REPLACE INTO state VALUES(?,?)",
+                ("retry_bindings:" + cid, json.dumps(labels)),
+            )
+        prior = (
+            db.execute(
+                "SELECT id,status FROM jobs WHERE daily_key=?", (daily_key,)
+            ).fetchone()
+            if daily_key
+            else None
+        )
+        if prior:
+            run_id = prior[0]
+        else:
+            db.execute(
+                "INSERT INTO jobs VALUES(?,?,?,?,?,?)",
+                (run_id, now(), "queued", json.dumps(request), "{}", daily_key),
+            )
+    if spawn:
+        script = Path(__file__).resolve().parents[3] / "scripts" / "collect_otter.py"
+        with (root / "worker.log").open("ab") as output:
+            (root / "worker.log").chmod(0o600)
+            subprocess.Popen(
+                [sys.executable, str(script), "work", "--resource-id", resource_id],
+                cwd=script.parent.parent,
+                stdin=subprocess.DEVNULL,
+                stdout=output,
+                stderr=output,
+                start_new_session=True,
+            )
+    return {
+        "success": True,
+        "run_id": run_id,
+        "status": prior["status"] if prior else "queued",
+        "collection_complete": bool(prior and prior["status"].startswith("completed")),
+    }
+
+
+def status(resource_id, run_id=None):
+    _, root, settings = config(resource_id)
+    if run_id and not re.fullmatch(r"[a-f0-9]{32}", run_id):
+        raise ValueError("invalid_run_id")
+    with state_db(root) as db:
+        rows = db.execute(
+            "SELECT id,created,status,receipt FROM jobs WHERE (? IS NULL OR id=?) ORDER BY created DESC LIMIT 10",
+            (run_id, run_id),
+        ).fetchall()
+        pending = db.execute("SELECT count(*) FROM pending").fetchone()[0]
+    runs = []
+    for row in rows:
+        receipt = json.loads(row["receipt"])
+        meetings = receipt.get("meetings", [])
+        receipt["meetings"] = meetings[:20]
+        receipt["omitted_meeting_receipts"] = max(0, len(meetings) - 20)
+        runs.append({**dict(row), "receipt": receipt})
+    return {
+        "success": True,
+        "runs": runs,
+        "pending_meetings": pending,
+        "schedule": settings.get("schedule", {}),
+        "coverage_note": "Date-window discovery; exact-ID refresh also supports older changed/shared meetings. Audio and screenshots are not collected.",
+    }
+
+
+def import_snapshot(archive, meeting):
+    executable = (
+        archive.project_dir
+        / ".venv"
+        / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    )
+    result = subprocess.run(
+        [
+            str(executable),
+            "-m",
+            "otter_archive_mcp.cli",
+            "--database",
+            str(archive.database),
+            "import-live",
+        ],
+        input=json.dumps({"meeting": meeting, "retrieved_at": now()}),
+        text=True,
+        capture_output=True,
+        env=archive.env,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeError("otter_archive_import_failed")
+    receipt = json.loads(result.stdout)
+    if (
+        receipt.get("success") is not True
+        or receipt.get("conversation_id") != meeting["id"]
+    ):
+        raise RuntimeError("otter_archive_import_unverified")
+    return receipt
+
+
+async def collect(resource_id, run_id, request):
+    archive, root, settings = config(resource_id)
+    receipt = {
+        "started_at": now(),
+        "counts": {"new": 0, "revised": 0, "unchanged": 0, "failed": 0},
+        "meetings": [],
+        "discovery_complete": True,
+    }
+
+    def checkpoint():
+        with state_db(root) as db:
+            db.execute(
+                "UPDATE jobs SET receipt=? WHERE id=?", (json.dumps(receipt), run_id)
+            )
+
+    async with otter_session(archive.database.parent / "credentials") as session:
+        info = unwrap(await session.call_tool("otter_get_user_info", {}))
+        if not isinstance(info, str) or not re.search(
+            r"^Email:\s*" + re.escape(settings["account_email"]) + r"\s*$",
+            info,
+            re.MULTILINE | re.IGNORECASE,
+        ):
+            raise PermissionError("otter_source_account_mismatch")
+        name = re.search(r"^Name:\s*(.+)$", info, re.MULTILINE)
+        with state_db(root) as db:
+            pending = [r[0] for r in db.execute("SELECT id FROM pending")]
+            watermark = db.execute(
+                "SELECT value FROM state WHERE key='last_complete_date'"
+            ).fetchone()
+        ids = list(dict.fromkeys(request["meeting_ids"] + pending))
+        if not request["meeting_ids"]:
+            end = (
+                date.fromisoformat(request["created_before"])
+                if request.get("created_before")
+                else datetime.now(UTC).date()
+            )
+            start = (
+                date.fromisoformat(request["created_after"])
+                if request.get("created_after")
+                else min(
+                    end - timedelta(days=7),
+                    date.fromisoformat(watermark[0]) if watermark else end,
+                )
+            )
+            receipt["date_window"] = {"from": start.isoformat(), "to": end.isoformat()}
+            cursor = None
+            seen_cursors = set()
+            for _ in range(100):
+                arguments = (
+                    {"cursor": cursor, "page_size": 25}
+                    if cursor
+                    else {
+                        "created_after": start.strftime("%Y/%m/%d"),
+                        "created_before": end.strftime("%Y/%m/%d"),
+                        "page_size": 25,
+                        "username": name[1] if name else None,
+                    }
+                )
+                result = unwrap(await session.call_tool("otter_search", arguments))
+                if not isinstance(result, dict) or not isinstance(
+                    result.get("results"), list
+                ):
+                    raise TypeError("otter_search_shape_unsupported")
+                ids.extend(meeting_id(x["id"]) for x in result["results"])
+                cursor = result.get("next_cursor")
+                reason = result.get("pagination_completion_reason")
+                if not cursor:
+                    receipt["discovery_complete"] = reason == "all_results_returned"
+                    receipt["discovery_completion_reason"] = (
+                        reason or "upstream_completion_unspecified"
+                    )
+                    break
+                if cursor in seen_cursors:
+                    receipt["discovery_complete"] = False
+                    break
+                seen_cursors.add(cursor)
+            else:
+                receipt["discovery_complete"] = False
+                receipt["discovery_completion_reason"] = "bounded_page_limit"
+        ids = list(dict.fromkeys(ids))
+        # Persist all discovered IDs before processing any item. Failures survive windows.
+        with state_db(root) as db:
+            db.executemany(
+                "INSERT OR IGNORE INTO pending VALUES(?)", [(cid,) for cid in ids]
+            )
+        checkpoint()
+        for cid in ids:
+            try:
+                current_archive, _, current_settings = config(resource_id)
+                if (
+                    current_archive.owner_user_concept_id
+                    != archive.owner_user_concept_id
+                    or current_settings["account_email"] != settings["account_email"]
+                ):
+                    raise PermissionError("otter_collection_binding_changed")
+                raw = await session.call_tool("otter_fetch", {"id": cid})
+                meeting = unwrap(raw)
+                if not isinstance(meeting, dict) or meeting.get("id") != cid:
+                    raise RuntimeError("otter_fetch_identity_mismatch")
+                archived = await asyncio.to_thread(import_snapshot, archive, meeting)
+                from .otter_representation_service import represent_meeting
+
+                with state_db(root) as db:
+                    retry_bindings = db.execute(
+                        "SELECT value FROM state WHERE key=?",
+                        ("retry_bindings:" + cid,),
+                    ).fetchone()
+                bindings = json.loads(retry_bindings[0]) if retry_bindings else {}
+                represented = await asyncio.to_thread(
+                    represent_meeting,
+                    archive.owner_user_concept_id,
+                    meeting,
+                    archived,
+                    bindings,
+                )
+                available = archived.get("transcript_available", True)
+                receipt["counts"][archived["status"] if available else "failed"] += 1
+                receipt["meetings"].append({**archived, **represented})
+                if not available:
+                    receipt["meetings"][-1]["error_code"] = (
+                        "otter_transcript_unavailable"
+                    )
+                    checkpoint()
+                    continue
+                with state_db(root) as db:
+                    db.execute("DELETE FROM pending WHERE id=?", (cid,))
+                    db.execute(
+                        "DELETE FROM state WHERE key=?", ("retry_bindings:" + cid,)
+                    )
+            except Exception as exc:  # noqa: BLE001 - durable per-item recovery and redacted receipts
+                receipt["counts"]["failed"] += 1
+                # Exception messages may contain upstream transcript/credentials.
+                receipt["meetings"].append(
+                    {
+                        "conversation_id": cid,
+                        "error_type": type(exc).__name__,
+                        "error_code": str(exc)
+                        if re.fullmatch(r"[a-z_]{1,100}", str(exc))
+                        else "collection_item_failed",
+                    }
+                )
+            checkpoint()
+        if (
+            receipt["discovery_complete"]
+            and not receipt["counts"]["failed"]
+            and not request["meeting_ids"]
+        ):
+            with state_db(root) as db:
+                db.execute(
+                    "INSERT OR REPLACE INTO state VALUES('last_complete_date',?)",
+                    (end.isoformat(),),
+                )
+    receipt["finished_at"] = now()
+    receipt["collection_complete"] = not receipt["counts"]["failed"]
+    receipt["collection_scope"] = (
+        "returned_meetings"
+        if not receipt["discovery_complete"]
+        else "requested_meetings"
+    )
+    return receipt
+
+
+def work(resource_id):
+    import fcntl  # Host worker supports macOS/Linux; no network lock service is needed.
+
+    _, root, _ = config(resource_id)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with (root / "worker.lock").open("a") as lock:
+        # Wait for the previous worker, then drain requests that arrived during it.
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        with state_db(root) as db:
+            db.execute("UPDATE jobs SET status='queued' WHERE status='running'")
+        while True:
+            with state_db(root) as db:
+                job = db.execute(
+                    "SELECT * FROM jobs WHERE status='queued' ORDER BY created LIMIT 1"
+                ).fetchone()
+                if not job:
+                    break
+                db.execute("UPDATE jobs SET status='running' WHERE id=?", (job["id"],))
+            try:
+                receipt = asyncio.run(
+                    collect(resource_id, job["id"], json.loads(job["request"]))
+                )
+                terminal = (
+                    (
+                        "completed"
+                        if receipt["discovery_complete"]
+                        else "completed_with_coverage_limit"
+                    )
+                    if receipt["collection_complete"]
+                    else "partial"
+                )
+            except Exception as exc:  # noqa: BLE001 - durable per-item recovery and redacted receipts
+                with state_db(root) as db:
+                    receipt = json.loads(
+                        db.execute(
+                            "SELECT receipt FROM jobs WHERE id=?", (job["id"],)
+                        ).fetchone()[0]
+                    )
+                receipt.update(
+                    {
+                        "collection_complete": False,
+                        "finished_at": now(),
+                        "error_type": type(exc).__name__,
+                        "error_code": "otter_connection_or_collection_failed",
+                    }
+                )
+                terminal = "failed"
+            with state_db(root) as db:
+                db.execute(
+                    "UPDATE jobs SET status=?,receipt=? WHERE id=?",
+                    (terminal, json.dumps(receipt), job["id"]),
+                )
+    return status(resource_id)

--- a/src/backend/services/otter_representation_service.py
+++ b/src/backend/services/otter_representation_service.py
@@ -1,0 +1,206 @@
+"""Canonical private meeting representation from preserved Otter evidence.
+
+Exact caller-reviewed participant bindings connect existing people. Unresolved
+source labels remain meeting-local participant concepts, never global identity
+merges. Summaries and action items do not execute instructions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+
+def speaker_labels(text):
+    return list(
+        dict.fromkeys(
+            re.findall(
+                r"^\[(?:\d+:)?\d{1,2}:\d{2}\]\s+([^:\n]{1,200}):", text, re.MULTILINE
+            )
+        )
+    )
+
+
+def stable_id(kind, *parts):
+    material = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
+    return "#V#otter_" + kind + "_" + hashlib.sha256(material.encode()).hexdigest()
+
+
+def represent_meeting(owner, meeting, archived, bindings):
+    from ..security.access_control import override_current_actor
+    from .concept_service import (
+        ConceptNotFoundError,
+        create_concept,
+        get_concept_by_concept_id_exact,
+    )
+    from .scoped_assertion_service import (
+        list_visible_scoped_assertions_page,
+        retract_scoped_assertion,
+        upsert_scoped_assertion,
+    )
+    from .workflow_event_integration_service import suppress_event_workflow_launches
+
+    cid = meeting["id"]
+    meeting_concept = stable_id("meeting", owner, cid)
+    labels = speaker_labels(meeting["text"])
+    if set(bindings) - set(labels):
+        raise ValueError("participant_binding_label_not_in_source")
+    source = {
+        "source": "otter_live_collection",
+        "source_url": meeting["url"],
+        "otter_id": cid,
+        "source_sha256": archived["source_sha256"],
+    }
+    with (
+        override_current_actor(owner, None),
+        suppress_event_workflow_launches("otter_source_collection"),
+    ):
+
+        def lookup(concept_id):
+            try:
+                return get_concept_by_concept_id_exact(concept_id)
+            except ConceptNotFoundError:
+                return None
+
+        def ensure(concept_id, name, type_id, note):
+            existing = lookup(concept_id)
+            if existing is None:
+                create_concept(
+                    name=name,
+                    concept_id=concept_id,
+                    parent_concept_ids=[type_id],
+                    create_as_instance=True,
+                    created_by_concept_id=owner,
+                    notes=note,
+                    maintain_relationship_inverses=False,
+                )
+                existing = lookup(concept_id)
+            if existing is None:
+                raise RuntimeError("otter_concept_readback_failed")
+            return existing
+
+        def assert_fact(subject, predicate, *, target=None, text=None, evidence=None):
+            result = upsert_scoped_assertion(
+                subject_concept_id=subject,
+                predicate=predicate,
+                target_concept_id=target,
+                target_text=text,
+                acting_user_concept_id=owner,
+                scope_mode="user",
+                evidence=evidence or source,
+            )
+            if not result.get("success"):
+                raise RuntimeError("otter_assertion_readback_failed")
+            return result
+
+        ensure(
+            meeting_concept,
+            meeting.get("title") or cid,
+            "#V#meeting",
+            "Otter source meeting " + meeting["url"],
+        )
+        prior_page = list_visible_scoped_assertions_page(
+            subject_concept_ids=[meeting_concept],
+            predicates=["#V#meeting_participant", "hasContent"],
+            user_concept_id=owner,
+            limit=200,
+        )
+        prior_bindings = {}
+        for row in prior_page["items"]:
+            evidence = row.get("provenance", {}).get("evidence", {})
+            label = evidence.get("speaker_label")
+            if (
+                row.get("predicate") == "#V#meeting_participant"
+                and label
+                and evidence.get("identity_basis") == "caller_reviewed_identity"
+            ):
+                prior_bindings[label] = row["object_concept_id"]
+        bindings = {**prior_bindings, **bindings}
+        assert_fact(meeting_concept, "hasNote", text=json.dumps(source, sort_keys=True))
+        # Source timestamps have no offset; preserve them without inventing UTC.
+        if meeting.get("metadata", {}).get("start_time"):
+            assert_fact(
+                meeting_concept,
+                "hasNote",
+                text="Otter recorded start (source timezone unspecified): "
+                + meeting["metadata"]["start_time"],
+            )
+        transcript = next(
+            (x for x in archived["artifacts"] if x["kind"] == "transcript"), None
+        )
+        if transcript:
+            assert_fact(
+                meeting_concept,
+                "hasContent",
+                text="Transcript: /von/api/otter-archive/artifacts/"
+                + transcript["artifact_id"],
+            )
+        else:
+            assert_fact(
+                meeting_concept,
+                "hasNote",
+                text="Otter reports no transcript available; source metadata preserved and collection will retry.",
+            )
+            for row in prior_page["items"]:
+                if (
+                    row.get("predicate") == "hasContent"
+                    and row.get("provenance", {}).get("evidence", {}).get("source")
+                    == "otter_live_collection"
+                ):
+                    retract_scoped_assertion(
+                        assertion_id=row["assertion_id"], acting_user_concept_id=owner
+                    )
+        participants = []
+        unresolved = []
+        for label in labels:
+            if re.match(r"(?i)^(unknown speaker|speaker\s*\d+)", label):
+                unresolved.append(label)
+                continue
+            target = bindings.get(label)
+            if target:
+                if lookup(target) is None:
+                    raise ValueError("participant_binding_target_not_visible")
+                basis = "caller_reviewed_identity"
+            else:
+                target = stable_id("participant", owner, cid, label)
+                ensure(
+                    target,
+                    label + " (Otter participant)",
+                    "#V#person",
+                    "Source label in "
+                    + meeting["url"]
+                    + "; real-world identity not yet reconciled. This concept is local to this meeting.",
+                )
+                basis = "meeting_local_source_label"
+            assert_fact(
+                meeting_concept,
+                "#V#meeting_participant",
+                target=target,
+                evidence={**source, "speaker_label": label, "identity_basis": basis},
+            )
+            for row in prior_page["items"]:
+                evidence = row.get("provenance", {}).get("evidence", {})
+                if (
+                    row.get("predicate") == "#V#meeting_participant"
+                    and evidence.get("source") == "otter_live_collection"
+                    and evidence.get("speaker_label") == label
+                    and row.get("object_concept_id") != target
+                ):
+                    result = retract_scoped_assertion(
+                        assertion_id=row["assertion_id"], acting_user_concept_id=owner
+                    )
+                    if not result.get("success"):
+                        raise RuntimeError("otter_participant_rebinding_failed")
+            participants.append(
+                {"label": label, "concept_id": target, "identity_basis": basis}
+            )
+        return {
+            "meeting_concept_id": meeting_concept,
+            "participants": participants,
+            "unresolved_speaker_labels": unresolved,
+            "transcript_url": "/von/api/otter-archive/artifacts/"
+            + transcript["artifact_id"]
+            if transcript
+            else None,
+        }

--- a/src/backend/services/tool_metadata_service.py
+++ b/src/backend/services/tool_metadata_service.py
@@ -1227,6 +1227,8 @@ _DEFAULT_TOOL_METADATA: dict[str, dict[str, Any]] = {
 }
 
 _DEFAULT_VONTOLOGY_STDIO_EXPOSED_TOOL_NAMES = {
+    "otter_collect_now",
+    "otter_collection_status",
     "add_names",
     "add_relationship",
     "assign_task",
@@ -1421,6 +1423,7 @@ _DEFAULT_JIRA_FAMILY_SERVER_EXPOSED_TOOL_NAMES = {
 }
 
 _DEFAULT_WRITE_TOOL_NAMES = {
+    "otter_collect_now",
     "add_issue_comment",
     "add_names",
     "add_relationship",

--- a/tests/backend/test_internal_mcp_otter_archive_tools.py
+++ b/tests/backend/test_internal_mcp_otter_archive_tools.py
@@ -33,6 +33,7 @@ def test_archive_tools_are_registered_without_removing_linkedin():
     names = set(build_default_catalogue().list_methods())
     assert {"otter_archive_" + name for name in TOOL_SPECS} <= names
     assert "linkedin_index_status" in names
+    assert {"otter_collect_now", "otter_collection_status"} <= names
 
 
 def test_resource_binding_is_returned_only_for_configured_owner():
@@ -65,6 +66,9 @@ def test_otter_archive_tools_are_projected_only_with_server_bound_resource():
 
     assert "otter_archive_search_archive" not in without_binding
     assert "otter_archive_search_archive" in with_binding
+    assert "otter_collect_now" in with_binding
+    assert "otter_collection_status" in with_binding
+    assert "otter_collect_now" not in without_binding
 
     definition = gateway.get_method_definition("otter_archive_search_archive")
     assert definition is not None

--- a/tests/backend/test_otter_collection.py
+++ b/tests/backend/test_otter_collection.py
@@ -1,0 +1,265 @@
+"""Synthetic outcomes for private collection; no source credentials or live DB."""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from src.backend.integrations.internal_mcp.catalogue import build_default_catalogue
+from src.backend.integrations.internal_mcp.gateway import InternalMCPGateway
+from src.backend.integrations.internal_mcp.transport import InternalMCPTransport
+from src.backend.integrations.otter_live_client import (
+    CredentialStore,
+    private_json,
+    unwrap,
+)
+from src.backend.security.access_control import override_current_actor
+from src.backend.services import otter_collection_service as service
+from src.backend.services import otter_representation_service as representation
+
+
+@pytest.fixture
+def configured(tmp_path, monkeypatch):
+    archive = SimpleNamespace(
+        database=tmp_path / "archive.sqlite3", owner_user_concept_id="#V#owner"
+    )
+    root = tmp_path / "collection"
+    settings = {"account_email": "owner@example.org"}
+    monkeypatch.setattr(service, "config", lambda _: (archive, root, settings))
+    return archive, root, settings
+
+
+def test_queue_daily_deduplicates_and_reports_terminal_state(configured):
+    first = service.enqueue("private", daily=True, spawn=False)
+    with service.state_db(configured[1]) as db:
+        db.execute("UPDATE jobs SET status='completed' WHERE id=?", (first["run_id"],))
+    repeated = service.enqueue("private", daily=True, spawn=False)
+    assert repeated["run_id"] == first["run_id"]
+    assert repeated["status"] == "completed"
+    assert repeated["collection_complete"]
+    with pytest.raises(ValueError):
+        service.enqueue(
+            "private", meeting_ids=["https://evil.example/u/id"], spawn=False
+        )
+
+
+def test_denied_actor_cannot_enqueue(monkeypatch):
+    monkeypatch.setenv("VON_OTTER_ARCHIVE_OWNER_USER_CONCEPT_ID", "#V#owner")
+    monkeypatch.setattr(
+        service, "enqueue", lambda *a, **kw: pytest.fail("worker must not launch")
+    )
+    with override_current_actor("#V#other", None):
+        result = (
+            InternalMCPGateway(
+                catalogue=build_default_catalogue(),
+                transport=InternalMCPTransport(),
+                enabled=True,
+            )
+            .invoke("otter_collect_now", {"resource_id": "personal_otter_archive"})
+            .payload
+        )
+    assert result["success"] is False
+    assert result["error_code"] == "otter_archive_resource_not_authorised"
+
+
+def test_source_errors_do_not_discard_partial_progress_and_retry_bindings(
+    configured, monkeypatch
+):
+    calls = []
+    fail = {"b"}
+
+    class Session:
+        async def call_tool(self, name, arguments):
+            calls.append((name, arguments))
+            if name == "otter_get_user_info":
+                return "Name: Owner\nEmail: owner@example.org"
+            if name == "otter_search":
+                return {
+                    "results": [{"id": "a"}, {"id": "b"}],
+                    "pagination_completion_reason": "all_results_returned",
+                }
+            if arguments["id"] in fail:
+                raise RuntimeError("private source text must never enter receipt")
+            return {
+                "id": arguments["id"],
+                "text": "[0:01] Person: Hello",
+                "url": "https://otter.ai/u/" + arguments["id"],
+            }
+
+    @asynccontextmanager
+    async def session(_):
+        yield Session()
+
+    monkeypatch.setattr(service, "otter_session", session)
+    monkeypatch.setattr(
+        service,
+        "import_snapshot",
+        lambda a, m: {"conversation_id": m["id"], "status": "new"},
+    )
+    observed = []
+    monkeypatch.setattr(
+        representation,
+        "represent_meeting",
+        lambda o, m, a, b: observed.append(b) or {"participants": []},
+    )
+    first = service.enqueue(
+        "private",
+        meeting_ids=["a", "b"],
+        participant_bindings={"b": {"Person": "#V#person"}},
+        spawn=False,
+    )
+    service.work("private")
+    result = service.status("private", first["run_id"])
+    assert result["runs"][0]["status"] == "partial"
+    assert result["pending_meetings"] == 1
+    assert "private source text" not in json.dumps(result)
+    fail.clear()
+    second = service.enqueue("private", meeting_ids=["b"], spawn=False)
+    service.work("private")
+    assert (
+        service.status("private", second["run_id"])["runs"][0]["status"] == "completed"
+    )
+    assert observed[-1] == {"Person": "#V#person"}
+    assert service.status("private")["pending_meetings"] == 0
+
+
+def test_missing_pagination_proof_does_not_advance_watermark(configured, monkeypatch):
+    class Session:
+        async def call_tool(self, name, arguments):
+            return (
+                "Name: Owner\nEmail: owner@example.org"
+                if name == "otter_get_user_info"
+                else {"results": []}
+            )
+
+    @asynccontextmanager
+    async def session(_):
+        yield Session()
+
+    monkeypatch.setattr(service, "otter_session", session)
+    run = service.enqueue("private", spawn=False)
+    service.work("private")
+    row = service.status("private", run["run_id"])["runs"][0]
+    assert row["status"] == "completed_with_coverage_limit"
+    assert row["receipt"]["collection_scope"] == "returned_meetings"
+    with service.state_db(configured[1]) as db:
+        assert (
+            db.execute("SELECT * FROM state WHERE key='last_complete_date'").fetchone()
+            is None
+        )
+
+
+def test_account_mismatch_stops_before_fetch(configured, monkeypatch):
+    class Session:
+        async def call_tool(self, name, arguments):
+            assert name == "otter_get_user_info"
+            return "Email: other@example.org"
+
+    @asynccontextmanager
+    async def session(_):
+        yield Session()
+
+    monkeypatch.setattr(service, "otter_session", session)
+    run = service.enqueue("private", meeting_ids=["a"], spawn=False)
+    service.work("private")
+    assert service.status("private", run["run_id"])["runs"][0]["status"] == "failed"
+
+
+def test_nested_envelopes_and_token_age_survive_restart(tmp_path):
+    assert unwrap({"structuredContent": {"result": '{"id":"a"}'}}) == {"id": "a"}
+    with pytest.raises(RuntimeError):
+        unwrap({"isError": True, "content": []})
+    private_json(
+        tmp_path / "tokens.json",
+        {
+            "access_token": "synthetic",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "expires_at": 1,
+        },
+    )
+    token = asyncio.run(CredentialStore(tmp_path).get_tokens())
+    assert token.expires_in == 0
+    assert (tmp_path / "tokens.json").stat().st_mode & 0o777 == 0o600
+
+
+def test_source_speaker_labels_do_not_invent_identities():
+    assert representation.speaker_labels(
+        "[0:01] Person: Hello\n[0:01:02] Person: Again\n[0:02:03] Other: Yes"
+    ) == ["Person", "Other"]
+
+
+def test_participant_binding_survives_refresh_and_rebinding_retracts_old_link(
+    monkeypatch,
+):
+    from contextlib import nullcontext
+
+    from src.backend.services import (
+        concept_service,
+        scoped_assertion_service,
+        workflow_event_integration_service,
+    )
+
+    concepts = {"#V#person": {}, "#V#corrected": {}}
+    assertions = []
+    monkeypatch.setattr(
+        concept_service,
+        "get_concept_by_concept_id_exact",
+        lambda cid: concepts.get(cid),
+    )
+    monkeypatch.setattr(
+        concept_service,
+        "create_concept",
+        lambda **kw: concepts.setdefault(kw["concept_id"], kw),
+    )
+    monkeypatch.setattr(
+        workflow_event_integration_service,
+        "suppress_event_workflow_launches",
+        lambda _: nullcontext(),
+    )
+    monkeypatch.setattr(
+        scoped_assertion_service,
+        "list_visible_scoped_assertions_page",
+        lambda **kw: {"items": list(assertions)},
+    )
+
+    def upsert(**kw):
+        assert kw["scope_mode"] == "user"
+        assert kw["acting_user_concept_id"] == "#V#owner"
+        row = {
+            "assertion_id": str(len(assertions)),
+            "predicate": kw["predicate"],
+            "object_concept_id": kw["target_concept_id"],
+            "provenance": {"evidence": kw["evidence"]},
+        }
+        if kw["predicate"] == "#V#meeting_participant" and not any(
+            r["object_concept_id"] == row["object_concept_id"] for r in assertions
+        ):
+            assertions.append(row)
+        return {"success": True}
+
+    def retract(**kw):
+        assertions[:] = [
+            r for r in assertions if r["assertion_id"] != kw["assertion_id"]
+        ]
+        return {"success": True}
+
+    monkeypatch.setattr(scoped_assertion_service, "upsert_scoped_assertion", upsert)
+    monkeypatch.setattr(scoped_assertion_service, "retract_scoped_assertion", retract)
+    meeting = {"id": "a", "url": "https://otter.ai/u/a", "text": "[0:01] Person: Hello"}
+    archived = {
+        "source_sha256": "test",
+        "artifacts": [{"kind": "transcript", "artifact_id": "test"}],
+    }
+    first = representation.represent_meeting(
+        "#V#owner", meeting, archived, {"Person": "#V#person"}
+    )
+    repeated = representation.represent_meeting("#V#owner", meeting, archived, {})
+    assert first == repeated
+    assert len(assertions) == 1
+    representation.represent_meeting(
+        "#V#owner", meeting, archived, {"Person": "#V#corrected"}
+    )
+    assert [r["object_concept_id"] for r in assertions] == ["#V#corrected"]


### PR DESCRIPTION
New Otter meetings can now be collected into the existing private archive through Von or a daily host job. The collector uses its own OAuth connection to Otter's official hosted MCP, preserves source responses and revisions, and represents meetings with owner-scoped participant links. `otter_collect_now` queues discovery or exact-ID refresh; `otter_collection_status` exposes durable progress, failures and source links. Reviewed participant identities survive refresh and can be corrected; unresolved source labels remain meeting-local concepts.

The macOS installer creates a 06:00 local-time launchd job using the deployed checkout. Credentials and operational SQLite state remain outside Git. The archive query subprocess does not receive OAuth credentials. This depends on the companion OtterArchiveMCP live-import change.

Validation: 26 targeted collection, archive-authority and stdio-authority tests passed; 14 of 15 manifest/registry checks passed, with the existing Jira-family expectation omitting `jira_get_comments`. Ruff and diff checks passed. Live evidence: authenticated native fetch, forced unattended token renewal, preserved transcript opened through Von's source viewer, unchanged repeat import, retained Michael/Yitan links and unavailable-transcript retry. MCP listing and status were exercised. No models were invoked.

Otter currently omits pagination completion metadata: receipts explicitly limit completeness to returned meetings and do not advance a completeness watermark. Older newly shared/changed meetings may require exact IDs or explicit windows. Audio/screenshots are not collected by these tools. Scheduled activation/read-back follows publication under the user's explicit setup request. The later Von-UI-authored slides/papers workflow is JVNAUTOSCI-2732.

Merge decision: ready for the bounded collection capability, subject to required CI. Source unavailability remains a visible retry state; exhaustive discovery and screenshot collection are not claimed.
