### PR TITLE
Clarify hourly conversation naming mechanism and schedule reconciliation

### DIFF
--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1373,7 +1373,32 @@ The owned unnamed-conversation naming consumer is
 `#V#unnamed_conversation_naming_workflow`. Its repository bundle and prompt are
 release inputs for the startup bootstrap; execution reads the published
 Vontology definition and linked prompt. Bootstrap does not create an actor's
-schedule. Use the normal actor-bound schedule route with an interval of 3600
+schedule. Reuse this direct consumer for the bounded hourly naming job. A
+[recurring task continuation](task_responsibility_continuation.md#recurring-encounters)
+also uses a workflow schedule, then submits a separate Tasks/chat execution.
+That path is useful when a responsibility needs evolving task guidance, a work
+product and conversation continuity. It requires a pending or in-progress task
+assigned to Von, created by the actor, with an accessible actor-owned originating
+conversation in the same organisation. A recurring task type or a coding-agent
+assignment alone does not supply an hourly executor. The existing naming
+consumer already provides discovery, inspection, semantic title choice and
+guarded effects without that additional task launch. This is a reuse decision,
+not a measured claim about comparative model quality, cost or latency.
+
+Before creating a naming schedule, list the actor's schedules including disabled
+ones and read back candidate definitions and launch inputs. Reuse a matching
+schedule and explicitly resume it if paused. A create retry does not resume a
+paused schedule. Preserve an existing schedule ID: the creation identity hashes
+the actor, definition identity, cadence, inputs and caller key, so a stable key
+alone does not deduplicate legacy schedules or schedules with changed inputs or
+definition identities. Reconcile any older naming consumer before enabling a
+replacement, preserving active work and enough state to restore its prior
+enabled status. Do not create a second assignment or leave competing naming
+schedules enabled. A bounded or incomplete schedule listing does not prove that
+no prior schedule exists.
+
+If no suitable schedule exists after reconciliation, use the normal actor-bound
+schedule route with an interval of 3600
 seconds, a stable idempotency key such as
 `hourly-owned-unnamed-conversation-naming-v1`, and an explicit allowed model in
 `default_inputs.requested_model`. For the bounded naming slice, `gpt-5.4` with

--- a/docs/engineering/von_workflow_language_manual.md
+++ b/docs/engineering/von_workflow_language_manual.md
@@ -1398,8 +1398,7 @@ schedules enabled. A bounded or incomplete schedule listing does not prove that
 no prior schedule exists.
 
 If no suitable schedule exists after reconciliation, use the normal actor-bound
-schedule route with an interval of 3600
-seconds, a stable idempotency key such as
+schedule route with an interval of 3600 seconds, a stable idempotency key such as
 `hourly-owned-unnamed-conversation-naming-v1`, and an explicit allowed model in
 `default_inputs.requested_model`. For the bounded naming slice, `gpt-5.4` with
 `requested_model_parameters: {"reasoning_effort": "medium"}` is the initial
@@ -1421,8 +1420,8 @@ incomplete source coverage is not exhaustive success; resume/retry the existing
 instance from its checkpoint. Completion covers the traversed source snapshot,
 not concurrent additions. Check occurrence identity, step receipts and canonical
 titles before claiming the hourly responsibility is working; schedule creation
-and source publication alone are insufficient. JVNAUTOSCI-2698 owns the live
-activation and acceptance status.
+and source publication alone are insufficient. Record live activation and
+acceptance on the current requesting task.
 
 Awaited durable execution contract:
 


### PR DESCRIPTION
Merge decision: ready — operators can choose the existing naming consumer and reconcile its hourly schedule without mistaking a task assignment or a create retry for activation.

## User outcome

For the bounded job of inspecting an actor's owned unnamed conversations and assigning concise titles hourly, reuse the naming workflow delivered in #645. Recurring task continuation uses the same scheduler plus a Tasks/chat launch; it is useful for evolving responsibilities but adds task, conversation and execution dependencies to this existing consumer.

## Material changes

Document that mechanism comparison in the VWL schedule guide. Explain how to reuse an existing schedule, explicitly resume it, and reconcile an older naming consumer before creating a replacement. The schedule creation hash includes the definition identity and inputs, so a stable caller key alone does not prevent duplicate schedules across configuration changes.

## Evidence

Inspected the current naming bundle, recurring-task submission path, actor-owned schedule service and durable scheduler. `pdm run pytest -q tests/backend/test_conversation_naming_workflow.py tests/backend/test_workflow_schedule_service.py tests/backend/test_task_execution_actions.py tests/backend/test_conversation_search_service.py`: 38 passed using a mock database and scripted model responses. This includes due-occurrence creation, deduplication, checkpoint recovery, canonical rename read-back and existing/concurrent-title preservation. Diff whitespace and the new local link/anchor were checked.

## Ship boundary

This documentation change records the current implementation and operational reconciliation behaviour. Live actor-scope definition, schedule and occurrence read-back remain outstanding: this worker has no Von control tools and is prohibited from live mutations through shell. No schedule, assignment, conversation name, represented prompt, running service or deployment is changed by this PR. Actual live title quality and hourly execution remain unverified.
