### PR TITLE
Complete mobile image picker and recoverable attachment lifecycle

### DIFF
--- a/docs/engineering/otter_archive_and_conversation_images.md
+++ b/docs/engineering/otter_archive_and_conversation_images.md
@@ -204,3 +204,52 @@ handoff increments `event_handoff_failures`, leaves the meeting pending, and
 makes the run partial while retaining the successful preservation receipt. A
 retry reuses the event's durable instance when one already exists. A queued or
 reused workflow does not prove its later mail, deck or paper effects succeeded.
+
+## Mobile/PWA image picker (candidate evidence, 12 September 2026)
+
+The composer has an **Attach image** button beside the draft. Choose one or more
+photos/files, wait for previews, enter an instruction, then send. **More actions →
+Paste image** attempts the browser clipboard API; ordinary image paste into the
+conversation and the general **Upload File** control use the same image pipeline.
+Remove an image and choose another to replace it. Removal cancels an in-progress
+browser upload and excludes any late result from the request; an already stored
+source is not deleted. Failed uploads remain visible, block sending, and offer
+retry/removal. Closing the picker leaves the existing draft intact.
+
+The picker advertises PNG, JPEG and WebP. HEIC, animated and other unsupported
+images need conversion to a supported still format; the backend checks actual
+bytes, dimensions and size. Recognised image filenames with an empty browser MIME
+type still use that validator. Clipboard denial, cancellation, missing APIs and
+an empty clipboard provide the picker as a fallback. No clipboard permission is
+requested until **Paste image** is pressed. Native photo-library menus, clipboard
+availability and installed-PWA behaviour depend on the device/browser and have
+not been established by the local Chromium fixture below. No offline upload queue
+is supplied: retry when connectivity returns. Unsent image selections are not
+restored after a page reload.
+
+Candidate checks:
+
+- `tests/frontend/chatAttachmentWorkflowInput.test.js`,
+  `static/js/test/conversationImages.test.js` and `static/js/test/imagePicker.test.js`:
+  24 tests pass, including the actual chat request builder receiving only the
+  replacement image ID, and the next text request receiving none.
+- `tests/backend/test_conversation_images.py`: 15 tests pass, including the
+  authenticated upload route, byte validation, descriptor return, actor isolation,
+  original retrieval and provider-byte transport.
+- `tests/browser/imagePicker.cjs`: production template/CSS and image/compact-composer
+  modules in a localhost fixture, with stubbed upload/original endpoints. Chromium
+  passed at 360, 412 and 1440 pixels: native file chooser event, decoded preview,
+  removal/replacement, 44-pixel picker control and no composer overflow. Evidence:
+  task-worktree `.run/image-picker/results.json` and `*-preview.png`.
+- `tests/browser/composerControls.cjs`: all six desktop/touch/short-viewport
+  profiles pass with the added keyboard stop and unchanged one-row controls.
+
+These are bounded component/request-path checks, not authenticated PWA acceptance
+or a live vision-model trial. The DGX browser README's attachment profile on 5013
+was unreachable on this run and is documented as bound to another task. Before
+claiming the requested local PWA verification, the operator must prepare a separate
+localhost AgentTest profile bound to this task checkout/revision, with synthetic
+actors and disposable blob/data storage, browser-test login, and a working restart
+bridge. Keep real profiles and public port 5000 untouched. Then exercise the actual
+composer/upload/request/history path and PWA shell on that candidate. No deployment
+was requested by this task.

--- a/src/frontend/web/von_interface/static/js/chatTab.js
+++ b/src/frontend/web/von_interface/static/js/chatTab.js
@@ -11,7 +11,7 @@ import { CONVERSATION_LAYOUT_KEY, CONVERSATION_LAYOUT_KEYS, CONVERSATION_NARROW_
 import { createVoiceConversation } from './voiceConversation.js';
 import { getClientContext } from './clientContext.js';
 import { createDictationController } from './dictation.js';
-import { renderImageAttachments, renderImageComposer, uploadConversationImage, imagesBlocked, imageItems, takeImages, restoreImages, descriptorsForIds } from "./utils/conversationImages.js";
+import { initialiseImagePicker, renderImageAttachments, renderImageComposer, uploadConversationImage, imagesBlocked, imageItems, takeImages, restoreImages, descriptorsForIds } from "./utils/conversationImages.js";
 // Chat Tab Module
 import { annotateTurn, fetchWithTimeout, getJsonDetailed, getUserContext, getWindowSessionId, postJson, WINDOW_SESSION_HEADER } from './apiService.js';
 import {
@@ -6662,7 +6662,7 @@ function updateExternalConversationUi() {
                 : promptInput.dataset.nativePlaceholder
         );
     }
-    [resetButton, uploadButton, dictateButton].forEach((button) => {
+    [resetButton, uploadButton, dictateButton, document.getElementById('attachImageButton'), document.getElementById('pasteImageButton')].forEach((button) => {
         if (button) {
             button.disabled = readOnly;
         }
@@ -22020,7 +22020,7 @@ async function performUploadFilesToVon(list, uploadState) {
     let index = 0;
 
     for (const file of list) {
-        if (file.type?.startsWith('image/')) {
+        if (file.type?.startsWith('image/') || /\.(png|jpe?g|webp|heic|heif|gif|bmp|tiff?|svg)$/i.test(file.name || '')) {
             index += 1;
             const uploaded = await uploadConversationImage(file, uploadTargetSessionId, buildChatFetchHeaders(), refreshConversationImages);
             if (uploaded) successCount += 1; else failureCount += 1;
@@ -34180,6 +34180,8 @@ export function initializeChatTab() {
             }
         });
     }
+
+    initialiseImagePicker(uploadFilesToVon, renderUploadStatus);
 
     if (uploadFileButton && uploadFileInput) {
         uploadFileButton.addEventListener('click', () => {

--- a/src/frontend/web/von_interface/static/js/test/conversationImages.test.js
+++ b/src/frontend/web/von_interface/static/js/test/conversationImages.test.js
@@ -24,7 +24,7 @@ test('failed preparation remains visible and prevents text-only submission until
     expect(panel.querySelector('[role=alert]').textContent).toMatch(/still PNG/);
     expect(imagesBlocked('failed')).toBe(true);
     expect(() => takeImages('failed')).toThrow(/preparation failed/);
-    panel.querySelector('button').click();
+    panel.querySelector('button[aria-label^=Remove]').click();
     expect(imagesBlocked('failed')).toBe(false);
 });
 
@@ -50,4 +50,39 @@ test('fallback Markdown resolves exact archive citations without allowing arbitr
     parent.innerHTML = simpleMarkdownToHtml(`[Source](otter-archive://artifact/${artifact}) [Bad](otter-archive://other/private)`);
     expect(parent.querySelector('a').getAttribute('href')).toBe(`/von/api/otter-archive/artifacts/${artifact}`);
     expect(parent.querySelectorAll('a')).toHaveLength(1);
+});
+
+test('removal cancels in-flight upload and ignores a late response', async () => {
+    let finish;
+    global.fetch = jest.fn(() => new Promise(resolve => { finish = resolve; }));
+    const panel = document.createElement('div');
+    const render = () => renderImageComposer(panel, 'cancel', render);
+    const upload = uploadConversationImage(new File(['bytes'], 'cancel.png', {type:'image/png'}), 'cancel', {}, render);
+    panel.querySelector('button').click();
+    expect(fetch.mock.calls[0][1].signal.aborted).toBe(true);
+    finish({ok:true, json:async () => ({image_attachment:{concept_id:'#V#late'}})});
+    expect(await upload).toBe(false);
+    expect(takeImages('cancel')).toEqual([]);
+});
+
+test('network failure can retry without duplicating or crossing conversation bindings', async () => {
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error('Network unavailable')).mockResolvedValueOnce({ok:true, json:async () => ({image_attachment:{concept_id:'#V#retried'}})});
+    const panel = document.createElement('div');
+    const render = () => renderImageComposer(panel, 'retry', render);
+    await uploadConversationImage(new File(['bytes'], 'retry.png', {type:'image/png'}), 'retry', {}, render);
+    expect(imagesBlocked('retry')).toBe(true);
+    await imageItems('retry')[0].retry();
+    expect(imageItems('retry')).toHaveLength(1);
+    expect(takeImages('elsewhere')).toEqual([]);
+    expect(takeImages('retry')).toEqual(['#V#retried']);
+});
+
+test.each([
+    ['large.png', 'image/png', 8 * 1024 * 1024 + 1, /8 MiB/],
+    ['phone.heic', 'image/heic', 1, /Convert HEIC/]
+])('invalid selection %s reports actionable error before upload', async (name, type, size, message) => {
+    global.fetch = jest.fn();
+    await uploadConversationImage(new File([new Uint8Array(size)], name, {type}), name, {}, () => {});
+    expect(fetch).not.toHaveBeenCalled();
+    expect(imageItems(name)[0].error).toMatch(message);
 });

--- a/src/frontend/web/von_interface/static/js/test/imagePicker.test.js
+++ b/src/frontend/web/von_interface/static/js/test/imagePicker.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+import { initialiseImagePicker } from '../utils/conversationImages.js';
+let upload, status;
+beforeEach(() => {
+    document.body.innerHTML = '<button id="attachImageButton"></button><input id="attachImageInput" type="file"><button id="pasteImageButton"></button>';
+    upload = jest.fn(); status = jest.fn();
+    Object.defineProperty(navigator, 'clipboard', {configurable:true, value:undefined});
+    initialiseImagePicker(upload, status);
+});
+test('picker cancellation preserves draft; selection uses shared upload path', () => {
+    const input = document.querySelector('input');
+    const click = jest.spyOn(input, 'click');
+    document.querySelector('#attachImageButton').click();
+    expect(click).toHaveBeenCalled();
+    input.dispatchEvent(new Event('cancel'));
+    expect(upload).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(expect.stringContaining('unchanged'));
+    const file = new File(['image'], 'photo.png', {type:'image/png'});
+    Object.defineProperty(input, 'files', {value:[file]});
+    input.dispatchEvent(new Event('change'));
+    expect(upload).toHaveBeenCalledWith([file]);
+    expect(input.value).toBe('');
+});
+test('missing clipboard API offers the picker', () => {
+    document.querySelector('#pasteImageButton').click();
+    expect(status).toHaveBeenCalledWith(expect.stringContaining('Use Attach image'), 'error');
+});
+test.each(['denied', 'empty', 'image'])('clipboard %s', async mode => {
+    Object.defineProperty(navigator, 'clipboard', {value:{read:jest.fn(async () => {
+        if (mode === 'denied') throw new Error('NotAllowedError');
+        return mode === 'empty' ? [] : [{types:['image/png'], getType:async () => new Blob(['image'], {type:'image/png'})}];
+    })}});
+    document.querySelector('#pasteImageButton').click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    if (mode === 'image') expect(upload.mock.calls[0][0][0].type).toBe('image/png');
+    else expect(status).toHaveBeenCalledWith(expect.stringContaining('Attach image'), 'error');
+});

--- a/src/frontend/web/von_interface/static/js/utils/conversationImages.js
+++ b/src/frontend/web/von_interface/static/js/utils/conversationImages.js
@@ -34,7 +34,7 @@ export function renderImageComposer(parent, sessionId, changed) {
     parent.replaceChildren();
     for (const item of imageItems(sessionId)) {
         const card = document.createElement('div');
-        card.style.cssText = 'display:inline-flex;flex-direction:column;gap:4px;margin:6px;max-width:180px';
+        card.className = 'conversation-image-draft';
         if (item.descriptor) renderImageAttachments(card, [item.descriptor]);
         const label = document.createElement('span');
         label.textContent = item.error || (item.descriptor ? item.name : `Uploading ${item.name}…`);
@@ -42,23 +42,79 @@ export function renderImageComposer(parent, sessionId, changed) {
         card.appendChild(label);
         const remove = document.createElement('button');
         remove.type = 'button'; remove.textContent = 'Remove'; remove.setAttribute('aria-label', `Remove ${item.name}`);
-        remove.onclick = () => { pending.set(sessionId, imageItems(sessionId).filter(x => x !== item)); changed(); };
+        remove.onclick = () => { item.controller?.abort(); pending.set(sessionId, imageItems(sessionId).filter(x => x !== item)); changed(); };
+        if (item.error && item.retry) {
+            const retry = document.createElement('button');
+            retry.type = 'button'; retry.textContent = 'Retry upload';
+            retry.onclick = item.retry; card.appendChild(retry);
+        }
         card.appendChild(remove); parent.appendChild(card);
     }
 }
 export async function uploadConversationImage(file, sessionId, headers, changed) {
     const item = {name: file.name};
     pending.set(sessionId, [...imageItems(sessionId), item]); changed();
-    try {
-        if (imageItems(sessionId).length > 8) throw new Error('At most eight images per message. Remove an image before sending.');
-        const form = new FormData(); form.append('file', file, file.name || 'image.png');
-        const response = await fetch('/von/api/images/upload', {method:'POST', headers, body:form});
-        const result = await response.json();
-        if (!response.ok || !result.image_attachment) throw new Error(result.message || result.error || 'Image upload failed');
-        item.descriptor = result.image_attachment; known.set(item.descriptor.concept_id, item);
-    } catch (error) { item.error = String(error.message || error); }
-    changed();
-    return Boolean(item.descriptor);
+    const upload = async () => {
+        item.error = null;
+        item.retry = null;
+        item.controller = new AbortController();
+        changed();
+        try {
+            if (imageItems(sessionId).length > 8) throw new Error('At most eight images per message. Remove an image before sending.');
+            if (!file.size || file.size > 8 * 1024 * 1024) throw new Error('Images must be nonempty and at most 8 MiB.');
+            if (file.type && !['image/png', 'image/jpeg', 'image/webp'].includes(file.type)) {
+                throw new Error('Use a still PNG, JPEG or WebP image. Convert HEIC or other formats before attaching.');
+            }
+            const form = new FormData(); form.append('file', file, file.name || 'image.png');
+            const response = await fetch('/von/api/images/upload', {method:'POST', headers, body:form, signal:item.controller.signal});
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok || !result.image_attachment) throw new Error(result.message || result.error || `Image upload failed (${response.status}). Retry or remove the image.`);
+            // A removed upload must never reappear or become a request attachment.
+            if (!imageItems(sessionId).includes(item)) return false;
+            item.descriptor = result.image_attachment; known.set(item.descriptor.concept_id, item);
+        } catch (error) {
+            if (!imageItems(sessionId).includes(item)) return false;
+            item.error = String(error.message || error);
+            item.retry = upload;
+        }
+        changed();
+        return Boolean(item.descriptor);
+    };
+    return upload();
+}
+
+// Both controls use the existing session-bound upload path supplied by chatTab.
+export function initialiseImagePicker(upload, status) {
+    const input = document.getElementById('attachImageInput');
+    const button = document.getElementById('attachImageButton');
+    const paste = document.getElementById('pasteImageButton');
+    if (button && input) {
+        button.addEventListener('click', () => input.click());
+        input.addEventListener('change', () => {
+            const files = Array.from(input.files || []);
+            input.value = '';
+            if (files.length) void upload(files);
+        });
+        input.addEventListener('cancel', () => status('Image selection cancelled. Your draft is unchanged.'));
+    }
+    paste?.addEventListener('click', async () => {
+        if (!navigator.clipboard?.read) {
+            status('Clipboard images are unavailable here. Use Attach image, or paste into the message field.', 'error');
+            return;
+        }
+        try {
+            const items = await navigator.clipboard.read();
+            const files = [];
+            for (const item of items) {
+                const type = item.types.find(value => value.startsWith('image/'));
+                if (type) files.push(new File([await item.getType(type)], `pasted-image-${files.length + 1}.${type.split('/')[1]}`, {type}));
+            }
+            if (files.length) await upload(files);
+            else status('No image found on the clipboard. Use Attach image to choose a photo.', 'error');
+        } catch (_) {
+            status('Clipboard access was unavailable or cancelled. Use Attach image, or paste into the message field.', 'error');
+        }
+    });
 }
 export function takeImages(sessionId) {
     if (imagesBlocked(sessionId)) throw new Error('Image preparation failed or is still running. Remove or finish the upload before sending.');

--- a/src/frontend/web/von_interface/static/styles.css
+++ b/src/frontend/web/von_interface/static/styles.css
@@ -11854,7 +11854,7 @@ body[data-active-tab="settingsTab"] .tab-content-area {
     }
 
     .chat-composer-primary-actions {
-        width: 96px;
+        width: 148px;
     }
 
     .chat-composer-primary-actions>button:not(.composer-icon-button) {
@@ -18558,4 +18558,17 @@ body.settings-body {
     .unified-message-content .message-input[data-has-draft="false"] + .send-message-btn:not([aria-busy="true"]) { display: none; }
     .unified-message-content .send-message-btn { padding: 0 12px; font-size: 14px; }
     .unified-message-content .message-reply-destination { margin: 0 0 4px; font-size: 12px; }
+}
+
+/* Image drafts remain within the compact mobile/PWA composer. */
+#conversationImageComposer { flex-basis: 100%; min-width: 0; width: 100%; }
+#conversationImageComposer:empty { display: none; }
+.conversation-image-draft { display: inline-flex; vertical-align: top; flex-direction: column; gap: 4px; margin: 6px; max-width: min(180px, calc(100% - 12px)); overflow-wrap: anywhere; }
+.conversation-image-draft button { min-height: 44px; }
+.conversation-image-draft .conversation-image-gallery img { max-height: 140px !important; }
+@media (max-width: 800px), (max-width: 1024px) and (pointer: coarse) {
+    .chat-composer { grid-template-columns: 44px 44px minmax(0, 1fr) auto; }
+    .chat-composer #attachImageButton { grid-column: 2; grid-row: 1; width: 44px; min-width: 44px; }
+    .chat-composer > .prompt-input-wrapper, .chat-composer > #promptInput { grid-column: 3; }
+    .chat-composer #sendButton { grid-column: 4; }
 }

--- a/src/frontend/web/von_interface/templates/chat_tab.html
+++ b/src/frontend/web/von_interface/templates/chat_tab.html
@@ -236,6 +236,10 @@
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5m-7 7 7-7 7 7" /></svg>
             <span class="button-label sr-only">Send Prompt</span>
           </button>
+          <button id="attachImageButton" class="btn btn-secondary composer-icon-button" type="button" title="Attach image" aria-label="Attach image" aria-describedby="imageAttachmentHelp">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8" cy="8" r="1"/><path d="m3 17 6-6 4 4 3-3 5 5"/></svg>
+          </button>
+          <input id="attachImageInput" class="visually-hidden" type="file" tabindex="-1" accept="image/png,image/jpeg,image/webp" multiple aria-label="Choose images" />
           <button id="dictateButton" class="btn btn-secondary composer-icon-button" type="button" aria-describedby="microphoneHelp" title="Click to dictate into your draft. Shift-click or long-press to start a voice conversation: speech is sent automatically and Von replies aloud.">
             <svg class="microphone-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="6" height="12" rx="3" /><path d="M5 10v2a7 7 0 0 0 14 0v-2M12 19v3m-4 0h8" /></svg>
             <svg class="dictation-stop-icon" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2" /></svg>
@@ -261,6 +265,8 @@
               title="End this conversation (resets Von's context while keeping the conversation view)">End
               conversation</button>
 
+            <p id="imageAttachmentHelp">Attach up to eight still PNG, JPEG or WebP images, each up to 8 MiB and 25 million pixels. Review previews before sending. Remove an image to replace it.</p>
+            <button id="pasteImageButton" class="btn btn-secondary" type="button">Paste image</button>
             <button id="uploadFileButton" class="btn btn-secondary" type="button"
               title="Upload a file, drag and drop onto the conversation, or paste an image">Upload File</button>
             <input id="uploadFileInput" class="visually-hidden" type="file" multiple aria-label="Upload file" />

--- a/tests/backend/test_conversation_images.py
+++ b/tests/backend/test_conversation_images.py
@@ -302,3 +302,34 @@ def test_archive_resource_citations_resolve_only_to_authenticated_source_route()
     links = BeautifulSoup(html, "html.parser").find_all("a")
     assert links[0]["href"] == "/von/api/otter-archive/artifacts/" + artifact
     assert not links[1].has_attr("href")
+
+
+def test_picker_upload_validates_bytes_and_returns_request_descriptor(monkeypatch):
+    from flask import Blueprint, Flask
+    from src.backend.server.routes.conversation_image_routes import register_image_routes
+
+    stored = []
+
+    def store(**kwargs):
+        info = images.inspect_image(kwargs['data'])
+        stored.append(kwargs)
+        return {**info, 'concept_id': '#V#phone_image', 'filename': kwargs['filename']}
+
+    monkeypatch.setattr(images, 'store_image', store)
+    app = Flask(__name__)
+    bp = Blueprint('picker_test', __name__)
+    register_image_routes(bp)
+    app.register_blueprint(bp, url_prefix='/von')
+    client = app.test_client()
+    assert client.post('/von/api/images/upload').status_code == 401
+    with override_current_actor('#V#owner', None):
+        assert client.post('/von/api/images/upload').status_code == 400
+        invalid = client.post('/von/api/images/upload', data={'file': (io.BytesIO(b'bad'), 'phone.png')})
+        assert invalid.status_code == 400
+        assert invalid.json['error'] == 'invalid_image'
+        response = client.post('/von/api/images/upload', data={'file': (io.BytesIO(png()), 'phone.png')})
+    assert response.status_code == 201
+    assert response.json['image_attachment']['concept_id'] == '#V#phone_image'
+    assert response.json['image_attachment']['content_type'] == 'image/png'
+    assert len(stored) == 1
+    assert stored[0]['user_concept_id'] == '#V#owner'

--- a/tests/browser/composerControls.cjs
+++ b/tests/browser/composerControls.cjs
@@ -82,6 +82,8 @@ async function bounds(page, selector) {
             await page.keyboard.press('Tab');
             await expect(send).toBeFocused();
             await page.keyboard.press('Tab');
+            await expect(page.getByRole('button', { name: 'Attach image', exact: true })).toBeFocused();
+            await page.keyboard.press('Tab');
             if (profile.desktop) {
                 await expect(mic).toBeFocused();
                 await page.keyboard.press('Tab');

--- a/tests/browser/imagePicker.cjs
+++ b/tests/browser/imagePicker.cjs
@@ -1,0 +1,87 @@
+// Local production-template/module fixture; no authentication or model requests.
+// Run with PLAYWRIGHT_BROWSERS_PATH=/tmp/von-playwright node tests/browser/imagePicker.cjs .run/image-picker
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const { chromium, expect } = require('@playwright/test');
+
+const root = path.resolve(__dirname, '../../src/frontend/web/von_interface');
+const markup = fs.readFileSync(path.join(root, 'templates/chat_tab.html'), 'utf8')
+    .replace(/{%[\s\S]*?%}/g, '').replace(/{{[\s\S]*?}}/g, '');
+const evidence = process.argv[2];
+if (evidence) fs.mkdirSync(evidence, { recursive: true });
+const server = http.createServer((req, res) => {
+    if (req.url === '/') {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(`<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+            <link rel="stylesheet" href="/static/styles.css">${markup}`);
+        return;
+    }
+    const file = path.resolve(root, `.${req.url}`);
+    if (!file.startsWith(`${root}/static/`) || !fs.existsSync(file)) {
+        res.writeHead(404).end();
+        return;
+    }
+    res.setHeader('Content-Type', file.endsWith('.css') ? 'text/css' : 'text/javascript');
+    res.end(fs.readFileSync(file));
+});
+
+
+(async () => {
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const browser = await chromium.launch({headless:true});
+    const results = [];
+    try {
+        for (const width of [360, 412, 1440]) {
+            const page = await browser.newPage({viewport:{width, height:900}, isMobile:width < 800, hasTouch:width < 800});
+            let uploads = 0;
+            const png = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a2ioAAAAASUVORK5CYII=', 'base64');
+            await page.route('**/von/api/images/upload', route => {
+                uploads++;
+                return route.fulfill({json:{image_attachment:{concept_id:`#V#fixture-${uploads}`, filename:'phone.png'}}});
+            });
+            await page.route('**/von/api/images/*/original', route => route.fulfill({contentType:'image/png', body:png}));
+            await page.goto(`http://127.0.0.1:${server.address().port}`);
+            await page.evaluate(async () => {
+                document.querySelector('#messagesContainer').style.display = 'none';
+                document.querySelector('#scrollableField').textContent = 'Image picker acceptance draft';
+                const images = await import('/static/js/utils/conversationImages.js');
+                const { initialiseCompactChatComposer } = await import('/static/js/components/compactComposer.js');
+                initialiseCompactChatComposer(document.querySelector('.chat-composer'));
+                const panel = document.createElement('div'); panel.id = 'conversationImageComposer';
+                document.querySelector('.chat-composer').append(panel);
+                const render = () => images.renderImageComposer(panel, 'fixture', render);
+                images.initialiseImagePicker(async files => {
+                    for (const file of files) await images.uploadConversationImage(file, 'fixture', {}, render);
+                }, message => {
+                    document.querySelector('#uploadFileStatus').textContent = message;
+                    document.querySelector('#chatAttachmentStatus').classList.remove('hidden');
+                });
+                window.fixtureImages = images;
+            });
+            const button = page.getByRole('button', {name:'Attach image', exact:true});
+            await expect(button).toBeVisible();
+            const box = await button.boundingBox();
+            assert(box.width >= 44 && box.height >= 44);
+            const chooser = page.waitForEvent('filechooser');
+            await button.click();
+            await (await chooser).setFiles({name:'phone.png', mimeType:'image/png', buffer:png});
+            await expect(page.locator('#conversationImageComposer img')).toBeVisible();
+            await expect(page.locator('#conversationImageComposer img')).toHaveJSProperty('naturalWidth', 1);
+            await page.getByRole('button', {name:'Remove phone.png', exact:true}).click();
+            await expect(page.locator('#conversationImageComposer img')).toHaveCount(0);
+            await page.locator('#attachImageInput').setInputFiles({name:'replacement.png', mimeType:'image/png', buffer:png});
+            await expect(page.locator('#conversationImageComposer img')).toBeVisible();
+            const overflow = await page.locator('.chat-composer').evaluate(el => el.scrollWidth > el.clientWidth);
+            assert(!overflow, `composer overflow at ${width}`);
+            if (evidence) await page.screenshot({path:path.join(evidence, `${width}-preview.png`)});
+            const ids = await page.evaluate(() => window.fixtureImages.takeImages('fixture'));
+            assert.deepEqual(ids, ['#V#fixture-2']);
+            results.push({width, uploads, ids, overflow});
+            await page.close();
+        }
+        if (evidence) fs.writeFileSync(path.join(evidence, 'results.json'), JSON.stringify(results, null, 2));
+        console.log(JSON.stringify(results));
+    } finally { await browser.close(); server.close(); }
+})().catch(error => { console.error(error); server.close(); process.exitCode = 1; });

--- a/tests/frontend/chatAttachmentWorkflowInput.test.js
+++ b/tests/frontend/chatAttachmentWorkflowInput.test.js
@@ -75,6 +75,34 @@ describe('chat attachment workflow input binding', () => {
         delete global.fetch;
     });
 
+    test('phone image without MIME binds only to its next request, after preview and removal', async () => {
+        const { __testOnly_uploadFilesToVon, sendMessage } = require(chatTabModulePath);
+        const bodies = [];
+        let uploaded = 0;
+        global.fetch = jest.fn(async (url, options = {}) => {
+            if (url === '/von/api/images/upload') return {ok:true, json:async () => ({image_attachment:{concept_id:`#V#phone-${++uploaded}`, filename:'phone.png'}})};
+            if (String(url).startsWith('/von/generate')) {
+                bodies.push(JSON.parse(options.body));
+                return {ok:true, json:async () => ({response:'Image received.', llm_debug:{model:'test-model'}})};
+            }
+            if (String(url).startsWith('/von/history/length')) return {ok:true, json:async () => ({history_length:0, authenticated:true})};
+            if (String(url).startsWith('/von/api/render_markdown')) return {ok:true, json:async () => ({html:JSON.parse(options.body).text || ''})};
+            return {ok:true, json:async () => ({})};
+        });
+        await __testOnly_uploadFilesToVon([new File(['png'], 'phone.png')]);
+        expect(document.querySelector('#conversationImageComposer img')).not.toBeNull();
+        document.querySelector('#conversationImageComposer button[aria-label^=Remove]').click();
+        await __testOnly_uploadFilesToVon([new File(['png'], 'replacement.png')]);
+        document.querySelector('#promptInput').value = 'Describe this screenshot';
+        await sendMessage();
+        expect(bodies[0].image_attachment_ids).toEqual(['#V#phone-2']);
+        expect(bodies[0]).not.toHaveProperty('workflow_inputs');
+        document.querySelector('#promptInput').value = 'Now a text-only question';
+        await sendMessage();
+        expect(bodies[1]).not.toHaveProperty('image_attachment_ids');
+        expect(fetch.mock.calls.some(([url]) => url === '/von/api/files/upload')).toBe(false);
+    });
+
     test('normal upload binds its trusted file-copy id to the next generate request', async () => {
         const {
             __testOnly_uploadFilesToVon,
@@ -341,7 +369,7 @@ describe('chat attachment workflow input binding', () => {
         await Promise.resolve();
 
         expect(sendButton.disabled).toBe(false);
-        expect(sendButton.hasAttribute('title')).toBe(false);
+        expect(sendButton.title).toBe('Send Prompt');
 
         await sendMessage();
 


### PR DESCRIPTION
Merge decision: ready — mobile users can attach images beside the draft, review or replace previews, recover failed uploads, and submit each image with the intended request.

## User outcome

Adds a direct image picker to the compact composer and completes the mobile attachment lifecycle. Builds on the merged screenshot-paste recovery in #693, preserving its clipboard helper and guidance without duplicate controls.

## Material changes

- Route image filenames with missing browser MIME types through image validation and keep them out of generic workflow-file bindings.
- Validate supported still formats and the 8 MiB upload limit; retain errors and retry/removal, and abort removed uploads.
- Keep image controls and previews usable within narrow composers.
- Preserve the retained implementation, reconcile main, and add reproducible authenticated acceptance.

Native task: `#V#task_agent_ca207e7d618fae369ec5b9c43f3e7741`.

## Evidence

- 34 targeted frontend tests and 16 backend image tests pass; affected static JS lint passes.
- Authenticated disposable localhost fixture, product revision `87f70a14f973ccedb1500b395ea554fb523dddb2`: actual upload and original-byte/SHA-256 read-back, preview/removal/replacement, caption preservation, upload retry and next-request/conversation binding at 360, 412 and 1440 pixels.
- Actual standalone manifest and service worker controlling the local PWA shell. Generation intercepted at the fixture boundary; no model-output or saved-history claim.
- Three image-picker widths, six composer profiles, and three desktop clipboard recovery widths pass.
- Operator-provided Android 17 / Chrome 145 / Gboard 17.2 evidence verifies the unchanged helper using native permission approval, decoded PNG and preserved captions.

Evidence and limitations: `docs/engineering/otter_archive_and_conversation_images.md`; retained results/screenshots in `.run/image-picker-authenticated/` and `.run/image-picker-current/`. The final commit changes only the acceptance harness and documentation after the tested product revision.

## Ship boundary

Minimum ship criteria are met: supported picker, recoverable attachment lifecycle, correct request binding, and authenticated local mobile/PWA-shell acceptance. Wrong attachment binding, lost drafts, upload failure without recovery or inaccessible narrow controls would block shipping; none remain in the affected tests.

Physical-device PWA installation, iOS, Chrome 152, vision-model answers, saved-history acceptance and offline uploads are not claimed. Native clipboard evidence does not claim original-byte fidelity or repair of Gboard keyboard-tile refusal. No public deployment is requested.
