### PR TITLE
Identify the Von deployment health client at the public edge

### DIFF
--- a/scripts/deploy_local_main.py
+++ b/scripts/deploy_local_main.py
@@ -262,7 +262,11 @@ class _NoHealthRedirect(urllib.request.HTTPRedirectHandler):
 def _read_health(url: str, headers: dict[str, str] | None = None) -> dict[str, Any]:
     try:
         opener = urllib.request.build_opener(_NoHealthRedirect())
-        request = urllib.request.Request(url, headers=headers or {})
+        # Identify this authorised client explicitly: the public edge rejects
+        # urllib's generic bot identifier before evaluating Service Auth.
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "Von-Deployment/1", **(headers or {})}
+        )
         with opener.open(request, timeout=5) as response:
             payload = json.load(response)
     except urllib.error.HTTPError as exc:

--- a/tests/test_codex_von_deploy.py
+++ b/tests/test_codex_von_deploy.py
@@ -10,6 +10,35 @@ pytest.importorskip("fcntl")
 from scripts import codex_von_deploy as deployer
 
 
+def test_public_health_identifies_client_and_preserves_service_credentials():
+    seen = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            agent = self.headers.get("User-Agent", "")
+            seen.append((agent, self.headers.get("CF-Access-Client-Secret")))
+            self.send_response(403 if agent.startswith("Python-urllib") else 200)
+            self.end_headers()
+            self.wfile.write(b'{"status":"healthy"}')
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        assert deployer.runtime._read_health(
+            f"http://127.0.0.1:{server.server_port}/health",
+            {"CF-Access-Client-Secret": "fixture-only"},
+        ) == {"status": "healthy"}
+        assert seen == [("Von-Deployment/1", "fixture-only")]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
 def test_public_credentials_are_not_forwarded_through_redirects():
     paths = []
 


### PR DESCRIPTION
Cloudflare rejects the default Python urllib User-Agent before evaluating the deployment service credential. This made a healthy DGX release enter code recovery and report a blocked task. Identify health requests as `Von-Deployment/1`, preserving the service headers and refusal to follow redirects.

Validation: 21 focused deployment/recovery tests passed, including a local HTTP regression for the edge behaviour; Ruff, Black check and diff check passed. The exact candidate health reader also returned HTTP 200 with the production service credential and current clean public revision. Jira: JVNAUTOSCI-2740.
