### PR TITLE
Reveal the latest chat turn on submission

### DIFF
--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -37590,6 +37590,10 @@ async function handleSendPrompt(options = {}) {
     // Add user message to chat with turnId
     if (isRequestVisible() && userTurnShouldRender) {
         appendMessage('User', promptText, userTurnId, false, false, userTurnTimestamp);
+        // Sending explicitly returns to the latest turn, even from older history.
+        // Do this after the thinking card and user message have changed the layout;
+        // incoming responses still respect any subsequent manual scroll away.
+        scrollConversationToEnd(document.getElementById('scrollableField'), { smooth: false });
         // Fire-and-forget annotate user turn (do not await) - only if toggle is enabled
         const annotationToggle = document.getElementById('annotationToggle');
         if (annotationToggle && annotationToggle.checked) {

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -8054,6 +8054,69 @@ describe('thinking card toggle accessibility', () => {
         expect(fetchCalls.some(({ url }) => String(url).includes('/finish'))).toBe(false);
     });
 
+    test.each([false, true])('sending reveals the new turn and respects manual scrolling during the response (scroll away: %s)', async (scrollAway) => {
+        const { getUserContext } = require('../apiService.js');
+        getUserContext.mockReturnValue({ user_id: 'user', org_id: 'org', language: 'en-NZ' });
+        document.getElementById('promptInput').value = 'Show the latest turn';
+        const originalHeight = Object.getOwnPropertyDescriptor(document.documentElement, 'scrollHeight');
+        const originalViewport = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+        const originalScroll = Object.getOwnPropertyDescriptor(window, 'scrollY');
+        Object.defineProperty(document.documentElement, 'scrollHeight', {
+            configurable: true,
+            get: () => 1800 + document.querySelectorAll('.message-container').length * 300
+        });
+        Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true });
+        Object.defineProperty(window, 'scrollY', { value: 100, writable: true, configurable: true });
+        jest.spyOn(window, 'scrollTo').mockImplementation(({ top }) => {
+            window.scrollY = Math.min(top, document.documentElement.scrollHeight - window.innerHeight);
+        });
+        let resolveGenerate;
+        global.fetch = jest.fn((url, options = {}) => {
+            if (url === '/von/api/chat_prompt_queue' && options.method === 'POST') {
+                return Promise.resolve({ ok: true, json: async () => ({ item: {
+                    queue_id: 'queue-scroll-test', session_id: 'thinking-card-test-session',
+                    prompt_raw: 'Show the latest turn', status: 'queued'
+                } }) });
+            }
+            if (String(url).startsWith('/von/generate')) {
+                return new Promise((resolve) => {
+                    resolveGenerate = () => resolve({ ok: true, json: async () => ({ response: 'Latest answer' }) });
+                });
+            }
+            return Promise.resolve({ ok: true, json: async () => ({}) });
+        });
+        try {
+            const sending = sendMessage();
+            for (let flush = 0; flush < 40 && !resolveGenerate; flush += 1) {
+                await Promise.resolve();
+            }
+            expect(resolveGenerate).toBeDefined();
+            expect(document.querySelector('.user-turn').textContent).toContain('Show the latest turn');
+            expect(window.scrollY).toBe(document.documentElement.scrollHeight - window.innerHeight);
+            if (scrollAway) window.scrollY = 100;
+            window.scrollTo.mockClear();
+            resolveGenerate();
+            await sending;
+            expect(document.querySelector('.assistant-turn')).toBeTruthy();
+            if (scrollAway) {
+                expect(window.scrollTo).not.toHaveBeenCalled();
+                expect(window.scrollY).toBe(100);
+            } else {
+                expect(window.scrollTo).toHaveBeenCalled();
+                expect(window.scrollY).toBe(document.documentElement.scrollHeight - window.innerHeight);
+            }
+        } finally {
+            for (const [target, key, descriptor] of [
+                [document.documentElement, 'scrollHeight', originalHeight],
+                [window, 'innerHeight', originalViewport],
+                [window, 'scrollY', originalScroll]
+            ]) {
+                if (descriptor) Object.defineProperty(target, key, descriptor);
+                else delete target[key];
+            }
+        }
+    });
+
     test('preserves the active user turn when a delayed history load finishes after send', async () => {
         const { getUserContext } = require('../apiService.js');
         jest.spyOn(window, 'scrollTo').mockImplementation(() => {});


### PR DESCRIPTION
Merge decision: ready — submitting a chat turn reveals the newly added content while subsequent incoming responses continue to respect manual scrolling.

## User outcome

Sending from earlier in the conversation currently leaves the viewport in place because the append renderer follows messages only when already near the bottom. Showing the thinking card before appending can also move that bottom before the check.

## Material changes

Scroll to the page end immediately after rendering the visible submitted turn and thinking card. Keep the existing near-bottom behaviour for incoming output and background/history rendering. No server, represented-authority, or model changes.

Von task: `#V#task_agent_9b0f5c7bd0c6e3265d7dcefc9c434bba`.

## Evidence

- Two regression cases exercise the actual send handler with a deferred response: submission reveals the new turn, an answer follows when still at the bottom, and scrolling away while waiting is preserved. Both fail on the original implementation (scroll position remains 100 instead of 1500) and pass with the fix.
- Full chatTab Jest file: 289 passed, 2 failed. The unchanged baseline has the same two unrelated unnamed-conversation aria-label failures (287 passed, 2 failed).
- Static frontend ESLint and `git diff --check` pass.
- Tier 1, mocked DOM/network evidence. No live-browser acceptance; the screenshot's Von file reference was not accessible through this worker's tools.

## Ship boundary

Minimum criteria are revealing a submitted turn and preserving subsequent manual scrolling, covered by the send-path regression tests. Failure of either blocks delivery. The existing conversation-label test failures do not change the merge decision. Deployment, late image/Markdown layout changes, and unrelated conversation-label repairs are outside this change. No deployment requested.
