### PR TITLE
Reject malformed explicit workflow graphs (JVNAUTOSCI-2732)

### DIFF
--- a/src/backend/workflows/durable/workflow_creation_workflow.py
+++ b/src/backend/workflows/durable/workflow_creation_workflow.py
@@ -924,6 +924,15 @@ def _normalise_workflow_spec(
 ) -> dict[str, Any]:
     request_text = _extract_request_text(context)
     raw_spec = _extract_workflow_spec(context)
+    if raw_spec:
+        raw_steps = raw_spec.get("steps")
+        if not isinstance(raw_steps, list) or not raw_steps or any(
+            not isinstance(step, Mapping) for step in raw_steps
+        ):
+            raise ValueError(
+                "workflow_authoring_spec_invalid:steps_must_be_a_nonempty_list_of_objects;"
+                "use_steps_not_states"
+            )
     template_resolution: dict[str, Any] = {}
     identity = _resolve_workflow_authoring_identity(
         context={**context, **raw_spec},

--- a/tests/backend/test_workflow_creation_workflow.py
+++ b/tests/backend/test_workflow_creation_workflow.py
@@ -1398,6 +1398,33 @@ def test_normalise_workflow_spec_derives_bounded_stable_generated_workflow_id() 
     assert assess_workflow_id_hygiene(workflow_id)["valid"] is True
 
 
+@pytest.mark.parametrize(
+    "graph",
+    [
+        {"states": [{"state_key": "process", "action_id": "llm.action"}]},
+        {"steps": []},
+        {"steps": "process"},
+        {"steps": [None]},
+    ],
+)
+def test_explicit_invalid_graph_cannot_fall_back_to_marker_workflow(graph) -> None:
+    from src.backend.workflows.durable import workflow_creation_workflow as creation
+
+    with (
+        patch.object(creation, "infer_workflow_authoring_identity") as infer,
+        patch.object(creation, "_resolve_workflow_template_spec") as template,
+        pytest.raises(ValueError, match="workflow_authoring_spec_invalid:steps"),
+    ):
+        creation._normalise_workflow_spec(
+            {
+                "workflow_spec": {"workflow_id": "#V#existing_workflow", **graph},
+                "prompt": "Replace an existing workflow",
+            }
+        )
+    infer.assert_not_called()
+    template.assert_not_called()
+
+
 def test_creation_stages_reuse_persisted_design_without_identity_reinference() -> None:
     from src.backend.workflows.durable import workflow_creation_workflow as creation
 


### PR DESCRIPTION
An explicit authoring request using `states` instead of the supported `steps` silently fell back to a marker graph and overwrote the candidate definition. Reject missing, empty or malformed explicit step lists before identity inference or materialisation, returning a repairable schema error. Prose-only authoring and valid persisted specifications retain their existing paths.

Validation: six targeted cases pass; the complete authoring test file has 17 passes and the same six pre-existing failures (four stale entity seed-version assertions and two PhD template cases). `git diff --check` passes. The live UI input established the original failure. This change does not claim the Otter presentation-and-paper workflow is accepted or active; JVNAUTOSCI-2732 remains in progress.
