### PR TITLE
Fix unread reconciliation and conversation participant alignment (JVNAUTOSCI-2747)

### DIFF
--- a/src/frontend/web/von_interface/static/css/participantProfile.css
+++ b/src/frontend/web/von_interface/static/css/participantProfile.css
@@ -15,7 +15,13 @@
 .unified-message-content .messages-sidebar { display: none; }
 .unified-message-content .messages-main { flex: 1; min-width: 0; min-height: 0; }
 .unified-message-content .message-list { max-width: 900px; width: 100%; margin-inline: auto; }
-.unified-message-content .message-bubble { max-width: 100%; width: auto; align-self: stretch; border-radius: 10px; }
+.unified-message-content .message-bubble { max-width: min(88%, 760px); width: fit-content; border-radius: 10px; }
+.unified-message-content .message-bubble.sent { align-self: flex-end; }
+.unified-message-content .message-bubble.received { align-self: flex-start; }
+.message-bubble.is-unread { outline: 2px solid #2563eb; outline-offset: 2px; }
+.message-unread-label { display: block; width: fit-content; margin-bottom: 6px; padding: 2px 6px; border-radius: 4px; background: #dbeafe; color: #1e40af; font-size: 12px; font-weight: 600; }
+.message-read-status { position: sticky; top: 0; z-index: 1; padding: 8px; background: #eff6ff; color: #1e40af; }
+@media (max-width: 600px) { .unified-message-content .message-bubble { max-width: 94%; } }
 .unified-message-content .message-content { white-space: normal; overflow-wrap: anywhere; }
 .unified-message-content .message-content pre { overflow: auto; white-space: pre; max-width: 100%; }
 .unified-message-content .message-author { font-weight: 600; margin-bottom: 8px; }

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -38879,6 +38879,11 @@ function appendMessage(sender, message, turnId, hasLlmDebug = false, isHistory =
             messageHeader.style.cssText = 'font-weight: bold; margin-bottom: 5px; font-size: 0.9em; display: flex; flex-wrap: wrap; align-items: center; gap: 8px; min-width: 0;';
             messageHeader.style.color = sender === 'Error' ? '#dc3545' : '#28a745';
             const authorId = options.authorConceptId || (!isHistory ? getCurrentUserConceptId() : null);
+            // Legacy user turns without author metadata belong to the local user.
+            if (sender !== 'Error' && !externalActor
+                && (!authorId || authorId === getCurrentUserConceptId())) {
+                messageContainer.classList.add('own-contribution');
+            }
             if (sender !== 'Error' && !externalActor && authorId) messageHeader.append(participantIdentityAvatar(authorId, sender));
 
             const headerText = document.createElement('span');

--- a/src/frontend/web/von_interface/static/js/components/conversationCatalogue.js
+++ b/src/frontend/web/von_interface/static/js/components/conversationCatalogue.js
@@ -125,6 +125,7 @@ export function renderMessageConversationRow(row, { selected = false, pinned = f
         badge.className = 'chat-session-tab-unread';
         badge.textContent = String(row.shared_unread_count);
         badge.setAttribute('aria-label', `${row.shared_unread_count} unread messages`);
+        badge.title = 'Messages addressed to you that have not been marked read, including earlier pages. Scroll to an Unread label or load earlier messages to read them.';
         header.append(badge);
     }
     const meta = document.createElement('span');

--- a/src/frontend/web/von_interface/static/js/components/messagePanel.js
+++ b/src/frontend/web/von_interface/static/js/components/messagePanel.js
@@ -43,6 +43,7 @@ let _exchangeGeneration = 0;
 let _olderCursor = null;
 let _readObserver = null;
 const _exchangeDrafts = new Map();
+const _pendingReads = new Set();
 
 function exchangeScope(row = _exchange) {
     return row ? `${row.browser_scope ?? getSessionScopedOrgId() ?? ''}:${row.viewer_id}:${row.session_id}` : '';
@@ -121,24 +122,83 @@ export async function refreshOpenMessageExchange() {
     await loadConversation(_currentConversationUserId, { silent: true });
 }
 
+function isUnreadMessage(message) {
+    return (message.relationships?.['#V#has_recipient'] || []).includes(_currentUserId)
+        && !(message.concept_data?.read_by || []).includes(_currentUserId);
+}
+
+function updateUnreadMarkers() {
+    _messagesContainer?.querySelectorAll('[data-contribution-id]').forEach(element => {
+        const message = _currentMessages.find(item => item.concept_id === element.dataset.contributionId);
+        const unread = Boolean(message && isUnreadMessage(message));
+        element.classList.toggle('is-unread', unread);
+        let label = element.querySelector('.message-unread-label');
+        if (unread && !label) {
+            label = document.createElement('span');
+            label.className = 'message-unread-label';
+            label.textContent = 'Unread';
+            element.prepend(label);
+        } else if (!unread) label?.remove();
+    });
+}
+
 function observeDisplayedMessages() {
     _readObserver?.disconnect();
     if (typeof IntersectionObserver !== 'function') return;
     const root = _messagesContainer?.querySelector('#messageViewContent');
-    _readObserver = new IntersectionObserver(entries => {
-        if (document.hidden || !root?.getClientRects().length) return;
-        const ids = entries.filter(entry => entry.isIntersecting && entry.intersectionRatio > 0)
+    const generation = _exchangeGeneration;
+    const org = getSessionScopedOrgId();
+    const observer = new IntersectionObserver(entries => {
+        // Disconnected observers can still deliver entries for the old pane.
+        if (observer !== _readObserver || generation !== _exchangeGeneration
+            || org !== getSessionScopedOrgId() || document.hidden || !root?.getClientRects().length) return;
+        const ids = entries.filter(entry => entry.isIntersecting && entry.intersectionRatio > 0 && entry.target.isConnected)
             .map(entry => entry.target.dataset.contributionId)
-            .filter(id => _currentMessages.some(m => m.concept_id === id && (m.relationships?.['#V#has_recipient'] || []).includes(_currentUserId) && !(m.concept_data?.read_by || []).includes(_currentUserId)));
+            .filter(id => !_pendingReads.has(`${generation}:${id}`) && _currentMessages.some(m => m.concept_id === id && isUnreadMessage(m)));
         if (!ids.length) return;
-        const generation = _exchangeGeneration;
-        void postJson('/api/messages/read/bulk', { message_ids: ids }).then(() => {
+        ids.forEach(id => _pendingReads.add(`${generation}:${id}`));
+        entries.filter(entry => ids.includes(entry.target.dataset.contributionId))
+            .forEach(entry => observer.unobserve(entry.target));
+        void postJson('/api/messages/read/bulk', { message_ids: ids }).then(async response => {
+            if (generation !== _exchangeGeneration || org !== getSessionScopedOrgId()) return;
+            if (response?.success !== true) throw new Error('Read state was not saved');
+            // A full update receipt confirms every submitted ID, including loaded
+            // older pages. Partial receipts require read-back; never clear all IDs.
+            if (response.updated_count === ids.length) {
+                _currentMessages.forEach(message => {
+                    if (!ids.includes(message.concept_id)) return;
+                    message.concept_data ||= {};
+                    message.concept_data.read_by = [...new Set([...(message.concept_data.read_by || []), _currentUserId])];
+                });
+                updateUnreadMarkers();
+            } else await loadConversation(_currentConversationUserId, { silent: true, observeReads: false });
             if (generation !== _exchangeGeneration) return;
-            _currentMessages.forEach(m => { if (ids.includes(m.concept_id)) { m.concept_data ||= {}; m.concept_data.read_by = [...new Set([...(m.concept_data.read_by || []), _currentUserId])]; } });
-            document.dispatchEvent(new CustomEvent('von:conversation-contribution'));
-        }).catch(() => {});
+            if (_currentMessages.some(m => ids.includes(m.concept_id) && isUnreadMessage(m))) showReadFailure();
+            else {
+                root.querySelector('.message-read-status')?.remove();
+                document.dispatchEvent(new CustomEvent('von:conversation-contribution'));
+            }
+        }).catch(() => {
+            if (generation === _exchangeGeneration) showReadFailure();
+        }).finally(() => ids.forEach(id => _pendingReads.delete(`${generation}:${id}`)));
     }, { root, threshold: 0.01 });
-    root?.querySelectorAll('[data-contribution-id]').forEach(el => _readObserver.observe(el));
+    _readObserver = observer;
+    root?.querySelectorAll('.is-unread[data-contribution-id]').forEach(el => observer.observe(el));
+}
+
+function showReadFailure() {
+    const root = _messagesContainer?.querySelector('#messageViewContent');
+    if (!root || root.querySelector('.message-read-status')) return;
+    const status = document.createElement('div');
+    status.className = 'message-read-status';
+    status.setAttribute('role', 'status');
+    status.textContent = 'Could not save read state. Unread labels are retained. ';
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.textContent = 'Retry';
+    retry.onclick = () => observeDisplayedMessages();
+    status.append(retry);
+    root.prepend(status);
 }
 
 const COMPOSE_SCOPE_REPLY = 'reply';
@@ -627,7 +687,7 @@ function bindMessageStreamMenu(element, getOtherUserId) {
 /**
  * Load messages for a conversation with a specific user.
  */
-async function loadConversation(userId, { silent = false, before = null } = {}) {
+async function loadConversation(userId, { silent = false, before = null, observeReads = true } = {}) {
     if (_isLoading) return;
     _isLoading = true;
     const generation = _exchangeGeneration;
@@ -655,7 +715,11 @@ async function loadConversation(userId, { silent = false, before = null } = {}) 
         }
         const sameContent = JSON.stringify(nextMessages.map(m => [m.concept_id, m.concept_data?.content_fallback])) === JSON.stringify(_currentMessages.map(m => [m.concept_id, m.concept_data?.content_fallback]));
         _currentMessages = nextMessages;
-        if (silent && !before && sameContent) return;
+        if (silent && !before && sameContent) {
+            updateUnreadMarkers();
+            if (observeReads) observeDisplayedMessages();
+            return;
+        }
         if (before || !silent) _olderCursor = response.before || null;
         _currentUserId = response.current_user_id || null;
         await renderMessages();
@@ -673,7 +737,8 @@ async function loadConversation(userId, { silent = false, before = null } = {}) 
             jump.onclick = () => { contentEl.scrollTop = contentEl.scrollHeight; jump.remove(); };
             contentEl.append(jump);
         }
-        observeDisplayedMessages();
+        updateUnreadMarkers();
+        if (observeReads) observeDisplayedMessages();
     } catch (_) {
         if (generation === _exchangeGeneration && contentEl && !silent) contentEl.innerHTML = '<div class="message-error">Could not load this conversation. Try Refresh.</div>';
     } finally { if (generation === _exchangeGeneration) _isLoading = false; }

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -5403,6 +5403,25 @@ h1 {
     min-width: 0;
 }
 
+/* Keep participant interchange visible with space for rich controls. */
+#scrollableField > .message-container {
+    width: 88%;
+    max-width: 1100px;
+    margin-right: auto;
+}
+#scrollableField > .message-container.own-contribution {
+    margin-left: auto;
+    margin-right: 0;
+}
+#scrollableField > .message-container.user-turn,
+#scrollableField > .message-container.error-turn {
+    flex-direction: column;
+}
+.shared-remote-message.user-message { margin-left: 0; margin-right: auto; }
+@media (max-width: 600px) {
+    #scrollableField > .message-container { width: 94%; }
+}
+
 .message-container.assistant-turn {
     align-items: flex-start;
     gap: 12px;
@@ -5475,7 +5494,7 @@ h1 {
     gap: 8px;
     width: 100%;
     margin: 10px 0 8px;
-    color: #7b1fa2;
+    color: #1d4ed8;
     font-size: 0.72rem;
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -5486,14 +5505,14 @@ h1 {
 .latest-unread-boundary::after {
     content: '';
     flex: 1;
-    border-top: 1px solid rgba(123, 31, 162, 0.35);
+    border-top: 1px solid rgba(37, 99, 235, 0.35);
 }
 
 .new-shared-messages-indicator {
     position: sticky;
     top: 0;
     z-index: 10;
-    background: linear-gradient(135deg, #9c27b0, #7b1fa2);
+    background: #2563eb;
     color: white;
     border: none;
     padding: 8px 16px;
@@ -5508,7 +5527,7 @@ h1 {
 }
 
 .new-shared-messages-indicator:hover {
-    background: linear-gradient(135deg, #7b1fa2, #6a1b9a);
+    background: #1d4ed8;
 }
 
 .new-shared-messages-indicator:focus-visible {
@@ -8443,7 +8462,7 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     font-size: 11px;
     line-height: 1.1;
     color: #ffffff;
-    background: #a855f7;
+    background: #2563eb;
     border-radius: 10px;
     padding: 1px 6px;
     margin-left: auto;
@@ -8453,8 +8472,8 @@ body[data-active-tab="settingsTab"] .tab-content-area {
 }
 
 .chat-session-tab.has-unread {
-    border-color: #a855f7;
-    box-shadow: inset 0 -2px 0 #7e22ce;
+    border-color: #2563eb;
+    box-shadow: inset 0 -2px 0 #1d4ed8;
 }
 
 .chat-session-tabs-placeholder {

--- a/tests/browser/conversationReadability.cjs
+++ b/tests/browser/conversationReadability.cjs
@@ -1,0 +1,160 @@
+// Explicitly isolated fixture acceptance: real templates/modules, in-memory API state.
+// No authentication, live messages, database writes, or model calls are exercised.
+// PLAYWRIGHT_BROWSERS_PATH=/tmp/von-playwright node tests/browser/conversationReadability.cjs DIR
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const { chromium, expect } = require('@playwright/test');
+const root = path.resolve(__dirname, '../../src/frontend/web/von_interface');
+const evidence = process.argv[2] || '/tmp/conversation-readability';
+fs.mkdirSync(evidence, { recursive: true });
+function template(name) {
+    return fs.readFileSync(path.join(root, 'templates', name), 'utf8')
+        .replace(/{% include '([^']+)' %}/g, (_, child) => template(child))
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/g, '')
+        .replace(/{{ url_for\('static', filename='([^']+)'\) }}/g, '/static/$1')
+        .replace(/{%[\s\S]*?%}|{{[\s\S]*?}}/g, '');
+}
+const server = http.createServer((req, res) => {
+    const pathname = new URL(req.url, 'http://localhost').pathname;
+    if (pathname === '/') { res.setHeader('Content-Type', 'text/html'); return res.end(template('von_interface.html')); }
+    const file = path.resolve(root, `.${pathname}`);
+    if (!file.startsWith(`${root}/static/`) || !fs.existsSync(file)) return res.writeHead(404).end();
+    res.setHeader('Content-Type', file.endsWith('.css') ? 'text/css' : file.endsWith('.png') ? 'image/png' : 'text/javascript');
+    res.end(fs.readFileSync(file));
+});
+const actor = '#V#alice', other = '#V#bob';
+const row = { session_id: 'messages:fixture', source_kind: 'message_exchange', viewer_id: actor,
+    participant_ids: [actor, other], other_participant_ids: [other], session_name: 'Bob fixture', organisation_concept_id: null,
+    last_message_at: '2026-09-12T10:59:00Z', preview: 'Fixture conversation' };
+let messages, reads, failRead;
+function seed() {
+    reads = []; failRead = false;
+    messages = Array.from({ length: 60 }, (_, i) => ({ concept_id: `fixture-${i}`, created_at: `2026-09-12T10:${String(i).padStart(2, '0')}:00Z`,
+        relationships: { '#V#has_sender': [i % 2 ? actor : other], '#V#has_recipient': [i % 2 ? other : actor] },
+        concept_data: { read_by: [], content_fallback: `Contribution ${i}. ` + 'A research update with observations, provenance and next steps. '.repeat(5) } }));
+}
+const unread = () => messages.filter(m => m.relationships['#V#has_recipient'].includes(actor) && !m.concept_data.read_by.includes(actor));
+async function setup(page) {
+    await page.goto(`http://127.0.0.1:${server.address().port}`);
+    await page.evaluate(async ({ row, actor }) => {
+        document.body.classList.remove('von-auth-pending');
+        document.querySelector('#vonAuthenticationGate').hidden = true;
+        document.querySelector('#vonAuthenticatedApp').hidden = false;
+        localStorage.setItem('von_current_user', JSON.stringify({ concept_id: actor }));
+        const workspace = document.querySelector('#conversationWorkspace');
+        const { createConversationTray } = await import('/static/js/components/conversationTray.js');
+        const tray = createConversationTray(workspace);
+        const refresh = () => { workspace.dataset.effectiveTabsLayout = innerWidth <= 900 ? 'horizontal' : 'vertical'; tray.refresh({ width: 260, collapsed: false, expandOnHover: true }); };
+        refresh(); window.addEventListener('resize', refresh);
+        const { setupDynamicLayout } = await import('/static/js/components/dynamicLayout.js'); setupDynamicLayout();
+        const catalogue = await import('/static/js/components/conversationCatalogue.js');
+        window.fixtureCatalogue = catalogue;
+        window.fixturePanel = await import('/static/js/components/messagePanel.js');
+        const render = () => {
+            const tabs = document.querySelector('#chatSessionTabs'); tabs.replaceChildren();
+            catalogue.directConversationRows().forEach(item => tabs.append(catalogue.renderMessageConversationRow(item)));
+        };
+        catalogue.initialiseConversationCatalogue({ render });
+        await catalogue.refreshMessageCatalogue();
+        await catalogue.selectMessageConversation(row);
+    }, { row, actor });
+}
+async function measure(page, name) {
+    const result = await page.evaluate(() => {
+        const root = document.querySelector('#messageViewContent');
+        const box = el => { const r = el.getBoundingClientRect(); return { x: r.x, right: r.right, width: r.width }; };
+        return { width: innerWidth, overflow: document.documentElement.scrollWidth - innerWidth,
+            paneOverflow: root.scrollWidth - root.clientWidth,
+            sent: box(document.querySelector('.message-bubble.sent')), received: box(document.querySelector('.message-bubble.received')),
+            badge: getComputedStyle(document.querySelector('.chat-session-tab-unread')).backgroundColor };
+    });
+    assert(result.sent.x > result.received.x + 5, `${name}: own messages on right`);
+    assert(result.overflow <= 1 && result.paneOverflow <= 1, `${name}: overflow ${JSON.stringify(result)}`);
+    assert.equal(result.badge, 'rgb(37, 99, 235)');
+    await page.screenshot({ path: path.join(evidence, `${name}.png`) });
+    return { name, ...result };
+}
+(async () => {
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const browser = await chromium.launch();
+    const results = [];
+    try {
+        for (const width of [1440, 360]) {
+            seed();
+            const page = await browser.newPage({ viewport: { width, height: 900 } });
+            await page.route('**/*', async route => {
+                const req = route.request(), url = new URL(req.url());
+                if (url.pathname.startsWith('/static/') || url.pathname === '/') return route.continue();
+                if (url.pathname === '/api/messages/exchange') {
+                    const before = req.postDataJSON().before;
+                    const eligible = messages.filter(m => !before || m.created_at < before.created_at);
+                    const rows = eligible.slice(-50);
+                    return route.fulfill({ json: { current_user_id: actor, messages: rows, before: eligible.length > 50 ? { created_at: rows[0].created_at, concept_id: rows[0].concept_id } : null } });
+                }
+                if (url.pathname === '/api/messages/read/bulk') {
+                    const ids = req.postDataJSON().message_ids;
+                    if (failRead) return route.fulfill({ status: 503, json: { error: 'isolated failure' } });
+                    reads.push(ids);
+                    for (const id of ids) messages.find(m => m.concept_id === id).concept_data.read_by.push(actor);
+                    return route.fulfill({ json: { success: true, updated_count: ids.length } });
+                }
+                if (url.pathname.includes('conversation-catalogue')) return route.fulfill({ json: { conversations: [{ ...row, shared_unread_count: unread().length }] } });
+                if (url.pathname.endsWith('/participants/profiles')) return route.fulfill({ json: { profiles: [actor, other].map(concept_id => ({ concept_id, display_name: concept_id === actor ? 'Alice' : 'Bob' })) } });
+                // All remaining non-static calls are fixtures. Never forward to a live API.
+                return route.fulfill({ json: {} });
+            });
+            await setup(page);
+            await expect.poll(() => reads.length).toBeGreaterThan(0);
+            assert(unread().length > 20, 'Opening cannot clear unseen messages');
+            assert(unread().some(m => m.concept_id === 'fixture-0'), 'unloaded page stays unread');
+            await expect(page.locator('.chat-session-tab-unread')).toHaveText(String(unread().length));
+            results.push(await measure(page, `messages-${width}`));
+            const firstUnread = page.locator('.message-bubble.is-unread').first();
+            const id = await firstUnread.getAttribute('data-contribution-id');
+            failRead = true;
+            await firstUnread.scrollIntoViewIfNeeded();
+            await expect(page.locator('.message-read-status')).toBeVisible();
+            assert(unread().some(m => m.concept_id === id));
+            failRead = false;
+            await page.locator('.message-read-status button').click();
+            await expect.poll(() => unread().some(m => m.concept_id === id)).toBe(false);
+            await page.evaluate(() => fixturePanel.refreshOpenMessageExchange());
+            await expect(page.locator(`[data-contribution-id="${id}"] .message-unread-label`)).toHaveCount(0);
+            // An arrival stays unread while the reader is inspecting earlier content.
+            messages.push({ concept_id: 'arrival', created_at: '2026-09-12T11:01:00Z', relationships: { '#V#has_sender': [other], '#V#has_recipient': [actor] }, concept_data: { read_by: [], content_fallback: 'A new incoming research update.' } });
+            await page.evaluate(() => fixturePanel.refreshOpenMessageExchange());
+            await expect(page.locator('.message-jump-latest')).toBeVisible();
+            assert(unread().some(m => m.concept_id === 'arrival'));
+            await page.locator('.message-jump-latest').click();
+            await expect.poll(() => unread().some(m => m.concept_id === 'arrival')).toBe(false);
+            await page.getByRole('button', { name: 'Load earlier messages', exact: true }).click();
+            await expect(page.locator('[data-contribution-id="fixture-0"]')).toHaveCount(1);
+            assert(unread().some(m => m.concept_id === 'fixture-0'));
+            await page.locator('[data-contribution-id="fixture-0"]').scrollIntoViewIfNeeded();
+            await expect.poll(() => unread().some(m => m.concept_id === 'fixture-0')).toBe(false);
+            const persisted = unread().length;
+            await setup(page); // Simulate page reload against retained canonical fixture state.
+            assert(unread().length <= persisted);
+            assert(!unread().some(m => m.concept_id === id));
+            await page.evaluate(async () => {
+                fixtureCatalogue.showChatConversation();
+                const chat = await import('/static/js/chatTab.js');
+                document.querySelector('#scrollableField').replaceChildren();
+                chat.__testOnly_appendMessage('Alice', 'An own contribution with the existing edit and copy controls.', 'own', false, true, null, null, null, { authorConceptId: '#V#alice' });
+                chat.__testOnly_appendMessage('Bob', 'A contribution from another participant, preserving its sender label.', 'other', false, true, null, null, null, { authorConceptId: '#V#bob' });
+                chat.__testOnly_appendMessage('Von', 'A useful assistant response with retained controls and readable content.', 'assistant', false, true);
+            });
+            const layout = await page.evaluate(() => [...document.querySelectorAll('#scrollableField > .message-container')].map(el => ({ classes: el.className, x: el.getBoundingClientRect().x, right: el.getBoundingClientRect().right, overflow: el.scrollWidth - el.clientWidth, text: el.textContent })));
+            assert(layout[0].x > layout[1].x + 5 && layout[0].x > layout[2].x + 5, 'Old-style participant alignment');
+            assert(layout.every(item => item.overflow <= 1), 'Old-style controls/content fit');
+            assert(layout[1].text.includes('Bob'));
+            results.push({ name: `chat-${width}`, layout });
+            await page.screenshot({ path: path.join(evidence, `chat-${width}.png`) });
+            await page.close();
+        }
+        fs.writeFileSync(path.join(evidence, 'results.json'), JSON.stringify({ fixture: true, results }, null, 2));
+        console.log(JSON.stringify({ passed: true, evidence, cases: results.length }));
+    } finally { await browser.close(); server.close(); }
+})().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/frontend/messageExchangeView.test.js
+++ b/tests/frontend/messageExchangeView.test.js
@@ -75,3 +75,87 @@ test('cancelling a new message restores the ordinary conversation pane', async (
     document.getElementById('cancelNewMessage').click();
     expect(document.getElementById('conversationWorkspace').classList.contains('show-message-exchange')).toBe(false);
 });
+
+function unreadResponse() {
+    const result = response();
+    result.messages[0].relationships['#V#has_recipient'] = ['#V#alice'];
+    result.messages[0].concept_data.read_by = [];
+    return result;
+}
+function mockReadObserver() {
+    const observers = [];
+    global.IntersectionObserver = jest.fn(function (callback) {
+        this.callback = callback;
+        this.observe = jest.fn(); this.unobserve = jest.fn(); this.disconnect = jest.fn();
+        observers.push(this);
+    });
+    return observers;
+}
+function visibleEntry() {
+    document.getElementById('messageViewContent').getClientRects = () => [{}];
+    return { target: document.querySelector('[data-contribution-id]'), isIntersecting: true, intersectionRatio: 0.5 };
+}
+afterEach(() => { delete global.IntersectionObserver; });
+
+test('only visible incoming unread messages are marked, with confirmed labels and a catalogue refresh', async () => {
+    const observers = mockReadObserver();
+    const api = require(base + 'apiService.js');
+    api.postJson.mockResolvedValueOnce(unreadResponse());
+    const panel = require(base + 'components/messagePanel.js');
+    await panel.openMessageExchange(row('#V#bob'));
+    expect(document.querySelector('.message-unread-label').textContent).toBe('Unread');
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+    const entry = visibleEntry();
+    observers[0].callback([{ ...entry, isIntersecting: false, intersectionRatio: 0 }]);
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+    api.postJson.mockResolvedValueOnce({ success: true, updated_count: 1 });
+    const refresh = jest.fn(); document.addEventListener('von:conversation-contribution', refresh, { once: true });
+    observers[0].callback([entry]); await flush();
+    expect(api.postJson).toHaveBeenLastCalledWith('/api/messages/read/bulk', { message_ids: ['one'] });
+    expect(document.querySelector('.message-unread-label')).toBeNull();
+    expect(refresh).toHaveBeenCalledTimes(1);
+});
+
+test('a failed visible read stays labelled and same-content refresh re-arms the observer', async () => {
+    const observers = mockReadObserver();
+    const api = require(base + 'apiService.js');
+    api.postJson.mockResolvedValueOnce(unreadResponse());
+    const panel = require(base + 'components/messagePanel.js');
+    await panel.openMessageExchange(row('#V#bob'));
+    api.postJson.mockRejectedValueOnce(new Error('offline'));
+    observers[0].callback([visibleEntry()]); await flush();
+    expect(document.querySelector('.message-unread-label')).not.toBeNull();
+    expect(document.querySelector('.message-read-status').textContent).toContain('Retry');
+    api.postJson.mockResolvedValueOnce(unreadResponse());
+    await panel.refreshOpenMessageExchange();
+    expect(observers).toHaveLength(2);
+    expect(observers[1].observe).toHaveBeenCalledTimes(1);
+});
+
+test('partial update receipts do not optimistically clear unread contributions', async () => {
+    const observers = mockReadObserver();
+    const api = require(base + 'apiService.js');
+    api.postJson.mockResolvedValueOnce(unreadResponse());
+    const panel = require(base + 'components/messagePanel.js');
+    await panel.openMessageExchange(row('#V#bob'));
+    api.postJson.mockResolvedValueOnce({ success: true, updated_count: 0 }).mockResolvedValueOnce(unreadResponse());
+    observers[0].callback([visibleEntry()]); await flush();
+    expect(document.querySelector('.message-unread-label')).not.toBeNull();
+    expect(document.querySelector('.message-read-status')).not.toBeNull();
+    expect(observers).toHaveLength(1); // No immediate retry loop on scope failure.
+});
+
+test('queued observers from a previous selection and hidden documents cannot mark messages', async () => {
+    const observers = mockReadObserver();
+    const api = require(base + 'apiService.js');
+    api.postJson.mockResolvedValue(unreadResponse());
+    const panel = require(base + 'components/messagePanel.js');
+    await panel.openMessageExchange(row('#V#bob'));
+    const entry = visibleEntry();
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    observers[0].callback([entry]);
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await panel.openMessageExchange(row('#V#carol'));
+    observers[0].callback([visibleEntry()]);
+    expect(api.postJson.mock.calls.filter(([url]) => url === '/api/messages/read/bulk')).toHaveLength(0);
+});

--- a/tests/frontend/messagePanelSingleThreadAutoOpen.test.js
+++ b/tests/frontend/messagePanelSingleThreadAutoOpen.test.js
@@ -33,6 +33,7 @@ describe('message panel single-thread auto-open', () => {
         jest.resetModules();
         jest.clearAllMocks();
         delete global.fetch;
+        delete global.IntersectionObserver;
     });
 
     test('automatically opens the only available conversation', async () => {
@@ -145,6 +146,11 @@ describe('message panel single-thread auto-open', () => {
     });
 
     test('shows a self-addressed subject and marks the message read as the current user', async () => {
+        let observeVisible;
+        global.IntersectionObserver = jest.fn(function (callback) {
+            observeVisible = callback;
+            this.observe = jest.fn(); this.unobserve = jest.fn(); this.disconnect = jest.fn();
+        });
         const { getJson, postJson } = require('../../src/frontend/web/von_interface/static/js/apiService.js');
         const { initializeMessagePanel, showMessagesTab } = require(modulePath);
 
@@ -202,6 +208,10 @@ describe('message panel single-thread auto-open', () => {
         expect(document.querySelector('.message-subject')?.textContent).toBe('Messaging test');
         expect(document.querySelector('.message-content')?.textContent).toContain('Please confirm that this arrived.');
         expect(document.querySelector('.message-bubble')?.classList.contains('sent')).toBe(true);
+        expect(postJson).not.toHaveBeenCalledWith('/api/messages/read/bulk', expect.anything());
+        document.getElementById('messageViewContent').getClientRects = () => [{}];
+        observeVisible([{ target: document.querySelector('.message-bubble'), isIntersecting: true, intersectionRatio: 1 }]);
+        await flushUi();
         expect(postJson).toHaveBeenCalledWith('/api/messages/read/bulk', {
             message_ids: ['#V#message_self_1'],
         });


### PR DESCRIPTION
Messages that fail to save their read state currently remain silently unread: unchanged-content refreshes return before rearming visibility observation. The UI also treats every successful bulk response as confirmation for every submitted ID. This change retains explicit blue Unread labels until the update count confirms all IDs or a refresh confirms their read state, exposes failures with Retry, and rearms visibility observation on unchanged-content refreshes. Queued observers from an old pane and duplicate pending reads are ignored.

The badge counts recipient messages whose read_by list excludes the viewer, including unloaded earlier pages. Its tooltip now explains that meaning. Opening a conversation does not clear those older or off-screen messages. This diagnoses reproducible code paths; the particular live records behind the reported 16 and 2 counts were not inspected.

The unified Messages stylesheet had overridden sent/received alignment with align-self: stretch. Restore right/left bubbles, align old-style chat by explicit author identity (with a legacy own-user fallback), retain participant labels and controls, and use blue for unread badges, outlines and boundaries.

Validation:
- 44 focused frontend tests across seven message/tray suites; 50 backend message service, route and catalogue tests.
- Static frontend lint and git diff checks pass.
- New repeatable Playwright fixture acceptance uses production templates and modules with isolated in-memory API state. Desktop 1440px and narrow 360px checks cover visible-only read marking, badge reconciliation, failure/retry, new off-screen arrivals, older pagination, reload persistence, both conversation layouts and zero measured horizontal overflow.
- Browser screenshots/measurements retained under .run/evidence/jvnautosci-2747 in the assigned worker checkout. These are explicitly fixture observations, not public authentication or production message read-back.

Merge decision: ready, subject to repository CI. No database, schema, credentials, migration-worker or infrastructure changes. Deployment is separately handed to the DGX controller using the verified merged origin/main SHA. Jira connector requires reauthentication; the controller receives this evidence for Jira close-out.

Task: https://naoinstitute.atlassian.net/browse/JVNAUTOSCI-2747
