### PR TITLE
Preserve Unicode attachment metadata on S3 uploads (JVNAUTOSCI-2737)

### DIFF
--- a/src/backend/services/blob_store.py
+++ b/src/backend/services/blob_store.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from collections.abc import Mapping
 from dataclasses import dataclass
+from email.header import Header
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 from urllib.parse import urlsplit
@@ -123,7 +124,13 @@ def _normalise_s3_metadata(metadata: Mapping[str, str] | None) -> dict[str, str]
             raise ValueError(
                 f"S3 metadata keys collide after normalisation: {wire_key!r}"
             )
-        wire_metadata[wire_key] = str(value)
+        wire_value = str(value)
+        if not wire_value.isascii():
+            # Botocore requires ASCII metadata headers. S3 specifies RFC 2047
+            # for Unicode values; preserve the original in the returned BlobRef
+            # and canonical file metadata, encoding only the transport value.
+            wire_value = Header(wire_value, "utf-8").encode(linesep=" ")
+        wire_metadata[wire_key] = wire_value
     return wire_metadata
 
 

--- a/tests/test_blob_store.py
+++ b/tests/test_blob_store.py
@@ -603,6 +603,48 @@ def test_s3_blob_store_normalises_metadata_keys_for_wire():
     assert ref.metadata == metadata
 
 
+@pytest.mark.parametrize("upload_mode", ["bytes", "file"])
+@pytest.mark.parametrize(
+    "filename",
+    ["Research \u2013 \u201csummary\u201d.pdf", "\u7814\u7a76\u8a08\u753b.pdf", "\u7814\u7a76\u8a08\u753b " * 25 + ".pdf"],
+)
+def test_s3_blob_store_preserves_unicode_metadata_on_upload(
+    tmp_path, upload_mode, filename
+):
+    from email.header import decode_header, make_header
+
+    from botocore.handlers import validate_ascii_metadata
+
+    class _DummyClient:
+        def put_object(self, **kwargs):
+            validate_ascii_metadata(kwargs)
+            self.metadata = kwargs["Metadata"]
+
+        def upload_fileobj(self, handle, bucket, key, *, ExtraArgs):
+            assert handle.read() == b"source bytes"
+            self.put_object(**ExtraArgs)
+
+    store = S3BlobStore.__new__(S3BlobStore)
+    store._bucket = "demo-bucket"
+    store._prefix = ""
+    store._public_base_url = None
+    store._client = _DummyClient()
+    metadata = {"original_filename": filename, "sha256": "abc123"}
+    store._endpoint_url = "https://storage.example"
+    if upload_mode == "file":
+        source = tmp_path / "source.pdf"
+        source.write_bytes(b"source bytes")
+        ref = store.put_file("source.pdf", source, metadata=metadata)
+    else:
+        ref = store.put_bytes("source.pdf", b"source bytes", metadata=metadata)
+
+    wire_filename = store._client.metadata["original-filename"]
+    assert "\n" not in wire_filename and "\r" not in wire_filename
+    assert str(make_header(decode_header(wire_filename))) == filename
+    assert store._client.metadata["sha256"] == "abc123"
+    assert ref.metadata == metadata
+
+
 def test_s3_blob_store_exists_returns_false_for_missing_object():
     class _MissingObject(Exception):
         def __init__(self):


### PR DESCRIPTION
S3 rejected native Jira attachment uploads when original filenames contained curly quotes or en dashes. The bytes remained in retained Jira originals, but the native task attachments lacked file bindings.

Encode non-ASCII metadata values as RFC 2047 on the S3 transport boundary, following [S3's metadata contract](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html). Preserve the exact original values in canonical file metadata and the returned BlobRef. The shared path covers byte and streamed-file uploads; ASCII values and existing key normalisation are unchanged.

Validation: 37 targeted blob-store and file-ingestion tests passed, including real Botocore metadata validation, Unicode round-trip and long-value coverage. No new Ruff findings. Both affected live attachments were recovered from retained originals; canonical read-back preserved native attachment identities and matched the original source SHA-256 values with Jira credentials disabled. Captured source data and audit artefacts are outside Git.

Merge decision: ready, subject to required CI. This repairs the observed upload failure; estate import, source reconciliation, paired restore and project writer cutover remain in progress under JVNAUTOSCI-2737.
