### PR TITLE
Separate active chat steering from queued follow-up requests

### DIFF
--- a/docs/design_index.md
+++ b/docs/design_index.md
@@ -97,6 +97,7 @@ live.
 | Evaluation, benchmarks, or research-sensitive architecture | [agent evaluation and research uptake](engineering/agent_evaluation_and_research_uptake.md) |
 | Minimal imposition, elicitation, or write policy | [minimal-imposition principle](engineering/minimal_imposition_design_principle.md) |
 | Frontend or browser acceptance | [Frontend browser validation](engineering/frontend_browser_user_view_validation.md), at the validation tier justified by the claim |
+| Steering an active chat turn versus queueing a follow-up | [Chat steering and queueing](engineering/chat_steering_and_queueing.md) |
 | Dictation, audio transcription or mobile speech playback | [Speech I/O](engineering/speech_io.md); current conversational delivery plan remains in its linked Jira issue |
 | Live user-visible behaviour or telemetry diagnosis | Applicable sections of the [real-path replay and telemetry loop](engineering/real_path_server_replay_and_telemetry_loop.md), using the risk tier in `AGENTS.md` |
 | Substantial Jira task definition or pull-request merge boundary | The decision discipline in [`AGENTS.md`](../AGENTS.md#5-capability-slice-planning), the practical [Jira guidance](engineering/operational_engineering_guide.md#53-jira) and [merge-decision procedure](engineering/operational_engineering_guide.md#62-make-new-evidence-change-a-decision), and the [pull-request template](../.github/PULL_REQUEST_TEMPLATE.md) |

--- a/docs/engineering/chat_steering_and_queueing.md
+++ b/docs/engineering/chat_steering_and_queueing.md
@@ -1,0 +1,97 @@
+# Chat steering and queueing
+
+- **Kind:** Capability reference
+- **Lifecycle:** Active
+- **Scope:** Ordinary adaptive chat turns; text steering and existing prompt queue
+- **Owner:** Von maintainers
+- **Last reviewed:** 11 September 2026
+- **Review trigger:** Changes to turn admission, model continuation or composer submission
+
+“Q” means queueing here. The existing chat code provides a durable FIFO prompt
+queue; no separate Q product operation was found in the assigned task or code.
+The source conversation was unavailable; the task description was sufficient.
+
+The user job is to correct ongoing work without accidentally scheduling the
+correction as a separate job, while retaining an explicit way to request later
+work. The baseline is the existing Queue Prompt path. Semantic interpretation
+of guidance remains with the active model, under its original actor and tool
+authority. No represented workflow or new prompt policy is needed.
+
+## Interaction
+
+During a running turn, **Steer** sends composer text to that exact attempt.
+**Queue Prompt** (including the ordinary Enter/send action) continues to submit
+an independent FIFO request. Steering neither consumes nor reorders the queue.
+When idle, the ordinary Send Prompt action starts a turn.
+
+The composer shows pending steering and allows **Cancel steer** until the active
+turn has taken it. After delivery, withdrawal is rejected: another steer can
+correct it, or the existing Stop action can request turn cancellation. Neither
+steering nor Stop claims to undo completed tool effects. Steering waits for the
+next model boundary, including completion of a running tool batch; it does not
+interrupt an in-flight provider request or tool execution.
+
+Text-only steering is disabled while attachments or unfinished dictation are
+present. The established queue/send path handles those inputs. Imported
+read-only conversations and concept Q&A do not expose this ordinary-turn action.
+
+A successful submission clears only the unchanged draft in the same session.
+Failures retain it. An uncertain network response can be retried with the same
+submission ID. Session/organisation switches suppress stale acknowledgements;
+receipts for visited sessions remain in browser memory and pending active-turn
+receipts can be fetched again from the server.
+
+## State and persistence
+
+`/von/api/chat_prompt_queue/<queue_id>/steering` supports POST, GET and DELETE.
+It reuses the queue's authenticated actor/organisation scope. A POST also names
+the exact admitted attempt and a client-generated idempotency ID. Body identity
+fields never supply authority. A wrong actor or attempt cannot steer that turn.
+
+The existing queue document contains the ordered mailbox and delivery/withdrawal
+receipts. No collection, index or data migration is required. The embedded
+mailbox is limited to 100 submissions and 100,000 total characters per record,
+so prompt text cannot grow the document beyond its storage boundary.
+
+- **pending:** durably accepted, awaiting the active turn's model boundary;
+- **delivered:** taken by the active turn for context/history insertion;
+- **cancelled:** withdrawn before delivery;
+- **not_applied:** still unread when the attempt stopped/ended or was replaced.
+
+Delivery is a handoff receipt, not proof of model compliance, provider success
+or an external effect. A crash between mailbox take and context/history
+insertion can leave a delivery receipt without a completed model call; the
+original text remains available through canonical GET for reconciliation.
+This path does not replay delivered guidance or executed tools after a crash.
+
+At a normal final answer boundary, mailbox closure and POST acceptance are
+serialised on the same record. Already accepted guidance causes another model
+call in the same turn. Guidance arriving after closure is rejected with the
+draft retained. Pending guidance at error/cancellation is shown as not applied;
+it is not silently converted into a different queued task. Users can choose to
+queue it. Completed receipts remain available through exact scoped GET for the
+queue record's existing retention period. A page reload after terminalisation
+does not discover old queue receipts automatically; delivered guidance is also
+written as attributed user history before the final assistant answer.
+
+Native model continuation is reset when guidance arrives, retaining the original
+job and bounded tool receipts in the local context. This ensures new guidance
+is visible without repeating tools. Final synthesis retains the guidance too.
+Queue records and ordinary conversation history remain their respective
+canonical stores; no Vontology semantics are changed.
+
+## Reference and validation
+
+GitHub's [Copilot SDK steering and queueing documentation](https://docs.github.com/en/copilot/how-tos/copilot-sdk/features/steering-and-queueing)
+describes the same core distinction: guidance inside a turn versus sequential
+follow-up turns. Von deliberately reports late/unread steering instead of
+silently turning it into a new task. The reference supports the interaction
+choice, not a claim that every current chatbot has identical behaviour.
+
+Targeted tests cover mailbox order and idempotency, exact actor/attempt scope,
+withdrawal, terminal races, retried attempts, bounded storage, model-boundary
+injection, retained tool evidence, and composer acknowledgement/session races.
+The real Flask generation route is exercised with a test model and mock storage;
+no live model is required. A Chromium fixture uses the repository composer
+markup and styles at 375px to exercise submit, pending feedback and cancellation.
+This is fixture-backed acceptance, not authenticated public-server validation.

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1663,6 +1663,40 @@ def update_chat_prompt_queue_route(queue_id: str):
         )
 
 
+@von_bp.route(
+    "/api/chat_prompt_queue/<queue_id>/steering", methods=["GET", "POST", "DELETE"]
+)
+def chat_prompt_steering_route(queue_id: str):
+    from ...services import chat_steering_service
+
+    scope = _get_current_chat_prompt_queue_scope()
+    if isinstance(scope, tuple):
+        return scope
+    try:
+        payload = _chat_prompt_queue_payload()
+        if request.method == "POST":
+            result = chat_steering_service.submit(
+                scope=scope,
+                queue_id=queue_id,
+                attempt_id=payload.get("attempt_id"),
+                submission_id=payload.get("submission_id"),
+                text=payload.get("text"),
+            )
+        elif request.method == "DELETE":
+            result = chat_steering_service.cancel(
+                scope=scope,
+                queue_id=queue_id,
+                submission_id=payload.get("submission_id"),
+            )
+        else:
+            result = chat_steering_service.read(scope=scope, queue_id=queue_id)
+        return jsonify({"success": True, **result})
+    except Exception as exc:
+        return _chat_prompt_queue_error_response(
+            exc, action="steer", queue_id=queue_id, scope=scope
+        )
+
+
 @von_bp.route("/api/chat_prompt_queue/<queue_id>", methods=["DELETE"])
 def cancel_chat_prompt_queue_route(queue_id: str):
     scope = _get_current_chat_prompt_queue_scope()
@@ -13867,7 +13901,39 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
                 )
             assistant_opening_claimed = True
 
+        def _take_steering(*, close_if_empty: bool = False):
+            from ...services import chat_steering_service
+
+            token = getattr(g, _TURN_ADMISSION_CONTEXT_KEY, None)
+            if token is None or not getattr(token, "attempt_id", None):
+                return []
+            steering_items = chat_steering_service.take(
+                scope=token.scope,
+                queue_id=token.queue_id,
+                attempt_id=token.attempt_id,
+                close_if_empty=close_if_empty,
+            )
+            for item in steering_items:
+                if history_user_id:
+                    _add_chat_history_message(
+                        user_id=history_user_id,
+                        session_id=session_id,
+                        message={
+                            "role": "user",
+                            "content": item["text"],
+                            "author_user_id": user_concept_id,
+                            "turn_id": f"steer-{request_id}-{item['id']}",
+                            "steering_submission_id": item["id"],
+                        },
+                        namespace=history_namespace,
+                        organisation_concept_id=org_concept_id,
+                        role_in_org=role_in_org,
+                        skip_rag_indexing=True,
+                    )
+            return steering_items
+
         adaptive_turn_result = execute_adaptive_turn(
+            steering_reader=_take_steering,
             gateway=gateway,
             prompt=prompt_text,
             context=adaptive_input_context,
@@ -13933,7 +13999,12 @@ def _generate_impl():  # pyright: ignore[reportGeneralTypeIssues]
             and bool(response_text.strip())
         )
         adaptive_delivery_success = adaptive_success or adaptive_partial_delivery
-        tool_messages = [dict(msg) for msg in adaptive_turn_result.extra_messages]
+        # Steering user messages were attributed and persisted on receipt,
+        # including turns that later stop. Finalisation must not append them twice.
+        tool_messages = [
+            dict(msg) for msg in adaptive_turn_result.extra_messages
+            if not msg.get("steering_submission_id")
+        ]
         tool_invocations = list(adaptive_turn_result.tool_invocations)
         auxiliary_llm_calls.extend(adaptive_turn_result.aux_llm_calls)
         deterministic_situation_projection: Mapping[str, Any] | None = None

--- a/src/backend/services/adaptive_turn_service.py
+++ b/src/backend/services/adaptive_turn_service.py
@@ -6807,6 +6807,7 @@ def execute_adaptive_turn(
     model_registry_snapshot: Any = None,
     learning_advice_projection: Mapping[str, Any] | None = None,
     model_request_observer: Callable[[Mapping[str, Any]], None] | None = None,
+    steering_reader: Callable[..., Sequence[Mapping[str, Any]]] | None = None,
     allow_represented_workflow_discovery: bool = True,
     allow_represented_tool_projection: bool = True,
     turn_budget_seconds: float | None = None,
@@ -9138,7 +9139,48 @@ def execute_adaptive_turn(
             },
         )
 
+    steering_received = False
+
+    def receive_steering(*, close_if_empty: bool = False) -> bool:
+        nonlocal continuation, pending_results, steering_received
+        if steering_reader is None:
+            return False
+        items = steering_reader(close_if_empty=close_if_empty)
+        if not items:
+            return False
+        if not steering_received:
+            current_context.append({"role": "user", "content": prompt})
+        for previous in extra_messages:
+            if previous not in current_context:
+                current_context.append(dict(previous))
+        steering_received = True
+        for item in items:
+            message = {
+                "role": "user",
+                "content": str(item["text"]),
+                "steering_submission_id": item["id"],
+            }
+            current_context.append(message)
+            extra_messages.append(message)
+            if final_context_base is not None:
+                final_context_base.append(dict(message))
+        # Rebuild from the complete local transcript, including prior tool
+        # receipts, so provider continuation state cannot hide the new input.
+        continuation = None
+        pending_results = []
+        _emit(
+            progress_tracker,
+            {
+                "status": "thinking",
+                "phase_label": "Steering received",
+                "result_summary": "New user guidance added to the active turn.",
+            },
+        )
+        return True
+
     while True:
+        _check_cancellation(progress_tracker)
+        receive_steering()
         model_call_sequence += 1
         model_call_id = f"{turn_id or 'adaptive-turn'}:llm:{model_call_sequence}"
         _check_cancellation(progress_tracker)
@@ -9226,7 +9268,7 @@ def execute_adaptive_turn(
             and _render_learning_advice_projection(prepared_learning_advice)
         )
         pending_elapsed_time_advisories.clear()
-        provider_prompt = "" if continuation is not None else prompt
+        provider_prompt = "" if continuation is not None or steering_received else prompt
         _observe_model_request(
             model_request_observer,
             model_call_id=model_call_id,
@@ -9769,6 +9811,8 @@ def execute_adaptive_turn(
             )
         if not calls:
             if response.text_response.strip():
+                if receive_steering(close_if_empty=True):
+                    continue
                 return finish(response.text_response.strip())
             if provider_tool_call_diagnostics:
                 available_tool_names = [tool.name for tool in request_tools]

--- a/src/backend/services/chat_steering_service.py
+++ b/src/backend/services/chat_steering_service.py
@@ -1,0 +1,186 @@
+"""Attempt-bound steering mailbox on the existing durable prompt queue record.
+
+Steering never changes FIFO admission or grants a new actor's authority. Delivery
+means copied into the active model context, not that a requested effect occurred.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+from pymongo import ReturnDocument
+
+from . import chat_prompt_queue_service as queue
+
+
+def _query(scope: Mapping[str, Any], queue_id: str) -> dict[str, Any]:
+    return {
+        **queue._compatible_scope_query(scope),
+        "queue_id": queue._coerce_scope_value(queue_id, field="queue_id"),
+    }
+
+
+def read(*, scope: Mapping[str, Any], queue_id: str) -> dict[str, Any]:
+    doc = queue._collection().find_one(_query(scope, queue_id))
+    if doc is None:
+        raise queue.ChatPromptQueueRecordNotFound("Turn not found")
+    pending = doc.get("steering_pending", [])
+    cancelled = doc.get("steering_cancelled", [])
+    delivered = doc.get("steering_delivered", [])
+    active = doc.get("status") == queue.STATUS_IN_PROGRESS and not doc.get(
+        "cancellation_requested_at"
+    )
+    items = []
+    for item in doc.get("steering_messages", []):
+        if item["id"] in cancelled:
+            status = "cancelled"
+        elif item["id"] in delivered:
+            status = "delivered"
+        elif (
+            active
+            and item.get("attempt_id") == doc.get("attempt_id")
+            and item["id"] in pending
+        ):
+            status = "pending"
+        else:
+            status = "not_applied"
+        items.append({**item, "status": status})
+    return {"queue_id": queue_id, "items": items}
+
+
+def submit(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    attempt_id: str,
+    submission_id: str,
+    text: str,
+) -> dict[str, Any]:
+    attempt_id = queue._coerce_scope_value(attempt_id, field="attempt_id")
+    submission_id = queue._coerce_scope_value(submission_id, field="submission_id")
+    if (
+        len(submission_id) > 200
+        or not isinstance(text, str)
+        or not text.strip()
+        or len(text) > queue.MAX_PROMPT_RAW_CHARS
+    ):
+        raise queue.InvalidChatPromptQueueInput(
+            "Supply a non-empty steering message within the prompt size limit"
+        )
+    query = {**_query(scope, queue_id), "attempt_id": attempt_id}
+    item = {"id": submission_id, "text": text, "attempt_id": attempt_id}
+    doc = queue._collection().find_one_and_update(
+        {
+            **query,
+            "status": queue.STATUS_IN_PROGRESS,
+            "active_conversation_key": {"$exists": True},
+            "cancellation_requested_at": {"$exists": False},
+            "steering_closed_attempt_id": {"$ne": attempt_id},
+            "steering_messages.id": {"$ne": submission_id},
+            # Keep this embedded mailbox below Mongo's document size boundary.
+            "steering_messages.99": {"$exists": False},
+            "$or": [
+                {"steering_char_count": {"$exists": False}},
+                {
+                    "steering_char_count": {
+                        "$lte": queue.MAX_PROMPT_RAW_CHARS - len(text)
+                    }
+                },
+            ],
+        },
+        {
+            "$push": {"steering_messages": item, "steering_pending": submission_id},
+            "$inc": {"steering_char_count": len(text)},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        doc = queue._collection().find_one(query)
+        previous = next(
+            (
+                m
+                for m in (doc or {}).get("steering_messages", [])
+                if m["id"] == submission_id
+            ),
+            None,
+        )
+        if previous != item:
+            raise queue.ChatPromptQueueRecordNotFound(
+                "Steering was not accepted: the turn ended, is stopping, the mailbox is full, or the message conflicts. Your draft can be queued instead.",
+                error_code="steering_not_accepted",
+            )
+    return read(scope=scope, queue_id=queue_id)
+
+
+def cancel(
+    *, scope: Mapping[str, Any], queue_id: str, submission_id: str
+) -> dict[str, Any]:
+    submission_id = queue._coerce_scope_value(submission_id, field="submission_id")
+    query = _query(scope, queue_id)
+    doc = queue._collection().find_one_and_update(
+        {**query, "steering_pending": submission_id},
+        {
+            "$pull": {"steering_pending": submission_id},
+            "$addToSet": {"steering_cancelled": submission_id},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        doc = queue._collection().find_one(
+            {**query, "steering_cancelled": submission_id}
+        )
+        if doc is None:
+            raise queue.ChatPromptQueueRecordNotFound(
+                "Steering already delivered or not found; it cannot be withdrawn"
+            )
+    return read(scope=scope, queue_id=queue_id)
+
+
+def take(
+    *,
+    scope: Mapping[str, Any],
+    queue_id: str,
+    attempt_id: str,
+    close_if_empty: bool = False,
+) -> list[dict[str, str]]:
+    query = {
+        **_query(scope, queue_id),
+        "attempt_id": attempt_id,
+        "status": queue.STATUS_IN_PROGRESS,
+        "cancellation_requested_at": {"$exists": False},
+    }
+    coll = queue._collection()
+    while True:
+        if close_if_empty:
+            closed = coll.find_one_and_update(
+                {**query, "steering_pending.0": {"$exists": False}},
+                {"$set": {"steering_closed_attempt_id": attempt_id}},
+            )
+            if closed is not None:
+                return []
+        doc = coll.find_one({**query, "steering_pending.0": {"$exists": True}})
+        if not doc:
+            if close_if_empty and coll.find_one(query):
+                # Withdrawal raced final closure: retry the empty-mailbox CAS.
+                continue
+            return []
+        pending = doc["steering_pending"]
+        items = [
+            m
+            for m in doc.get("steering_messages", [])
+            if m["id"] in pending and m.get("attempt_id") == attempt_id
+        ]
+        changed = coll.find_one_and_update(
+            {**query, "steering_pending": pending},
+            {
+                "$set": {"steering_pending": []},
+                "$addToSet": {
+                    "steering_delivered": {"$each": [m["id"] for m in items]}
+                },
+            },
+        )
+        if changed is None:
+            # A submit/withdrawal raced this snapshot; preserve its ordering.
+            continue
+        if items or not close_if_empty:
+            return items
+        # Only stale-attempt input remained. Close this attempt atomically too.

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,10 +1,11 @@
+import { createChatSteeringControls } from './components/chatSteeringControls.js';
 import { setButtonLabel } from './utils/buttonLabel.js';
 import { createConversationTray } from './components/conversationTray.js';
 import { CONVERSATION_LAYOUT_KEY, CONVERSATION_LAYOUT_KEYS, CONVERSATION_NARROW_QUERY, loadConversationLayoutPreferences, normaliseConversationLayout, saveConversationLayoutPreference } from './utils/conversationLayoutPreferences.js';
 import { createVoiceConversation } from './voiceConversation.js';
 import { getClientContext } from './clientContext.js';
 import { createDictationController } from './dictation.js';
-import { renderImageAttachments, renderImageComposer, uploadConversationImage, imagesBlocked, takeImages, restoreImages, descriptorsForIds } from "./utils/conversationImages.js";
+import { renderImageAttachments, renderImageComposer, uploadConversationImage, imagesBlocked, imageItems, takeImages, restoreImages, descriptorsForIds } from "./utils/conversationImages.js";
 // Chat Tab Module
 import { annotateTurn, fetchWithTimeout, getJsonDetailed, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
 import {
@@ -6664,6 +6665,9 @@ function updateExternalConversationUi() {
     updateSendButtonForCurrentChatState();
 }
 
+let chatSteeringControls = null;
+let chatSteeringSendButton = null;
+
 function updateSendButtonForCurrentChatState() {
     const sendButton = document.getElementById('sendButton');
     if (!sendButton) {
@@ -6703,6 +6707,34 @@ function updateSendButtonForCurrentChatState() {
         || conceptQaBusy
         || conceptQaTerminal
         || conceptQaAwaitingInitialQuestion;
+    if (chatSteeringSendButton !== sendButton) {
+        chatSteeringControls?.dispose();
+        chatSteeringSendButton = sendButton;
+        chatSteeringControls = createChatSteeringControls({
+            sendButton,
+            request: fetchChatPromptQueueJson,
+            getDraft: () => getPromptInputElement()?.value || '',
+            clearDraft: (submitted) => {
+                const input = getPromptInputElement();
+                if (input?.value === submitted) setPromptComposerValue('', { promptInput: input });
+            },
+            createId: createClientRequestId
+        });
+    }
+    const steeringRecord = queuedChatPrompts.find(entry =>
+        entry.sessionId === activeChatSessionId && entry.status === CHAT_PROMPT_QUEUE_STATUS_IN_PROGRESS
+        && entry.queueId && entry.attemptId);
+    const liveRequest = getLiveChatRequestForSession();
+    const steeringTarget = steeringRecord || (liveRequest?.promptQueueRecordId && liveRequest?.attemptId
+        ? { queueId: liveRequest.promptQueueRecordId, attemptId: liveRequest.attemptId } : null);
+    chatSteeringControls.update({
+        scopeKey: `${chatOrganisationGeneration}:${activeChatSessionId}`,
+        target: readOnly || conceptQaSession ? null : steeringTarget,
+        disabled: sendButton.disabled || pendingChatOrganisationSwitchId !== null
+            || pendingFileCopyConceptIdsBySession.has(getPendingFileCopySessionKey(activeChatSessionId))
+            || imageItems(activeChatSessionId).length > 0
+            || !!dictationController?.hasPendingInput()
+    });
     sendButton.setAttribute(
         'aria-busy',
         chatCreationInFlight || queueSubmissionInFlight || conceptQaBusy ? 'true' : 'false'
@@ -6744,7 +6776,9 @@ function updateSendButtonForCurrentChatState() {
     } else if (uploadInFlight) {
         sendButton.title = ATTACHMENT_UPLOAD_SEND_BLOCK_MESSAGE;
     } else {
-        sendButton.title = sessionBusy ? 'Queue Prompt' : 'Send Prompt';
+        sendButton.title = sessionBusy
+            ? 'Queue a separate request after the current turn finishes. Use Steer to guide the active turn.'
+            : 'Send Prompt';
     }
 }
 
@@ -37215,6 +37249,7 @@ function getQueuedChatPromptHeadsBySession() {
 }
 
 async function handleSendPrompt(options = {}) {
+    if (!options?.fromQueue && !options?.observeServerDispatch && chatSteeringControls?.isSending()) return;
     if (pendingChatOrganisationSwitchId !== null) {
         return;
     }
@@ -41965,6 +42000,9 @@ export function __testOnly_handleChatPromptQueueStorageEvent(event) {
     handleChatPromptQueueStorageEvent(event);
 }
 export function __testOnly_resetChatRequestState() {
+    chatSteeringControls?.dispose();
+    chatSteeringControls = null;
+    chatSteeringSendButton = null;
     if (conversationRuntimeCostState.handoverRetryTimerId) {
         clearTimeout(conversationRuntimeCostState.handoverRetryTimerId);
     }

--- a/src/frontend/web/von_interface/static/js/components/chatSteeringControls.js
+++ b/src/frontend/web/von_interface/static/js/components/chatSteeringControls.js
@@ -1,0 +1,150 @@
+/** Steering is bound to the displayed actor/session and exact active attempt. */
+export function createChatSteeringControls({ sendButton, request, getDraft, clearDraft, createId }) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.id = 'steerButton';
+    button.className = 'btn btn-secondary';
+    button.textContent = 'Steer';
+    button.title = 'Guide the active turn at its next model boundary. Running tools are not undone. Text only; use Queue Prompt for attachments.';
+    sendButton.before(button);
+    const feedback = document.createElement('div');
+    feedback.className = 'chat-steering-feedback';
+    feedback.setAttribute('aria-live', 'polite');
+    sendButton.parentElement.after(feedback);
+    let current = {};
+    let scopeKey;
+    let records = new Map();
+    const recordsByScope = new Map();
+    let timer;
+    let sending = false;
+    let retry = null;
+    let notice = '';
+    let generation = 0;
+    function receiptItems(data) {
+        if (!Array.isArray(data?.items)) throw new Error('Invalid steering status response');
+        return data.items;
+    }
+    const path = (id) => `/${encodeURIComponent(id)}/steering`;
+    const labels = {
+        pending: 'Pending steer — waiting for the next model boundary',
+        delivered: 'Delivered to active turn',
+        cancelled: 'Steer cancelled',
+        not_applied: 'Not applied — turn ended or stopped; copy this text to queue it'
+    };
+    function render() {
+        button.hidden = !current.target;
+        button.disabled = sending || current.disabled;
+        button.textContent = sending ? 'Steering…' : 'Steer';
+        feedback.replaceChildren();
+        if (notice) {
+            const status = document.createElement('p');
+            status.textContent = notice;
+            feedback.append(status);
+        }
+        for (const [queueId, items] of records) {
+            for (const item of items) {
+                const row = document.createElement('div');
+                const label = document.createElement('span');
+                label.textContent = `${labels[item.status] || item.status}: ${item.text}`;
+                row.append(label);
+                if (item.status === 'pending') {
+                    const cancel = document.createElement('button');
+                    cancel.type = 'button';
+                    cancel.textContent = 'Cancel steer';
+                    cancel.className = 'btn-mini';
+                    cancel.onclick = async () => {
+                        const version = generation;
+                        cancel.disabled = true;
+                        try {
+                            const data = await request(path(queueId), { method: 'DELETE', body: JSON.stringify({ submission_id: item.id }) });
+                            if (version !== generation) return;
+                            records.set(queueId, receiptItems(data));
+                        } catch (error) {
+                            if (version !== generation) return;
+                            notice = error.message;
+                        }
+                        render();
+                    };
+                    row.append(cancel);
+                }
+                feedback.append(row);
+            }
+        }
+        feedback.hidden = !feedback.childElementCount;
+    }
+    async function refresh() {
+        clearTimeout(timer);
+        if (!button.isConnected) return;
+        const version = generation;
+        const ids = new Set([...records].filter(([, items]) => items.some(i => i.status === 'pending')).map(([id]) => id));
+        if (current.target) ids.add(current.target.queueId);
+        for (const id of ids) {
+            try {
+                const data = await request(path(id), { method: 'GET' });
+                if (version !== generation) return;
+                records.set(id, receiptItems(data));
+                if (notice.startsWith('Steering status unavailable')) notice = '';
+            } catch (_) {
+                if (version !== generation) return;
+                notice = 'Steering status unavailable; delivery has not been confirmed.';
+            }
+        }
+        render();
+        if (current.target || [...records.values()].some(items => items.some(i => i.status === 'pending'))) {
+            timer = setTimeout(refresh, 1500);
+        }
+    }
+    button.onclick = async () => {
+        if (!current.target || current.disabled || sending) return;
+        const text = getDraft();
+        if (!text.trim()) return;
+        const target = { ...current.target };
+        const version = generation;
+        // An uncertain POST is retried with the same ID, never duplicated.
+        if (!retry || retry.text !== text || retry.queueId !== target.queueId || retry.attemptId !== target.attemptId) {
+            retry = { ...target, text, id: createId() };
+        }
+        const submission = retry;
+        sending = true;
+        notice = '';
+        render();
+        try {
+            const data = await request(path(target.queueId), { method: 'POST', body: JSON.stringify({
+                text, submission_id: submission.id, attempt_id: target.attemptId
+            }) });
+            if (version !== generation) return;
+            records.set(target.queueId, receiptItems(data));
+            clearDraft(text);
+            retry = null;
+        } catch (error) {
+            if (version !== generation) return;
+            notice = `${error.message} Draft retained. Retry Steer to check an uncertain submission before queueing it.`;
+        } finally {
+            if (version === generation) {
+                sending = false;
+                render();
+                void refresh();
+            }
+        }
+    };
+    return {
+        update(options) {
+            const changed = scopeKey !== options.scopeKey;
+            const targetChanged = current.target?.queueId !== options.target?.queueId;
+            if (changed) {
+                generation += 1;
+                records = recordsByScope.get(options.scopeKey) || new Map();
+                recordsByScope.set(options.scopeKey, records);
+                retry = null;
+                sending = false;
+                notice = '';
+                scopeKey = options.scopeKey;
+            }
+            current = options;
+            render();
+            if (changed || targetChanged) void refresh();
+        },
+        isSending() { return sending; },
+        dispose() { generation += 1; clearTimeout(timer); button.remove(); feedback.remove(); }
+    };
+}

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -18253,3 +18253,18 @@ body.settings-body {
 }
 .task-current-product-content pre { white-space: pre-wrap; }
 .task-continuation-instruction { min-height: 80px; resize: vertical; }
+
+.chat-steering-feedback {
+    max-height: 10rem;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    font-size: 0.85rem;
+    padding: 0.4rem;
+}
+.chat-steering-feedback > div {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-block: 0.3rem;
+}
+.chat-steering-feedback .btn-mini { flex-shrink: 0; }

--- a/tests/backend/test_adaptive_turn_service.py
+++ b/tests/backend/test_adaptive_turn_service.py
@@ -16357,3 +16357,87 @@ def test_scoped_text_recovery_uses_exact_defaulted_language(
         assert failure["attempted_recovery_effect_id"] == recovery["effect_id"]
     assert recovery["canonical_readback"]["object_text_identity_sha256"]
     assert result.terminal_status == expected_terminal_status
+
+
+def test_steering_arriving_during_final_model_call_continues_same_turn():
+    client = _SequenceClient(
+        LLMResponse(text_response="Old answer"),
+        LLMResponse(text_response="Revised answer"),
+    )
+    delivered = False
+
+    def reader(*, close_if_empty=False):
+        nonlocal delivered
+        if close_if_empty and not delivered:
+            delivered = True
+            return [{"id": "steer-1", "text": "Use the revised scope"}]
+        return []
+
+    result = execute_adaptive_turn(
+        gateway=_gateway(lambda **_kwargs: {"success": True}),
+        prompt="Original job",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        steering_reader=reader,
+    )
+    assert result.response_text == "Revised answer"
+    assert len(client.calls) == 2
+    assert client.calls[1]["prompt"] == ""
+    assert client.calls[1]["context"][-1]["content"] == "Use the revised scope"
+    assert any(
+        m.get("steering_submission_id") == "steer-1" for m in result.extra_messages
+    )
+
+
+def test_steering_after_tool_keeps_receipt_and_does_not_repeat_effect():
+    read_count = 0
+    delivered = False
+
+    def read(**_kwargs):
+        nonlocal read_count
+        read_count += 1
+        return {"success": True, "record": "canonical evidence"}
+
+    def reader(*, close_if_empty=False):
+        nonlocal delivered
+        if read_count and not delivered:
+            delivered = True
+            return [{"id": "s", "text": "Use this evidence in a shorter answer"}]
+        return []
+
+    client = _SequenceClient(
+        LLMResponse(
+            text_response="",
+            tool_calls=[
+                ToolCall(
+                    tool_name="turn_invoke_capability",
+                    call_id="read",
+                    payload={"name": "general_read", "arguments": {"query": "record"}},
+                )
+            ],
+            continuation=LLMContinuation(
+                provider="test",
+                api_surface="responses",
+                model="test-model",
+                response_id="previous",
+            ),
+        ),
+        LLMResponse(text_response="Short answer"),
+    )
+    result = execute_adaptive_turn(
+        gateway=_gateway(read),
+        prompt="Read and explain",
+        context=[],
+        llm_client=client,
+        model="test-model",
+        steering_reader=reader,
+    )
+    assert result.response_text == "Short answer"
+    assert read_count == 1
+    assert "continuation" not in client.calls[1]
+    assert "canonical evidence" in json.dumps(client.calls[1]["context"])
+    assert (
+        client.calls[1]["context"][-1]["content"]
+        == "Use this evidence in a shorter answer"
+    )

--- a/tests/backend/test_chat_prompt_queue_routes.py
+++ b/tests/backend/test_chat_prompt_queue_routes.py
@@ -718,3 +718,63 @@ def test_server_handoff_route_links_replays_and_rejects_second_replacement(
     )
     queue_rows = chat_prompt_queue_service.list_active_queue_records(scope=scope)
     assert [row["queue_id"] for row in queue_rows] == [created["queue_id"]]
+
+
+def test_steering_routes_use_authenticated_scope_and_exact_attempt(client):
+    from src.backend.services import chat_steering_service
+
+    scope = chat_prompt_queue_service.build_queue_scope(
+        user_concept_id="#V#test_user",
+        organisation_concept_id="#V#test_org",
+        namespace="#V#test_user@test_org",
+    )
+    created = chat_prompt_queue_service.create_queue_record(
+        scope=scope, prompt_raw="Original", session_id="session-1"
+    )
+    queue_id = created["queue_id"]
+    chat_prompt_queue_service._collection().update_one(
+        {"queue_id": queue_id},
+        {
+            "$set": {
+                "status": "in_progress",
+                "attempt_id": "attempt",
+                "active_conversation_key": "conversation",
+            }
+        },
+    )
+    url = f"/von/api/chat_prompt_queue/{queue_id}/steering"
+    response = client.post(
+        url,
+        json={
+            "attempt_id": "attempt",
+            "submission_id": "s",
+            "text": "Correction",
+            "user_id": "#V#impostor",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json["items"][0]["status"] == "pending"
+    assert (
+        client.post(
+            url,
+            json={"attempt_id": "wrong", "submission_id": "x", "text": "Wrong attempt"},
+        ).status_code
+        == 404
+    )
+    assert client.delete(url, json={}).status_code == 400
+    with client.session_transaction() as sess:
+        sess["user_concept_id"] = "#V#other"
+        sess["namespace"] = "#V#other@test_org"
+    assert client.get(url).status_code == 404
+    assert client.delete(url, json={"submission_id": "s"}).status_code == 404
+    assert (
+        len(
+            chat_steering_service.take(
+                scope=scope, queue_id=queue_id, attempt_id="attempt"
+            )
+        )
+        == 1
+    )
+    with client.session_transaction() as sess:
+        sess.clear()
+    assert client.get(url).status_code == 401

--- a/tests/backend/test_chat_steering_service.py
+++ b/tests/backend/test_chat_steering_service.py
@@ -1,0 +1,141 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from src.backend.db import mongo_client
+from src.backend.services import chat_steering_service as steering
+from src.backend.services import chat_prompt_queue_service as queue
+
+
+@pytest.fixture()
+def active(monkeypatch):
+    monkeypatch.setenv("VON_USE_MOCK_DB", "1")
+    monkeypatch.setenv("VON_DB_NAME", "test_steering")
+    mongo_client.close_connection()
+    scope = queue.build_queue_scope(
+        user_concept_id="#V#user",
+        organisation_concept_id="#V#org",
+        namespace="#V#user@org",
+    )
+    record = queue.create_queue_record(
+        scope=scope, prompt_raw="Original job", session_id="session"
+    )
+    queue._collection().update_one(
+        {"queue_id": record["queue_id"]},
+        {
+            "$set": {
+                "status": "in_progress",
+                "active_conversation_key": "conversation",
+                "attempt_id": "attempt",
+            }
+        },
+    )
+    yield {"scope": scope, "queue_id": record["queue_id"], "attempt_id": "attempt"}
+    mongo_client.close_connection()
+
+
+def statuses(active):
+    return [
+        i["status"]
+        for i in steering.read(scope=active["scope"], queue_id=active["queue_id"])[
+            "items"
+        ]
+    ]
+
+
+def test_fifo_steering_idempotency_and_queue_independence(active):
+    later = queue.create_queue_record(
+        scope=active["scope"], prompt_raw="Later job", session_id="session"
+    )
+    for id in ["a", "b", "a"]:
+        steering.submit(**active, submission_id=id, text=id)
+    assert statuses(active) == ["pending", "pending"]
+    assert [m["text"] for m in steering.take(**active)] == ["a", "b"]
+    assert steering.take(**active) == []
+    assert statuses(active) == ["delivered", "delivered"]
+    assert (
+        queue._collection().find_one({"queue_id": later["queue_id"]})["status"]
+        == "queued"
+    )
+    with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+        steering.submit(**active, submission_id="a", text="different")
+
+
+def test_withdrawal_and_terminal_readback(active):
+    steering.submit(**active, submission_id="a", text="Withdraw me")
+    steering.submit(**active, submission_id="b", text="Keep me")
+    steering.cancel(
+        scope=active["scope"], queue_id=active["queue_id"], submission_id="a"
+    )
+    assert [m["id"] for m in steering.take(**active)] == ["b"]
+    with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+        steering.cancel(
+            scope=active["scope"], queue_id=active["queue_id"], submission_id="b"
+        )
+    steering.submit(**active, submission_id="c", text="Unseen")
+    queue._collection().update_one(
+        {"queue_id": active["queue_id"]}, {"$set": {"status": "cancelled"}}
+    )
+    assert statuses(active) == ["cancelled", "delivered", "not_applied"]
+    assert steering.take(**active) == []
+
+
+def test_final_boundary_and_submission_are_atomic(active):
+    def submit():
+        try:
+            steering.submit(**active, submission_id="race", text="Correct this")
+            return True
+        except queue.ChatPromptQueueRecordNotFound:
+            return False
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        accepted = pool.submit(submit)
+        taken = pool.submit(steering.take, **active, close_if_empty=True)
+    assert accepted.result() == bool(taken.result())
+    steering.take(**active, close_if_empty=True)
+    with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+        steering.submit(**active, submission_id="late", text="Too late")
+
+
+def test_scope_attempt_and_stopping_boundaries(active):
+    for changes in [
+        {"attempt_id": "other"},
+        {"scope": {**active["scope"], "user_concept_id": "#V#other"}},
+    ]:
+        with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+            steering.submit(
+                **{**active, **changes}, submission_id="a", text="Wrong scope"
+            )
+    steering.submit(**active, submission_id="a", text="Old attempt")
+    queue._collection().update_one(
+        {"queue_id": active["queue_id"]}, {"$set": {"attempt_id": "new"}}
+    )
+    assert steering.take(**{**active, "attempt_id": "new"}) == []
+    assert statuses(active) == ["not_applied"]
+    from datetime import datetime, timezone
+
+    queue._collection().update_one(
+        {"queue_id": active["queue_id"]},
+        {"$set": {"cancellation_requested_at": datetime.now(timezone.utc)}},
+    )
+    with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+        steering.submit(
+            **{**active, "attempt_id": "new"}, submission_id="b", text="Stopping"
+        )
+
+
+def test_new_attempt_accepts_steering_without_rewriting_old_delivery(active):
+    steering.submit(**active, submission_id='old', text='Delivered earlier')
+    steering.take(**active)
+    steering.take(**active, close_if_empty=True)
+    queue._collection().update_one({'queue_id': active['queue_id']}, {'$set': {'attempt_id': 'next'}})
+    steering.submit(**{**active, 'attempt_id': 'next'}, submission_id='new', text='New guidance')
+    assert statuses(active) == ['delivered', 'pending']
+    assert [m['id'] for m in steering.take(**{**active, 'attempt_id': 'next'})] == ['new']
+
+
+def test_mailbox_size_is_bounded_without_discarding_accepted_guidance(active):
+    steering.submit(**active, submission_id='full', text='x' * queue.MAX_PROMPT_RAW_CHARS)
+    with pytest.raises(queue.ChatPromptQueueRecordNotFound):
+        steering.submit(**active, submission_id='overflow', text='y')
+    assert statuses(active) == ['pending']

--- a/tests/backend/test_von_generate_early_user_message_persist.py
+++ b/tests/backend/test_von_generate_early_user_message_persist.py
@@ -233,3 +233,53 @@ def test_generate_continues_when_chat_history_context_read_is_transient(
     assert all(
         call.get("role") == "system" for call in llm.calls[-1]["context"]
     )
+
+
+def test_steering_normal_generate_admission_and_history(app, recorder, monkeypatch):
+    from flask import g
+    from src.backend.server.routes import von_routes
+    from src.backend.languagemodels.structured_tool_calling.types import LLMResponse
+
+    model_contexts = []
+
+    def generate_with_tools(*_args, **kwargs):
+        model_contexts.append(kwargs['context'])
+        return LLMResponse(text_response='Revised response')
+
+    monkeypatch.setattr(app.config['TEST_LLM'], 'generate_with_tools', generate_with_tools, raising=False)
+    original = von_routes.execute_adaptive_turn
+    receipts = []
+
+    def execute_with_incoming_steer(**kwargs):
+        token = getattr(g, von_routes._TURN_ADMISSION_CONTEXT_KEY)
+        assert token.queue_id and token.attempt_id
+        with app.app_context(), app.test_client() as sender:
+            with sender.session_transaction() as sess:
+                sess['user_concept_id'] = '#V#test_user'
+                sess['namespace'] = '#V#test_user'
+            url = f'/von/api/chat_prompt_queue/{token.queue_id}/steering'
+            response = sender.post(url, json={
+                'attempt_id': token.attempt_id, 'submission_id': 'normal-route',
+                'text': 'Use the revised scope',
+            })
+            assert response.status_code == 200
+        result = original(**kwargs)
+        with app.app_context(), app.test_client() as sender:
+            with sender.session_transaction() as sess:
+                sess['user_concept_id'] = '#V#test_user'
+                sess['namespace'] = '#V#test_user'
+            receipts.extend(sender.get(url).json['items'])
+        return result
+
+    monkeypatch.setattr(von_routes, 'execute_adaptive_turn', execute_with_incoming_steer)
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['user_concept_id'] = '#V#test_user'
+            sess['namespace'] = '#V#test_user'
+        response = client.post('/von/generate', json={'prompt': 'Original scope'})
+    assert response.status_code == 200
+    assert response.json['response'] == 'Revised response'
+    assert any(message.get('role') == 'user' and message.get('content') == 'Use the revised scope'
+               for context in model_contexts for message in context)
+    assert [entry['message']['content'] for entry in recorder.user_message_calls] == ['Original scope', 'Use the revised scope']
+    assert receipts[0]['status'] == 'delivered'

--- a/tests/frontend/chatSteeringControls.test.js
+++ b/tests/frontend/chatSteeringControls.test.js
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+import { createChatSteeringControls } from '../../src/frontend/web/von_interface/static/js/components/chatSteeringControls.js';
+
+const tick = async () => { await Promise.resolve(); await Promise.resolve(); };
+let control;
+let request;
+let draft;
+let options;
+let counter;
+beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div><button id="send">Queue Prompt</button></div>';
+    draft = 'Correct the scope';
+    counter = 0;
+    request = jest.fn(async () => ({ items: [] }));
+    control = createChatSteeringControls({
+        sendButton: document.getElementById('send'), request,
+        getDraft: () => draft,
+        clearDraft: (text) => { if (draft === text) draft = ''; },
+        createId: () => `id-${++counter}`
+    });
+    options = { scopeKey: 'actor:session', target: { queueId: 'queue', attemptId: 'attempt' }, disabled: false };
+    control.update(options);
+});
+afterEach(() => { control.dispose(); jest.useRealTimers(); });
+
+test('Steer targets exact active attempt; pending guidance is cancellable', async () => {
+    await tick();
+    request.mockImplementation(async (_url, opts) => {
+        if (opts.method === 'POST') return { items: [{ id: 'id-1', text: draft, status: 'pending' }] };
+        if (opts.method === 'DELETE') return { items: [{ id: 'id-1', text: 'Correct the scope', status: 'cancelled' }] };
+        return { items: [{ id: 'id-1', text: 'Correct the scope', status: 'pending' }] };
+    });
+    document.getElementById('steerButton').click();
+    await tick();
+    const [, post] = request.mock.calls.find(([, opts]) => opts.method === 'POST');
+    expect(JSON.parse(post.body)).toEqual({ text: 'Correct the scope', submission_id: 'id-1', attempt_id: 'attempt' });
+    expect(draft).toBe('');
+    expect(document.body.textContent).toContain('Pending steer');
+    [...document.querySelectorAll('button')].find(b => b.textContent === 'Cancel steer').click();
+    await tick();
+    expect(document.body.textContent).toContain('Steer cancelled');
+});
+
+test('uncertain submission preserves draft and reuses ID on retry', async () => {
+    await tick();
+    request.mockImplementation(async (_url, opts) => {
+        if (opts.method === 'POST') throw new Error('Connection lost');
+        return { items: [] };
+    });
+    document.getElementById('steerButton').click();
+    await tick();
+    expect(draft).toBe('Correct the scope');
+    expect(document.body.textContent).toContain('Draft retained');
+    document.getElementById('steerButton').click();
+    await tick();
+    const posts = request.mock.calls.filter(([, opts]) => opts.method === 'POST');
+    expect(posts).toHaveLength(2);
+    expect(posts[0][1].body).toBe(posts[1][1].body);
+});
+
+test('session switch isolates late acknowledgements and leaves new draft alone', async () => {
+    await tick();
+    let resolve;
+    request.mockImplementation((_url, opts) => opts.method === 'POST'
+        ? new Promise(r => { resolve = r; }) : Promise.resolve({ items: [] }));
+    document.getElementById('steerButton').click();
+    control.update({ scopeKey: 'actor:other-session', target: null, disabled: false });
+    draft = 'New session draft';
+    resolve({ items: [{ id: 'old', text: 'Private old text', status: 'delivered' }] });
+    await tick();
+    expect(draft).toBe('New session draft');
+    expect(document.body.textContent).not.toContain('Private old text');
+    expect(document.getElementById('steerButton').hidden).toBe(true);
+});
+
+test('idle and attachment-disabled states cannot send steering', async () => {
+    await tick();
+    control.update({ ...options, disabled: true });
+    document.getElementById('steerButton').click();
+    expect(request.mock.calls.some(([, opts]) => opts.method === 'POST')).toBe(false);
+    control.update({ ...options, target: null });
+    expect(document.getElementById('steerButton').hidden).toBe(true);
+});
+
+test('pending receipt survives turn completion and reports not applied', async () => {
+    await tick();
+    request.mockResolvedValue({ items: [{ id: 'id-1', text: 'Late steer', status: 'pending' }] });
+    document.getElementById('steerButton').click();
+    await tick();
+    request.mockResolvedValue({ items: [{ id: 'id-1', text: 'Late steer', status: 'not_applied' }] });
+    control.update({ ...options, target: null });
+    await tick();
+    expect(document.body.textContent).toContain('Not applied');
+    expect(document.body.textContent).toContain('Late steer');
+});


### PR DESCRIPTION
While Von is answering, users can now choose **Steer** to guide that exact active turn or keep using **Queue Prompt** for an independent FIFO request. Steering is delivered at a model boundary without consuming queued work or repeating completed tools. The UI shows pending/delivered/not-applied receipts and allows withdrawal before delivery.

The mailbox reuses the durable queue record and authenticated actor/organisation scope, with exact attempt binding, idempotent submission, atomic final-answer closure and bounded storage. Accepted guidance is attributed in history once. The design reference documents semantics, current chatbot reference, interruption behaviour and limitations.

Validation: 350 targeted backend tests passed, including the normal Flask generation/admission/history path with mock storage and model; 53 frontend steering/queue/abort tests passed; changed-JS static checks and Python 3.11 syntax checks passed. A Chromium fixture using repository composer markup/styles at 375px passed submit, pending feedback and cancellation without overflow or page errors.

Merge decision: ready. Two older generate tests fail identically using unchanged HEAD route/turn code (`test_generate_executes_direct_read_tool_call`, missing gateway stub `enabled`; `test_assistant_message_still_persisted`, legacy model stub). Those are baseline limitations, not additional acceptance gates.

Limitations: steering is text-only and waits for an active provider request/tool batch; it does not undo effects. Delivery is a handoff receipt, not proof of model compliance. A crash between take and context/history insertion needs reconciliation from the retained receipt. Old terminal queue receipts are available by scoped GET but are not automatically rediscovered after a page reload. Browser validation was fixture-backed, not against the authenticated public service. No deployment or migration requested.

Von task: #V#task_agent_4491b679903b26fcc8c22a1fc5e62474
