### PR TITLE
Expose administrator event binding in Von conversations (JVNAUTOSCI-2732)

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -45722,6 +45722,7 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                 description="Binding write result.",
             ),
             category="write",
+            ordinary_turn_effect=True,
             description=(
                 "Register or update an event-to-workflow binding with optional input mapping and represented condition metadata. "
                 "Set replace_existing=true to overwrite an existing conflicting binding."
@@ -45780,6 +45781,7 @@ def _build_default_catalogue_task_and_workflow_definitions() -> List[MethodDefin
                 description="Event binding enabled/disabled result.",
             ),
             category="write",
+            ordinary_turn_effect=True,
             description=(
                 "Enable or disable an existing event binding without deleting it. "
                 "Use workflow_list_event_bindings first to identify binding_id values."

--- a/tests/backend/test_internal_mcp_workflow_tools.py
+++ b/tests/backend/test_internal_mcp_workflow_tools.py
@@ -3564,6 +3564,54 @@ def test_workflow_bind_event_and_list_event_bindings_gateway_paths(monkeypatch):
     assert listed.get("has_conflicts") is False
 
 
+def test_ordinary_turn_can_bind_and_disable_events_as_live_administrator(monkeypatch):
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services.adaptive_turn_service import (
+        ordinary_turn_capability_delegation,
+    )
+
+    manager = _StubWorkflowManager()
+    _patch_read_only_registry(monkeypatch, "#V#meeting_workflow")
+    monkeypatch.setattr(
+        "src.backend.workflows.durable.WorkflowInstanceManager", lambda: manager
+    )
+    monkeypatch.setattr(
+        "src.backend.workflows.workflow_listing_service.filter_workflow_ids_for_current_actor",
+        lambda workflow_ids: list(workflow_ids),
+    )
+    monkeypatch.setattr(
+        "src.backend.services.von_operational_administrator_service."
+        "is_live_von_operational_administrator",
+        lambda actor: actor == "#V#workflow_admin",
+    )
+    gateway = _build_gateway()
+    operations = {"workflow_bind_event", "workflow_set_event_binding_enabled"}
+    assert operations <= set(
+        ordinary_turn_capability_delegation(
+            gateway, user_concept_id="#V#workflow_admin"
+        )
+    )
+    assert not operations.intersection(
+        ordinary_turn_capability_delegation(gateway, user_concept_id=None)
+    )
+    with override_current_actor("#V#workflow_admin", None):
+        created = gateway.invoke(
+            "workflow_bind_event",
+            {
+                "event_type": "otter.meeting_collected",
+                "workflow_id": "#V#meeting_workflow",
+            },
+        ).payload
+        assert created["success"] is True, created
+        binding_id = created["binding"]["binding_id"]
+        disabled = gateway.invoke(
+            "workflow_set_event_binding_enabled",
+            {"binding_id": binding_id, "enabled": False},
+        ).payload
+        assert disabled["success"] is True
+    assert manager.get_event_binding(binding_id).enabled is False
+
+
 def test_workflow_bind_event_conflict_requires_replace(monkeypatch):
     manager = _StubWorkflowManager()
     _patch_read_only_registry(monkeypatch, "#V#enrichment_workflow")


### PR DESCRIPTION
Von could author the Otter follow-up workflow through the ordinary UI, but could not activate its event trigger: binding and enable/disable operations were absent from delegated capabilities even for an operational administrator. Expose those two bounded operations while retaining their existing live administrator checks and workflow visibility checks.

Validation: five targeted gateway tests pass, covering ordinary-turn capability projection, administrator bind/disable/read-back, anonymous exclusion, ordinary-user denial, conflicting bindings and existing binding lifecycle operations. `git diff --check` passes. Live UI discovery confirmed the original omission; activation through the updated runtime remains part of JVNAUTOSCI-2732 acceptance. No generic workflow execution or binding deletion capability is added to ordinary turns.
