### PR TITLE
Make represented workflow repair discoverable (JVNAUTOSCI-2732)

### DIFF
--- a/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
+++ b/src/backend/workflows/repo_seed_bundles/canonical_workflow_publication_seed_bundle.json
@@ -1,7 +1,7 @@
 {
   "family_id": "canonical_workflow_publication_seed_bundle",
   "schema_version": "repo_seed_workflow_bundle.v1",
-  "seed_version": "53",
+  "seed_version": "54",
   "known_legacy_authority_payload_sha256_by_seed_version": {
     "#V#tool_calling_workflow": {
       "42": [
@@ -7104,6 +7104,7 @@
           "lang": "en-NZ"
         }
       ],
+      "description": "Repair an existing represented workflow definition. Load its current specification, use the governed repair prompt to design executable steps and tool bindings, then materialise and validate the revised definition while preserving the target workflow identity.",
       "workflow_id": "#V#workflow_authoring_repair_workflow"
     },
     {
@@ -7518,6 +7519,7 @@
           "lang": "en-NZ"
         }
       ],
+      "description": "Author a represented workflow by discovering existing capabilities, deciding whether to reuse or repair an existing workflow or create a new one, and invoking the corresponding authoring workflow. Prefer repairing an existing workflow when it can satisfy the requested behaviour.",
       "workflow_id": "#V#workflow_repair_or_create_workflow"
     },
     {


### PR DESCRIPTION
The existing workflow repair and repair-or-create graphs have routing profiles but no authoritative purpose descriptions in their canonical seed entries. Live discovery excludes the repair workflow with `missing_authoritative_purpose`, preventing the Von UI from selecting the intended authoring capability.

Add descriptions to both existing identities and advance the seed version. No workflow graph or task semantics change. The same metadata is being restored through the Von UI for JVNAUTOSCI-2732.

Validation: the canonical DB-free seed builder loads both graphs (five and seven states) with the supplied authoritative descriptions; JSON and diff checks pass. Full Otter follow-up implementation remains In Progress under epic JVNAUTOSCI-2239.
