### PR TITLE
Recover mobile conversation space with header scope and on-demand footer controls

### DIFF
--- a/src/frontend/web/von_interface/static/js/components/dynamicLayout.js
+++ b/src/frontend/web/von_interface/static/js/components/dynamicLayout.js
@@ -3,18 +3,69 @@
  * JVNAUTOSCI-550: Replace hard-coded CSS positions with JavaScript calculation
  */
 export function setupDynamicLayout() {
-  // Reuse the actual diagnostic controls so their handlers and live values survive.
+  // Reparent live nodes so asynchronous refreshes and conversation scope survive.
   const footerContainer = document.querySelector('.footer-container');
-  const secondaryFooterItems = footerContainer
-    ? Array.from(footerContainer.children).filter(item => item.id !== 'modelInfoFooter') : [];
+  const footerHome = document.createComment('desktop footer');
+  footerContainer?.before(footerHome);
+  const aboutButton = document.getElementById('infoIcon');
+  const aboutHome = document.createComment('desktop organisation information');
+  aboutButton?.before(aboutHome);
+  const mobileControls = document.createElement('div');
+  mobileControls.className = 'mobile-shell-controls';
   const footerDetails = document.createElement('details');
   footerDetails.className = 'mobile-footer-details';
   const summary = document.createElement('summary');
   summary.textContent = 'Info';
-  summary.setAttribute('aria-label', 'Footer information and diagnostics');
+  summary.setAttribute('aria-label', 'Conversation model, cost, account and diagnostics');
   const detailsPanel = document.createElement('div');
   detailsPanel.className = 'mobile-footer-details-panel';
   footerDetails.append(summary, detailsPanel);
+  mobileControls.append(footerDetails);
+  let organisation = null;
+  let organisationHome = null;
+  const narrowLayout = () => window.matchMedia('(max-width: 800px), (max-width: 1024px) and (pointer: coarse)').matches;
+
+  function placeOrganisation() {
+    const fresh = footerContainer?.querySelector('.footer-org-switcher');
+    if (fresh && fresh !== organisation) {
+      organisation?.remove();
+      organisationHome?.remove();
+      organisation = fresh;
+      organisationHome = document.createComment('desktop organisation');
+      fresh.before(organisationHome);
+    }
+    if (organisation && narrowLayout()) {
+      if (organisation.parentElement !== mobileControls) mobileControls.prepend(organisation);
+      const button = organisation.querySelector('.footer-org-current-button');
+      const trigger = organisation.querySelector('.footer-org-menu-trigger');
+      let compactLabel = trigger?.querySelector('.mobile-org-label');
+      if (trigger && !compactLabel) {
+        compactLabel = document.createElement('span');
+        compactLabel.className = 'mobile-org-label';
+        trigger.prepend(compactLabel);
+      }
+      const label = button?.textContent || 'Personal';
+      if (compactLabel && compactLabel.textContent !== label) compactLabel.textContent = label;
+      trigger?.setAttribute('aria-label', `Switch organisation: ${button?.dataset.conceptName || label}`);
+    } else if (organisationHome?.isConnected && organisation?.parentNode !== organisationHome.parentNode) {
+      organisationHome.after(organisation);
+    }
+  }
+  footerDetails.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      footerDetails.open = false;
+      summary.focus();
+    }
+  });
+  document.addEventListener('pointerdown', event => {
+    if (footerDetails.open && !footerDetails.contains(event.target)) footerDetails.open = false;
+  });
+  // Rendering replaces children; compact canonical identity labels arrive later.
+  if (footerContainer && typeof MutationObserver === 'function') {
+    const observer = new MutationObserver(placeOrganisation);
+    observer.observe(footerContainer, { childList: true, subtree: true, characterData: true });
+    observer.observe(mobileControls, { childList: true, subtree: true, characterData: true });
+  }
 
   function updateLayout() {
     const header = document.getElementById('globalHeader');
@@ -27,26 +78,25 @@ export function setupDynamicLayout() {
       return;
     }
 
-    // Get actual header height including search box
+    const narrow = narrowLayout();
+    const headerSlot = header.querySelector('.global-organisation-identity') || header;
+    if (footerContainer && narrow && !mobileControls.isConnected) {
+      headerSlot.append(mobileControls);
+      detailsPanel.append(footerContainer);
+      if (aboutButton) detailsPanel.append(aboutButton);
+    } else if (!narrow && mobileControls.isConnected) {
+      footerHome.after(footerContainer);
+      if (aboutButton) aboutHome.after(aboutButton);
+      mobileControls.remove();
+    }
+    placeOrganisation();
     const headerHeight = header.getBoundingClientRect().height;
     tabContainer.style.top = `${headerHeight}px`;
-    const measuredTabHeight = Math.max(
-      44,
-      Math.ceil(tabContainer.getBoundingClientRect().height || tabContainer.scrollHeight || 44)
-    );
-    const tabHeight = measuredTabHeight;
-    const contentTop = headerHeight + tabHeight + 8; // 8px margin
-    const narrow = window.matchMedia('(max-width: 800px), (max-width: 1024px) and (pointer: coarse)').matches;
-    const footer = document.querySelector('.footer-container');
-    if (footer && narrow && !footerDetails.isConnected) {
-      detailsPanel.append(...secondaryFooterItems);
-      footer.append(footerDetails);
-    } else if (!narrow && footerDetails.isConnected) {
-      footer.append(...secondaryFooterItems);
-      footerDetails.remove();
-      footerDetails.open = false;
-    }
-    const footerSpace = narrow ? Math.ceil(footer?.getBoundingClientRect().height || 64) + 8 : Math.max(64, Math.ceil(footer?.getBoundingClientRect().height || 0));
+    const tabHeight = Math.max(44, Math.ceil(tabContainer.getBoundingClientRect().height || tabContainer.scrollHeight || 44));
+    const contentTop = headerHeight + tabHeight + 8;
+    const composer = document.querySelector('.chat-composer');
+    document.documentElement.style.setProperty('--von-mobile-composer-height', `${Math.ceil(composer?.getBoundingClientRect().height || 0)}px`);
+    const footerSpace = narrow ? 0 : Math.max(64, Math.ceil(footerContainer?.getBoundingClientRect().height || 0));
     // At normal zoom the visual viewport excludes the on-screen keyboard.
     // Pinch zoom must not resize the application or discard a draft.
     const viewport = window.visualViewport;
@@ -79,6 +129,11 @@ export function setupDynamicLayout() {
         area.style.marginTop = `${contentTop}px`;
       }
     });
+  }
+
+  const composer = document.querySelector('.chat-composer');
+  if (composer && typeof ResizeObserver === 'function') {
+    new ResizeObserver(() => requestAnimationFrame(updateLayout)).observe(composer);
   }
 
   // Initial layout

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -18268,6 +18268,7 @@ body.settings-body {
     margin-block: 0.3rem;
 }
 .chat-steering-feedback .btn-mini { flex-shrink: 0; }
+.mobile-org-label { display: none; }
 /* Phone and folded-device shell. Keep the existing desktop layout and DOM;
    resizing must never recreate a conversation or its draft. */
 @media (max-width: 800px), (max-width: 1024px) and (pointer: coarse) {
@@ -18332,58 +18333,67 @@ body.settings-body {
     .unified-message-content .message-view-content { padding-bottom: 130px; }
 
     .chat-composer {
+        position: fixed;
+        left: max(8px, env(safe-area-inset-left)); right: max(8px, env(safe-area-inset-right));
+        margin: 0;
         bottom: calc(var(--von-fixed-footer-clearance, 64px) + var(--von-keyboard-inset, 0px));
         max-height: calc(var(--von-viewport-height, 100dvh) - 60px);
         overflow-y: auto;
     }
+    #chatTab > .content-wrapper { padding-bottom: calc(var(--von-mobile-composer-height, 180px) + 16px); box-sizing: border-box; }
     #promptInput { font-size: 16px; }
     .chat-composer-more-actions > summary { min-height: 44px; display: flex; align-items: center; }
 
-    .footer-container {
-        /* Let the fixed organisation menu use the viewport, not a filter-created containing block. */
-        backdrop-filter: none;
-        -webkit-backdrop-filter: none;
-        bottom: var(--von-keyboard-inset, 0px);
-        padding: 4px max(8px, env(safe-area-inset-right)) max(4px, env(safe-area-inset-bottom))
-            max(8px, env(safe-area-inset-left));
-        gap: 8px;
+    /* Use the existing header row for scope and on-demand information. */
+    .global-header-shell { flex-wrap: nowrap; }
+    .global-header .global-concept-search { flex: 1 1 0; min-width: 0; }
+    .global-header .main-container { flex: 0 0 auto; }
+    .global-organisation-identity > .global-organisation-title,
+    .global-organisation-identity > .info-icon { display: none; }
+    .mobile-shell-controls { display: flex; align-items: center; gap: 6px; }
+    .mobile-shell-controls .footer-org-switcher > .footer-label-inline,
+    .mobile-shell-controls .footer-org-current-button { display: none; }
+    .mobile-shell-controls .footer-org-menu-trigger {
+        width: auto; min-width: 44px; min-height: 44px; padding: 0 6px;
+        display: flex; align-items: center; gap: 4px;
     }
-    .footer-info {
-        min-width: 0; display: flex; flex-wrap: wrap; gap: 4px;
-        white-space: normal;
-    }
-    .footer-info > .footer-separator { display: none; }
-    .footer-user-segment { order: -2; }
-    .footer-org-switcher { order: -1; }
-    .footer-user-segment, .footer-org-switcher { max-width: 100%; }
-    .footer-user-segment .concept-footer-button,
-    .footer-org-current-button { max-width: min(150px, calc((100vw - 140px) / 2)); overflow: hidden; text-overflow: ellipsis; }
-    .footer-info .conversation-model-controls { flex-basis: 100%; }
-
-    .mobile-footer-details { flex-shrink: 0; }
+    .mobile-org-label { display: inline; max-width: 76px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .mobile-footer-details > summary {
-        min-height: 44px; display: flex; align-items: center; cursor: pointer;
+        min-width: 44px; min-height: 44px; display: flex;
+        align-items: center; justify-content: center; cursor: pointer;
     }
     .mobile-footer-details-panel {
-        position: fixed;
-        left: 8px; right: 8px;
-        bottom: calc(var(--von-fixed-footer-clearance, 64px) + var(--von-keyboard-inset, 0px));
-        max-height: calc(var(--von-viewport-height, 100dvh) - var(--von-fixed-footer-clearance, 64px) - 16px);
+        position: fixed; z-index: 1200;
+        left: max(8px, env(safe-area-inset-left)); right: max(8px, env(safe-area-inset-right));
+        top: var(--von-fixed-shell-height);
+        max-height: calc(var(--von-viewport-height, 100dvh) - var(--von-fixed-shell-height) - 16px);
         overflow: auto; padding: 12px;
         background: var(--background-color, white); color: var(--text-color, #222);
         border: 1px solid #aaa; border-radius: 8px;
     }
+    .mobile-footer-details-panel .footer-container {
+        position: static; display: flex; flex-direction: column; align-items: stretch;
+        width: auto; padding: 0; margin: 0; gap: 8px;
+        backdrop-filter: none; -webkit-backdrop-filter: none;
+        box-shadow: none; border: 0;
+    }
+    .mobile-footer-details-panel .footer-info {
+        min-width: 0; display: flex; flex-direction: column; align-items: stretch;
+        gap: 8px; white-space: normal;
+    }
+    .mobile-footer-details-panel .footer-separator { display: none; }
     .mobile-footer-details-panel p { display: block; white-space: normal; }
-    .footer-info button, .footer-org-menu-trigger { min-height: 44px; }
-    .footer-org-menu {
-        position: fixed;
-        left: max(8px, env(safe-area-inset-left));
-        right: max(8px, env(safe-area-inset-right));
-        bottom: calc(var(--von-fixed-footer-clearance, 64px) + var(--von-keyboard-inset, 0px));
-        width: auto;
-        max-width: none;
-        max-height: calc(var(--von-viewport-height, 100dvh) - var(--von-fixed-footer-clearance, 64px) - 16px);
+    .mobile-footer-details-panel button, .mobile-footer-details-panel select { min-height: 44px; }
+    .mobile-shell-controls .footer-org-menu {
+        position: fixed; z-index: 1201;
+        left: max(8px, env(safe-area-inset-left)); right: max(8px, env(safe-area-inset-right));
+        top: var(--von-fixed-shell-height); bottom: auto;
+        width: auto; max-width: none;
+        max-height: calc(var(--von-viewport-height, 100dvh) - var(--von-fixed-shell-height) - 16px);
         overflow-y: auto;
+    }
+    .chat-composer, .unified-message-content .message-compose-area {
+        bottom: calc(var(--von-keyboard-inset, 0px) + max(8px, env(safe-area-inset-bottom)));
     }
 
     .tab-content.dynamic-concept-tab { width: 100% !important; min-width: 0; }

--- a/tests/browser/mobileFooter.cjs
+++ b/tests/browser/mobileFooter.cjs
@@ -36,7 +36,11 @@ async function switchScope(page, id) {
     }).toPass({ timeout: 15000 });
     await expect(page.locator('.footer-org-current-button')).toHaveAttribute('data-concept-id', id);
     await page.waitForTimeout(2500);
-    const scope = await page.evaluate(async () => (await fetch('/von/api/session/context')).json());
+    const scope = await page.evaluate(async () => {
+        return (await fetch('/von/api/session/context', {
+            headers: { 'X-Von-Window-Session': sessionStorage.getItem('von_window_session_id') }
+        })).json();
+    });
     assert.equal(scope.organisation_id || '', id);
 }
 async function measure(page, name) {
@@ -107,8 +111,7 @@ async function measure(page, name) {
         await switchScope(page, orgId);
         // Exercise the production asynchronous render entry point, without generation.
         await page.evaluate(async () => {
-            const { setModelInfoFooterText } = await import('/static/js/domUtils.js');
-            await setModelInfoFooterText();
+            await window.updateModelInfoFooterDisplay();
         });
         await expect(page.locator('.mobile-shell-controls .footer-org-switcher')).toHaveCount(1);
         await expect(page.locator('.footer-container')).toBeHidden();
@@ -117,7 +120,11 @@ async function measure(page, name) {
         await page.locator('.conversation-model-controls button').click();
         await page.locator('.mobile-footer-details > summary').click();
         await expect(page.frameLocator('#settingsFrame').locator('#premium-model-settings')).toBeVisible();
-        await expect(page.frameLocator('#settingsFrame').locator('#openaiReasoningEffortSelect')).toBeVisible();
+        const reasoningState = async p => {
+            const select = p.frameLocator('#settingsFrame').locator('#openaiReasoningEffortSelect');
+            return { visible: await select.isVisible(), disabled: await select.isDisabled() };
+        };
+        const candidateReasoning = await reasoningState(page);
         await page.screenshot({ path: path.join(evidence, 'model-settings.png') });
         const desktop = await login(browser, candidate, false);
         const control = await login(browser, baseline, false);
@@ -142,7 +149,10 @@ async function measure(page, name) {
         }
         await desktop.locator('.footer-org-menu-trigger').click();
         await expect(desktop.locator('.footer-org-options')).toBeVisible();
-        fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ sha, metrics, noSendsOrModelCalls: true, simulationLimits: 'Chromium viewport/touch simulation; no physical keyboard or public OAuth claim' }, null, 2));
+        await control.locator('.conversation-model-controls button').click();
+        await expect(control.frameLocator('#settingsFrame').locator('#premium-model-settings')).toBeVisible();
+        assert.deepEqual(await reasoningState(control), candidateReasoning);
+        fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ sha, metrics, reasoningState: candidateReasoning, noSendsOrModelCalls: true, simulationLimits: 'Chromium viewport/touch simulation; no physical keyboard or public OAuth claim' }, null, 2));
         console.log(JSON.stringify({ sha, profiles: metrics.length, passed: true }));
     } finally { await browser.close(); }
 })().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/browser/mobileFooter.cjs
+++ b/tests/browser/mobileFooter.cjs
@@ -1,0 +1,148 @@
+// Read-only authenticated layout acceptance; organisation changes affect only
+// the fixture session. Never sends drafts or invokes models/workflows.
+// PLAYWRIGHT_BROWSERS_PATH=... node tests/browser/mobileFooter.cjs CANDIDATE BASELINE SHA DIR
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { chromium, expect } = require('@playwright/test');
+const [candidate, baseline, sha, evidence] = process.argv.slice(2);
+for (const url of [candidate, baseline]) assert(['localhost', '127.0.0.1'].includes(new URL(url).hostname));
+fs.mkdirSync(evidence, { recursive: true });
+const orgId = '#V#university_of_auckland_strong_ai_lab';
+const metrics = [];
+async function login(browser, base, mobile) {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, isMobile: mobile, hasTouch: mobile });
+    const page = await context.newPage();
+    page.setDefaultTimeout(20000);
+    await page.route('**/von/generate', route => route.abort());
+    const health = await (await page.request.get(`${base}/health`)).json();
+    assert.equal(health.agent_test_instance, true);
+    if (base === candidate) assert.equal(health.version_details.git_commit, sha);
+    await page.goto(`${base}/von/`);
+    await page.locator('#vonBrowserTestLoginButton').click();
+    await expect(page.locator('#promptInput')).toBeVisible();
+    await page.waitForTimeout(4000);
+    const auth = await page.evaluate(async () => (await fetch('/von/api/auth/status')).json());
+    assert.equal(auth.authenticated, true);
+    assert.equal(auth.auth_provider, 'browser_test_fixture');
+    return page;
+}
+async function switchScope(page, id) {
+    await expect(async () => {
+        const option = page.locator(`.footer-org-option[data-organisation-concept-id="${id}"]`);
+        if (!await option.isVisible()) await page.locator('.footer-org-menu-trigger').click();
+        if (!await option.isDisabled()) await option.click({ timeout: 2000 });
+        else await page.locator('.footer-org-menu-trigger').click();
+    }).toPass({ timeout: 15000 });
+    await expect(page.locator('.footer-org-current-button')).toHaveAttribute('data-concept-id', id);
+    await page.waitForTimeout(2500);
+    const scope = await page.evaluate(async () => (await fetch('/von/api/session/context')).json());
+    assert.equal(scope.organisation_id || '', id);
+}
+async function measure(page, name) {
+    await page.waitForTimeout(250);
+    const result = await page.evaluate(() => {
+        const rect = selector => {
+            const node = document.querySelector(selector);
+            const r = node?.getBoundingClientRect();
+            return r ? { x: r.x, y: r.y, width: r.width, height: r.height } : null;
+        };
+        const footer = document.querySelector('.footer-container');
+        return { header: rect('#globalHeader'), tabs: rect('.tab-container'), footer: rect('.footer-container'),
+            composer: rect(document.querySelector('#messageInput') ? '.message-compose-area' : '.chat-composer'),
+            footerPosition: getComputedStyle(footer).position, width: innerWidth,
+            overflow: document.documentElement.scrollWidth - innerWidth,
+            clearance: getComputedStyle(document.documentElement).getPropertyValue('--von-fixed-footer-clearance') };
+    });
+    assert(result.overflow <= 1, `${name}: document overflow`);
+    metrics.push({ name, ...result });
+    fs.writeFileSync(path.join(evidence, 'measurements.json'), JSON.stringify(metrics, null, 2));
+    await page.screenshot({ path: path.join(evidence, `${name}.png`), animations: 'disabled' });
+    return result;
+}
+(async () => {
+    const browser = await chromium.launch();
+    try {
+        const page = await login(browser, candidate, true);
+        await switchScope(page, orgId);
+        await page.locator('.chat-session-tab').filter({ hasText: 'MIT Contacts and Settings' }).click();
+        await expect(page.locator('#promptInput')).toBeVisible();
+        await page.waitForTimeout(2500);
+        const draft = 'Unsent mobile footer acceptance draft';
+        for (const kind of ['normal', 'agent']) {
+            if (kind === 'agent') await page.locator('.message-conversation-row').filter({ hasText: 'Codex DGX' }).first().click();
+            const input = page.locator(kind === 'normal' ? '#promptInput' : '#messageInput');
+            if (kind === 'agent') {
+                await expect(input).toHaveAttribute('placeholder', /Reply to Codex DGX/);
+                await page.waitForTimeout(1500);
+            }
+            await input.fill(draft);
+            for (const [name, width, height] of [['small', 360, 640], ['pixel', 412, 915], ['keyboard', 412, 430], ['foldable', 840, 900]]) {
+                await page.setViewportSize({ width, height });
+                await expect(input).toHaveValue(draft);
+                const m = await measure(page, `${kind}-${name}`);
+                assert.equal(m.clearance, '0px');
+                assert(m.composer.y >= m.header.height + m.tabs.height, `${kind}-${name}: composer overlaps header`);
+                assert(m.composer.y + m.composer.height <= height, `${kind}-${name}: composer clipped`);
+                await page.locator(kind === 'normal' ? '#sendButton' : '#sendMessageBtn').click({ trial: true });
+                await expect(page.locator('[data-tab="workflowStudioTab"]')).toBeHidden();
+                await page.locator('.mobile-footer-details > summary').click();
+                await expect(page.locator('#modelInfoFooter')).toBeVisible();
+                if (kind === 'normal') {
+                    const cost = page.locator('.conversation-runtime-cost-button[data-cost-scope="conversation"]');
+                    await expect(cost).toBeVisible();
+                    await cost.click();
+                    await expect(cost).toHaveAttribute('aria-expanded', 'true');
+                    await cost.click();
+                }
+                await page.screenshot({ path: path.join(evidence, `${kind}-${name}-info.png`) });
+                await page.locator('.mobile-footer-details > summary').focus();
+                await page.keyboard.press('Escape');
+                await expect(page.locator('#modelInfoFooter')).toBeHidden();
+                await expect(input).toHaveValue(draft);
+            }
+        }
+        await page.setViewportSize({ width: 360, height: 640 });
+        await switchScope(page, '');
+        await switchScope(page, orgId);
+        // Exercise the production asynchronous render entry point, without generation.
+        await page.evaluate(async () => {
+            const { setModelInfoFooterText } = await import('/static/js/domUtils.js');
+            await setModelInfoFooterText();
+        });
+        await expect(page.locator('.mobile-shell-controls .footer-org-switcher')).toHaveCount(1);
+        await expect(page.locator('.footer-container')).toBeHidden();
+        await measure(page, 'after-refresh');
+        await page.locator('.mobile-footer-details > summary').click();
+        await page.locator('.conversation-model-controls button').click();
+        await page.locator('.mobile-footer-details > summary').click();
+        await expect(page.frameLocator('#settingsFrame').locator('#premium-model-settings')).toBeVisible();
+        await expect(page.frameLocator('#settingsFrame').locator('#openaiReasoningEffortSelect')).toBeVisible();
+        await page.screenshot({ path: path.join(evidence, 'model-settings.png') });
+        const desktop = await login(browser, candidate, false);
+        const control = await login(browser, baseline, false);
+        for (const p of [desktop, control]) {
+            await switchScope(p, orgId);
+            await p.locator('.chat-session-tab').filter({ hasText: 'MIT Contacts and Settings' }).click();
+            await p.waitForTimeout(2500);
+        }
+        const before = await measure(control, 'desktop-baseline');
+        await desktop.locator('#promptInput').fill(draft);
+        await desktop.setViewportSize({ width: 360, height: 640 });
+        await desktop.setViewportSize({ width: 1440, height: 900 });
+        await expect(desktop.locator('#promptInput')).toHaveValue(draft);
+        await expect(desktop.locator('.mobile-shell-controls')).toHaveCount(0);
+        const after = await measure(desktop, 'desktop-candidate');
+        for (const key of ['header', 'tabs', 'footer', 'composer']) {
+            for (const dimension of ['x', 'y', 'width', 'height']) assert(Math.abs(before[key][dimension] - after[key][dimension]) <= 1, `desktop ${key}.${dimension}`);
+        }
+        for (const [name, width, height] of [['small', 360, 640], ['pixel', 412, 915]]) {
+            await control.setViewportSize({ width, height });
+            await measure(control, `baseline-${name}`);
+        }
+        await desktop.locator('.footer-org-menu-trigger').click();
+        await expect(desktop.locator('.footer-org-options')).toBeVisible();
+        fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ sha, metrics, noSendsOrModelCalls: true, simulationLimits: 'Chromium viewport/touch simulation; no physical keyboard or public OAuth claim' }, null, 2));
+        console.log(JSON.stringify({ sha, profiles: metrics.length, passed: true }));
+    } finally { await browser.close(); }
+})().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/frontend/dynamicLayout.test.js
+++ b/tests/frontend/dynamicLayout.test.js
@@ -25,9 +25,10 @@ test('tracks footer and visual viewport changes without replacing the draft or r
     const input = document.querySelector('#promptInput');
     setupDynamicLayout();
     const value = name => document.documentElement.style.getPropertyValue(name);
-    expect(value('--von-fixed-footer-clearance')).toBe('60px');
+    expect(value('--von-fixed-footer-clearance')).toBe('0px');
     const diagnostics = document.querySelector('#serverUptimeFooter');
-    expect(diagnostics.parentElement.className).toBe('mobile-footer-details-panel');
+    expect(footer.parentElement.className).toBe('mobile-footer-details-panel');
+    expect(diagnostics.parentElement).toBe(footer);
     viewport.height = 430;
     viewport.dispatchEvent(new Event('resize'));
     expect(value('--von-keyboard-inset')).toBe('485px');
@@ -37,7 +38,7 @@ test('tracks footer and visual viewport changes without replacing the draft or r
     expect(value('--von-keyboard-inset')).toBe('465px');
     footerHeight = 76;
     observed.find(item => item.target === footer).callback();
-    expect(value('--von-fixed-footer-clearance')).toBe('84px');
+    expect(value('--von-fixed-footer-clearance')).toBe('0px');
     viewport.scale = 2;
     viewport.dispatchEvent(new Event('resize'));
     expect(value('--von-keyboard-inset')).toBe('0px');
@@ -49,4 +50,33 @@ test('tracks footer and visual viewport changes without replacing the draft or r
     expect(document.querySelector('.mobile-footer-details')).toBeNull();
     expect(document.querySelector('#promptInput')).toBe(input);
     expect(input.value).toBe('Keep this draft');
+});
+
+test('keeps refreshed controls unique and restores their desktop order', async () => {
+    document.body.innerHTML = `<header id="globalHeader"></header><div class="tab-container"></div>
+        <footer class="footer-container"><div id="modelInfoFooter"><span id="model">Model</span>
+        <span class="footer-org-switcher"><button class="footer-org-current-button" data-concept-name="Full organisation">SAIL</button><details><summary class="footer-org-menu-trigger">▾</summary></details></span>
+        <span id="cost">Cost</span></div><p id="uptime">Uptime</p></footer>`;
+    let narrow = true;
+    window.matchMedia = () => ({ matches: narrow });
+    const footer = document.querySelector('footer');
+    const modelInfo = document.querySelector('#modelInfoFooter');
+    setupDynamicLayout();
+    const oldOrg = document.querySelector('.footer-org-switcher');
+    expect(oldOrg.parentElement.className).toBe('mobile-shell-controls');
+    expect(document.querySelector('.mobile-org-label').textContent).toBe('SAIL');
+    const replacement = oldOrg.cloneNode(true);
+    replacement.querySelector('.footer-org-current-button').textContent = 'Personal';
+    modelInfo.replaceChildren(document.querySelector('#model'), replacement, document.querySelector('#cost'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.querySelectorAll('.footer-org-switcher')).toHaveLength(1);
+    expect(oldOrg.isConnected).toBe(false);
+    expect(replacement.parentElement.className).toBe('mobile-shell-controls');
+    expect(document.querySelector('.mobile-org-label').textContent).toBe('Personal');
+    narrow = false;
+    window.dispatchEvent(new Event('resize'));
+    expect([...modelInfo.children].map(node => node.id || node.className)).toEqual(['model', 'footer-org-switcher', 'cost']);
+    expect(footer.parentElement).toBe(document.body);
+    expect([...footer.children].map(node => node.id)).toEqual(['modelInfoFooter', 'uptime']);
 });


### PR DESCRIPTION
Merge decision: ready — the candidate removes the permanent mobile footer, recovers conversation space and preserves the desktop layout.

## User outcome

Mobile conversations gain roughly 220–226px of vertical space at 360×640 and 412×915 compared with the clean baseline. Organisation switching and Info share the existing header row. Task: #V#task_agent_5efc3b89d65f6241d5cf2452afbdd68f.

## Material changes

Move the live footer into an on-demand Info panel, keeping its existing model/settings, conversation cost, account and diagnostic controls. Move the canonical organisation picker into the header, retain its full accessible identity, and restore desktop DOM order on resize. Follow asynchronous footer replacement without duplicate controls or polling. Keep the normal mobile composer within the visual viewport, with measured clearance and existing pinch-zoom handling.

## Evidence

37 focused frontend tests pass, including async replacement, unique controls, desktop restoration and draft/viewport behaviour. Static JS lint and diff checks pass. Authenticated localhost AgentTest acceptance covers normal and agent conversations at 360×640, 412×915, a short 412×430 viewport and coarse-pointer 840×900; no sends or model calls. Desktop header, tabs, footer and composer geometry match clean baseline e15c4d697a1458fdc0b3bb400d64551adf56c8c7 within one pixel. The retained browser harness passed 13 measured views, canonical window-scoped Personal/SAIL read-back, menus, drafts, model-settings access and asynchronous refresh. Browser evidence binds to product commit 7da474b6df3ab4e6b2914161157b2b25bcd65516; the subsequent commit corrects only the browser harness. Evidence is retained in the worker worktree at .run/footer-acceptance/final/. Reasoning controls are disabled in this fixture on both candidate and baseline; no model eligibility or scope configuration was changed.

## Ship boundary

Minimum ship evidence is the authenticated affected path plus desktop comparison and required CI. Inaccessible controls, lost drafts, incorrect scope, clipped composer or a candidate-caused desktop regression block merge. Browser evidence uses simulated viewports and fixture authentication, not physical keyboards or public OAuth. Navigation/tray redesign and unrelated service health are outside scope. No production deployment or live represented-state change is requested.
