### PR TITLE
fix(speech): convert browser locales to transcription language codes

### DIFF
--- a/docs/engineering/speech_io.md
+++ b/docs/engineering/speech_io.md
@@ -67,6 +67,11 @@ hints, not required output or tool instructions. Transcription uses one audio
 model call and no semantic rewriting pass. `gpt-transcribe` receives plural
 `languages`/`keywords`; the GPT-4o audio models receive the compatible prompt
 and singular language parameter.
+Browser locales such as `en-NZ` are reduced to the primary language code `en`
+for either provider API; the response retains the original locale hint. A live
+DGX request on 10 September rejected `languages=["en-NZ"]` with HTTP 400 but
+accepted the otherwise identical `languages=["en"]` request and correctly
+transcribed the synthetic fixture's Von, Vontology and Wikidata vocabulary.
 
 ## Playback repair
 
@@ -106,6 +111,11 @@ or live DGX acceptance. The DGX transcript was read through its own canonical
 history service after temporarily reconnecting this Mac's existing Tailscale
 profile. Its observed pre-repair runtime was `12ae94c0`. Runtime deployment and
 physical iOS/Android behaviour require separate verification receipts.
+The merged repair was subsequently deployed to the DGX as `702530d9`; the
+runtime, served asset and authenticated browser build were read back. An
+operator-scoped synthetic-audio replay exposed the locale incompatibility above,
+which requires the accompanying provider-language correction. This does not
+establish physical-device microphone or autoplay behaviour.
 
 Provider reference: [OpenAI file transcription](https://developers.openai.com/api/docs/guides/speech-to-text).
 Browser reference: [MDN SpeechRecognition](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition).

--- a/src/backend/services/speech_transcription_service.py
+++ b/src/backend/services/speech_transcription_service.py
@@ -111,7 +111,9 @@ def transcribe_audio(
     if model == "gpt-transcribe":
         options["extra_body"] = {
             "keywords": terms,
-            **({"languages": [language]} if language else {}),
+            # The provider accepts language codes, not browser locales: a live
+            # en-NZ request is rejected while the otherwise identical en works.
+            **({"languages": [language.split("-", 1)[0].lower()]} if language else {}),
         }
     elif language:
         options["language"] = language.split("-", 1)[0].lower()

--- a/tests/backend/test_speech_transcription.py
+++ b/tests/backend/test_speech_transcription.py
@@ -47,10 +47,11 @@ def test_recorded_audio_carries_vocabulary_and_language(provider, mime, extensio
     assert args["file"][0] == "dictation." + extension
     assert args["extra_body"] == {
         "keywords": ["Vontology", "Wikidata"],
-        "languages": ["en-NZ"],
+        "languages": ["en"],
     }
     assert "Discuss Vontology" in args["prompt"]
     assert result["text"] == "Von uses Vontology."
+    assert result["language_hint"] == "en-NZ"
     gate.assert_called_once_with(
         provider="openai",
         model="gpt-transcribe",


### PR DESCRIPTION
Recorded dictation using Von's default `en-NZ` preference failed with HTTP 400 from gpt-transcribe. Convert browser locales to their primary language code for the provider request, while preserving the original locale in the response receipt. The same live DGX audio request succeeded with `en` and recovered Von, Vontology and Wikidata correctly.

Validation: all 10 speech backend tests pass, including the regional-locale request regression; formatting and diff checks pass. The main speech UI repair is already merged in #601. This follow-up fixes the incompatibility found during its DGX activation. Physical iOS/Android microphone and autoplay behaviour remain unverified.

Merge decision: ready for this bounded transport correction; the live controlled comparison isolates the rejection to the locale value. Repeat the canonical route with `en-NZ` after deployment before closing JVNAUTOSCI-888.
