### PR TITLE
Hand off collected Otter meetings to durable workflows (JVNAUTOSCI-2732)

### DIFF
--- a/docs/engineering/otter_archive_and_conversation_images.md
+++ b/docs/engineering/otter_archive_and_conversation_images.md
@@ -181,3 +181,26 @@ represent mentioned papers is tracked in
 [JVNAUTOSCI-2732](https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2732).
 It must be authored and exercised through the Von UI; collection does not send
 presenter requests or assert paper interpretations.
+
+### Collection events
+
+After source preservation and canonical meeting representation, the collector
+emits `otter.meeting_collected` through the existing durable event dispatcher.
+The event ID combines the private meeting concept ID and source hash, so an
+identical revision has the same identity across account fallback and retries.
+Bindings and their represented conditions select the downstream workflow; the
+collector does not identify presenters, send requests or interpret papers.
+
+Inputs contain `resource_id`, `otter_id`, `meeting_concept_id`, `source_sha256`,
+`source_url`, `source_title`, `collected_via_account`, `collection_status`,
+`transcript_available` and `transcript_url`. Source text remains in the private
+archive and is retrieved through its existing actor-bound tools. The event actor
+comes from the validated archive-owner configuration, with no organisation
+publication implied. Source metadata cannot choose a different actor.
+
+Each meeting receipt includes `workflow_event`. An absent binding is an explicit
+unconfigured handoff, compatible with ordinary collection. A failed configured
+handoff increments `event_handoff_failures`, leaves the meeting pending, and
+makes the run partial while retaining the successful preservation receipt. A
+retry reuses the event's durable instance when one already exists. A queued or
+reused workflow does not prove its later mail, deck or paper effects succeeded.

--- a/src/backend/services/otter_collection_service.py
+++ b/src/backend/services/otter_collection_service.py
@@ -355,6 +355,41 @@ def import_snapshot(archive, meeting):
     return receipt
 
 
+def emit_collection_event(archive, resource_id, meeting, archived, represented):
+    """Publish preserved-source evidence through the canonical event dispatcher.
+
+    An identical source revision has an identical event ID, including across
+    retries/accounts. Represented bindings own selection and workflow policy.
+    The trusted archive configuration owns the actor; source metadata cannot.
+    """
+    from ..security.access_control import override_current_actor
+    from .workflow_event_integration_service import launch_event_workflow
+
+    payload = {
+        "resource_id": resource_id,
+        "otter_id": meeting["id"],
+        "meeting_concept_id": represented["meeting_concept_id"],
+        "source_sha256": archived["source_sha256"],
+        "source_url": meeting["url"],
+        "source_title": meeting.get("title"),
+        "collected_via_account": archived.get("collected_via_account"),
+        "collection_status": archived["status"],
+        "transcript_available": archived.get("transcript_available", True),
+        "transcript_url": represented.get("transcript_url"),
+    }
+    with override_current_actor(archive.owner_user_concept_id, None):
+        return launch_event_workflow(
+            event_type="otter.meeting_collected",
+            event_id=represented["meeting_concept_id"]
+            + ":"
+            + archived["source_sha256"],
+            user_id=archive.owner_user_concept_id,
+            org_id=None,
+            inputs=payload,
+            event_payload=payload,
+        )
+
+
 async def collect(resource_id, run_id, request):
     archive, root, settings = config(resource_id)
     receipt = {
@@ -362,6 +397,7 @@ async def collect(resource_id, run_id, request):
         "counts": {"new": 0, "revised": 0, "unchanged": 0, "failed": 0},
         "meetings": [],
         "discovery_complete": True,
+        "event_handoff_failures": 0,
     }
 
     def checkpoint():
@@ -441,11 +477,34 @@ async def collect(resource_id, run_id, request):
                 )
                 available = archived.get("transcript_available", True)
                 receipt["counts"][archived["status"] if available else "failed"] += 1
-                receipt["meetings"].append({**archived, **represented})
-                if not available:
-                    receipt["meetings"][-1]["error_code"] = (
-                        "otter_transcript_unavailable"
+                item_receipt = {**archived, **represented}
+                receipt["meetings"].append(item_receipt)
+                try:
+                    handoff = await asyncio.to_thread(
+                        emit_collection_event,
+                        archive,
+                        resource_id,
+                        meeting,
+                        archived,
+                        represented,
                     )
+                except Exception as exc:  # noqa: BLE001 - retain source and retry the handoff
+                    handoff = {
+                        "success": False,
+                        "reason": "otter_event_handoff_failed",
+                        "error_type": type(exc).__name__,
+                    }
+                item_receipt["workflow_event"] = handoff
+                handoff_ok = bool(handoff.get("success")) or (
+                    handoff.get("reason") == "workflow_not_configured"
+                )
+                if not handoff_ok:
+                    receipt["event_handoff_failures"] += 1
+                if not available:
+                    item_receipt["error_code"] = "otter_transcript_unavailable"
+                    checkpoint()
+                    return
+                if not handoff_ok:
                     checkpoint()
                     return
                 with state_db(root) as db:
@@ -478,6 +537,7 @@ async def collect(resource_id, run_id, request):
         if (
             receipt["discovery_complete"]
             and not receipt["counts"]["failed"]
+            and not receipt["event_handoff_failures"]
             and not request["meeting_ids"]
         ):
             with state_db(root) as db:
@@ -486,7 +546,9 @@ async def collect(resource_id, run_id, request):
                     (end.isoformat(),),
                 )
     receipt["finished_at"] = now()
-    receipt["collection_complete"] = not receipt["counts"]["failed"]
+    receipt["collection_complete"] = (
+        not receipt["counts"]["failed"] and not receipt["event_handoff_failures"]
+    )
     receipt["collection_scope"] = (
         "returned_meetings"
         if not receipt["discovery_complete"]

--- a/src/backend/workflows/durable/workflow_creation_workflow.py
+++ b/src/backend/workflows/durable/workflow_creation_workflow.py
@@ -180,9 +180,14 @@ def _extract_request_text(context: Mapping[str, Any]) -> str:
 
 
 def _extract_workflow_spec(context: Mapping[str, Any]) -> Mapping[str, Any]:
-    raw = context.get("workflow_spec")
-    if isinstance(raw, Mapping):
-        return dict(raw)
+    # Later creation stages and resumed instances must use the design already
+    # produced by identify_need. Re-inference can give each stage a different
+    # identity and leave the materialised graph pointing at missing concepts.
+    # An explicitly supplied repair spec still takes precedence.
+    for key in ("workflow_spec", "workflow_creation_spec"):
+        raw = context.get(key)
+        if isinstance(raw, Mapping) and raw:
+            return dict(raw)
     return {}
 
 

--- a/tests/backend/test_otter_collection.py
+++ b/tests/backend/test_otter_collection.py
@@ -28,6 +28,11 @@ def configured(tmp_path, monkeypatch):
     root = tmp_path / "collection"
     settings = {"account_email": "owner@example.org"}
     monkeypatch.setattr(service, "config", lambda _: (archive, root, settings))
+    monkeypatch.setattr(
+        service,
+        "emit_collection_event",
+        lambda *args: {"success": False, "reason": "workflow_not_configured"},
+    )
     return archive, root, settings
 
 
@@ -381,3 +386,113 @@ def test_mismatched_account_does_not_fetch_or_block_valid_account(
             ).fetchone()
             is None
         )
+
+
+def test_collection_event_uses_trusted_private_actor_and_stable_source_identity(
+    monkeypatch,
+):
+    from src.backend.security.access_control import get_effective_user_concept_id
+    from src.backend.services import workflow_event_integration_service as events
+
+    calls = []
+
+    def launch(**kwargs):
+        assert get_effective_user_concept_id() == "#V#owner"
+        calls.append(kwargs)
+        return {"success": True, "triggered": len(calls) == 1}
+
+    monkeypatch.setattr(events, "launch_event_workflow", launch)
+    archive = SimpleNamespace(owner_user_concept_id="#V#owner")
+    meeting = {
+        "id": "same-recording",
+        "url": "https://otter.ai/u/same-recording",
+        "text": "Private source content is retrieved separately",
+        "metadata": {"owner_user_concept_id": "#V#attacker", "org_id": "#V#other"},
+    }
+    archived = {"status": "new", "source_sha256": "abc", "transcript_available": True}
+    represented = {
+        "meeting_concept_id": "#V#meeting",
+        "transcript_url": "/private-source",
+    }
+    service.emit_collection_event(archive, "private", meeting, archived, represented)
+    service.emit_collection_event(
+        archive, "private", meeting, {**archived, "status": "unchanged"}, represented
+    )
+    assert calls[0]["event_id"] == calls[1]["event_id"]
+    assert calls[0]["event_type"] == "otter.meeting_collected"
+    assert calls[0]["user_id"] == "#V#owner"
+    assert calls[0]["org_id"] is None
+    assert "Private source content" not in json.dumps(calls)
+    service.emit_collection_event(
+        archive,
+        "private",
+        meeting,
+        {**archived, "source_sha256": "changed"},
+        represented,
+    )
+    assert calls[-1]["event_id"] != calls[0]["event_id"]
+
+
+def test_failed_event_handoff_preserves_import_and_retries_same_recording(
+    configured, monkeypatch
+):
+    class Session:
+        async def call_tool(self, name, arguments):
+            if name == "otter_get_user_info":
+                return "Name: Owner\nEmail: owner@example.org"
+            return {
+                "id": "a",
+                "url": "https://otter.ai/u/a",
+                "text": "[0:01] Person: Hello",
+            }
+
+    @asynccontextmanager
+    async def session(_):
+        yield Session()
+
+    imported = []
+    monkeypatch.setattr(service, "otter_session", session)
+    monkeypatch.setattr(
+        service,
+        "import_snapshot",
+        lambda a, m: (
+            imported.append(m["id"])
+            or {
+                "conversation_id": m["id"],
+                "status": "new" if len(imported) == 1 else "unchanged",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        representation,
+        "represent_meeting",
+        lambda *args: {"meeting_concept_id": "#V#meeting"},
+    )
+    monkeypatch.setattr(
+        service,
+        "emit_collection_event",
+        lambda *args: {"success": False, "reason": "launch_failed"},
+    )
+    first = service.enqueue("private", meeting_ids=["a"], spawn=False)
+    service.work("private")
+    status = service.status("private", first["run_id"])
+    assert status["runs"][0]["status"] == "partial"
+    assert status["runs"][0]["receipt"]["counts"] == {
+        "new": 1,
+        "revised": 0,
+        "unchanged": 0,
+        "failed": 0,
+    }
+    assert status["runs"][0]["receipt"]["event_handoff_failures"] == 1
+    assert status["pending_meetings"] == 1
+    monkeypatch.setattr(
+        service,
+        "emit_collection_event",
+        lambda *args: {"success": True, "idempotent_reused": True},
+    )
+    second = service.enqueue("private", meeting_ids=["a"], spawn=False)
+    service.work("private")
+    status = service.status("private", second["run_id"])
+    assert status["runs"][0]["status"] == "completed"
+    assert status["pending_meetings"] == 0
+    assert imported == ["a", "a"]

--- a/tests/backend/test_workflow_creation_workflow.py
+++ b/tests/backend/test_workflow_creation_workflow.py
@@ -1398,6 +1398,49 @@ def test_normalise_workflow_spec_derives_bounded_stable_generated_workflow_id() 
     assert assess_workflow_id_hygiene(workflow_id)["valid"] is True
 
 
+def test_creation_stages_reuse_persisted_design_without_identity_reinference() -> None:
+    from src.backend.workflows.durable import workflow_creation_workflow as creation
+
+    persisted_spec = {
+        "workflow_id": "#V#meeting_followup_workflow",
+        "workflow_name": "Meeting Follow-up",
+        "steps": [
+            {
+                "state_key": "read_source",
+                "action_id": "fetch_concept",
+                "inputs": {"concept_id": "#V#meeting_source"},
+                "next_state_key": "completed",
+            },
+            {"state_key": "completed", "terminal": True},
+        ],
+        "required_effects": ["source_read"],
+    }
+    with (
+        patch.object(creation, "infer_workflow_authoring_identity") as infer,
+        patch.object(creation, "_resolve_workflow_template_spec") as template,
+    ):
+        context = {
+            "prompt": "Create a meeting workflow",
+            "workflow_creation_spec": persisted_spec,
+        }
+        for _ in range(4):
+            normalised = creation._normalise_workflow_spec(context)
+            assert normalised["workflow_id"] == persisted_spec["workflow_id"]
+            assert normalised["steps"][0]["action_id"] == "fetch_concept"
+            assert normalised["required_effects"] == ["source_read"]
+            context["workflow_creation_spec"] = normalised
+        infer.assert_not_called()
+        template.assert_not_called()
+
+        # A repair supplied by the authoring workflow replaces the prior design.
+        context["workflow_spec"] = {
+            **persisted_spec,
+            "steps": [{"state_key": "repaired", "terminal": True}],
+        }
+        repaired = creation._normalise_workflow_spec(context)
+        assert repaired["steps"][0]["state_key"] == "repaired"
+
+
 def test_workflow_authoring_preflight_create_routes_through_wrapper_workflow() -> None:
     _publish_workflow_authoring_governance_workflows()
 


### PR DESCRIPTION
Otter collection currently preserves meetings without handing them to a downstream workflow. This change emits `otter.meeting_collected` after archive and canonical concept writes, uses a stable meeting/source-revision event identity, and retains failed handoffs for retry without losing successful preservation receipts. The event uses the trusted private archive owner and leaves presenter selection and follow-up behaviour to represented workflows.

A real Von UI authoring run also exposed identity drift: each creation stage ignored the preceding stage's saved design and could infer another workflow ID. Creation now reuses its persisted specification, while an explicit repair specification retains precedence.

Validation: 12 collector tests, 13 authoring tests and four existing event idempotency/condition tests pass. Six broader authoring tests fail before and after this change: four stale template-version expectations and two existing PhD-template failures. The two ambiguous failures were replayed with the original extraction function and reproduced unchanged. Existing authoring-file lint findings are outside the changed lines; collector lint and diff checks pass.

This is supporting implementation for JVNAUTOSCI-2732 under existing epic JVNAUTOSCI-2239. It does not claim that the live presentation/paper workflow is complete or active. UI authoring, activation and real effect/replay acceptance remain tracked on that issue.
