### PR TITLE
Open task links in the existing panel and add message reference menus

### DIFF
--- a/src/backend/integrations/internal_mcp/catalogue.py
+++ b/src/backend/integrations/internal_mcp/catalogue.py
@@ -6875,6 +6875,7 @@ def _message_list_direct(**kwargs):
         thread_id=kwargs.get("thread_id"),
         limit=limit,
         skip=offset,
+        other_user_id=kwargs.get("other_user_concept_id"),
     )
     projected = [project_direct_message(message) for message in messages]
     return {
@@ -13094,6 +13095,7 @@ def _message_list_direct_input_schema() -> Schema:
             "include_sent": (bool, type(None)),
             "include_received": (bool, type(None)),
             "thread_id": (str, type(None)),
+            "other_user_concept_id": (str, type(None)),
             "limit": (int, type(None)),
             "offset": (int, type(None)),
             "acting_user_concept_id": (str, type(None)),
@@ -13102,7 +13104,8 @@ def _message_list_direct_input_schema() -> Schema:
         },
         allow_unknown=False,
         description=(
-            "List the authenticated actor's sent and received internal direct messages."
+            "List the authenticated actor's sent and received internal direct messages, "
+            "optionally narrowed to a conversation with other_user_concept_id."
         ),
     )
 

--- a/src/backend/server/routes/message_routes.py
+++ b/src/backend/server/routes/message_routes.py
@@ -875,6 +875,7 @@ def list_threads() -> ResponseReturnValue:
             {
                 "threads": threads,
                 "count": len(threads),
+                "current_user_id": user_id,
             }
         ),
         200,

--- a/src/backend/services/message_service.py
+++ b/src/backend/services/message_service.py
@@ -337,11 +337,7 @@ def project_direct_message(message_doc: Dict[str, Any]) -> Dict[str, Any]:
         "content": concept_data.get("content_fallback"),
         "sent_at": concept_data.get("sent_at"),
         "status": concept_data.get("message_status"),
-        "read_by": [
-            item
-            for item in raw_read_by
-            if isinstance(item, str)
-        ],
+        "read_by": [item for item in raw_read_by if isinstance(item, str)],
         "thread_id": (
             relationship_values(PREDICATE_THREAD)[0]
             if relationship_values(PREDICATE_THREAD)
@@ -429,7 +425,9 @@ def create_message(
         relationships[PREDICATE_REPLY_TO] = [reply_to_id.strip()]
 
     metadata_payload = metadata if isinstance(metadata, dict) else {}
-    metadata_payload = {str(k): v for k, v in metadata_payload.items() if isinstance(k, str)}
+    metadata_payload = {
+        str(k): v for k, v in metadata_payload.items() if isinstance(k, str)
+    }
     attribution = metadata_payload.get("attribution")
     if not isinstance(attribution, str) or not attribution.strip():
         attribution = f"Sent by Von on behalf of {sender_id}"
@@ -745,6 +743,7 @@ def get_messages_for_user(
     thread_id: Optional[str] = None,
     limit: int = 50,
     skip: int = 0,
+    other_user_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Get messages for a user (sent and/or received).
 
@@ -784,6 +783,24 @@ def get_messages_for_user(
 
     if thread_id:
         base_filter[f"relationships.{PREDICATE_THREAD}"] = thread_id.strip()
+
+    if other_user_id:
+        # Further narrow the actor's existing mailbox; never replace its scope.
+        counterpart = other_user_id.strip()
+        base_filter["$and"] = [
+            {
+                "$or": [
+                    {
+                        f"relationships.{PREDICATE_SENDER}": user_id,
+                        f"relationships.{PREDICATE_RECIPIENT}": counterpart,
+                    },
+                    {
+                        f"relationships.{PREDICATE_SENDER}": counterpart,
+                        f"relationships.{PREDICATE_RECIPIENT}": user_id,
+                    },
+                ]
+            }
+        ]
 
     query = apply_concept_query_filter(base_filter)
 

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -28181,7 +28181,7 @@ function populateChatSessionMenu(items) {
     return menu;
 }
 
-function openChatSessionMenu(x, y, items, options = {}) {
+export function openChatSessionMenu(x, y, items, options = {}) {
     if (!Array.isArray(items) || items.length === 0) {
         return;
     }

--- a/src/frontend/web/von_interface/static/js/components/messagePanel.js
+++ b/src/frontend/web/von_interface/static/js/components/messagePanel.js
@@ -10,6 +10,8 @@ import { getSessionScopedOrgId } from '../utils/sessionScopedStorage.js';
 import { hydrateConceptCartouchesInRoot } from '../utils/selectConceptByIdHandler.js';
 import { cartouchifyElementText } from '../utils/textDecorator.js';
 import { showToast } from '../utils/toast.js';
+import { buildMessageStreamReference } from '../utils/messageStreamReference.js';
+import { copyTextWithClipboardFallback } from '../utils/copyJsonButtonState.js';
 import {
     clearRecommendationReviewResults,
     renderRecommendationReviewPayload,
@@ -136,7 +138,8 @@ function renderMessagesTabContent() {
             </div>
             <div class="messages-main">
                 <div id="messageViewHeader" class="message-view-header hidden">
-                    <span id="conversationTitle" class="conversation-title">Select a conversation</span>
+                    <span id="conversationTitle" class="conversation-title" tabindex="0">Select a conversation</span>
+                    <button id="messageTaskPanelBtn" class="chat-export-btn" type="button" title="Open tasks panel" aria-label="Tasks">📋</button>
                     <button id="refreshMessagesBtn" class="message-refresh-btn" type="button" title="Refresh" aria-label="Refresh messages">
                         ${renderMessagePanelIcon('refresh')}
                     </button>
@@ -305,6 +308,7 @@ async function loadMessageThreads() {
     try {
         const response = await getJson('/api/messages/threads?limit=20');
         _threads = response.threads || [];
+        _currentUserId = response.current_user_id || null;
         renderThreadList();
         autoOpenUserId = resolveStoredReplyAttemptAutoOpenUserId()
             || resolveAutoOpenThreadUserId();
@@ -392,7 +396,7 @@ function renderThreadList() {
         const userId = getThreadUserId(thread);
 
         html += `
-            <div class="message-thread-item" data-user-id="${escapeHtml(userId)}"
+            <div class="message-thread-item" tabindex="0" data-user-id="${escapeHtml(userId)}"
                  title="Conversation with ${escapeHtml(displayName)}">
                 <div class="thread-avatar">${getInitials(displayName)}</div>
                 <div class="thread-info">
@@ -411,7 +415,9 @@ function renderThreadList() {
 
     // Attach click handlers
     threadListEl.querySelectorAll('.message-thread-item').forEach(item => {
-        item.addEventListener('click', () => {
+        bindMessageStreamMenu(item, () => item.dataset.userId);
+        item.addEventListener('click', (event) => {
+            if (event.ctrlKey) return;
             const userId = item.dataset.userId;
             if (userId) {
                 selectConversation(userId);
@@ -458,9 +464,52 @@ async function selectConversation(userId) {
     if (header) header.classList.remove('hidden');
     if (compose) compose.classList.remove('hidden');
     if (title) title.textContent = `Conversation with ${formatUserName(userId)}`;
+    if (title && !title.dataset.menuBound) {
+        bindMessageStreamMenu(title, () => _currentConversationUserId);
+        title.dataset.menuBound = 'true';
+    }
+    const taskButton = _messagesContainer?.querySelector('#messageTaskPanelBtn');
+    if (taskButton) taskButton.onclick = () => void openMessageTasks();
 
     // Load the conversation
     await loadConversation(userId);
+}
+
+async function openMessageTasks() {
+    const { showTaskPanel } = await import('./taskPanel.js');
+    const taskIds = [...(_messagesContainer?.querySelectorAll('[data-task-concept="true"]') || [])]
+        .map(element => element.dataset.fullConceptId);
+    await showTaskPanel({ taskIds, sessionId: null });
+}
+
+function bindMessageStreamMenu(element, getOtherUserId) {
+    const open = async event => {
+        event.preventDefault();
+        event.stopPropagation();
+        const otherUserId = getOtherUserId();
+        const userId = _currentUserId;
+        if (!otherUserId || !userId) return;
+        const thread = _threads.find(row => getThreadUserId(row) === otherUserId);
+        const messages = otherUserId === _currentConversationUserId ? _currentMessages : [thread?.last_message].filter(Boolean);
+        const payload = buildMessageStreamReference({ currentUserId: userId, otherUserId, messages, displayName: `Conversation with ${formatUserName(otherUserId)}` });
+        const { openChatSessionMenu } = await import('../chatTab.js');
+        if (!element.isConnected || _currentUserId !== userId) return;
+        const rect = element.getBoundingClientRect();
+        openChatSessionMenu(event.clientX || rect.left, event.clientY || rect.bottom, [{
+            label: 'Copy conversation reference',
+            onClick: async () => {
+                if (_currentUserId !== userId) return;
+                const copied = await copyTextWithClipboardFallback(JSON.stringify(payload, null, 2));
+                showToast(copied ? 'Copied message conversation reference.' : 'Failed to copy conversation reference.', copied ? 'success' : 'error');
+            }
+        }], { returnFocus: element, focusFirst: true });
+    };
+    element.addEventListener('contextmenu', open);
+    element.addEventListener('click', event => { if (event.ctrlKey) void open(event); });
+    element.addEventListener('keydown', event => {
+        if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) void open(event);
+        else if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); void selectConversation(getOtherUserId()); }
+    });
 }
 
 /**

--- a/src/frontend/web/von_interface/static/js/components/taskPanel.js
+++ b/src/frontend/web/von_interface/static/js/components/taskPanel.js
@@ -29,6 +29,8 @@ let _filterTaskSourceId = 'all';
 let _isGlobalTabMode = false;  // True when rendering into global tasks tab
 let _taskDetailState = {};  // taskId -> detail panel state
 let _selectedTaskId = '';
+let _panelTaskIds = null;
+let _panelLoadGeneration = 0;
 let _bulkTaskVisibility = 'exclude';
 let _bulkTaskCollectionId = '';
 let _taskProjects = [];
@@ -173,6 +175,8 @@ async function ensureTaskOrganisationOptionsLoaded() {
 }
 
 function resetTaskPanelScopedState(activeOrganisationConceptId, { actorChanged = false } = {}) {
+    _panelTaskIds = null;
+    _panelLoadGeneration += 1;
     _taskQueueActivityGeneration += 1;
     stopTaskQueueActivityPolling();
     _taskQueueActivityLoadPromise = null;
@@ -734,6 +738,7 @@ function pruneTaskDetailState() {
  * Call this once on page load to set up the panel element.
  */
 export function initializeTaskPanel() {
+    if (_panelEl?.isConnected && _panelEl.dataset.initialized === 'true') return;
     _panelEl = document.getElementById('taskPanel');
     _taskListEl = document.getElementById('taskList');
 
@@ -741,6 +746,9 @@ export function initializeTaskPanel() {
         console.warn('[taskPanel] Panel elements not found in DOM');
         return;
     }
+    // One existing popup, available from Messages as well as Conversations.
+    document.body.appendChild(_panelEl);
+    _panelEl.dataset.initialized = 'true';
     loadTaskGroupSelectionFromStorage();
     ensureTaskPanelOrganisationSwitchListener();
     ensureTaskPanelAuthStatusListener();
@@ -794,7 +802,7 @@ export function initializeTaskPanel() {
     // Set up refresh button
     const refreshBtn = document.getElementById('refreshTasksBtn');
     if (refreshBtn) {
-        refreshBtn.addEventListener('click', () => loadTasks(_currentSessionId));
+        refreshBtn.addEventListener('click', () => refreshTasks());
     }
 
     console.log('[taskPanel] Initialized');
@@ -804,24 +812,55 @@ export function initializeTaskPanel() {
  * Show the task panel.
  */
 export function showTaskPanel(options = {}) {
+    initializeTaskPanel();
     applyPanelOpenOptions(options);
     if (_panelEl) {
         loadTaskGroupSelectionFromStorage();
+        _globalTaskLoadGeneration += 1;
         _isGlobalTabMode = false;
         syncTaskQueueActivityPolling();
         _taskListEl = document.getElementById('taskList') || _taskListEl;
         _panelEl.classList.remove('hidden');
         _panelEl.setAttribute('aria-hidden', 'false');
+        _panelEl.querySelectorAll('.task-create-form, .task-filter-row').forEach(element => {
+            element.classList.toggle('hidden', _panelTaskIds !== null);
+        });
         _isVisible = true;
         // Auto-refresh tasks when panel becomes visible
-        refreshTasks();
+        return refreshTasks();
     }
 }
 
 function applyPanelOpenOptions(options = {}) {
     if (!options || typeof options !== 'object') return;
+    _panelTaskIds = Array.isArray(options.taskIds) ? [...new Set(options.taskIds.filter(Boolean))] : null;
+    _panelLoadGeneration += 1;
     if (Object.prototype.hasOwnProperty.call(options, 'sessionId')) {
         _currentSessionId = options.sessionId || null;
+    }
+}
+
+export async function openTaskInPanel(taskId) {
+    await showTaskPanel({ taskIds: [taskId], sessionId: null });
+    if (!_tasks.some(task => getTaskId(task) === taskId) || _isGlobalTabMode) return;
+    getTaskDetailState(taskId).expanded = true;
+    await loadTaskDetails(taskId);
+    _panelEl?.querySelector('.task-item')?.scrollIntoView?.({ block: 'nearest' });
+}
+
+async function loadReferencedPanelTasks() {
+    const generation = ++_panelLoadGeneration;
+    const scopeGeneration = _taskQueueActivityGeneration;
+    _tasks = [];
+    _taskDetailState = {};
+    renderTaskList();
+    try {
+        const tasks = await Promise.all(_panelTaskIds.map(id => getJson(`/api/tasks/${encodeURIComponent(id)}`)));
+        if (generation !== _panelLoadGeneration || scopeGeneration !== _taskQueueActivityGeneration || _isGlobalTabMode) return;
+        _tasks = tasks;
+        renderTaskList();
+    } catch (_) {
+        if (generation === _panelLoadGeneration) showToast('Could not load the referenced tasks.', 'error');
     }
 }
 
@@ -1224,6 +1263,8 @@ export function getTaskCount() {
  */
 export async function loadTasks(sessionId = null) {
     if (_isLoading) return;
+    const panelGeneration = _panelLoadGeneration;
+    const scopeGeneration = _taskQueueActivityGeneration;
 
     loadTaskGroupSelectionFromStorage();
     _isLoading = true;
@@ -1252,6 +1293,7 @@ export async function loadTasks(sessionId = null) {
         }
 
         const response = await getJson(url);
+        if (panelGeneration !== _panelLoadGeneration || scopeGeneration !== _taskQueueActivityGeneration) return;
         _tasks = response.tasks || [];
         setBulkTaskVisibilitySummary(response);
         pruneTaskDetailState();
@@ -1273,6 +1315,8 @@ export async function loadTasks(sessionId = null) {
  */
 export async function loadMyTasks(statusFilter = null) {
     if (_isLoading) return;
+    const panelGeneration = _panelLoadGeneration;
+    const scopeGeneration = _taskQueueActivityGeneration;
 
     loadTaskGroupSelectionFromStorage();
     _isLoading = true;
@@ -1281,6 +1325,7 @@ export async function loadMyTasks(statusFilter = null) {
     try {
         const url = buildMyTasksUrl(statusFilter);
         const response = await getJson(url);
+        if (panelGeneration !== _panelLoadGeneration || scopeGeneration !== _taskQueueActivityGeneration) return;
         _tasks = response.tasks || [];
         setBulkTaskVisibilitySummary(response);
         pruneTaskDetailState();
@@ -1457,6 +1502,8 @@ function buildTaskSearchText(task) {
 }
 
 function getFilteredTasks() {
+    // Exact references remain reachable regardless of saved list filters.
+    if (!_isGlobalTabMode && _panelTaskIds !== null) return _tasks;
     return _tasks.filter((task) => {
         if (!taskMatchesGlobalScope(task)) {
             return false;
@@ -1780,9 +1827,10 @@ function renderTaskList() {
 
     const previousScrollLeft = _taskListEl.scrollLeft;
     const previousScrollTop = _taskListEl.scrollTop;
-    const isBoardView = _viewMode === 'board';
+    const effectiveViewMode = !_isGlobalTabMode && _panelTaskIds !== null ? 'list' : _viewMode;
+    const isBoardView = effectiveViewMode === 'board';
     const scrollHintEl = _globalTasksContainer?.querySelector('#globalTaskBoardScrollHint');
-    _taskListEl.dataset.viewMode = _viewMode;
+    _taskListEl.dataset.viewMode = effectiveViewMode;
     _taskListEl.setAttribute('aria-label', isBoardView ? 'Task board' : 'Task list');
     if (isBoardView) {
         _taskListEl.setAttribute('aria-describedby', 'globalTaskBoardScrollHint');
@@ -1817,7 +1865,7 @@ function renderTaskList() {
     }
 
     let html = '';
-    if (_viewMode === 'list') {
+    if (effectiveViewMode === 'list') {
         const sortedTasks = [...filteredTasks].sort((left, right) => {
             const leftTimestamp = new Date(left.updated_at || left.created_at || 0).getTime();
             const rightTimestamp = new Date(right.updated_at || right.created_at || 0).getTime();
@@ -3997,6 +4045,8 @@ export function getTasks() {
 export async function refreshTasks() {
     if (_isGlobalTabMode) {
         await loadGlobalTasks();
+    } else if (_panelTaskIds !== null) {
+        await loadReferencedPanelTasks();
     } else if (_currentSessionId) {
         await loadTasks(_currentSessionId);
     } else {

--- a/src/frontend/web/von_interface/static/js/utils/messageStreamReference.js
+++ b/src/frontend/web/von_interface/static/js/utils/messageStreamReference.js
@@ -1,0 +1,21 @@
+/** Participant stream identity; this is not a chat-history session reference. */
+export function buildMessageStreamReference({ currentUserId, otherUserId, messages = [], displayName = '' }) {
+    if (!currentUserId || !otherUserId) return null;
+    return {
+        kind: 'von_message_stream_ref',
+        schema_version: 'message_stream_reference.v1',
+        message_stream_ref: {
+            participant_concept_ids: [...new Set([currentUserId, otherUserId])].sort(),
+            viewer_concept_id: currentUserId,
+            other_user_concept_id: otherUserId,
+        },
+        message_lookup: {
+            method: 'message_list_direct',
+            other_user_concept_id: otherUserId,
+            include_sent: true,
+            include_received: true,
+        },
+        visible_message_ids: messages.map(message => message.concept_id).filter(Boolean),
+        display: { name: displayName || `Conversation with ${otherUserId}` },
+    };
+}

--- a/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
+++ b/src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js
@@ -437,7 +437,8 @@ async function fetchConceptMetadata(conceptId, fetchFn) {
             bestName: bestName ? String(bestName) : null,
             shortestName: shortestName ? String(shortestName) : null,
             kind: json?.kind || json?.computed_kind || null,
-            names: names || null
+            names: names || null,
+            isTask: (json?.raw_doc?.relationships?.is_an_instance_of || []).includes('#V#task_specification')
         };
     } catch (_) {
         return null;
@@ -470,6 +471,7 @@ function updateCartouchesForConcept(conceptId, metadata) {
                 kindEl.textContent = formatKindLabel(kind);
             }
             el.dataset.kind = kind;
+            el.dataset.taskConcept = metadata.isTask ? 'true' : 'false';
             applyCartoucheAppearance(el, prefs);
         } catch (_) {
             // Ignore per-cartouche update failures.
@@ -1113,6 +1115,7 @@ export async function handleSelectConceptByIdDetail(detail, deps) {
     // Normal click: open in background.
     // Shift-click: open and switch to it.
     const shouldActivate = !!modifierKeys.shiftKey;
+    const hadConceptTab = [...document.querySelectorAll('.tab-button')].some(tab => tab.dataset.conceptId === id);
     const openConceptTab = (displayName, tabKind = null, { forceKindUpdate = false } = {}) => {
         const openOptions = {};
         if (tabKind) {
@@ -1151,6 +1154,12 @@ export async function handleSelectConceptByIdDetail(detail, deps) {
     if (exists) {
         const metadata = await fetchConceptMetadata(id, fetchFn);
         updateCartouchesForConcept(id, metadata);
+        if (metadata?.isTask && detail?.presentation !== 'concept') {
+            if (!hadConceptTab) deps?.closeDynamicConceptTab?.(id);
+            const openTask = deps?.openTaskPanel || (await import('../components/taskPanel.js')).openTaskInPanel;
+            await openTask(id);
+            return;
+        }
         const resolvedKind = metadata?.kind || kind || null;
         openConceptTab(metadata?.displayName || id, resolvedKind, {
             forceKindUpdate: !!resolvedKind

--- a/tests/backend/test_internal_mcp_direct_message_tools.py
+++ b/tests/backend/test_internal_mcp_direct_message_tools.py
@@ -5,6 +5,23 @@ from typing import Any
 import pytest
 
 
+def test_message_stream_lookup_keeps_trusted_actor_and_passes_counterpart(monkeypatch):
+    from src.backend.integrations.internal_mcp import catalogue
+    from src.backend.security.access_control import override_current_actor
+    from src.backend.services import message_service
+
+    calls = []
+    monkeypatch.setattr(message_service, 'get_messages_for_user', lambda **kwargs: calls.append(kwargs) or [])
+    with override_current_actor('#V#user_alice', '#V#org_test'):
+        result = catalogue._message_list_direct(
+            acting_user_concept_id='#V#user_alice', organisation_concept_id='#V#org_test',
+            other_user_concept_id='#V#codex_dgx', include_sent=True, include_received=True,
+        )
+    assert result['success'] is True
+    assert calls[0]['user_id'] == '#V#user_alice'
+    assert calls[0]['other_user_id'] == '#V#codex_dgx'
+
+
 def _message_doc(
     *,
     message_id: str = "#V#message_test",

--- a/tests/backend/test_message_service.py
+++ b/tests/backend/test_message_service.py
@@ -690,6 +690,40 @@ class TestGetMessage:
 class TestGetMessagesForUser:
     """Tests for get_messages_for_user function."""
 
+    def test_counterpart_filter_preserves_actor_mailbox(self, monkeypatch):
+        import mongomock
+        from src.backend.services import message_service as service
+
+        collection = mongomock.MongoClient().von_test.concepts
+        for ident, sender, recipient in [
+            ("out", "alice", "bob"),
+            ("in", "bob", "alice"),
+            ("private", "bob", "charlie"),
+            ("other", "alice", "charlie"),
+        ]:
+            collection.insert_one(
+                {
+                    "concept_id": ident,
+                    "relationships": {
+                        "is_an_instance_of": [service.MESSAGE_TYPE_CONCEPT_ID],
+                        service.PREDICATE_SENDER: [f"#V#{sender}"],
+                        service.PREDICATE_RECIPIENT: [f"#V#{recipient}"],
+                    },
+                }
+            )
+        monkeypatch.setattr(service, "get_concepts_collection", lambda: collection)
+        monkeypatch.setattr(service, "apply_concept_query_filter", lambda query: query)
+        assert {
+            row["concept_id"]
+            for row in service.get_messages_for_user("#V#alice", other_user_id="#V#bob")
+        } == {"in", "out"}
+        assert {
+            row["concept_id"]
+            for row in service.get_messages_for_user(
+                "#V#alice", include_sent=False, other_user_id="#V#bob"
+            )
+        } == {"in"}
+
     @patch("src.backend.services.message_service.get_concepts_collection")
     @patch("src.backend.services.message_service.apply_concept_query_filter")
     def test_get_messages_sent_and_received(

--- a/tests/frontend/messageStreamNavigation.test.js
+++ b/tests/frontend/messageStreamNavigation.test.js
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({ getJson: jest.fn(), postJson: jest.fn(), postJsonDetailed: jest.fn() }));
+jest.mock('../../src/frontend/web/von_interface/static/js/chatTab.js', () => ({ openChatSessionMenu: jest.fn() }));
+jest.mock('../../src/frontend/web/von_interface/static/js/components/taskPanel.js', () => ({ showTaskPanel: jest.fn() }));
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/selectConceptByIdHandler.js', () => ({ hydrateConceptCartouchesInRoot: jest.fn() }));
+jest.mock('../../src/frontend/web/von_interface/static/js/utils/copyJsonButtonState.js', () => ({ copyTextWithClipboardFallback: jest.fn(async () => true) }));
+const base = '../../src/frontend/web/von_interface/static/js/';
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="messagesContainer"></div>';
+    window.scrollTo = jest.fn();
+    const { getJson } = require(base + 'apiService.js');
+    getJson.mockImplementation(async url => {
+        if (url.includes('/threads')) return { current_user_id: '#V#michael', threads: [{ _id: ['#V#codex_dgx'], message_count: 1 }] };
+        if (url.includes('/conversation/')) return { current_user_id: '#V#michael', messages: [{ concept_id: '#V#message_one', concept_data: { content_fallback: 'Finished.' } }] };
+        return {};
+    });
+    const panel = require(base + 'components/messagePanel.js');
+    panel.initializeMessagePanel();
+    await panel.showMessagesTab();
+});
+afterEach(() => jest.clearAllMocks());
+
+test.each(['contextmenu', 'ctrlclick', 'keyboard'])('%s offers a copyable real message-stream reference', async gesture => {
+    const item = document.querySelector('.message-thread-item');
+    if (gesture === 'keyboard') item.dispatchEvent(new KeyboardEvent('keydown', { key: 'F10', shiftKey: true, bubbles: true }));
+    else item.dispatchEvent(new MouseEvent(gesture === 'ctrlclick' ? 'click' : 'contextmenu', { ctrlKey: gesture === 'ctrlclick', bubbles: true, cancelable: true }));
+    await flush();
+    const { openChatSessionMenu } = require(base + 'chatTab.js');
+    const items = openChatSessionMenu.mock.calls.at(-1)[2];
+    expect(items[0].label).toBe('Copy conversation reference');
+    await items[0].onClick();
+    const { copyTextWithClipboardFallback } = require(base + 'utils/copyJsonButtonState.js');
+    const copied = JSON.parse(copyTextWithClipboardFallback.mock.calls.at(-1)[0]);
+    expect(copied.message_stream_ref.participant_concept_ids).toEqual(['#V#codex_dgx', '#V#michael']);
+    expect(copied.message_lookup).toMatchObject({ method: 'message_list_direct', other_user_concept_id: '#V#codex_dgx' });
+    expect(copied.visible_message_ids).toEqual(['#V#message_one']);
+    expect(copied).not.toHaveProperty('conversation_ref');
+    expect(copied).not.toHaveProperty('chat_history_lookup');
+});
+
+test('Messages task button uses the existing task panel with represented task links', async () => {
+    document.querySelector('#messageViewContent').insertAdjacentHTML('beforeend', '<span data-task-concept="true" data-full-concept-id="#V#task_one"></span>');
+    document.getElementById('messageTaskPanelBtn').click();
+    await flush();
+    expect(require(base + 'components/taskPanel.js').showTaskPanel).toHaveBeenCalledWith({ taskIds: ['#V#task_one'], sessionId: null });
+});

--- a/tests/frontend/selectConceptByIdHandler.test.js
+++ b/tests/frontend/selectConceptByIdHandler.test.js
@@ -4,6 +4,19 @@ const handlerPath = '../../src/frontend/web/von_interface/static/js/utils/select
 const decoratorPath = '../../src/frontend/web/von_interface/static/js/utils/textDecorator.js';
 
 describe('handleSelectConceptByIdDetail', () => {
+    test('a represented task opens the shared task panel; explicit concept presentation remains available', async () => {
+        const { handleSelectConceptByIdDetail } = require(handlerPath);
+        const deps = {
+            createOrActivateConceptTab: jest.fn(), closeDynamicConceptTab: jest.fn(), openTaskPanel: jest.fn(),
+            fetchFn: jest.fn(async () => ({ ok: true, json: async () => ({ kind: 'individual', raw_doc: { relationships: { is_an_instance_of: ['#V#task_specification'] } } }) }))
+        };
+        await handleSelectConceptByIdDetail({ conceptId: '#V#example_task', createConceptTab: true }, deps);
+        expect(deps.openTaskPanel).toHaveBeenCalledWith('#V#example_task');
+        expect(deps.closeDynamicConceptTab).toHaveBeenCalledWith('#V#example_task');
+        deps.openTaskPanel.mockClear();
+        await handleSelectConceptByIdDetail({ conceptId: '#V#example_task', createConceptTab: true, presentation: 'concept' }, deps);
+        expect(deps.openTaskPanel).not.toHaveBeenCalled();
+    });
     beforeEach(() => {
         document.body.innerHTML = '<div></div>';
     });

--- a/tests/frontend/taskPanelReference.test.js
+++ b/tests/frontend/taskPanelReference.test.js
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({ getJson: jest.fn(), getUserContext: jest.fn(() => ({})) }));
+jest.mock('../../src/frontend/web/von_interface/static/js/tabNavigation.js', () => ({ activateTab: jest.fn() }));
+const base = '../../src/frontend/web/von_interface/static/js/';
+test('opens a completed referenced task from Messages outside the hidden Conversations tab', async () => {
+    document.body.innerHTML = '<div id="chatTab" hidden><div id="taskPanel" class="hidden"><div id="taskList"></div></div></div><div id="messagesTab"></div>';
+    const { getJson } = require(base + 'apiService.js');
+    getJson.mockImplementation(async url => url === '/api/tasks/%23V%23exact_task' ? { task_concept_id: '#V#exact_task', title: 'Exact completed task', status: 'completed', description: 'Original instructions' } : {});
+    await require(base + 'components/taskPanel.js').openTaskInPanel('#V#exact_task');
+    expect(document.getElementById('taskPanel').parentElement).toBe(document.body);
+    expect(document.getElementById('taskPanel').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('taskList').textContent).toContain('Exact completed task');
+    expect(document.querySelector('.task-detail-panel')).toBeTruthy();
+    expect(document.getElementById('taskList').dataset.viewMode).toBe('list');
+    expect(getJson.mock.calls.some(([url]) => url.startsWith('/api/tasks/my'))).toBe(false);
+});


### PR DESCRIPTION
Task links now open the existing task popup on the referenced task, including completed tasks, while preserving the current conversation or message stream. Messages gains the same task-panel button and Control-click, right-click and keyboard Copy conversation reference menu. Referenced tasks use a readable list within the popup; the relationship with the All Tasks tab is unchanged.

Message references describe actual participant streams and message IDs. The existing `message_list_direct` tool accepts a counterpart filter that narrows the trusted actor's mailbox.

Validated with 28 focused frontend tests, 47 backend messaging/tool tests, and an isolated Playwright browser using the real components and styles: exact task details, refresh, both menu gestures, Escape focus return, Messages tasks button and preserved draft. ESLint reports no errors. Public deployment and runtime/asset verification will follow merge under the user's explicit instruction.

Tracking: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2742
