### PR TITLE
Restrict Workflow Studio to Admin desktop access

### DIFF
--- a/src/backend/security/workflow_studio_access.py
+++ b/src/backend/security/workflow_studio_access.py
@@ -1,0 +1,38 @@
+"""Studio's desktop expert capability uses Von's existing operational Admin role.
+
+This admission check does not grant workflow visibility or publication authority.
+"""
+
+from functools import wraps
+
+from flask import jsonify, session
+
+from .authentication_assurance import session_has_required_authentication_assurance
+from ..services.von_operational_administrator_service import (
+    is_live_von_operational_administrator,
+)
+
+
+def can_access_workflow_studio() -> bool:
+    actor = session.get("user_concept_id")
+    if not (
+        actor
+        and session.get("user_email")
+        and session_has_required_authentication_assurance(session)
+    ):
+        return False
+    try:
+        return is_live_von_operational_administrator(actor)
+    except Exception:
+        # An unreadable role is not an authority grant.
+        return False
+
+
+def require_workflow_studio_admin(view):
+    @wraps(view)
+    def guarded(*args, **kwargs):
+        if not can_access_workflow_studio():
+            return jsonify({"error": "workflow_studio_admin_required"}), 403
+        return view(*args, **kwargs)
+
+    return guarded

--- a/src/backend/server/routes/auth_routes.py
+++ b/src/backend/server/routes/auth_routes.py
@@ -114,7 +114,10 @@ def _build_auth_status_payload() -> dict:
     if authenticated and auth_provider != "browser_test_fixture":
         from ...services.login_organisation_preference_service import initialise_login_context
         login_context = initialise_login_context(session)
+    from ...security.workflow_studio_access import can_access_workflow_studio
+
     return {
+        "workflow_studio_access": authenticated and can_access_workflow_studio(),
         "authenticated": authenticated,
         "email": user_email if authenticated else None,
         "name": (

--- a/src/backend/server/routes/von_routes.py
+++ b/src/backend/server/routes/von_routes.py
@@ -1,3 +1,4 @@
+from ...security.workflow_studio_access import require_workflow_studio_admin
 from flask import (
     Blueprint,
     request,
@@ -11368,12 +11369,14 @@ def serve_page():
 
 
 @von_bp.route("/workflow-studio")
+@require_workflow_studio_admin
 def serve_workflow_studio_page():
     """Keep existing Studio bookmarks on the authenticated application surface."""
     return redirect(url_for("von.serve_page", _anchor="workflowStudioTab"))
 
 
 @von_bp.route("/workflow-studio/content")
+@require_workflow_studio_admin
 def serve_workflow_studio_content():
     """Serve Studio markup on first tab activation; APIs retain actor checks."""
     return render_template("workflow_studio.html")

--- a/src/backend/server/routes/workflows_routes.py
+++ b/src/backend/server/routes/workflows_routes.py
@@ -59,6 +59,7 @@ from ...workflows.workflow_listing_service import (
     filter_workflow_ids_for_current_actor,
     project_workflow_introspection_payload_for_current_actor,
 )
+from ...security.workflow_studio_access import require_workflow_studio_admin
 from ...workflows.workflow_studio_service import (
     WorkflowStudioAuthorityError,
     WorkflowStudioConflictError,
@@ -1040,6 +1041,7 @@ def api_get_workflow_capability_index_status():
 
 
 @workflows_bp.get("/api/workflow-studio/catalogue")
+@require_workflow_studio_admin
 def api_workflow_studio_catalogue():
     limit_raw = request.args.get("limit", "250")
     try:
@@ -1143,6 +1145,7 @@ def _resolve_workflow_studio_mutation_actor(workflow_id: str):
 
 
 @workflows_bp.get("/api/workflow-studio/workflows/<path:workflow_id>")
+@require_workflow_studio_admin
 def api_get_workflow_studio_workflow(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:
@@ -1198,6 +1201,7 @@ def api_get_workflow_studio_workflow(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/authoring/preview")
+@require_workflow_studio_admin
 def api_preview_workflow_studio_authoring(workflow_id: str):
     payload = request.get_json(silent=True) or {}
     authoring_spec = payload.get("authoring_spec")
@@ -1240,6 +1244,7 @@ def api_preview_workflow_studio_authoring(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/authoring/apply")
+@require_workflow_studio_admin
 def api_apply_workflow_studio_authoring(workflow_id: str):
     _actor_scope, actor_error_response = _resolve_workflow_studio_mutation_actor(
         workflow_id
@@ -1295,6 +1300,7 @@ def api_apply_workflow_studio_authoring(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/proposals/authoring")
+@require_workflow_studio_admin
 def api_submit_workflow_studio_authoring_proposal(workflow_id: str):
     actor_scope, actor_error_response = _resolve_workflow_studio_mutation_actor(
         workflow_id
@@ -1347,6 +1353,7 @@ def api_submit_workflow_studio_authoring_proposal(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/proposals/review")
+@require_workflow_studio_admin
 def api_review_workflow_studio_authoring_proposal(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:
@@ -1411,6 +1418,7 @@ def api_review_workflow_studio_authoring_proposal(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/proposals/rollback")
+@require_workflow_studio_admin
 def api_rollback_workflow_studio_authoring_promotion(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:
@@ -1471,6 +1479,7 @@ def api_rollback_workflow_studio_authoring_promotion(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/publication/demote")
+@require_workflow_studio_admin
 def api_demote_workflow_studio_publication(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:
@@ -1510,6 +1519,7 @@ def api_demote_workflow_studio_publication(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/publication/supersede")
+@require_workflow_studio_admin
 def api_supersede_workflow_studio_publication(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:
@@ -1566,6 +1576,7 @@ def api_supersede_workflow_studio_publication(workflow_id: str):
 
 
 @workflows_bp.post("/api/workflow-studio/workflows/<path:workflow_id>/proposals/description")
+@require_workflow_studio_admin
 def api_build_workflow_studio_description_proposal(workflow_id: str):
     target_not_found = _workflow_studio_target_not_found(workflow_id)
     if target_not_found is not None:

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -1,3 +1,4 @@
+import { canUseWorkflowStudio } from './workflowStudioAccess.js';
 import { createChatSteeringControls } from './components/chatSteeringControls.js';
 import { directConversationRows, activeMessageConversationId, showChatConversation, resetConversationCatalogue, renderMessageConversationRow, mountCatalogueControls, initialiseConversationCatalogue, selectMessageConversation, filterCatalogueRows } from './components/conversationCatalogue.js';
 import { catalogueHasMore } from './components/conversationCatalogue.js';
@@ -1192,6 +1193,7 @@ function shouldMaintainSharedConversationStream(sessionId) {
 }
 
 function isWorkflowMonitorTabActive() {
+    if (!canUseWorkflowStudio()) return false;
     const { panel } = getWorkflowStatusElements();
     if (!panel) return false;
     const tab = panel.closest('.tab-content');
@@ -32197,6 +32199,7 @@ function clearWorkflowCapabilityIndexPollTimer() {
 }
 
 function shouldPollWorkflowCapabilityIndex() {
+    if (!isWorkflowMonitorTabActive()) return false;
     if (workflowStatusGroupUiState.globallyFurled) {
         return false;
     }
@@ -32312,6 +32315,7 @@ function describeWorkflowCapabilityIndexStatusFetchError(err) {
 }
 
 async function refreshWorkflowCapabilityIndexStatus({ silent = false, force = false } = {}) {
+    if (!isWorkflowMonitorTabActive()) return;
     const { panel } = getWorkflowStatusElements();
     if (!panel) return;
     ensureWorkflowCapabilityIndexStatusSubscription();
@@ -33543,12 +33547,14 @@ export function initializeWorkflowStatusPanel() {
 function syncWorkflowMonitorTabActivity() {
     if (!isWorkflowMonitorTabActive()) {
         stopWorkflowStatusStream('workflow_studio_hidden');
+        clearWorkflowCapabilityIndexPollTimer();
         clearWorkflowStatusSnapshotRetryTimer();
         clearWorkflowDefinitionsRetryTimer();
         setWorkflowEpisodesPopupVisible(false);
         return;
     }
     startWorkflowStatusStream();
+    syncWorkflowCapabilityIndexPolling();
     if (workflowDefinitionsState.visible) {
         void refreshAvailableWorkflowDefinitions({ silent: true });
     } else {

--- a/src/frontend/web/von_interface/static/js/main.js
+++ b/src/frontend/web/von_interface/static/js/main.js
@@ -1,3 +1,4 @@
+import { setWorkflowStudioAccess } from './workflowStudioAccess.js';
 import { setupDynamicLayout } from './components/dynamicLayout.js';
 import { initializeDomElements, initializeInfoPopup, loadAndDisplayGlobalModelInFooter, setFooterServerReachability } from './domUtils.js';
 import {
@@ -72,6 +73,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initializeDomElements();
   initializeInfoPopup();
   applyExpertTabGuards();
+  setWorkflowStudioAccess(authStatus);
   setupTabNavigation();
   setupSettingsFrameResizing();
   initialiseCopyJsonButtonPreCopyState();

--- a/src/frontend/web/von_interface/static/js/tabNavigation.js
+++ b/src/frontend/web/von_interface/static/js/tabNavigation.js
@@ -1,3 +1,4 @@
+import { canUseWorkflowStudio, setupWorkflowStudioAccess } from './workflowStudioAccess.js';
 import { fetchConceptList, initializeConceptTab, updateConceptTabUI } from './conceptTab.js';
 import { elements } from './domUtils.js';
 import { initializeDynamicTabs, loadDynamicConceptTabContent } from './dynamicTabs.js';
@@ -9,7 +10,8 @@ import { initializeVontologyTab } from './vontology.js';
 const GUARDED_TAB_IDS = new Set(['vontologyTab', 'importExportTab', 'annotationTab']);
 
 function isTabGuarded(tabId) {
-  return !isExpertTabsEnabled() && GUARDED_TAB_IDS.has(tabId);
+  return (tabId === 'workflowStudioTab' && !canUseWorkflowStudio())
+    || (!isExpertTabsEnabled() && GUARDED_TAB_IDS.has(tabId));
 }
 
 export function setupTabNavigation() {
@@ -17,6 +19,7 @@ export function setupTabNavigation() {
 
   // Initialize dynamic tabs functionality
   initializeDynamicTabs();
+  setupWorkflowStudioAccess(() => activateTab('chatTab'));
 
   // These need to be initialized here because they are used for setup
   elements.tabButtons = document.querySelectorAll('.tab-button');

--- a/src/frontend/web/von_interface/static/js/test/chatTab.test.js
+++ b/src/frontend/web/von_interface/static/js/test/chatTab.test.js
@@ -1,3 +1,4 @@
+jest.mock('../workflowStudioAccess.js', () => ({ canUseWorkflowStudio: jest.fn(() => true) }));
 import {
     __testOnly_buildThinkingProgressPresentation,
     __testOnly_buildThinkingCardProgressViewModel,
@@ -1587,6 +1588,21 @@ describe('workflow monitor definitions refresh contention handling', () => {
 });
 
 describe('workflow monitor active snapshot degradation handling', () => {
+    test('mobile or denied Studio cannot fetch even when an old tab remains active', async () => {
+        const { canUseWorkflowStudio } = require('../workflowStudioAccess.js');
+        canUseWorkflowStudio.mockReturnValue(false);
+        try {
+            document.body.innerHTML = '<section id="workflowStudioTab" class="tab-content active"><div id="workflowStatusPanel"><div id="workflowStatusBody"></div></div></section>';
+            global.fetch = jest.fn();
+            await __testOnly_refreshWorkflowStatusSnapshot();
+            await __testOnly_refreshAvailableWorkflowDefinitions();
+            await __testOnly_refreshWorkflowCapabilityIndexStatus({ force: true });
+            expect(global.fetch).not.toHaveBeenCalled();
+        } finally {
+            canUseWorkflowStudio.mockReturnValue(true);
+        }
+    });
+
     test('does not fetch snapshots or definitions while the Studio tab is inactive', async () => {
         document.body.innerHTML = '<section id="workflowStudioTab" class="tab-content"><div id="workflowStatusPanel"><div id="workflowStatusBody"></div></div></section>';
         __testOnly_resetWorkflowStatusState();

--- a/src/frontend/web/von_interface/static/js/test/workflowStudioPage.test.js
+++ b/src/frontend/web/von_interface/static/js/test/workflowStudioPage.test.js
@@ -1,3 +1,4 @@
+jest.mock('../workflowStudioAccess.js', () => ({ canUseWorkflowStudio: jest.fn(() => true) }));
 import {
   initialiseWorkflowStudio,
   buildDraftSource,

--- a/src/frontend/web/von_interface/static/js/workflowStudioAccess.js
+++ b/src/frontend/web/von_interface/static/js/workflowStudioAccess.js
@@ -20,9 +20,11 @@ export function setupWorkflowStudioAccess(onUnavailable) {
     }
   };
   window.matchMedia?.(STUDIO_MOBILE_QUERY).addEventListener('change', sync);
-  document.addEventListener('authStatusChanged', event => {
+  const updateAccess = event => {
     setWorkflowStudioAccess(event.detail);
     sync();
-  });
+  };
+  document.addEventListener('authStatusChanged', updateAccess);
+  document.addEventListener('von:studio-access-changed', updateAccess);
   sync();
 }

--- a/src/frontend/web/von_interface/static/js/workflowStudioAccess.js
+++ b/src/frontend/web/von_interface/static/js/workflowStudioAccess.js
@@ -1,0 +1,28 @@
+// Same responsive boundary as the mobile application shell (PR #631).
+export const STUDIO_MOBILE_QUERY = '(max-width: 800px), (max-width: 1024px) and (pointer: coarse)';
+let admin = false;
+
+export function canUseWorkflowStudio() {
+  return admin && !window.matchMedia?.(STUDIO_MOBILE_QUERY).matches;
+}
+
+export function setWorkflowStudioAccess(authStatus) {
+  admin = authStatus?.authenticated === true && authStatus?.workflow_studio_access === true;
+}
+
+export function setupWorkflowStudioAccess(onUnavailable) {
+  const sync = () => {
+    const allowed = canUseWorkflowStudio();
+    const button = document.querySelector('[data-tab="workflowStudioTab"]');
+    if (button) button.hidden = !allowed;
+    if (!allowed && document.getElementById('workflowStudioTab')?.classList.contains('active')) {
+      onUnavailable();
+    }
+  };
+  window.matchMedia?.(STUDIO_MOBILE_QUERY).addEventListener('change', sync);
+  document.addEventListener('authStatusChanged', event => {
+    setWorkflowStudioAccess(event.detail);
+    sync();
+  });
+  sync();
+}

--- a/src/frontend/web/von_interface/static/js/workflowStudioPage.js
+++ b/src/frontend/web/von_interface/static/js/workflowStudioPage.js
@@ -1,3 +1,4 @@
+import { canUseWorkflowStudio } from './workflowStudioAccess.js';
 import { ensureUniqueWindowSessionId, getWindowSessionId, WINDOW_SESSION_HEADER } from './apiService.js';
 
 function escapeHtml(value) {
@@ -350,7 +351,9 @@ function buildWorkflowStudioRequestHeaders(options = {}) {
 }
 
 async function fetchJson(url, options = {}) {
+  if (!canUseWorkflowStudio()) throw new Error("Workflow Studio is unavailable in this view.");
   await ensureUniqueWindowSessionId?.();
+  if (!canUseWorkflowStudio()) throw new Error("Workflow Studio is unavailable in this view.");
   const { headers: _ignoredHeaders, ...fetchOptions } = options || {};
   const response = await fetch(url, {
     ...fetchOptions,
@@ -1675,6 +1678,7 @@ function bindEvents() {
 }
 
 export async function initialiseWorkflowStudio() {
+  if (!canUseWorkflowStudio()) return;
   // The tab shares the authenticated parent window and its current scope.
   cacheElements();
   bindEvents();
@@ -1695,7 +1699,7 @@ export async function initialiseWorkflowStudio() {
     renderAll();
   };
   const refreshIfActive = () => {
-    if (state.needsRefresh && document.getElementById('workflowStudioTab')?.classList.contains('active')) {
+    if (canUseWorkflowStudio() && state.needsRefresh && document.getElementById('workflowStudioTab')?.classList.contains('active')) {
       state.needsRefresh = false;
       void loadCatalogue();
     }

--- a/src/frontend/web/von_interface/static/js/workflowStudioTab.js
+++ b/src/frontend/web/von_interface/static/js/workflowStudioTab.js
@@ -1,5 +1,7 @@
+import { canUseWorkflowStudio } from './workflowStudioAccess.js';
 // The Studio document and modules are requested only when its tab is activated.
 export async function loadWorkflowStudioTab(container) {
+  if (!canUseWorkflowStudio()) return;
   if (container.dataset.initialized === 'true' || container.dataset.loading === 'true') return;
   container.dataset.loading = 'true';
   container.setAttribute('aria-busy', 'true');
@@ -7,10 +9,12 @@ export async function loadWorkflowStudioTab(container) {
     const response = await fetch(container.dataset.src);
     if (!response.ok) throw new Error(`Workflow Studio returned HTTP ${response.status}`);
     const html = await response.text();
+    if (!canUseWorkflowStudio()) return;
     const [studio, monitor] = await Promise.all([
       import('./workflowStudioPage.js'),
       import('./chatTab.js')
     ]);
+    if (!canUseWorkflowStudio()) return;
     container.innerHTML = html;
     monitor.initializeWorkflowStatusPanel();
     // Initialise synchronously before the catalogue request; returning to the

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -18403,7 +18403,7 @@ body.settings-body {
 }
 
 /* Studio is an Admin desktop feature, including before JavaScript starts. */
-.tab-button[data-tab="workflowStudioTab"][hidden] { display: none; }
+.tab-button[data-tab="workflowStudioTab"][hidden] { display: none !important; }
 @media (max-width: 800px), (max-width: 1024px) and (pointer: coarse) {
   .tab-button[data-tab="workflowStudioTab"], #workflowStudioTab { display: none !important; }
 }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -18401,3 +18401,9 @@ body.settings-body {
     }
     .settings-container button, .settings-container select { min-height: 44px; }
 }
+
+/* Studio is an Admin desktop feature, including before JavaScript starts. */
+.tab-button[data-tab="workflowStudioTab"][hidden] { display: none; }
+@media (max-width: 800px), (max-width: 1024px) and (pointer: coarse) {
+  .tab-button[data-tab="workflowStudioTab"], #workflowStudioTab { display: none !important; }
+}

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -1333,6 +1333,10 @@
             renderBrowserTestModeStatus(authStatus);
             try {
                 document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
+                const hostDocument = getSettingsHostDocument();
+                if (hostDocument !== document) {
+                    hostDocument.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
+                }
             } catch { }
 
             const browserTestMode = authStatus?.browser_test_mode || {};

--- a/src/frontend/web/von_interface/templates/settings_tab.html
+++ b/src/frontend/web/von_interface/templates/settings_tab.html
@@ -1335,7 +1335,7 @@
                 document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
                 const hostDocument = getSettingsHostDocument();
                 if (hostDocument !== document) {
-                    hostDocument.dispatchEvent(new CustomEvent('authStatusChanged', { detail: authStatus || {} }));
+                    hostDocument.dispatchEvent(new CustomEvent('von:studio-access-changed', { detail: authStatus || {} }));
                 }
             } catch { }
 

--- a/src/frontend/web/von_interface/templates/von_interface.html
+++ b/src/frontend/web/von_interface/templates/von_interface.html
@@ -121,7 +121,7 @@
       <span id="globalTaskCountBadge" class="task-count-badge hidden" aria-hidden="true"></span>
       All Tasks
     </div>
-    <button type="button" class="tab-button" data-tab="workflowStudioTab" aria-controls="workflowStudioTab">
+    <button type="button" class="tab-button" hidden data-tab="workflowStudioTab" aria-controls="workflowStudioTab">
       Workflow Studio
     </button>
     <div class="tab-button settings-tab-button" data-tab="settingsTab">

--- a/tests/backend/test_workflows_routes.py
+++ b/tests/backend/test_workflows_routes.py
@@ -2606,7 +2606,9 @@ def test_workflow_definitions_list_refresh_in_progress_without_stale_returns_503
     assert resp.headers.get("Retry-After") == "1"
 
 
-def test_workflow_studio_bookmark_opens_tab_and_fragment_contains_monitor(app_client):
+def test_workflow_studio_bookmark_opens_tab_and_fragment_contains_monitor(
+    app_client, studio_admin
+):
     response = app_client.get("/von/workflow-studio")
     assert response.status_code == 302
     assert response.headers["Location"] == "/von/#workflowStudioTab"
@@ -2616,10 +2618,10 @@ def test_workflow_studio_bookmark_opens_tab_and_fragment_contains_monitor(app_cl
     assert 'id="workflowStatusPanel"' in html
     assert 'id="workflowEpisodesPopup"' in html
     assert 'id="workflowStudioCatalogue"' in html
-    assert '<body' not in html
+    assert "<body" not in html
 
 
-def test_workflow_studio_catalogue_endpoint(monkeypatch, app_client):
+def test_workflow_studio_catalogue_endpoint(monkeypatch, app_client, studio_admin):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
     seen: dict[str, object] = {}
@@ -2656,10 +2658,12 @@ def test_workflow_studio_catalogue_endpoint(monkeypatch, app_client):
     assert seen["include_designs"] is False
 
 
-def test_workflow_studio_detail_endpoint(monkeypatch, app_client):
+def test_workflow_studio_detail_endpoint(monkeypatch, app_client, studio_admin):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
     monkeypatch.setattr(
         workflows_routes,
         "build_workflow_studio_detail_payload",
@@ -2702,10 +2706,13 @@ def test_workflow_studio_detail_endpoint(monkeypatch, app_client):
 def test_workflow_studio_detail_hides_actor_incomplete_definition(
     monkeypatch,
     app_client,
+    studio_admin,
 ):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     def _raise_actor_authority_error(*_args, **_kwargs):
         raise workflows_routes.WorkflowStudioAuthorityError(
@@ -2727,10 +2734,14 @@ def test_workflow_studio_detail_hides_actor_incomplete_definition(
     }
 
 
-def test_workflow_studio_authoring_preview_conflict_returns_409(monkeypatch, app_client):
+def test_workflow_studio_authoring_preview_conflict_returns_409(
+    monkeypatch, app_client, studio_admin
+):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     def _raise_conflict(*_args, **_kwargs):
         raise workflows_routes.WorkflowStudioConflictError(
@@ -2753,10 +2764,14 @@ def test_workflow_studio_authoring_preview_conflict_returns_409(monkeypatch, app
     assert payload["error"] == "workflow_definition_hash_conflict"
 
 
-def test_workflow_studio_authoring_apply_endpoint(monkeypatch, app_client):
+def test_workflow_studio_authoring_apply_endpoint(
+    monkeypatch, app_client, studio_admin
+):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     monkeypatch.setattr(
         workflows_routes,
@@ -2784,10 +2799,14 @@ def test_workflow_studio_authoring_apply_endpoint(monkeypatch, app_client):
     assert payload["publication"]["summary"]["workflows_published"] == 1
 
 
-def test_workflow_studio_authoring_proposal_submit_endpoint(monkeypatch, app_client):
+def test_workflow_studio_authoring_proposal_submit_endpoint(
+    monkeypatch, app_client, studio_admin
+):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     captured: dict[str, object] = {}
 
@@ -2811,7 +2830,10 @@ def test_workflow_studio_authoring_proposal_submit_endpoint(monkeypatch, app_cli
     resp = app_client.post(
         "/api/workflow-studio/workflows/%23V%23alpha_workflow/proposals/authoring",
         json={
-            "authoring_spec": {"workflow_id": "#V#alpha_workflow", "steps": [{"state_id": "start"}]},
+            "authoring_spec": {
+                "workflow_id": "#V#alpha_workflow",
+                "steps": [{"state_id": "start"}],
+            },
             "base_definition_hash": "base-hash",
             "session_id": "session-1",
             "turn_id": "turn-1",
@@ -2828,10 +2850,14 @@ def test_workflow_studio_authoring_proposal_submit_endpoint(monkeypatch, app_cli
     assert payload["namespace"] == "#V#test_user@test_org"
 
 
-def test_workflow_studio_authoring_proposal_review_endpoint(monkeypatch, app_client):
+def test_workflow_studio_authoring_proposal_review_endpoint(
+    monkeypatch, app_client, studio_admin
+):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     captured: dict[str, object] = {}
 
@@ -2851,7 +2877,11 @@ def test_workflow_studio_authoring_proposal_review_endpoint(monkeypatch, app_cli
 
     resp = app_client.post(
         "/api/workflow-studio/workflows/%23V%23alpha_workflow/proposals/review",
-        json={"action": "approve", "review_reason": "Safe to publish", "namespace": "#V#reviewer@test_org"},
+        json={
+            "action": "approve",
+            "review_reason": "Safe to publish",
+            "namespace": "#V#reviewer@test_org",
+        },
     )
 
     assert resp.status_code == 200
@@ -2871,10 +2901,13 @@ def test_workflow_studio_authoring_proposal_review_endpoint(monkeypatch, app_cli
 def test_workflow_studio_publication_supersede_endpoint_requires_replacement_id(
     monkeypatch,
     app_client,
+    studio_admin,
 ):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
     _authenticate_workflow_studio_client(app_client)
     resp = app_client.post(
         "/api/workflow-studio/workflows/%23V%23alpha_workflow/publication/supersede",
@@ -2886,10 +2919,14 @@ def test_workflow_studio_publication_supersede_endpoint_requires_replacement_id(
     assert payload["error"] == "replacement_workflow_id_required"
 
 
-def test_workflow_studio_description_proposal_endpoint(monkeypatch, app_client):
+def test_workflow_studio_description_proposal_endpoint(
+    monkeypatch, app_client, studio_admin
+):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
 
     captured: dict[str, str | None] = {}
 
@@ -2939,7 +2976,7 @@ def test_workflow_studio_description_proposal_endpoint(monkeypatch, app_client):
     }
 
 
-def test_workflow_studio_preview_remains_available_to_anonymous_new_target(
+def test_workflow_studio_preview_denies_anonymous_new_target(
     monkeypatch,
     app_client,
 ):
@@ -2964,8 +3001,8 @@ def test_workflow_studio_preview_remains_available_to_anonymous_new_target(
         },
     )
 
-    assert response.status_code == 200
-    assert response.get_json()["workflow_id"] == "#V#new_workflow"
+    assert response.status_code == 403
+    assert response.get_json() == {"error": "workflow_studio_admin_required"}
 
 
 @pytest.mark.parametrize(
@@ -3013,11 +3050,7 @@ def test_workflow_studio_anonymous_actor_cannot_mutate_new_target(
     )
 
     assert response.status_code == 403
-    assert response.get_json() == {
-        "error": "workflow_actor_authority_required",
-        "error_code": "workflow_actor_authority_required",
-        "workflow_id": "#V#new_workflow",
-    }
+    assert response.get_json() == {"error": "workflow_studio_admin_required"}
 
 
 @pytest.mark.parametrize(
@@ -3073,7 +3106,9 @@ def test_workflow_studio_anonymous_actor_cannot_mutate_public_target(
     def _unexpected_mutation(*_args, **_kwargs):
         raise AssertionError("anonymous Studio route must not enter mutation service")
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: True)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: True
+    )
     monkeypatch.setattr(workflows_routes, service_name, _unexpected_mutation)
 
     response = app_client.post(
@@ -3082,11 +3117,7 @@ def test_workflow_studio_anonymous_actor_cannot_mutate_public_target(
     )
 
     assert response.status_code == 403
-    assert response.get_json() == {
-        "error": "workflow_actor_authority_required",
-        "error_code": "workflow_actor_authority_required",
-        "workflow_id": "#V#public_workflow",
-    }
+    assert response.get_json() == {"error": "workflow_studio_admin_required"}
 
 
 @pytest.mark.parametrize(
@@ -3102,10 +3133,13 @@ def test_workflow_studio_authoring_routes_allow_provably_new_targets(
     app_client,
     path,
     service_name,
+    studio_admin,
 ):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: False)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: False
+    )
     _authenticate_workflow_studio_client(
         app_client,
         user_id="#V#author",
@@ -3147,6 +3181,7 @@ def test_workflow_studio_authoring_routes_conceal_hidden_existing_targets(
     app_client,
     path,
     service_name,
+    studio_admin,
 ):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
@@ -3192,10 +3227,13 @@ def test_workflow_studio_existing_target_mutations_conceal_hidden_workflows(
     app_client,
     path,
     payload,
+    studio_admin,
 ):
     import src.backend.server.routes.workflows_routes as workflows_routes
 
-    monkeypatch.setattr(workflows_routes, "can_access_concept", lambda _workflow_id: False)
+    monkeypatch.setattr(
+        workflows_routes, "can_access_concept", lambda _workflow_id: False
+    )
 
     response = app_client.post(
         f"/api/workflow-studio/workflows/%23V%23hidden_workflow/{path}",
@@ -3209,9 +3247,73 @@ def test_workflow_studio_existing_target_mutations_conceal_hidden_workflows(
     }
 
 
-def test_workflow_studio_page_route(app_client):
+def test_workflow_studio_page_route(app_client, studio_admin):
     resp = app_client.get("/von/workflow-studio")
 
-    assert resp.status_code == 200
-    assert b"Workflow Studio" in resp.data
-    assert b'href="/von/"' in resp.data
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/von/#workflowStudioTab"
+
+
+@pytest.fixture()
+def studio_admin(monkeypatch, app_client):
+    from src.backend.security import workflow_studio_access
+
+    _authenticate_workflow_studio_client(app_client)
+    with app_client.session_transaction() as flask_session:
+        flask_session["user_email"] = "studio-admin@example.test"
+        flask_session["auth_provider"] = "browser_test_fixture"
+    monkeypatch.setattr(
+        workflow_studio_access,
+        "is_live_von_operational_administrator",
+        lambda actor: True,
+    )
+
+
+@pytest.mark.parametrize(
+    "identity", ["anonymous", "member", "org_admin", "stale_oauth", "unreadable_role"]
+)
+def test_studio_all_entry_points_deny_without_live_admin(
+    monkeypatch, app_client, identity
+):
+    from src.backend.security import workflow_studio_access
+
+    def resolve_role(actor):
+        if identity == "unreadable_role":
+            raise RuntimeError("role store unavailable")
+        return identity == "stale_oauth"
+
+    monkeypatch.setattr(
+        workflow_studio_access, "is_live_von_operational_administrator", resolve_role
+    )
+    if identity != "anonymous":
+        with app_client.session_transaction() as flask_session:
+            flask_session.update(
+                user_concept_id="#V#test_actor",
+                user_email="actor@example.test",
+                auth_provider=(
+                    "google_oauth"
+                    if identity == "stale_oauth"
+                    else "browser_test_fixture"
+                ),
+                role_in_org="admin" if identity == "org_admin" else "member",
+            )
+    rules = [
+        rule
+        for rule in app_client.application.url_map.iter_rules()
+        if "workflow-studio" in rule.rule
+    ]
+    assert len(rules) == 12
+    for rule in rules:
+        url = rule.rule.replace("<path:workflow_id>", "%23V%23test_workflow")
+        method = "POST" if "POST" in rule.methods else "GET"
+        response = app_client.open(
+            url, method=method, json={} if method == "POST" else None
+        )
+        assert response.status_code == 403, (identity, url, response.status_code)
+        assert response.get_json() == {"error": "workflow_studio_admin_required"}
+
+
+def test_studio_capability_uses_canonical_auth_status(app_client, studio_admin):
+    response = app_client.get("/von/api/auth/status")
+    assert response.get_json()["authenticated"] is True
+    assert response.get_json()["workflow_studio_access"] is True

--- a/tests/browser/workflowStudioAccess.cjs
+++ b/tests/browser/workflowStudioAccess.cjs
@@ -58,11 +58,15 @@ fs.mkdirSync(evidence, { recursive: true });
                 }
             }
             await page.screenshot({ path: path.join(evidence, `${role}-${mobile ? 'mobile' : 'desktop'}.png`) });
-            // The standard AgentTest fixture provides this conversation; edit only a local draft.
+            // Use an existing conversation; edit only a local, unsent draft.
             await page.locator('[data-tab="chatTab"]').click();
-            await page.locator('.footer-org-menu-trigger').click();
-            await page.locator('.footer-org-option').filter({ hasText: 'University' }).click();
-            await page.locator('.message-conversation-row').filter({ hasText: 'Workflow Reviewer' }).click();
+            if (role === 'member') {
+                await page.locator('.footer-org-menu-trigger').click();
+                await page.locator('.footer-org-option').filter({ hasText: 'University' }).click();
+            }
+            await page.locator('.message-conversation-row').filter({
+                hasText: role === 'admin' ? /Codex DGX|Codex VS Code/ : 'Workflow Reviewer'
+            }).first().click();
             const draft = page.locator('#messageInput');
             await draft.fill('Unsent Studio access acceptance draft');
             if (!mobile && role === 'admin') await studioButton.click();

--- a/tests/browser/workflowStudioAccess.cjs
+++ b/tests/browser/workflowStudioAccess.cjs
@@ -79,7 +79,7 @@ fs.mkdirSync(evidence, { recursive: true });
             await expect(page.frameLocator('#settingsFrame').locator('#preferredLanguageSelect')).toBeVisible();
             await context.close();
         }
-        const result = { commit, role, desktopAndMobile: true, draftsPreserved: true, generationBlocked: true, noWrites: true };
+        const result = { commit, role, desktopAndMobile: true, draftsPreserved: true, generationBlocked: true, noWorkflowOrMessageMutations: true };
         fs.writeFileSync(path.join(evidence, `${role}.json`), JSON.stringify(result, null, 2));
         console.log(JSON.stringify(result));
     } finally { await browser.close(); }

--- a/tests/browser/workflowStudioAccess.cjs
+++ b/tests/browser/workflowStudioAccess.cjs
@@ -60,14 +60,17 @@ fs.mkdirSync(evidence, { recursive: true });
             await page.screenshot({ path: path.join(evidence, `${role}-${mobile ? 'mobile' : 'desktop'}.png`) });
             // Use an existing conversation; edit only a local, unsent draft.
             await page.locator('[data-tab="chatTab"]').click();
-            if (role === 'member') {
-                await page.locator('.footer-org-menu-trigger').click();
-                await page.locator('.footer-org-option').filter({ hasText: 'University' }).click();
-            }
+            // Initial auth/scope refresh may rebuild and close the menu once.
+            await expect(async () => {
+                const organisation = page.locator('.footer-org-option[data-organisation-concept-id="#V#university_of_auckland_strong_ai_lab"]');
+                if (!await organisation.isVisible()) await page.locator('.footer-org-menu-trigger').click();
+                await organisation.click({ timeout: 2000 });
+            }).toPass({ timeout: 15000 });
             await page.locator('.message-conversation-row').filter({
                 hasText: role === 'admin' ? /Codex DGX|Codex VS Code/ : 'Workflow Reviewer'
             }).first().click();
             const draft = page.locator('#messageInput');
+            await expect(draft).toHaveAttribute('placeholder', /Reply to/);
             await draft.fill('Unsent Studio access acceptance draft');
             if (!mobile && role === 'admin') await studioButton.click();
             await page.setViewportSize({ width: 412, height: 915 });

--- a/tests/browser/workflowStudioAccess.cjs
+++ b/tests/browser/workflowStudioAccess.cjs
@@ -1,0 +1,86 @@
+// Read-only acceptance on an operator-prepared localhost AgentTest server.
+// No role changes, messages, workflow mutations or generation are performed.
+// Run for each role with PLAYWRIGHT_BROWSERS_PATH=/tmp/von-playwright:
+// node tests/browser/workflowStudioAccess.cjs URL SHA admin|member EVIDENCE_DIR
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { chromium, expect } = require('@playwright/test');
+const [base, commit, role, evidence] = process.argv.slice(2);
+assert(['localhost', '127.0.0.1'].includes(new URL(base).hostname));
+assert(['admin', 'member'].includes(role));
+assert(/^[0-9a-f]{40}$/.test(commit));
+fs.mkdirSync(evidence, { recursive: true });
+(async () => {
+    const browser = await chromium.launch();
+    try {
+        for (const mobile of [false, true]) {
+            const context = await browser.newContext({
+                viewport: mobile ? { width: 412, height: 915 } : { width: 1440, height: 900 },
+                isMobile: mobile, hasTouch: mobile
+            });
+            const page = await context.newPage();
+            page.setDefaultTimeout(20000);
+            await page.route('**/von/generate', route => route.abort());
+            const health = await (await page.request.get(`${base}/health`)).json();
+            assert.equal(health.version_details.git_commit, commit);
+            for (const url of ['/von/workflow-studio', '/von/workflow-studio/content', '/api/workflow-studio/catalogue']) {
+                assert.equal((await page.request.get(`${base}${url}`, { maxRedirects: 0 })).status(), 403);
+            }
+            const studioRequests = [];
+            page.on('request', request => {
+                if (/workflow-studio|workflowStudio(Page|Tab)\.js/.test(request.url())) studioRequests.push(request.url());
+            });
+            await page.goto(`${base}/von/#workflowStudioTab`);
+            await page.locator('#vonBrowserTestLoginButton').click();
+            await expect(page.locator('[data-tab="chatTab"]')).toBeVisible();
+            const auth = await page.evaluate(async () => (await fetch('/von/api/auth/status')).json());
+            assert.equal(auth.authenticated, true);
+            assert.equal(auth.auth_provider, 'browser_test_fixture');
+            assert.equal(auth.workflow_studio_access, role === 'admin');
+            const studioButton = page.locator('[data-tab="workflowStudioTab"]');
+            if (mobile || role === 'member') {
+                await expect(studioButton).toBeHidden();
+                await expect(page.locator('#chatTab')).toHaveClass(/active/);
+                assert.equal(studioRequests.length, 0, 'blocked saved link must not lazy-load Studio');
+                await page.evaluate(() => document.querySelector('[data-tab="workflowStudioTab"]').click());
+                await expect(page.locator('#chatTab')).toHaveClass(/active/);
+                assert.equal(studioRequests.length, 0);
+            } else {
+                await expect(studioButton).toBeVisible();
+                await expect(page.locator('#workflowStudioTab')).toHaveClass(/active/);
+                await expect(page.locator('#workflowStudioCatalogue')).toBeVisible();
+                assert.equal((await page.request.get(`${base}/api/workflow-studio/catalogue`)).status(), 200);
+            }
+            if (role === 'member') {
+                for (const url of ['/von/workflow-studio', '/von/workflow-studio/content', '/api/workflow-studio/catalogue']) {
+                    assert.equal((await page.request.get(`${base}${url}`, { maxRedirects: 0 })).status(), 403);
+                }
+            }
+            await page.screenshot({ path: path.join(evidence, `${role}-${mobile ? 'mobile' : 'desktop'}.png`) });
+            // The standard AgentTest fixture provides this conversation; edit only a local draft.
+            await page.locator('[data-tab="chatTab"]').click();
+            await page.locator('.footer-org-menu-trigger').click();
+            await page.locator('.footer-org-option').filter({ hasText: 'University' }).click();
+            await page.locator('.message-conversation-row').filter({ hasText: 'Workflow Reviewer' }).click();
+            const draft = page.locator('#messageInput');
+            await draft.fill('Unsent Studio access acceptance draft');
+            if (!mobile && role === 'admin') await studioButton.click();
+            await page.setViewportSize({ width: 412, height: 915 });
+            await expect(studioButton).toBeHidden();
+            await expect(page.locator('#chatTab')).toHaveClass(/active/);
+            await expect(draft).toHaveValue('Unsent Studio access acceptance draft');
+            await page.setViewportSize({ width: 840, height: 900 });
+            if (mobile) await expect(studioButton).toBeHidden(); // coarse-pointer foldable
+            else if (role === 'admin') await expect(studioButton).toBeVisible();
+            await page.locator('[data-tab="globalTasksTab"]').click();
+            await expect(page.locator('#globalTasksTab')).toHaveClass(/active/);
+            await page.locator('[data-tab="settingsTab"]').click();
+            await expect(page.frameLocator('#settingsFrame').locator('#preferredLanguageSelect')).toBeVisible();
+            await context.close();
+        }
+        const result = { commit, role, desktopAndMobile: true, draftsPreserved: true, generationBlocked: true, noWrites: true };
+        fs.writeFileSync(path.join(evidence, `${role}.json`), JSON.stringify(result, null, 2));
+        console.log(JSON.stringify(result));
+    } finally { await browser.close(); }
+})().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/frontend/workflowStudioAccess.test.js
+++ b/tests/frontend/workflowStudioAccess.test.js
@@ -51,10 +51,10 @@ describe('Studio admission and responsive navigation', () => {
         expect(document.body.dataset.activeTab).toBe('settingsTab');
         document.removeEventListener('von:tab-activated', changed);
     });
-    test('loss of authenticated capability closes Studio', () => {
+    test.each(['authStatusChanged', 'von:studio-access-changed'])('loss of capability closes Studio via %s', eventName => {
         setupTabNavigation();
         activateTab('workflowStudioTab');
-        document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: { authenticated: false } }));
+        document.dispatchEvent(new CustomEvent(eventName, { detail: { authenticated: false } }));
         expect(canUseWorkflowStudio()).toBe(false);
         expect(document.body.dataset.activeTab).toBe('chatTab');
     });

--- a/tests/frontend/workflowStudioAccess.test.js
+++ b/tests/frontend/workflowStudioAccess.test.js
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+const { setWorkflowStudioAccess, canUseWorkflowStudio, STUDIO_MOBILE_QUERY } = require('../../src/frontend/web/von_interface/static/js/workflowStudioAccess.js');
+const { activateTab, setupTabNavigation } = require('../../src/frontend/web/von_interface/static/js/tabNavigation.js');
+jest.mock('../../src/frontend/web/von_interface/static/js/workflowStudioTab.js', () => ({ loadWorkflowStudioTab: jest.fn() }));
+
+describe('Studio admission and responsive navigation', () => {
+    let media;
+    beforeEach(() => {
+        media = { matches: false, addEventListener: jest.fn() };
+        window.matchMedia = jest.fn(() => media);
+        setWorkflowStudioAccess({ authenticated: true, workflow_studio_access: true });
+        document.body.innerHTML = `
+            <button class="tab-button" data-tab="chatTab">Conversations</button>
+            <button class="tab-button" data-tab="workflowStudioTab" hidden>Studio</button>
+            <button class="tab-button" data-tab="settingsTab">Settings</button>
+            <section class="tab-content" id="chatTab"><textarea id="draft">Keep this draft</textarea></section>
+            <section class="tab-content" id="workflowStudioTab"></section>
+            <section class="tab-content" id="settingsTab"></section>`;
+    });
+    test.each([
+        [false, false], [false, true], [true, true]
+    ])('denies hidden clicks and saved selection: admin=%s mobile=%s', (admin, mobile) => {
+        setWorkflowStudioAccess({ authenticated: true, workflow_studio_access: admin });
+        media.matches = mobile;
+        setupTabNavigation();
+        localStorage.setItem('role_in_org', 'admin');
+        activateTab('workflowStudioTab');
+        document.querySelector('[data-tab="workflowStudioTab"]').click();
+        expect(document.body.dataset.activeTab).toBe('chatTab');
+        expect(location.hash).toBe('#chatTab');
+        expect(document.querySelector('[data-tab="workflowStudioTab"]').hidden).toBe(true);
+        expect(canUseWorkflowStudio()).toBe(false);
+    });
+    test('desktop Admin opens Studio; resize preserves drafts and stops active Studio', () => {
+        setupTabNavigation();
+        activateTab('workflowStudioTab');
+        expect(document.body.dataset.activeTab).toBe('workflowStudioTab');
+        expect(document.querySelector('[data-tab="workflowStudioTab"]').hidden).toBe(false);
+        const changed = jest.fn();
+        document.addEventListener('von:tab-activated', changed);
+        media.matches = true;
+        media.addEventListener.mock.calls[0][1]();
+        expect(document.body.dataset.activeTab).toBe('chatTab');
+        expect(document.getElementById('draft').value).toBe('Keep this draft');
+        expect(changed).toHaveBeenCalled();
+        expect(window.matchMedia).toHaveBeenCalledWith(STUDIO_MOBILE_QUERY);
+        media.matches = false;
+        media.addEventListener.mock.calls[0][1]();
+        expect(document.body.dataset.activeTab).toBe('chatTab');
+        activateTab('settingsTab');
+        expect(document.body.dataset.activeTab).toBe('settingsTab');
+        document.removeEventListener('von:tab-activated', changed);
+    });
+    test('loss of authenticated capability closes Studio', () => {
+        setupTabNavigation();
+        activateTab('workflowStudioTab');
+        document.dispatchEvent(new CustomEvent('authStatusChanged', { detail: { authenticated: false } }));
+        expect(canUseWorkflowStudio()).toBe(false);
+        expect(document.body.dataset.activeTab).toBe('chatTab');
+    });
+});

--- a/tests/frontend/workflowStudioTab.test.js
+++ b/tests/frontend/workflowStudioTab.test.js
@@ -1,3 +1,4 @@
+jest.mock('../../src/frontend/web/von_interface/static/js/workflowStudioAccess.js', () => ({ canUseWorkflowStudio: jest.fn(() => true) }));
 /** @jest-environment jsdom */
 jest.mock('../../src/frontend/web/von_interface/static/js/workflowStudioPage.js', () => ({
     initialiseWorkflowStudio: jest.fn(),
@@ -14,6 +15,7 @@ describe('Workflow Studio tab loading', () => {
     let container;
     beforeEach(() => {
         jest.clearAllMocks();
+        require('../../src/frontend/web/von_interface/static/js/workflowStudioAccess.js').canUseWorkflowStudio.mockReturnValue(true);
         document.body.innerHTML = '<section id="workflowStudioTab" data-src="/von/workflow-studio/content"></section>';
         container = document.getElementById('workflowStudioTab');
         global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => '<input aria-label="Draft" value="original">' });
@@ -43,4 +45,21 @@ describe('Workflow Studio tab loading', () => {
         expect(initialiseWorkflowStudio).toHaveBeenCalledTimes(1);
         error.mockRestore();
     });
+    test('unavailable Studio never requests content', async () => {
+        require('../../src/frontend/web/von_interface/static/js/workflowStudioAccess.js').canUseWorkflowStudio.mockReturnValue(false);
+        await loadWorkflowStudioTab(container);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+    test('resizing during content load does not initialise hidden Studio', async () => {
+        let resolve;
+        fetch.mockReturnValueOnce(new Promise(done => { resolve = done; }));
+        const loading = loadWorkflowStudioTab(container);
+        require('../../src/frontend/web/von_interface/static/js/workflowStudioAccess.js').canUseWorkflowStudio.mockReturnValue(false);
+        resolve({ ok: true, text: async () => '<div>Studio</div>' });
+        await loading;
+        expect(initialiseWorkflowStudio).not.toHaveBeenCalled();
+        expect(initializeWorkflowStatusPanel).not.toHaveBeenCalled();
+        expect(container.dataset.initialized).toBeUndefined();
+    });
+
 });


### PR DESCRIPTION
Workflow Studio is now available only to authenticated holders of Von’s existing operational-administrator role on desktop. All 12 Studio-specific page/data/edit routes enforce admission before their existing visibility and mutation-authority checks. Organisation Admin/Owner alone and client storage do not grant access; shared workflow APIs retain their existing semantics.

Studio is absent at the established mobile boundary: up to 800px, or up to 1024px with a coarse pointer. Saved links and hidden clicks recover to Conversations. Resizing preserves unsent conversation drafts and stops Studio streams, retries and capability-index polling. The hidden-state CSS overrides existing important tab display rules. Settings capability updates remain scoped to Studio.

Task: `#V#task_agent_81ca515c29e6e62b81332877e794cf34`

Validation:

- Existing 97 backend and 319 frontend tests passed on the retained implementation, covering all 12 route boundaries and ordinary shared workflow behaviour. These unchanged suites were not repeated; subsequent product changes only correct the CSS hidden-state precedence.
- Authenticated Playwright matrix passed on product revision `b869b9a00c11d185d2af6a2a98067c52e463bbeb`: operational Admin and non-Admin, desktop/mobile, saved Studio links, forced hidden-button clicks, unsent existing-conversation drafts, resize, coarse-pointer foldable, Tasks and Settings.
- Desktop Studio/navigation geometry matches baseline `eb145613aca4638cc7e912980ff853f0421d5e1c` exactly. Both screenshots were visually inspected.
- Browser harness now selects the existing SAIL organisation and role-appropriate conversation and waits for its reply input; final commit changes the harness only. JavaScript syntax and diff checks pass.
- Operator canonical membership evidence confirms the sole current operational administrator is Michael Witbrock. No roles were changed.

Browser acceptance uses separate localhost-only existing-user fixture profiles, not public Google OAuth. Generation is blocked; no messages or workflow mutations were submitted. The operator adapter reads existing identities/memberships without changing them. Local evidence is retained under `/tmp/studio-acceptance` and is not committed as public runtime data.

No deployment is requested or performed.

Additional focused browser boundary checks passed: all 12 Studio routes denied both anonymous and authenticated non-Admin requests; desktop-to-mobile resize closed the Studio EventSource and produced zero workflow requests for 65 seconds (beyond the 60-second polling interval); the standalone mobile bookmark recovered to Conversations without initialising Studio.

Merge decision changes — accepted for merge after required CI passed. The assigned acceptance matrix and desktop comparison pass, with no observed candidate-caused material regression. Physical-device and public OAuth acceptance are outside this bounded fixture claim.

Final candidate verification: both localhost profiles were restarted and read back clean at `178743401ecdd2f26ec6422ea9ae18b95b783988`. The full focused Admin/member desktop/mobile browser harness passed again on that exact revision. Both GitHub checks passed and GitHub reports the PR clean/mergeable. Product files are unchanged from the baseline-comparison and 65-second hidden-poll evidence revision.

Publication complete: merged as `e15c4d697a1458fdc0b3bb400d64551adf56c8c7`, verified current `origin/main` with a tree identical to the tested final candidate. Checkout returned to clean `main`. All three test profiles report unavailable and ports 5010/5011/5012 are closed. Stop controls emitted process-exit assertion errors, so shutdown was verified independently. No public deployment was requested or performed.
