### PR TITLE
Clear speech notices before the next user turn

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -37304,6 +37304,13 @@ async function handleSendPrompt(options = {}) {
         return;
     }
 
+    // Retire notices from the previous speech turn before submitting another
+    // user prompt. Active capture/playback keeps its own live feedback.
+    if (!assistantOpening) {
+        voiceConversation?.clearStatus();
+        dictationController?.clearStatus();
+    }
+
     const conceptQaSession = getConceptQaSessionForChat(targetSessionId);
     if (conceptQaSession && directComposerSubmission && !assistantOpening) {
         await submitActiveConceptQaPrompt({

--- a/src/frontend/web/von_interface/static/js/dictation.js
+++ b/src/frontend/web/von_interface/static/js/dictation.js
@@ -44,6 +44,7 @@ export function createDictationController({ input, button, status, cancelButton,
     const attemptIds = [];
     let engineChosen = false;
     let voiceActive = false;
+    let statusDismissed = false;
     let pressTimer = null, touchOrigin = null, suppressClick = false;
     const clearPress = () => { clearTimeout(pressTimer); pressTimer = null; touchOrigin = null; };
     const pointerDown = event => {
@@ -158,6 +159,7 @@ export function createDictationController({ input, button, status, cancelButton,
     }
 
     async function start() {
+        statusDismissed = false;
         if (current) cancel();
         const context = getContext();
         const capture = { key: context.key, context, base: input.value,
@@ -269,7 +271,7 @@ export function createDictationController({ input, button, status, cancelButton,
                 engineSelect.value = 'streaming';
                 engineChosen = true;
             }
-            render('idle', capability?.available
+            if (!statusDismissed && !voiceActive) render('idle', capability?.available
                 ? 'Recorded audio and visible conversation context are sent to OpenAI for transcription. Audio is not saved by Von.'
                 : capability?.reason || 'Recorded transcription is unavailable.');
         }
@@ -303,6 +305,10 @@ export function createDictationController({ input, button, status, cancelButton,
     render('idle');
     void refreshCapabilities();
     return { cancel, finish, start, refreshCapabilities,
+        clearStatus() {
+            statusDismissed = true;
+            if (!current && !voiceActive) render('idle');
+        },
         setVoiceActive: active => { voiceActive = active; render(state, status.textContent); }, getAttemptIds: () => [...attemptIds], clearAttemptIds: () => { attemptIds.length = 0; },
         getState: () => state, hasPendingInput: () => !!current,
         dispose: () => { clearPress(); cancel(); disposed = true;

--- a/src/frontend/web/von_interface/static/js/voiceConversation.js
+++ b/src/frontend/web/von_interface/static/js/voiceConversation.js
@@ -97,6 +97,7 @@ export function createVoiceConversation({ button, status, getContext, onSubmit, 
     root.addEventListener?.('pagehide', leave);
     root.document?.addEventListener('keydown', shortcut);
     return { start, end, reply, isActive: () => !!session,
+        clearStatus() { if (!session && !starting) status.textContent = ''; },
         dispose() { end(); disposed = true; playback.dispose(); button.removeEventListener('click', click);
             root.document?.removeEventListener('visibilitychange', hide); root.removeEventListener?.('pagehide', leave);
             root.document?.removeEventListener('keydown', shortcut); }

--- a/tests/frontend/chatTaskQueue.test.js
+++ b/tests/frontend/chatTaskQueue.test.js
@@ -3,7 +3,8 @@
 const chatTabModulePath = '../../src/frontend/web/von_interface/static/js/chatTab.js';
 
 jest.mock('../../src/frontend/web/von_interface/static/js/voiceConversation.js', () => ({
-    createVoiceConversation: jest.fn(() => ({ end: jest.fn(), dispose: jest.fn(), isActive: () => false, reply: jest.fn() }))
+    createVoiceConversation: jest.fn(({ status }) => ({ end: jest.fn(), dispose: jest.fn(), isActive: () => false, reply: jest.fn(),
+        clearStatus: jest.fn(() => { status.textContent = ''; }) }))
 }));
 
 jest.mock('../../src/frontend/web/von_interface/static/js/apiService.js', () => ({
@@ -79,7 +80,11 @@ describe('chat task queue', () => {
 
     test('voice utterances use canonical server enqueue with frozen speech correlation and a stable submission ID', async () => {
         const chat = require(chatTabModulePath);
-        document.body.insertAdjacentHTML('beforeend', '<button id="resetButton"></button><button id="voiceConversationButton"></button><p id="voiceConversationStatus"></p>');
+        document.body.insertAdjacentHTML('beforeend', `<button id="resetButton"></button>
+            <button id="voiceConversationButton"></button><p id="voiceConversationStatus"></p>
+            <button id="dictateButton"></button><p id="dictationStatus"></p>
+            <button id="cancelDictationButton"></button><button id="retryDictationButton"></button>
+            <select id="dictationEngineSelect"><option value="recorded">Recorded</option></select>`);
         const calls = [];
         global.fetch = jest.fn(async (url, options = {}) => {
             calls.push({ url, options });
@@ -98,6 +103,19 @@ describe('chat task queue', () => {
         expect(body).toMatchObject({ prompt_raw: 'Discuss Vontology', dispatch_mode: 'server', enqueue_submission_id: 'speech-attempt-item-one',
             execution_envelope: { client_context: { speech_attempt_ids: ['speech-attempt'], speech_item_id: 'item-one' } } });
         expect(calls.some(c => String(c.url).startsWith('/von/generate'))).toBe(false);
+        await flushMicrotasks();
+        const voiceStatus = document.getElementById('voiceConversationStatus');
+        const dictationStatus = document.getElementById('dictationStatus');
+        voiceStatus.textContent = 'Voice ended. Microphone released.';
+        dictationStatus.textContent = 'Recorded audio and visible conversation context are sent to OpenAI for transcription. Audio is not saved by Von.';
+        document.getElementById('thinkingCardWrapper').setAttribute('aria-hidden', 'false');
+        document.getElementById('promptInput').value = 'The following user turn';
+        const nextTurn = chat.sendMessage();
+        expect(voiceStatus.textContent).toBe('');
+        expect(dictationStatus.textContent).toBe('');
+        await nextTurn;
+        expect(voiceStatus.textContent).toBe('');
+        expect(dictationStatus.textContent).toBe('');
     });
 
     test('sends the stored Gemini choice as a bare model with its exact provider', async () => {

--- a/tests/frontend/dictation.test.js
+++ b/tests/frontend/dictation.test.js
@@ -34,6 +34,24 @@ describe('recorded dictation lifecycle', () => {
         await flush();
     });
     afterEach(() => controller.dispose());
+    test('next turn dismisses the audio notice through late and subsequent capability refreshes', async () => {
+        const status = document.querySelector('p');
+        expect(status.textContent).toContain('Recorded audio and visible conversation context');
+        const response = deferred();
+        fetchImpl.mockReturnValueOnce(response.promise);
+        const refresh = controller.refreshCapabilities();
+        controller.clearStatus();
+        expect(status.textContent).toBe('');
+        response.resolve({ ok: true, json: async () => ({ transcription: { available: true } }) });
+        await refresh;
+        await controller.refreshCapabilities();
+        expect(status.textContent).toBe('');
+        await controller.start();
+        expect(status.textContent).toContain('Listening');
+        controller.clearStatus();
+        expect(status.textContent).toContain('Listening');
+        expect(controller.hasPendingInput()).toBe(true);
+    });
     test('keeps the microphone icon and exposes recording state accessibly', async () => {
         const icon = buttons[0].querySelector('svg');
         await controller.start();

--- a/tests/frontend/voiceConversation.test.js
+++ b/tests/frontend/voiceConversation.test.js
@@ -35,6 +35,21 @@ test('End cancels capture and playback; late final cannot submit', async () => {
     expect(input.cancel).toHaveBeenCalled(); expect(playback.stop).toHaveBeenCalledWith('ended');
     expect(submit).not.toHaveBeenCalled();
 });
+test('next user turn clears the ended notice without stopping active voice', async () => {
+    await voice.start();
+    const status = document.querySelector('p');
+    const activeStatus = status.textContent;
+    voice.clearStatus();
+    expect(status.textContent).toBe(activeStatus);
+    expect(input.cancel).not.toHaveBeenCalled();
+    callbacks.onFinal('Voice turn', 'one');
+    voice.end();
+    expect(status.textContent).toBe('Voice ended. Microphone released.');
+    voice.clearStatus();
+    expect(status.textContent).toBe('');
+    callbacks.onPartial('late caption');
+    expect(status.textContent).toBe('');
+});
 test('conversation switch ends capture before next final can write elsewhere', async () => {
     await voice.start(); context = { key: 'other', sessionId: 'other' }; callbacks.onFinal('wrong scope', 'one');
     expect(input.cancel).toHaveBeenCalled(); expect(submit).not.toHaveBeenCalled();


### PR DESCRIPTION
Clear the ended-voice and audio-transcription notices when the next user prompt is submitted, while preserving active capture and playback feedback. Dismissed dictation notices stay cleared across delayed capability responses and later focus refreshes.

Validation: all 52 tests in dictation, voiceConversation and chatTaskQueue passed; static frontend lint and git diff checks passed. The chat-path regression checks both status fields before the next submission proceeds with the thinking card visible. Evidence is DOM-based with mocked media/network, not live microphone or deployed-browser acceptance.

Von task: #V#task_agent_c66ddf14a5785b411642237351bf91e8. No deployment requested.
