### PR TITLE
Collect from multiple authorised Otter accounts

### DIFF
--- a/docs/engineering/otter_archive_and_conversation_images.md
+++ b/docs/engineering/otter_archive_and_conversation_images.md
@@ -123,6 +123,20 @@ loopback callback verifies OAuth state; saved token expiry survives restarts and
 refresh tokens support unattended renewal. Revoked consent requires operator
 reauthorisation and appears as a failed run, never a successful empty import.
 
+Additional authorised source accounts use `additional_accounts` in the same
+private settings file, for example `[{"id": "zhan", "email": "account@example.org"}]`.
+Each has separate OAuth credentials at `accounts/<id>/credentials` beside the
+archive. Run `authorise --account <id>` after configuring it. Both scheduled and
+forced collection use these configured accounts, verifying each authenticated
+email before fetching. A disconnected or mismatched account is reported without
+blocking the other accounts; incomplete discovery never advances the watermark.
+Exact Otter IDs are deduplicated across sources, and fetch can fall back to another
+authorised account. The successful source account is retained in the receipt and
+canonical meeting provenance without altering or rehashing the source transcript.
+Different Otter IDs remain distinct source recordings even when they concern the
+same real meeting; reviewed same-meeting links can connect them without discarding
+complementary transcripts or images.
+
 The owning Von actor can use `otter_collect_now` for date-window discovery or
 exact meeting IDs/URLs, and `otter_collection_status` to inspect durable receipts.
 The ordinary-turn resource selector comes from trusted server context. The local

--- a/scripts/collect_otter.py
+++ b/scripts/collect_otter.py
@@ -28,6 +28,9 @@ def main():
     parser.add_argument("--before")
     parser.add_argument("--bindings-file", type=Path)
     parser.add_argument("--run-id")
+    parser.add_argument(
+        "--account", default="primary", help="Configured source ID for authorise only"
+    )
     args = parser.parse_args()
     from src.backend.integrations.internal_mcp.otter_archive_proxy_mcp import (
         _build_otter_archive_config,
@@ -38,7 +41,18 @@ def main():
         from src.backend.integrations.otter_live_client import authorise
 
         archive = _build_otter_archive_config(resource_id=args.resource_id)
-        result = asyncio.run(authorise(archive.database.parent / "credentials"))
+        _, _, settings = service.config(args.resource_id)
+        account = next(
+            (
+                x
+                for x in service.source_accounts(archive, settings)
+                if x["id"] == args.account
+            ),
+            None,
+        )
+        if account is None:
+            parser.error("Unknown configured account")
+        result = asyncio.run(authorise(account["credentials"]))
     elif args.action in {"collect", "daily"}:
         result = service.enqueue(
             args.resource_id,

--- a/src/backend/services/otter_collection_service.py
+++ b/src/backend/services/otter_collection_service.py
@@ -14,7 +14,7 @@ import sqlite3
 import subprocess
 import sys
 import uuid
-from contextlib import contextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
@@ -40,6 +40,140 @@ def config(resource_id):
     if not settings.get("enabled"):
         raise RuntimeError("otter_collection_disabled")
     return archive, root, settings
+
+
+def source_accounts(archive, settings):
+    """Trusted operator configuration; tool callers cannot select credentials."""
+    accounts = [
+        {
+            "id": "primary",
+            "email": settings["account_email"],
+            "credentials": archive.database.parent / "credentials",
+        }
+    ]
+    for item in settings.get("additional_accounts", []):
+        key = item["id"]
+        if not re.fullmatch(r"[a-z0-9_-]{1,40}", key) or key == "primary":
+            raise ValueError("invalid_otter_source_account")
+        if any(
+            x["id"] == key or x["email"].casefold() == item["email"].casefold()
+            for x in accounts
+        ):
+            raise ValueError("duplicate_otter_source_account")
+        accounts.append(
+            {
+                "id": key,
+                "email": item["email"],
+                "credentials": archive.database.parent
+                / "accounts"
+                / key
+                / "credentials",
+            }
+        )
+    return accounts
+
+
+@asynccontextmanager
+async def connected_sources(accounts, receipt):
+    async with AsyncExitStack() as stack:
+        sources = []
+        receipt["source_accounts"] = []
+        for account in accounts:
+            state = {"id": account["id"], "email": account["email"], "connected": False}
+            receipt["source_accounts"].append(state)
+            try:
+                session = await stack.enter_async_context(
+                    otter_session(account["credentials"])
+                )
+                info = unwrap(await session.call_tool("otter_get_user_info", {}))
+                if not isinstance(info, str) or not re.search(
+                    r"^Email:\s*" + re.escape(account["email"]) + r"\s*$",
+                    info,
+                    re.MULTILINE | re.IGNORECASE,
+                ):
+                    raise PermissionError("otter_source_account_mismatch")
+                name = re.search(r"^Name:\s*(.+)$", info, re.MULTILINE)
+                state["connected"] = True
+                sources.append(
+                    {**account, "session": session, "name": name[1] if name else None}
+                )
+            except Exception as exc:  # noqa: BLE001 - record account failure without source secrets
+                state["error_type"] = type(exc).__name__
+                receipt["discovery_complete"] = False
+        if not sources:
+            raise RuntimeError("otter_no_source_accounts_connected")
+        yield sources
+
+
+async def discover_sources(sources, arguments, receipt):
+    ids = []
+    for source in sources:
+        state = next(x for x in receipt["source_accounts"] if x["id"] == source["id"])
+        cursor = None
+        seen = set()
+        complete = False
+        try:
+            for _ in range(100):
+                query = (
+                    {"cursor": cursor, "page_size": 25}
+                    if cursor
+                    else {
+                        **arguments,
+                        "username": source["name"],
+                        "include_shared_meetings": True,
+                    }
+                )
+                result = unwrap(
+                    await source["session"].call_tool("otter_search", query)
+                )
+                if not isinstance(result, dict) or not isinstance(
+                    result.get("results"), list
+                ):
+                    raise TypeError("otter_search_shape_unsupported")
+                ids.extend(meeting_id(x["id"]) for x in result["results"])
+                cursor = result.get("next_cursor")
+                reason = result.get("pagination_completion_reason")
+                if not cursor:
+                    complete = reason == "all_results_returned"
+                    state["discovery_completion_reason"] = (
+                        reason or "upstream_completion_unspecified"
+                    )
+                    break
+                if cursor in seen:
+                    state["discovery_completion_reason"] = "repeated_cursor"
+                    break
+                seen.add(cursor)
+            else:
+                state["discovery_completion_reason"] = "bounded_page_limit"
+        except Exception as exc:  # noqa: BLE001 - preserve other accounts and partial discovery
+            state["discovery_error_type"] = type(exc).__name__
+        state["discovery_complete"] = complete
+        receipt["discovery_complete"] &= complete
+    return list(dict.fromkeys(ids))
+
+
+async def fetch_from_sources(sources, cid):
+    """A shared ID is one recording; another authorised account can supply it."""
+    notice = None
+    for source in sources:
+        try:
+            meeting = unwrap(
+                await source["session"].call_tool("otter_fetch", {"id": cid})
+            )
+            if not isinstance(meeting, dict) or meeting.get("id") != cid:
+                continue
+            text = meeting.get("text")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            if text.strip().casefold() == "no transcript available":
+                notice = notice or (meeting, source["email"])
+                continue
+            return meeting, source["email"]
+        except Exception:  # noqa: BLE001, S112 - try remaining authorised sources, then emit one typed failure
+            continue
+    if notice:
+        return notice
+    raise RuntimeError("otter_fetch_unavailable_from_connected_accounts")
 
 
 @contextmanager
@@ -181,6 +315,9 @@ def status(resource_id, run_id=None):
         "runs": runs,
         "pending_meetings": pending,
         "schedule": settings.get("schedule", {}),
+        "source_accounts": [
+            x["email"] for x in source_accounts(config(resource_id)[0], settings)
+        ],
         "coverage_note": "Date-window discovery; exact-ID refresh also supports older changed/shared meetings. Audio and screenshots are not collected.",
     }
 
@@ -233,15 +370,8 @@ async def collect(resource_id, run_id, request):
                 "UPDATE jobs SET receipt=? WHERE id=?", (json.dumps(receipt), run_id)
             )
 
-    async with otter_session(archive.database.parent / "credentials") as session:
-        info = unwrap(await session.call_tool("otter_get_user_info", {}))
-        if not isinstance(info, str) or not re.search(
-            r"^Email:\s*" + re.escape(settings["account_email"]) + r"\s*$",
-            info,
-            re.MULTILINE | re.IGNORECASE,
-        ):
-            raise PermissionError("otter_source_account_mismatch")
-        name = re.search(r"^Name:\s*(.+)$", info, re.MULTILINE)
+    accounts = source_accounts(archive, settings)
+    async with connected_sources(accounts, receipt) as sources:
         with state_db(root) as db:
             pending = [r[0] for r in db.execute("SELECT id FROM pending")]
             watermark = db.execute(
@@ -263,40 +393,17 @@ async def collect(resource_id, run_id, request):
                 )
             )
             receipt["date_window"] = {"from": start.isoformat(), "to": end.isoformat()}
-            cursor = None
-            seen_cursors = set()
-            for _ in range(100):
-                arguments = (
-                    {"cursor": cursor, "page_size": 25}
-                    if cursor
-                    else {
+            ids.extend(
+                await discover_sources(
+                    sources,
+                    {
                         "created_after": start.strftime("%Y/%m/%d"),
                         "created_before": end.strftime("%Y/%m/%d"),
                         "page_size": 25,
-                        "username": name[1] if name else None,
-                    }
+                    },
+                    receipt,
                 )
-                result = unwrap(await session.call_tool("otter_search", arguments))
-                if not isinstance(result, dict) or not isinstance(
-                    result.get("results"), list
-                ):
-                    raise TypeError("otter_search_shape_unsupported")
-                ids.extend(meeting_id(x["id"]) for x in result["results"])
-                cursor = result.get("next_cursor")
-                reason = result.get("pagination_completion_reason")
-                if not cursor:
-                    receipt["discovery_complete"] = reason == "all_results_returned"
-                    receipt["discovery_completion_reason"] = (
-                        reason or "upstream_completion_unspecified"
-                    )
-                    break
-                if cursor in seen_cursors:
-                    receipt["discovery_complete"] = False
-                    break
-                seen_cursors.add(cursor)
-            else:
-                receipt["discovery_complete"] = False
-                receipt["discovery_completion_reason"] = "bounded_page_limit"
+            )
         ids = list(dict.fromkeys(ids))
         # Persist all discovered IDs before processing any item. Failures survive windows.
         with state_db(root) as db:
@@ -304,20 +411,19 @@ async def collect(resource_id, run_id, request):
                 "INSERT OR IGNORE INTO pending VALUES(?)", [(cid,) for cid in ids]
             )
         checkpoint()
-        for cid in ids:
+
+        async def collect_item(cid):
             try:
                 current_archive, _, current_settings = config(resource_id)
                 if (
                     current_archive.owner_user_concept_id
                     != archive.owner_user_concept_id
-                    or current_settings["account_email"] != settings["account_email"]
+                    or source_accounts(current_archive, current_settings) != accounts
                 ):
                     raise PermissionError("otter_collection_binding_changed")
-                raw = await session.call_tool("otter_fetch", {"id": cid})
-                meeting = unwrap(raw)
-                if not isinstance(meeting, dict) or meeting.get("id") != cid:
-                    raise RuntimeError("otter_fetch_identity_mismatch")
+                meeting, source_email = await fetch_from_sources(sources, cid)
                 archived = await asyncio.to_thread(import_snapshot, archive, meeting)
+                archived["collected_via_account"] = source_email
                 from .otter_representation_service import represent_meeting
 
                 with state_db(root) as db:
@@ -341,7 +447,7 @@ async def collect(resource_id, run_id, request):
                         "otter_transcript_unavailable"
                     )
                     checkpoint()
-                    continue
+                    return
                 with state_db(root) as db:
                     db.execute("DELETE FROM pending WHERE id=?", (cid,))
                     db.execute(
@@ -360,6 +466,15 @@ async def collect(resource_id, run_id, request):
                     }
                 )
             checkpoint()
+
+        # Independent recordings use disjoint identities; bound upstream/Atlas load.
+        slots = asyncio.Semaphore(3)
+
+        async def bounded_item(cid):
+            async with slots:
+                await collect_item(cid)
+
+        await asyncio.gather(*(bounded_item(cid) for cid in ids))
         if (
             receipt["discovery_complete"]
             and not receipt["counts"]["failed"]

--- a/src/backend/services/otter_representation_service.py
+++ b/src/backend/services/otter_representation_service.py
@@ -34,6 +34,7 @@ def represent_meeting(owner, meeting, archived, bindings):
         create_concept,
         get_concept_by_concept_id_exact,
     )
+    from .relationship_extent_index_service import defer_relationship_extent_index_sync
     from .scoped_assertion_service import (
         list_visible_scoped_assertions_page,
         retract_scoped_assertion,
@@ -52,9 +53,12 @@ def represent_meeting(owner, meeting, archived, bindings):
         "otter_id": cid,
         "source_sha256": archived["source_sha256"],
     }
+    if archived.get("collected_via_account"):
+        source["collected_via_account"] = archived["collected_via_account"]
     with (
         override_current_actor(owner, None),
         suppress_event_workflow_launches("otter_source_collection"),
+        defer_relationship_extent_index_sync(),
     ):
 
         def lookup(concept_id):

--- a/tests/backend/test_otter_collection.py
+++ b/tests/backend/test_otter_collection.py
@@ -263,3 +263,121 @@ def test_participant_binding_survives_refresh_and_rebinding_retracts_old_link(
         "#V#owner", meeting, archived, {"Person": "#V#corrected"}
     )
     assert [r["object_concept_id"] for r in assertions] == ["#V#corrected"]
+
+
+def test_multi_account_union_fallback_and_exact_id_deduplication(
+    configured, monkeypatch
+):
+    configured[2]["additional_accounts"] = [
+        {"id": "second", "email": "second@example.org"}
+    ]
+    calls = []
+
+    class Session:
+        def __init__(self, second):
+            self.second = second
+
+        async def call_tool(self, name, args):
+            calls.append((self.second, name, args))
+            if name == "otter_get_user_info":
+                return "Name: Owner\nEmail: " + (
+                    "second@example.org" if self.second else "owner@example.org"
+                )
+            if name == "otter_search":
+                return {
+                    "results": [
+                        {"id": "shared"},
+                        {"id": "second_only" if self.second else "primary_only"},
+                    ],
+                    "pagination_completion_reason": "all_results_returned",
+                }
+            if args["id"] == "second_only" and not self.second:
+                raise RuntimeError("not accessible")
+            return {
+                "id": args["id"],
+                "text": "[0:01] Owner: Hello",
+                "url": "https://otter.ai/u/" + args["id"],
+            }
+
+    @asynccontextmanager
+    async def session(path):
+        yield Session("accounts" in path.parts)
+
+    monkeypatch.setattr(service, "otter_session", session)
+    imported = []
+    monkeypatch.setattr(
+        service,
+        "import_snapshot",
+        lambda a, m: (
+            imported.append(m["id"]) or {"conversation_id": m["id"], "status": "new"}
+        ),
+    )
+    monkeypatch.setattr(representation, "represent_meeting", lambda *a: {})
+    job = service.enqueue("private", spawn=False)
+    service.work("private")
+    result = service.status("private", job["run_id"])["runs"][0]
+    assert result["status"] == "completed"
+    assert sorted(imported) == ["primary_only", "second_only", "shared"]
+    assert (
+        next(
+            x
+            for x in result["receipt"]["meetings"]
+            if x["conversation_id"] == "second_only"
+        )["collected_via_account"]
+        == "second@example.org"
+    )
+    assert all(c[2]["include_shared_meetings"] for c in calls if c[1] == "otter_search")
+
+
+def test_mismatched_account_does_not_fetch_or_block_valid_account(
+    configured, monkeypatch
+):
+    configured[2]["additional_accounts"] = [
+        {"id": "second", "email": "second@example.org"}
+    ]
+
+    class Session:
+        def __init__(self, second):
+            self.second = second
+
+        async def call_tool(self, name, args):
+            if name == "otter_get_user_info":
+                return "Name: Owner\nEmail: " + (
+                    "second@example.org" if self.second else "unexpected@example.org"
+                )
+            assert self.second
+            if name == "otter_search":
+                return {
+                    "results": [{"id": "a"}],
+                    "pagination_completion_reason": "all_results_returned",
+                }
+            return {
+                "id": "a",
+                "text": "[0:01] Owner: Hello",
+                "url": "https://otter.ai/u/a",
+            }
+
+    @asynccontextmanager
+    async def session(path):
+        yield Session("accounts" in path.parts)
+
+    monkeypatch.setattr(service, "otter_session", session)
+    monkeypatch.setattr(
+        service,
+        "import_snapshot",
+        lambda a, m: {"conversation_id": m["id"], "status": "new"},
+    )
+    monkeypatch.setattr(representation, "represent_meeting", lambda *a: {})
+    job = service.enqueue("private", spawn=False)
+    service.work("private")
+    run = service.status("private", job["run_id"])["runs"][0]
+    assert run["status"] == "completed_with_coverage_limit"
+    assert run["receipt"]["counts"]["new"] == 1
+    assert run["receipt"]["source_accounts"][0]["connected"] is False
+    with service.state_db(configured[1]) as db:
+        assert (
+            db.execute(
+                "SELECT value FROM state WHERE key='last_complete_date'"
+            ).fetchone()
+            is None
+        )


### PR DESCRIPTION
Otter collection previously used only one authorised source account, so Zhan-owned recordings were absent from scheduled discovery and forced refreshes. Collection now verifies and queries separately configured OAuth accounts, deduplicates exact recording IDs, falls back between authorised sources, and records the successful source account in private receipts and canonical meeting provenance. Distinct recordings remain intact.

Backfill uses three concurrent recording slots and the existing deferred relationship-index refresh to avoid repeated derived-index work. Source-account failures preserve progress from working accounts and prevent a false complete-discovery watermark. Operator documentation and account-specific authorisation are included.

Validation: 27 targeted collection/archive/stdio-authority tests pass; Ruff and diff checks pass. Native OAuth verified both intended accounts; live collection has imported Zhan-owned recordings and refreshed shared recordings. The 102-recording UI inventory contains 99 existing IDs and 3 new IDs. All 3,003 previously preserved images passed checksum verification; 30 additional originals were recovered through DOCX exports. The historical transcript backfill and final canonical image linking are running; unavailable source transcripts remain explicit retries. No model calls or external presenter messages.

Jira: JVNAUTOSCI-2734. Search pagination completeness remains an upstream limitation and is reported explicitly.
